### PR TITLE
MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01 MBTI desktop clone media asset baseline

### DIFF
--- a/backend/docs/mbti-desktop-clone-owner.md
+++ b/backend/docs/mbti-desktop-clone-owner.md
@@ -116,6 +116,15 @@ MBTI Desktop clone 正文 owner 挂在现有 personality owner 域内：
 - `relationships-illustration`
 - `final-offer-illustration`
 
+当前 `zh-CN` 基线已将 32 个 fullCode × 7 个 slot 全部绑定为 `ready`：
+
+- Media Library baseline：`content_baselines/media_assets/mbti_desktop_clone_assets.v1.json`
+- Committed static assets：`backend/public/static/mbti/desktop-clone/{fullCode}/{slotId}.svg`
+- Desktop clone baseline：`content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json`
+- Public asset origin：`https://assets.fermatmind.com/static/mbti/desktop-clone/{fullCode}/{slotId}.svg`
+
+这些资产是 repo-backed system visuals，不是用户结果数据，也不是 frontend fallback。生产启用路径仍需要正常的 backend deploy / Media Library import / CDN sync 与 smoke 验证。
+
 ## 5. 继续属于 Runtime 的字段
 以下仍由结果 runtime/projection 提供，不进入 clone content owner：
 
@@ -177,7 +186,7 @@ compatibility 字段契约（当前阶段）：
 
 ## 8. 当前未覆盖
 - `en` locale backfill
-- 真实 AI 资产生成/上传与批处理
+- 人工美术级替换图与品牌视觉复审
 - runtime personalization（`selection_fingerprint` / `evidence` / `adaptive` / `memory`）
 
 ## 9. 后续 hard convergence 前置条件

--- a/backend/public/static/mbti/desktop-clone/enfj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,144.7 159.0,178.1 318.0,192.0 477.0,168.7 636.0,137.9 795.0,138.9 954.0,170.4 1113.0,192.2 1272.0,176.5" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1061.36" y1="225.79" x2="810.01" y2="53.28" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="452.32" y1="139.53" x2="200.98" y2="150.55" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="53.28" x2="558.66" y2="64.29" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="200.98" y1="150.55" x2="916.35" y2="161.56" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="64.29" x2="307.32" y2="75.3" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="75.3" x2="1022.69" y2="86.31" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1061.36" cy="225.79" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="452.32" cy="139.53" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="810.01" cy="53.28" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="200.98" cy="150.55" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="558.66" cy="64.29" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="916.35" cy="161.56" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="307.32" cy="75.3" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="665.0" cy="172.57" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="1022.69" cy="86.31" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,423.9 94.5,408.9 189.0,335.4 283.5,297.1 378.0,342.9 472.5,414.3 567.0,420.3 661.5,353.2 756.0,298.6" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="464.18" y1="384.78" x2="314.8" y2="409.33" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="102.21" y1="192.46" x2="527.39" y2="217.01" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="314.8" y1="409.33" x2="165.41" y2="433.88" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="527.39" y1="217.01" x2="378.0" y2="241.56" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="378.0" y1="241.56" x2="228.61" y2="266.11" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="228.61" y1="266.11" x2="464.18" y2="384.78" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="464.18" cy="384.78" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="102.21" cy="192.46" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="314.8" cy="409.33" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="527.39" cy="217.01" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="165.41" cy="433.88" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="378.0" cy="241.56" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="590.59" cy="458.44" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="228.61" cy="266.11" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="441.2" cy="482.99" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4A1E24" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,186.1 159.0,154.2 318.0,133.3 477.0,150.0 636.0,183.0 795.0,190.3 954.0,162.5 1113.0,135.1 1272.0,143.1" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="490.99" y1="117.51" x2="239.64" y2="128.52" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="214.78" x2="597.33" y2="225.79" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="239.64" y1="128.52" x2="955.02" y2="139.53" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="225.79" x2="345.98" y2="53.28" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="53.28" x2="1061.36" y2="64.29" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="64.29" x2="490.99" y2="117.51" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="490.99" cy="117.51" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="848.68" cy="214.78" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="239.64" cy="128.52" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="597.33" cy="225.79" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="955.02" cy="139.53" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="345.98" cy="53.28" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="703.67" cy="150.55" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="1061.36" cy="64.29" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="452.32" cy="161.56" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,219.0 88.5,232.1 177.0,285.9 265.5,311.7 354.0,276.7 442.5,225.5 531.0,223.4 619.5,273.1 708.0,311.2" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="612.28" y1="378.05" x2="472.38" y2="98.3" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="273.29" y1="238.18" x2="133.39" y2="256.03" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="472.38" y1="98.3" x2="332.48" y2="116.16" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="133.39" y1="256.03" x2="531.57" y2="273.89" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="332.48" y1="116.16" x2="192.58" y2="134.02" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="192.58" y1="134.02" x2="590.76" y2="151.87" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="612.28" cy="378.05" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="273.29" cy="238.18" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="472.38" cy="98.3" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="133.39" cy="256.03" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="332.48" cy="116.16" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="531.57" cy="273.89" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="192.58" cy="134.02" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="391.67" cy="291.74" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="590.76" cy="151.87" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4A1E24" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.3 159.0,149.8 318.0,182.9 477.0,190.3 636.0,162.7 795.0,135.2 954.0,142.9 1113.0,176.0 1272.0,192.3" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="935.68" y1="201.93" x2="684.34" y2="212.94" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="115.68" x2="1042.02" y2="126.69" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="684.34" y1="212.94" x2="432.99" y2="223.95" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="126.69" x2="790.68" y2="137.7" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="137.7" x2="539.33" y2="148.71" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="148.71" x2="935.68" y2="201.93" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="935.68" cy="201.93" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="326.65" cy="115.68" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="684.34" cy="212.94" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="1042.02" cy="126.69" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="432.99" cy="223.95" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="790.68" cy="137.7" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="181.64" cy="234.96" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="539.33" cy="148.71" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="897.01" cy="62.46" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,190.3 159.0,162.4 318.0,135.1 477.0,143.1 636.0,176.2 795.0,192.3 954.0,170.7 1113.0,139.1 1272.0,137.7" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="452.32" y1="110.17" x2="200.98" y2="121.18" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="207.44" x2="558.66" y2="218.45" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="200.98" y1="121.18" x2="916.35" y2="132.19" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="218.45" x2="307.32" y2="229.46" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="229.46" x2="1022.69" y2="56.95" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="56.95" x2="452.32" y2="110.17" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="452.32" cy="110.17" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="810.01" cy="207.44" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="200.98" cy="121.18" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="558.66" cy="218.45" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="916.35" cy="132.19" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="307.32" cy="229.46" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="665.0" cy="143.2" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="1022.69" cy="56.95" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="413.65" cy="154.22" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,173.6 90.0,160.6 180.0,191.1 270.0,226.2 360.0,221.1 450.0,182.3 540.0,159.3 630.0,181.4 720.0,220.5" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="403.78" y1="191.02" x2="261.5" y2="204.19" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="606.24" y1="87.86" x2="463.97" y2="101.03" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="261.5" y1="204.19" x2="119.23" y2="217.36" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="463.97" y1="101.03" x2="321.7" y2="114.2" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="119.23" y1="217.36" x2="524.16" y2="230.52" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="524.16" y1="230.52" x2="381.89" y2="243.69" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="403.78" cy="191.02" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="606.24" cy="87.86" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="261.5" cy="204.19" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="463.97" cy="101.03" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="119.23" cy="217.36" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="321.7" cy="114.2" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="524.16" cy="230.52" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="179.42" cy="127.37" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="381.89" cy="243.69" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4A1E24" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,181.5 159.0,191.0 318.0,164.5 477.0,135.9 636.0,141.6 795.0,174.3 954.0,192.4 1113.0,172.7 1272.0,140.4" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="278.31" y1="77.14" x2="993.69" y2="88.15" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="174.4" x2="384.65" y2="185.41" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="993.69" y1="88.15" x2="742.34" y2="99.16" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="185.41" x2="1100.03" y2="196.43" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="196.43" x2="848.68" y2="207.44" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="207.44" x2="278.31" y2="77.14" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="278.31" cy="77.14" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="636.0" cy="174.4" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="993.69" cy="88.15" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="384.65" cy="185.41" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="742.34" cy="99.16" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="1100.03" cy="196.43" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="490.99" cy="110.17" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="848.68" cy="207.44" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="239.64" cy="121.18" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,401.7 94.5,327.2 189.0,298.3 283.5,351.9 378.0,419.6 472.5,415.1 567.0,344.1 661.5,297.2 756.0,334.2" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="573.35" y1="462.53" x2="423.96" y2="487.08" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="211.38" y1="270.2" x2="636.55" y2="294.76" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="423.96" y1="487.08" x2="274.58" y2="511.63" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="636.55" y1="294.76" x2="487.17" y2="319.31" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="274.58" y1="511.63" x2="125.19" y2="126.98" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="125.19" y1="126.98" x2="550.37" y2="151.54" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="573.35" cy="462.53" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="211.38" cy="270.2" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="423.96" cy="487.08" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="636.55" cy="294.76" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="274.58" cy="511.63" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="487.17" cy="319.31" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="125.19" cy="126.98" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="337.78" cy="343.86" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="550.37" cy="151.54" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4A1E24" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,150.3 159.0,133.3 318.0,153.9 477.0,185.9 636.0,188.4 795.0,158.3 954.0,133.9 1113.0,146.4 1272.0,179.8" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="674.67" y1="152.38" x2="423.32" y2="163.39" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="1032.36" y1="66.13" x2="781.01" y2="77.14" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="163.39" x2="171.97" y2="174.4" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="781.01" y1="77.14" x2="529.66" y2="88.15" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="174.4" x2="887.35" y2="185.41" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="185.41" x2="636.0" y2="196.43" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="674.67" cy="152.38" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="1032.36" cy="66.13" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="423.32" cy="163.39" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="781.01" cy="77.14" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="171.97" cy="174.4" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="529.66" cy="88.15" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="887.35" cy="185.41" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="278.31" cy="99.16" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="636.0" cy="196.43" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,237.5 88.5,291.7 177.0,310.6 265.5,270.1 354.0,221.8 442.5,227.4 531.0,279.6 619.5,312.0 708.0,283.1" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="176.43" y1="136.99" x2="574.61" y2="154.85" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="375.52" y1="294.72" x2="235.62" y2="312.58" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="574.61" y1="154.85" x2="434.71" y2="172.7" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="235.62" y1="312.58" x2="95.72" y2="330.43" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="95.72" y1="330.43" x2="493.9" y2="348.29" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="493.9" y1="348.29" x2="176.43" y2="136.99" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="176.43" cy="136.99" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="375.52" cy="294.72" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="574.61" cy="154.85" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="235.62" cy="312.58" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="434.71" cy="172.7" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="95.72" cy="330.43" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="294.81" cy="190.56" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="493.9" cy="348.29" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="154.91" cy="208.42" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4A1E24" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,153.7 159.0,185.8 318.0,188.5 477.0,158.5 636.0,133.9 795.0,146.2 954.0,179.6 1113.0,191.6 1272.0,166.8" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="152.64" y1="53.28" x2="868.01" y2="64.29" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="510.33" y1="150.55" x2="258.98" y2="161.56" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="64.29" x2="616.67" y2="75.3" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="161.56" x2="974.35" y2="172.57" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="75.3" x2="365.32" y2="86.31" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="86.31" x2="1080.69" y2="97.32" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="152.64" cy="53.28" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="510.33" cy="150.55" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="868.01" cy="64.29" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="258.98" cy="161.56" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="616.67" cy="75.3" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="974.35" cy="172.57" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="365.32" cy="86.31" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="723.0" cy="183.58" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="1080.69" cy="97.32" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,158.3 159.0,133.9 318.0,146.4 477.0,179.8 636.0,191.5 795.0,166.6 954.0,136.8 1113.0,140.2 1272.0,172.4" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="636.0" y1="145.04" x2="384.65" y2="156.05" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="993.69" y1="58.79" x2="742.34" y2="69.8" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="156.05" x2="1100.03" y2="167.06" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="742.34" y1="69.8" x2="490.99" y2="80.81" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="167.06" x2="848.68" y2="178.07" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="178.07" x2="597.33" y2="189.08" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="636.0" cy="145.04" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="993.69" cy="58.79" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="384.65" cy="156.05" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="742.34" cy="69.8" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="1100.03" cy="167.06" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="490.99" cy="80.81" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="848.68" cy="178.07" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="239.64" cy="91.82" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="597.33" cy="189.08" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A1E24" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENFJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE0E0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FF6B6B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FF6B6B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4A1E24" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,162.2 90.0,196.1 180.0,228.2 270.0,217.6 360.0,177.8 450.0,159.6 540.0,186.2 630.0,223.6 720.0,224.2" fill="none" stroke="#FF6B6B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="507.74" y1="232.72" x2="365.47" y2="245.89" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="163.01" y1="129.56" x2="567.94" y2="142.73" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="365.47" y1="245.89" x2="223.2" y2="259.06" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="567.94" y1="142.73" x2="425.66" y2="155.9" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="425.66" y1="155.9" x2="283.39" y2="169.07" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/><line x1="283.39" y1="169.07" x2="507.74" y2="232.72" stroke="#FF6B6B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="507.74" cy="232.72" r="3" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="163.01" cy="129.56" r="4" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="365.47" cy="245.89" r="5" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="567.94" cy="142.73" r="3" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="223.2" cy="259.06" r="4" fill="#FF6B6B" fill-opacity="0.35"/><circle cx="425.66" cy="155.9" r="5" fill="#FF6B6B" fill-opacity="0.40"/><circle cx="628.13" cy="272.23" r="3" fill="#FF6B6B" fill-opacity="0.45"/><circle cx="283.39" cy="169.07" r="4" fill="#FF6B6B" fill-opacity="0.50"/><circle cx="485.86" cy="65.91" r="5" fill="#FF6B6B" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#FF6B6B" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A1E24" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4A1E24" fill-opacity="0.72">ENFJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4A1E24" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,155.9 159.0,187.1 318.0,187.3 477.0,156.2 636.0,133.5 795.0,148.2 954.0,181.5 1113.0,191.0 1272.0,164.5" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="152.64" y1="53.28" x2="868.01" y2="64.29" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="510.33" y1="150.55" x2="258.98" y2="161.56" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="64.29" x2="616.67" y2="75.3" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="161.56" x2="974.35" y2="172.57" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="75.3" x2="365.32" y2="86.31" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="86.31" x2="1080.69" y2="97.32" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="152.64" cy="53.28" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="510.33" cy="150.55" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="868.01" cy="64.29" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="258.98" cy="161.56" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="616.67" cy="75.3" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="974.35" cy="172.57" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="365.32" cy="86.31" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="723.0" cy="183.58" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="1080.69" cy="97.32" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,429.0 94.5,385.3 189.0,313.2 283.5,304.6 378.0,370.5 472.5,426.8 567.0,401.8 661.5,327.3 756.0,298.3" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="498.66" y1="409.33" x2="349.27" y2="433.88" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="136.68" y1="217.01" x2="561.86" y2="241.56" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="349.27" y1="433.88" x2="199.89" y2="458.44" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="561.86" y1="241.56" x2="412.47" y2="266.11" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="412.47" y1="266.11" x2="263.09" y2="290.66" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="263.09" y1="290.66" x2="498.66" y2="409.33" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="498.66" cy="409.33" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="136.68" cy="217.01" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="349.27" cy="433.88" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="561.86" cy="241.56" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="199.89" cy="458.44" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="412.47" cy="266.11" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="625.06" cy="482.99" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="263.09" cy="290.66" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="475.68" cy="507.54" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#493606" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,176.5 159.0,143.3 318.0,135.0 477.0,162.1 636.0,190.1 795.0,183.3 954.0,150.3 1113.0,133.3 1272.0,153.9" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="549.0" y1="128.52" x2="297.65" y2="139.53" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="225.79" x2="655.33" y2="53.28" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="297.65" y1="139.53" x2="1013.02" y2="150.55" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="53.28" x2="403.99" y2="64.29" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="64.29" x2="152.64" y2="75.3" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="152.64" y1="75.3" x2="549.0" y2="128.52" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="549.0" cy="128.52" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="906.68" cy="225.79" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="297.65" cy="139.53" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="655.33" cy="53.28" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="1013.02" cy="150.55" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="403.99" cy="64.29" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="761.67" cy="161.56" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="152.64" cy="75.3" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="510.33" cy="172.57" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,216.1 88.5,249.7 177.0,301.5 265.5,305.5 354.0,256.6 442.5,217.1 531.0,237.4 619.5,291.6 708.0,310.6" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="106.48" y1="98.3" x2="504.66" y2="116.16" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="305.57" y1="256.03" x2="165.67" y2="273.89" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="504.66" y1="116.16" x2="364.76" y2="134.02" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="165.67" y1="273.89" x2="563.85" y2="291.74" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="364.76" y1="134.02" x2="224.86" y2="151.87" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="224.86" y1="151.87" x2="84.96" y2="169.73" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="106.48" cy="98.3" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="305.57" cy="256.03" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="504.66" cy="116.16" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="165.67" cy="273.89" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="364.76" cy="134.02" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="563.85" cy="291.74" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="224.86" cy="151.87" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="423.95" cy="309.6" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="84.96" cy="169.73" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#493606" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,134.9 159.0,161.9 318.0,190.1 477.0,183.4 636.0,150.5 795.0,133.2 954.0,153.7 1113.0,185.7 1272.0,188.5" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="993.69" y1="212.94" x2="742.34" y2="223.95" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="126.69" x2="1100.03" y2="137.7" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="742.34" y1="223.95" x2="490.99" y2="234.96" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="137.7" x2="848.68" y2="148.71" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="148.71" x2="597.33" y2="159.72" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="159.72" x2="993.69" y2="212.94" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="993.69" cy="212.94" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="384.65" cy="126.69" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="742.34" cy="223.95" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="1100.03" cy="137.7" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="490.99" cy="234.96" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="848.68" cy="148.71" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="239.64" cy="62.46" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="597.33" cy="159.72" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="955.02" cy="73.47" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,183.3 159.0,150.3 318.0,133.3 477.0,153.9 636.0,185.9 795.0,188.4 954.0,158.3 1113.0,133.9 1272.0,146.4" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="510.33" y1="121.18" x2="258.98" y2="132.19" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="218.45" x2="616.67" y2="229.46" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="132.19" x2="974.35" y2="143.2" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="229.46" x2="365.32" y2="56.95" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="56.95" x2="1080.69" y2="67.96" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="67.96" x2="510.33" y2="121.18" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="510.33" cy="121.18" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="868.01" cy="218.45" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="258.98" cy="132.19" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="616.67" cy="229.46" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="974.35" cy="143.2" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="365.32" cy="56.95" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="723.0" cy="154.22" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="1080.69" cy="67.96" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="471.66" cy="165.23" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,163.8 90.0,167.5 180.0,205.9 270.0,230.1 360.0,209.1 450.0,169.8 540.0,162.2 630.0,196.1 720.0,228.2" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="436.61" y1="204.19" x2="294.34" y2="217.36" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="91.87" y1="101.03" x2="496.8" y2="114.2" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="294.34" y1="217.36" x2="152.06" y2="230.52" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="496.8" y1="114.2" x2="354.53" y2="127.37" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="152.06" y1="230.52" x2="556.99" y2="243.69" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="556.99" y1="243.69" x2="414.72" y2="256.86" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="436.61" cy="204.19" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="91.87" cy="101.03" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="294.34" cy="217.36" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="496.8" cy="114.2" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="152.06" cy="230.52" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="354.53" cy="127.37" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="556.99" cy="243.69" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="212.26" cy="140.54" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="414.72" cy="256.86" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#493606" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,189.3 159.0,184.7 318.0,152.2 477.0,133.2 636.0,151.9 795.0,184.5 954.0,189.4 1113.0,160.4 1272.0,134.4" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="336.32" y1="88.15" x2="1051.69" y2="99.16" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="694.0" y1="185.41" x2="442.66" y2="196.43" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="1051.69" y1="99.16" x2="800.34" y2="110.17" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="196.43" x2="191.31" y2="207.44" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="207.44" x2="906.68" y2="218.45" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="218.45" x2="336.32" y2="88.15" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="336.32" cy="88.15" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="694.0" cy="185.41" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="1051.69" cy="99.16" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="442.66" cy="196.43" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="800.34" cy="110.17" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="191.31" cy="207.44" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="549.0" cy="121.18" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="906.68" cy="218.45" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="297.65" cy="132.19" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,376.3 94.5,307.6 189.0,309.5 283.5,379.6 378.0,428.6 472.5,393.9 567.0,319.8 661.5,300.8 756.0,361.1" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="607.82" y1="487.08" x2="458.44" y2="511.63" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="245.85" y1="294.76" x2="96.47" y2="319.31" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="458.44" y1="511.63" x2="309.05" y2="126.98" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="96.47" y1="319.31" x2="521.64" y2="343.86" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="309.05" y1="126.98" x2="159.67" y2="151.54" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="159.67" y1="151.54" x2="584.84" y2="176.09" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="607.82" cy="487.08" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="245.85" cy="294.76" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="458.44" cy="511.63" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="96.47" cy="319.31" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="309.05" cy="126.98" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="521.64" cy="343.86" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="159.67" cy="151.54" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="372.25" cy="368.41" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="584.84" cy="176.09" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#493606" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,140.4 159.0,136.7 318.0,166.3 477.0,191.5 636.0,180.1 795.0,146.7 954.0,133.8 1113.0,157.9 1272.0,188.2" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="732.67" y1="163.39" x2="481.32" y2="174.4" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="77.14" x2="839.01" y2="88.15" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="174.4" x2="229.98" y2="185.41" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="839.01" y1="88.15" x2="587.66" y2="99.16" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="185.41" x2="945.35" y2="196.43" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="196.43" x2="694.0" y2="207.44" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="732.67" cy="163.39" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="1090.36" cy="77.14" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="481.32" cy="174.4" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="839.01" cy="88.15" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="229.98" cy="185.41" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="587.66" cy="99.16" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="945.35" cy="196.43" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="336.32" cy="110.17" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="694.0" cy="207.44" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,256.3 88.5,305.3 177.0,301.7 265.5,250.0 354.0,216.1 442.5,243.3 531.0,296.9 619.5,308.5 708.0,263.4" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="208.72" y1="154.85" x2="606.9" y2="172.7" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="407.81" y1="312.58" x2="267.91" y2="330.43" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="606.9" y1="172.7" x2="467.0" y2="190.56" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="267.91" y1="330.43" x2="128.01" y2="348.29" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="128.01" y1="348.29" x2="526.19" y2="366.14" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="526.19" y1="366.14" x2="208.72" y2="154.85" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="208.72" cy="154.85" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="407.81" cy="312.58" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="606.9" cy="172.7" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="267.91" cy="330.43" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="467.0" cy="190.56" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="128.01" cy="348.29" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="327.1" cy="208.42" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="526.19" cy="366.14" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="187.2" cy="226.27" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#493606" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,166.1 159.0,191.4 318.0,180.2 477.0,146.8 636.0,133.8 795.0,157.7 954.0,188.1 1113.0,186.2 1272.0,154.4" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="210.64" y1="64.29" x2="926.02" y2="75.3" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="568.33" y1="161.56" x2="316.98" y2="172.57" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="75.3" x2="674.67" y2="86.31" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="316.98" y1="172.57" x2="1032.36" y2="183.58" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="86.31" x2="423.32" y2="97.32" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="97.32" x2="171.97" y2="108.34" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="210.64" cy="64.29" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="568.33" cy="161.56" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="926.02" cy="75.3" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="316.98" cy="172.57" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="674.67" cy="86.31" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="1032.36" cy="183.58" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="423.32" cy="97.32" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="781.01" cy="194.59" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="171.97" cy="108.34" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,146.7 159.0,133.8 318.0,158.0 477.0,188.3 636.0,186.1 795.0,154.2 954.0,133.3 1113.0,150.0 1272.0,183.0" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="694.0" y1="156.05" x2="442.66" y2="167.06" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="1051.69" y1="69.8" x2="800.34" y2="80.81" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="167.06" x2="191.31" y2="178.07" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="800.34" y1="80.81" x2="549.0" y2="91.82" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="178.07" x2="906.68" y2="189.08" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="189.08" x2="655.33" y2="200.1" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="694.0" cy="156.05" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="1051.69" cy="69.8" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="442.66" cy="167.06" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="800.34" cy="80.81" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="191.31" cy="178.07" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="549.0" cy="91.82" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="906.68" cy="189.08" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="297.65" cy="102.83" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="655.33" cy="200.1" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#493606" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENFP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF0C2" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#FFB703" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#FFB703" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#493606" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,170.9 90.0,210.5 180.0,229.9 270.0,204.4 360.0,166.5 450.0,164.5 540.0,201.0 630.0,229.5 720.0,213.5" fill="none" stroke="#FFB703" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="540.58" y1="245.89" x2="398.3" y2="259.06" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="195.84" y1="142.73" x2="600.77" y2="155.9" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="398.3" y1="259.06" x2="256.03" y2="272.23" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="600.77" y1="155.9" x2="458.5" y2="169.07" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="458.5" y1="169.07" x2="316.22" y2="182.24" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/><line x1="316.22" y1="182.24" x2="540.58" y2="245.89" stroke="#FFB703" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="540.58" cy="245.89" r="3" fill="#FFB703" fill-opacity="0.35"/><circle cx="195.84" cy="142.73" r="4" fill="#FFB703" fill-opacity="0.40"/><circle cx="398.3" cy="259.06" r="5" fill="#FFB703" fill-opacity="0.45"/><circle cx="600.77" cy="155.9" r="3" fill="#FFB703" fill-opacity="0.50"/><circle cx="256.03" cy="272.23" r="4" fill="#FFB703" fill-opacity="0.35"/><circle cx="458.5" cy="169.07" r="5" fill="#FFB703" fill-opacity="0.40"/><circle cx="113.76" cy="65.91" r="3" fill="#FFB703" fill-opacity="0.45"/><circle cx="316.22" cy="182.24" r="4" fill="#FFB703" fill-opacity="0.50"/><circle cx="518.69" cy="79.08" r="5" fill="#FFB703" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#FFB703" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#493606" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#493606" fill-opacity="0.72">ENFP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#493606" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,172.4 159.0,192.4 318.0,174.6 477.0,141.8 636.0,135.7 795.0,164.2 954.0,190.9 1113.0,181.7 1272.0,148.5" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="229.98" y1="67.96" x2="945.35" y2="78.97" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="587.66" y1="165.23" x2="336.32" y2="176.24" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="78.97" x2="694.0" y2="89.98" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="336.32" y1="176.24" x2="1051.69" y2="187.25" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="694.0" y1="89.98" x2="442.66" y2="101.0" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="101.0" x2="191.31" y2="112.01" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="229.98" cy="67.96" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="587.66" cy="165.23" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="945.35" cy="78.97" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="336.32" cy="176.24" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="694.0" cy="89.98" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="1051.69" cy="187.25" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="442.66" cy="101.0" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="800.34" cy="198.26" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="191.31" cy="112.01" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,417.8 94.5,348.6 189.0,297.7 283.5,330.1 378.0,404.4 472.5,425.9 567.0,367.2 661.5,303.1 756.0,315.4" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="544.62" y1="442.07" x2="395.24" y2="466.62" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="182.65" y1="249.74" x2="607.82" y2="274.3" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="395.24" y1="466.62" x2="245.85" y2="491.17" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="607.82" y1="274.3" x2="458.44" y2="298.85" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="458.44" y1="298.85" x2="309.05" y2="323.4" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="309.05" y1="323.4" x2="544.62" y2="442.07" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="544.62" cy="442.07" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="182.65" cy="249.74" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="395.24" cy="466.62" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="607.82" cy="274.3" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="245.85" cy="491.17" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="458.44" cy="298.85" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="96.47" cy="515.72" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="309.05" cy="323.4" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="521.64" cy="131.08" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#2A174E" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,160.3 159.0,134.4 318.0,144.7 477.0,178.1 636.0,192.0 795.0,168.7 954.0,137.9 1113.0,138.9 1272.0,170.4" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="626.33" y1="143.2" x2="374.99" y2="154.22" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="56.95" x2="732.67" y2="67.96" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="374.99" y1="154.22" x2="1090.36" y2="165.23" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="67.96" x2="481.32" y2="78.97" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="78.97" x2="229.98" y2="89.98" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="89.98" x2="626.33" y2="143.2" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="626.33" cy="143.2" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="984.02" cy="56.95" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="374.99" cy="154.22" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="732.67" cy="67.96" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="1090.36" cy="165.23" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="481.32" cy="78.97" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="839.01" cy="176.24" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="229.98" cy="89.98" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="587.66" cy="187.25" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,225.3 88.5,276.4 177.0,311.7 265.5,286.2 354.0,232.4 442.5,218.9 531.0,263.0 619.5,308.4 708.0,297.2" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="149.53" y1="122.11" x2="547.71" y2="139.97" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="348.62" y1="279.84" x2="208.72" y2="297.7" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="547.71" y1="139.97" x2="407.81" y2="157.82" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="208.72" y1="297.7" x2="606.9" y2="315.55" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="407.81" y1="157.82" x2="267.91" y2="175.68" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="267.91" y1="175.68" x2="128.01" y2="193.54" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="149.53" cy="122.11" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="348.62" cy="279.84" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="547.71" cy="139.97" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="208.72" cy="297.7" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="407.81" cy="157.82" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="606.9" cy="315.55" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="267.91" cy="175.68" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="467.0" cy="333.41" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="128.01" cy="193.54" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#2A174E" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,144.5 159.0,177.9 318.0,192.0 477.0,168.9 636.0,138.0 795.0,138.7 954.0,170.2 1113.0,192.2 1272.0,176.7" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1071.02" y1="227.62" x2="819.68" y2="55.12" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="141.37" x2="210.64" y2="152.38" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="819.68" y1="55.12" x2="568.33" y2="66.13" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="210.64" y1="152.38" x2="926.02" y2="163.39" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="163.39" x2="674.67" y2="174.4" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="174.4" x2="1071.02" y2="227.62" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1071.02" cy="227.62" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="461.99" cy="141.37" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="819.68" cy="55.12" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="210.64" cy="152.38" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="568.33" cy="66.13" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="926.02" cy="163.39" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="316.98" cy="77.14" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="674.67" cy="174.4" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="1032.36" cy="88.15" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,168.7 159.0,137.9 318.0,138.9 477.0,170.4 636.0,192.2 795.0,176.5 954.0,143.3 1113.0,135.0 1272.0,162.1" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="587.66" y1="135.86" x2="336.32" y2="146.88" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="233.13" x2="694.0" y2="60.62" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="336.32" y1="146.88" x2="1051.69" y2="157.89" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="694.0" y1="60.62" x2="442.66" y2="71.63" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="71.63" x2="191.31" y2="82.64" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="82.64" x2="587.66" y2="135.86" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="587.66" cy="135.86" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="945.35" cy="233.13" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="336.32" cy="146.88" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="694.0" cy="60.62" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="1051.69" cy="157.89" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="442.66" cy="71.63" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="800.34" cy="168.9" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="191.31" cy="82.64" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="549.0" cy="179.91" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,159.4 90.0,183.8 180.0,222.1 270.0,225.5 360.0,189.6 450.0,160.2 540.0,174.8 630.0,214.8 720.0,229.1" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="480.38" y1="221.75" x2="338.11" y2="234.91" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="135.65" y1="118.59" x2="540.58" y2="131.76" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="338.11" y1="234.91" x2="195.84" y2="248.08" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="540.58" y1="131.76" x2="398.3" y2="144.93" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="195.84" y1="248.08" x2="600.77" y2="261.25" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="600.77" y1="261.25" x2="458.5" y2="274.42" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="480.38" cy="221.75" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="135.65" cy="118.59" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="338.11" cy="234.91" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="540.58" cy="131.76" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="195.84" cy="248.08" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="398.3" cy="144.93" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="600.77" cy="261.25" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="256.03" cy="158.1" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="458.5" cy="274.42" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#2A174E" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,192.2 159.0,170.7 318.0,139.1 477.0,137.7 636.0,168.3 795.0,191.9 954.0,178.4 1113.0,145.0 1272.0,134.3" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="413.65" y1="102.83" x2="162.31" y2="113.84" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="200.1" x2="519.99" y2="211.11" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="162.31" y1="113.84" x2="877.68" y2="124.85" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="211.11" x2="268.65" y2="222.12" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="222.12" x2="984.02" y2="233.13" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="233.13" x2="413.65" y2="102.83" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="413.65" cy="102.83" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="771.34" cy="200.1" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="162.31" cy="113.84" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="519.99" cy="211.11" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="877.68" cy="124.85" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="268.65" cy="222.12" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="626.33" cy="135.86" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="984.02" cy="233.13" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="374.99" cy="146.88" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,339.7 94.5,297.0 189.0,338.5 283.5,411.2 378.0,422.5 472.5,357.9 567.0,299.8 661.5,322.3 756.0,396.7" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="653.79" y1="519.82" x2="504.4" y2="135.17" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="291.82" y1="327.49" x2="142.43" y2="352.04" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="504.4" y1="135.17" x2="355.02" y2="159.72" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="142.43" y1="352.04" x2="567.6" y2="376.6" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="355.02" y1="159.72" x2="205.63" y2="184.27" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="205.63" y1="184.27" x2="630.81" y2="208.82" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="653.79" cy="519.82" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="291.82" cy="327.49" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="504.4" cy="135.17" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="142.43" cy="352.04" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="355.02" cy="159.72" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="567.6" cy="376.6" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="205.63" cy="184.27" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="418.22" cy="401.15" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="630.81" cy="208.82" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#2A174E" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.5 159.0,148.2 318.0,181.5 477.0,191.0 636.0,164.5 795.0,135.9 954.0,141.6 1113.0,174.3 1272.0,192.4" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="810.01" y1="178.07" x2="558.66" y2="189.08" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="200.98" y1="91.82" x2="916.35" y2="102.83" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="189.08" x2="307.32" y2="200.1" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="102.83" x2="665.0" y2="113.84" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="200.1" x2="1022.69" y2="211.11" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="211.11" x2="771.34" y2="222.12" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="810.01" cy="178.07" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="200.98" cy="91.82" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="558.66" cy="189.08" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="916.35" cy="102.83" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="307.32" cy="200.1" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="665.0" cy="113.84" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="1022.69" cy="211.11" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="413.65" cy="124.85" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="771.34" cy="222.12" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,282.8 88.5,312.0 177.0,280.0 265.5,227.6 354.0,221.7 442.5,269.7 531.0,310.5 619.5,292.0 708.0,237.8" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="251.76" y1="178.66" x2="111.86" y2="196.51" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="450.85" y1="336.38" x2="310.95" y2="354.24" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="111.86" y1="196.51" x2="510.04" y2="214.37" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="310.95" y1="354.24" x2="171.05" y2="372.1" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="171.05" y1="372.1" x2="569.23" y2="92.35" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="569.23" y1="92.35" x2="251.76" y2="178.66" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="251.76" cy="178.66" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="450.85" cy="336.38" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="111.86" cy="196.51" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="310.95" cy="354.24" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="510.04" cy="214.37" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="171.05" cy="372.1" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="370.14" cy="232.22" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="569.23" cy="92.35" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="230.24" cy="250.08" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#2A174E" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,181.3 159.0,191.0 318.0,164.7 477.0,136.0 636.0,141.4 795.0,174.1 954.0,192.4 1113.0,172.9 1272.0,140.5" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="287.98" y1="78.97" x2="1003.35" y2="89.98" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="645.67" y1="176.24" x2="394.32" y2="187.25" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="89.98" x2="752.01" y2="101.0" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="394.32" y1="187.25" x2="1109.69" y2="198.26" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="101.0" x2="500.66" y2="112.01" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="112.01" x2="249.31" y2="123.02" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="287.98" cy="78.97" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="645.67" cy="176.24" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="1003.35" cy="89.98" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="394.32" cy="187.25" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="752.01" cy="101.0" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="1109.69" cy="198.26" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="500.66" cy="112.01" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="858.35" cy="209.27" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="249.31" cy="123.02" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,135.9 159.0,141.6 318.0,174.3 477.0,192.4 636.0,172.7 795.0,140.4 954.0,136.7 1113.0,166.3 1272.0,191.5" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="771.34" y1="170.73" x2="519.99" y2="181.74" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="162.31" y1="84.48" x2="877.68" y2="95.49" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="181.74" x2="268.65" y2="192.76" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="877.68" y1="95.49" x2="626.33" y2="106.5" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="192.76" x2="984.02" y2="203.77" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="203.77" x2="732.67" y2="214.78" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="771.34" cy="170.73" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="162.31" cy="84.48" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="519.99" cy="181.74" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="877.68" cy="95.49" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="268.65" cy="192.76" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="626.33" cy="106.5" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="984.02" cy="203.77" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="374.99" cy="117.51" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="732.67" cy="214.78" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2A174E" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENTJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#ECDFFF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#9B5DE5" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#9B5DE5" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#2A174E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,188.6 90.0,225.0 180.0,222.7 270.0,184.7 360.0,159.4 450.0,179.1 540.0,218.7 630.0,227.7 720.0,194.6" fill="none" stroke="#9B5DE5" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="584.35" y1="263.45" x2="442.08" y2="276.62" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="239.62" y1="160.29" x2="97.34" y2="173.46" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="442.08" y1="276.62" x2="299.81" y2="70.3" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="97.34" y1="173.46" x2="502.27" y2="186.63" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="502.27" y1="186.63" x2="360.0" y2="199.8" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/><line x1="360.0" y1="199.8" x2="584.35" y2="263.45" stroke="#9B5DE5" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="584.35" cy="263.45" r="3" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="239.62" cy="160.29" r="4" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="442.08" cy="276.62" r="5" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="97.34" cy="173.46" r="3" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="299.81" cy="70.3" r="4" fill="#9B5DE5" fill-opacity="0.35"/><circle cx="502.27" cy="186.63" r="5" fill="#9B5DE5" fill-opacity="0.40"/><circle cx="157.54" cy="83.47" r="3" fill="#9B5DE5" fill-opacity="0.45"/><circle cx="360.0" cy="199.8" r="4" fill="#9B5DE5" fill-opacity="0.50"/><circle cx="562.46" cy="96.64" r="5" fill="#9B5DE5" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#9B5DE5" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2A174E" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#2A174E" fill-opacity="0.72">ENTJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#2A174E" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,183.1 159.0,190.3 318.0,162.4 477.0,135.1 636.0,143.1 795.0,176.2 954.0,192.3 1113.0,170.7 1272.0,139.1" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="287.98" y1="78.97" x2="1003.35" y2="89.98" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="645.67" y1="176.24" x2="394.32" y2="187.25" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="89.98" x2="752.01" y2="101.0" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="394.32" y1="187.25" x2="1109.69" y2="198.26" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="101.0" x2="500.66" y2="112.01" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="112.01" x2="249.31" y2="123.02" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="287.98" cy="78.97" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="645.67" cy="176.24" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="1003.35" cy="89.98" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="394.32" cy="187.25" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="752.01" cy="101.0" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="1109.69" cy="198.26" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="500.66" cy="112.01" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="858.35" cy="209.27" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="249.31" cy="123.02" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,397.9 94.5,323.4 189.0,299.4 283.5,356.5 378.0,421.9 472.5,412.1 567.0,339.7 661.5,297.0 756.0,338.4" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="579.1" y1="466.62" x2="429.71" y2="491.17" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="217.12" y1="274.3" x2="642.3" y2="298.85" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="429.71" y1="491.17" x2="280.32" y2="515.72" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="642.3" y1="298.85" x2="492.91" y2="323.4" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="492.91" y1="323.4" x2="343.53" y2="347.95" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="343.53" y1="347.95" x2="579.1" y2="466.62" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="579.1" cy="466.62" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="217.12" cy="274.3" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="429.71" cy="491.17" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="642.3" cy="298.85" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="280.32" cy="515.72" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="492.91" cy="323.4" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="130.94" cy="131.08" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="343.53" cy="347.95" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="556.11" cy="155.63" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#073B4C" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,148.4 159.0,133.5 318.0,155.9 477.0,187.1 636.0,187.3 795.0,156.2 954.0,133.5 1113.0,148.1 1272.0,181.5" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="684.34" y1="154.22" x2="432.99" y2="165.23" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="67.96" x2="790.68" y2="78.97" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="165.23" x2="181.64" y2="176.24" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="78.97" x2="539.33" y2="89.98" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="89.98" x2="287.98" y2="101.0" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="101.0" x2="684.34" y2="154.22" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="684.34" cy="154.22" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="1042.02" cy="67.96" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="432.99" cy="165.23" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="790.68" cy="78.97" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="181.64" cy="176.24" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="539.33" cy="89.98" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="897.01" cy="187.25" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="287.98" cy="101.0" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="645.67" cy="198.26" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,240.4 88.5,294.4 177.0,309.6 265.5,266.7 354.0,220.3 442.5,229.6 531.0,282.8 619.5,312.0 708.0,280.0" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="181.81" y1="139.97" x2="579.99" y2="157.82" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="380.9" y1="297.7" x2="241.0" y2="315.55" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="579.99" y1="157.82" x2="440.09" y2="175.68" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="241.0" y1="315.55" x2="101.1" y2="333.41" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="440.09" y1="175.68" x2="300.19" y2="193.54" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="300.19" y1="193.54" x2="160.29" y2="211.39" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="181.81" cy="139.97" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="380.9" cy="297.7" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="579.99" cy="157.82" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="241.0" cy="315.55" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="440.09" cy="175.68" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="101.1" cy="333.41" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="300.19" cy="193.54" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="499.28" cy="351.26" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="160.29" cy="211.39" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#073B4C" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,155.7 159.0,187.0 318.0,187.4 477.0,156.4 636.0,133.6 795.0,148.0 954.0,181.3 1113.0,191.0 1272.0,164.8" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="162.31" y1="55.12" x2="877.68" y2="66.13" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="152.38" x2="268.65" y2="163.39" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="877.68" y1="66.13" x2="626.33" y2="77.14" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="163.39" x2="984.02" y2="174.4" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="174.4" x2="732.67" y2="185.41" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="185.41" x2="162.31" y2="55.12" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="162.31" cy="55.12" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="519.99" cy="152.38" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="877.68" cy="66.13" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="268.65" cy="163.39" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="626.33" cy="77.14" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="984.02" cy="174.4" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="374.99" cy="88.15" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="732.67" cy="185.41" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="1090.36" cy="99.16" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,156.2 159.0,133.5 318.0,148.2 477.0,181.5 636.0,191.0 795.0,164.5 954.0,135.9 1113.0,141.6 1272.0,174.3" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="645.67" y1="146.88" x2="394.32" y2="157.89" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="60.62" x2="752.01" y2="71.63" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="394.32" y1="157.89" x2="1109.69" y2="168.9" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="71.63" x2="500.66" y2="82.64" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="82.64" x2="249.31" y2="93.65" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="93.65" x2="645.67" y2="146.88" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="645.67" cy="146.88" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="1003.35" cy="60.62" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="394.32" cy="157.89" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="752.01" cy="71.63" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="1109.69" cy="168.9" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="500.66" cy="82.64" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="858.35" cy="179.91" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="249.31" cy="93.65" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="607.0" cy="190.92" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,163.3 90.0,198.6 180.0,228.9 270.0,215.6 360.0,175.6 450.0,160.0 540.0,188.6 630.0,225.0 720.0,222.7" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="513.22" y1="234.91" x2="370.94" y2="248.08" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="168.48" y1="131.76" x2="573.41" y2="144.93" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="370.94" y1="248.08" x2="228.67" y2="261.25" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="573.41" y1="144.93" x2="431.14" y2="158.1" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="228.67" y1="261.25" x2="86.4" y2="274.42" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="86.4" y1="274.42" x2="491.33" y2="68.11" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="513.22" cy="234.91" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="168.48" cy="131.76" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="370.94" cy="248.08" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="573.41" cy="144.93" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="228.67" cy="261.25" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="431.14" cy="158.1" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="86.4" cy="274.42" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="288.86" cy="171.27" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="491.33" cy="68.11" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#073B4C" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,188.4 159.0,158.3 318.0,133.9 477.0,146.4 636.0,179.8 795.0,191.5 954.0,166.6 1113.0,136.8 1272.0,140.2" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="471.66" y1="113.84" x2="220.31" y2="124.85" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="211.11" x2="578.0" y2="222.12" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="220.31" y1="124.85" x2="935.68" y2="135.86" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="222.12" x2="326.65" y2="233.13" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="233.13" x2="1042.02" y2="60.62" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="60.62" x2="471.66" y2="113.84" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="471.66" cy="113.84" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="829.34" cy="211.11" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="220.31" cy="124.85" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="578.0" cy="222.12" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="935.68" cy="135.86" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="326.65" cy="233.13" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="684.34" cy="146.88" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="1042.02" cy="60.62" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="432.99" cy="157.89" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,316.4 94.5,302.6 189.0,365.8 283.5,425.5 378.0,405.4 472.5,331.3 567.0,297.6 661.5,347.3 756.0,417.1" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="113.7" y1="135.17" x2="538.88" y2="159.72" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="326.29" y1="352.04" x2="176.9" y2="376.6" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="538.88" y1="159.72" x2="389.49" y2="184.27" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="176.9" y1="376.6" x2="602.08" y2="401.15" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="389.49" y1="184.27" x2="240.11" y2="208.82" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="240.11" y1="208.82" x2="90.72" y2="233.38" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="113.7" cy="135.17" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="326.29" cy="352.04" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="538.88" cy="159.72" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="176.9" cy="376.6" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="389.49" cy="184.27" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="602.08" cy="401.15" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="240.11" cy="208.82" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="452.69" cy="425.7" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="90.72" cy="233.38" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#073B4C" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,134.3 159.0,160.0 318.0,189.3 477.0,184.8 636.0,152.2 795.0,133.2 954.0,151.9 1113.0,184.5 1272.0,189.4" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="868.01" y1="189.08" x2="616.67" y2="200.1" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="102.83" x2="974.35" y2="113.84" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="200.1" x2="365.32" y2="211.11" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="974.35" y1="113.84" x2="723.0" y2="124.85" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="211.11" x2="1080.69" y2="222.12" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="222.12" x2="829.34" y2="233.13" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="868.01" cy="189.08" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="258.98" cy="102.83" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="616.67" cy="200.1" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="974.35" cy="113.84" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="365.32" cy="211.11" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="723.0" cy="124.85" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="1080.69" cy="222.12" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="471.66" cy="135.86" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="829.34" cy="233.13" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,299.3 88.5,307.1 177.0,259.9 265.5,218.0 354.0,234.7 442.5,288.8 531.0,311.3 619.5,273.5 708.0,223.6" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="284.05" y1="196.51" x2="144.15" y2="214.37" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="483.14" y1="354.24" x2="343.24" y2="372.1" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="144.15" y1="214.37" x2="542.33" y2="232.22" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="343.24" y1="372.1" x2="203.34" y2="92.35" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="203.34" y1="92.35" x2="601.52" y2="110.21" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="601.52" y1="110.21" x2="284.05" y2="196.51" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="284.05" cy="196.51" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="483.14" cy="354.24" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="144.15" cy="214.37" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="343.24" cy="372.1" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="542.33" cy="232.22" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="203.34" cy="92.35" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="402.43" cy="250.08" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="601.52" cy="110.21" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="262.53" cy="267.94" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#073B4C" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,189.2 159.0,184.9 318.0,152.4 477.0,133.2 636.0,151.7 795.0,184.4 954.0,189.5 1113.0,160.6 1272.0,134.5" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="345.98" y1="89.98" x2="1061.36" y2="101.0" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="703.67" y1="187.25" x2="452.32" y2="198.26" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="101.0" x2="810.01" y2="112.01" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="452.32" y1="198.26" x2="200.98" y2="209.27" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="112.01" x2="558.66" y2="123.02" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="123.02" x2="307.32" y2="134.03" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="345.98" cy="89.98" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="703.67" cy="187.25" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="1061.36" cy="101.0" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="452.32" cy="198.26" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="810.01" cy="112.01" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="200.98" cy="209.27" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="558.66" cy="123.02" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="916.35" cy="220.28" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="307.32" cy="134.03" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.2 159.0,151.9 318.0,184.5 477.0,189.4 636.0,160.4 795.0,134.4 954.0,144.7 1113.0,178.0 1272.0,192.0" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="829.34" y1="181.74" x2="578.0" y2="192.76" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="220.31" y1="95.49" x2="935.68" y2="106.5" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="192.76" x2="326.65" y2="203.77" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="935.68" y1="106.5" x2="684.34" y2="117.51" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="203.77" x2="1042.02" y2="214.78" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="214.78" x2="790.68" y2="225.79" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="829.34" cy="181.74" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="220.31" cy="95.49" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="578.0" cy="192.76" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="935.68" cy="106.5" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="326.65" cy="203.77" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="684.34" cy="117.51" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="1042.02" cy="214.78" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="432.99" cy="128.52" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="790.68" cy="225.79" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#073B4C" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ENTP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ENTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9F3FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#00A6FB" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#00A6FB" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#073B4C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,203.5 90.0,229.8 180.0,211.4 270.0,171.6 360.0,161.3 450.0,193.6 540.0,227.3 630.0,219.4 720.0,180.0" fill="none" stroke="#00A6FB" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="617.18" y1="276.62" x2="474.91" y2="70.3" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="272.45" y1="173.46" x2="130.18" y2="186.63" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="474.91" y1="70.3" x2="332.64" y2="83.47" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="130.18" y1="186.63" x2="535.1" y2="199.8" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="535.1" y1="199.8" x2="392.83" y2="212.97" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/><line x1="392.83" y1="212.97" x2="617.18" y2="276.62" stroke="#00A6FB" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="617.18" cy="276.62" r="3" fill="#00A6FB" fill-opacity="0.35"/><circle cx="272.45" cy="173.46" r="4" fill="#00A6FB" fill-opacity="0.40"/><circle cx="474.91" cy="70.3" r="5" fill="#00A6FB" fill-opacity="0.45"/><circle cx="130.18" cy="186.63" r="3" fill="#00A6FB" fill-opacity="0.50"/><circle cx="332.64" cy="83.47" r="4" fill="#00A6FB" fill-opacity="0.35"/><circle cx="535.1" cy="199.8" r="5" fill="#00A6FB" fill-opacity="0.40"/><circle cx="190.37" cy="96.64" r="3" fill="#00A6FB" fill-opacity="0.45"/><circle cx="392.83" cy="212.97" r="4" fill="#00A6FB" fill-opacity="0.50"/><circle cx="595.3" cy="109.81" r="5" fill="#00A6FB" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#00A6FB" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#073B4C" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#073B4C" fill-opacity="0.72">ENTP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#073B4C" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,153.9 159.0,185.9 318.0,188.4 477.0,158.3 636.0,133.9 795.0,146.4 954.0,179.8 1113.0,191.5 1272.0,166.6" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1109.69" y1="234.96" x2="858.35" y2="62.46" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="148.71" x2="249.31" y2="159.72" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="858.35" y1="62.46" x2="607.0" y2="73.47" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="159.72" x2="964.68" y2="170.73" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="170.73" x2="713.34" y2="181.74" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="181.74" x2="1109.69" y2="234.96" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1109.69" cy="234.96" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="500.66" cy="148.71" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="858.35" cy="62.46" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="249.31" cy="159.72" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="607.0" cy="73.47" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="964.68" cy="170.73" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="355.65" cy="84.48" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="713.34" cy="181.74" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="1071.02" cy="95.49" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,428.9 94.5,389.6 189.0,316.4 283.5,302.6 378.0,365.8 472.5,425.5 567.0,405.4 661.5,331.3 756.0,297.6" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="492.91" y1="405.24" x2="343.53" y2="429.79" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="130.94" y1="212.92" x2="556.11" y2="237.47" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="343.53" y1="429.79" x2="194.14" y2="454.34" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="556.11" y1="237.47" x2="406.73" y2="262.02" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="194.14" y1="454.34" x2="619.32" y2="478.9" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="619.32" y1="478.9" x2="469.93" y2="503.45" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="492.91" cy="405.24" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="130.94" cy="212.92" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="343.53" cy="429.79" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="556.11" cy="237.47" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="194.14" cy="454.34" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="406.73" cy="262.02" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="619.32" cy="478.9" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="257.34" cy="286.57" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="469.93" cy="503.45" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4C2615" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,178.3 159.0,144.9 318.0,134.3 477.0,160.0 636.0,189.3 795.0,184.8 954.0,152.2 1113.0,133.2 1272.0,151.9" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="539.33" y1="126.69" x2="287.98" y2="137.7" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="897.01" y1="223.95" x2="645.67" y2="234.96" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="137.7" x2="1003.35" y2="148.71" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="645.67" y1="234.96" x2="394.32" y2="62.46" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="148.71" x2="752.01" y2="159.72" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="159.72" x2="500.66" y2="170.73" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="539.33" cy="126.69" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="897.01" cy="223.95" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="287.98" cy="137.7" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="645.67" cy="234.96" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="1003.35" cy="148.71" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="394.32" cy="62.46" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="752.01" cy="159.72" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="1109.69" cy="73.47" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="500.66" cy="170.73" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,216.0 88.5,246.5 177.0,299.3 265.5,307.1 354.0,259.9 442.5,218.0 531.0,234.7 619.5,288.8 708.0,311.3" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="101.1" y1="95.33" x2="499.28" y2="113.18" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="300.19" y1="253.06" x2="160.29" y2="270.91" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="499.28" y1="113.18" x2="359.38" y2="131.04" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="160.29" y1="270.91" x2="558.47" y2="288.77" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="558.47" y1="288.77" x2="418.57" y2="306.62" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="418.57" y1="306.62" x2="101.1" y2="95.33" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="101.1" cy="95.33" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="300.19" cy="253.06" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="499.28" cy="113.18" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="160.29" cy="270.91" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="359.38" cy="131.04" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="558.47" cy="288.77" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="219.48" cy="148.9" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="418.57" cy="306.62" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="617.66" cy="166.75" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4C2615" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,134.3 159.0,159.8 318.0,189.2 477.0,184.9 636.0,152.4 795.0,133.2 954.0,151.7 1113.0,184.4 1272.0,189.5" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="984.02" y1="211.11" x2="732.67" y2="222.12" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="374.99" y1="124.85" x2="1090.36" y2="135.86" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="222.12" x2="481.32" y2="233.13" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="135.86" x2="839.01" y2="146.88" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="233.13" x2="229.98" y2="60.62" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="60.62" x2="945.35" y2="71.63" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="984.02" cy="211.11" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="374.99" cy="124.85" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="732.67" cy="222.12" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="1090.36" cy="135.86" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="481.32" cy="233.13" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="839.01" cy="146.88" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="229.98" cy="60.62" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="587.66" cy="157.89" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="945.35" cy="71.63" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,184.7 159.0,152.2 318.0,133.2 477.0,151.9 636.0,184.5 795.0,189.4 954.0,160.4 1113.0,134.4 1272.0,144.7" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="500.66" y1="119.35" x2="249.31" y2="130.36" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="858.35" y1="216.61" x2="607.0" y2="227.62" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="130.36" x2="964.68" y2="141.37" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="607.0" y1="227.62" x2="355.65" y2="55.12" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="141.37" x2="713.34" y2="152.38" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="152.38" x2="461.99" y2="163.39" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="500.66" cy="119.35" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="858.35" cy="216.61" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="249.31" cy="130.36" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="607.0" cy="227.62" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="964.68" cy="141.37" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="355.65" cy="55.12" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="713.34" cy="152.38" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="1071.02" cy="66.13" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="461.99" cy="163.39" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,165.0 90.0,165.9 180.0,203.5 270.0,229.8 360.0,211.4 450.0,171.6 540.0,161.3 630.0,193.6 720.0,227.3" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="431.14" y1="201.99" x2="288.86" y2="215.16" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="86.4" y1="98.84" x2="491.33" y2="112.01" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="288.86" y1="215.16" x2="146.59" y2="228.33" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="491.33" y1="112.01" x2="349.06" y2="125.17" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="349.06" y1="125.17" x2="206.78" y2="138.34" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="206.78" y1="138.34" x2="431.14" y2="201.99" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="431.14" cy="201.99" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="86.4" cy="98.84" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="288.86" cy="215.16" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="491.33" cy="112.01" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="146.59" cy="228.33" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="349.06" cy="125.17" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="551.52" cy="241.5" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="206.78" cy="138.34" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="409.25" cy="254.67" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4C2615" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,188.3 159.0,186.1 318.0,154.2 477.0,133.3 636.0,150.0 795.0,183.0 954.0,190.3 1113.0,162.5 1272.0,135.1" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="326.65" y1="86.31" x2="1042.02" y2="97.32" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="684.34" y1="183.58" x2="432.99" y2="194.59" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="97.32" x2="790.68" y2="108.34" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="194.59" x2="181.64" y2="205.6" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="108.34" x2="539.33" y2="119.35" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="119.35" x2="287.98" y2="130.36" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="326.65" cy="86.31" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="684.34" cy="183.58" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="1042.02" cy="97.32" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="432.99" cy="194.59" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="790.68" cy="108.34" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="181.64" cy="205.6" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="539.33" cy="119.35" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="897.01" cy="216.61" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="287.98" cy="130.36" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,380.9 94.5,310.3 189.0,306.9 283.5,375.1 378.0,427.9 472.5,397.9 567.0,323.4 661.5,299.4 756.0,356.5" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="602.08" y1="482.99" x2="452.69" y2="507.54" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="240.11" y1="290.66" x2="90.72" y2="315.22" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="452.69" y1="507.54" x2="303.31" y2="122.89" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="90.72" y1="315.22" x2="515.89" y2="339.77" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="515.89" y1="339.77" x2="366.51" y2="364.32" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="366.51" y1="364.32" x2="602.08" y2="482.99" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="602.08" cy="482.99" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="240.11" cy="290.66" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="452.69" cy="507.54" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="90.72" cy="315.22" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="303.31" cy="122.89" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="515.89" cy="339.77" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="153.92" cy="147.44" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="366.51" cy="364.32" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="579.1" cy="172.0" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4C2615" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,141.8 159.0,135.7 318.0,164.2 477.0,190.9 636.0,181.7 795.0,148.5 954.0,133.5 1113.0,155.9 1272.0,187.1" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="723.0" y1="161.56" x2="471.66" y2="172.57" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="75.3" x2="829.34" y2="86.31" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="471.66" y1="172.57" x2="220.31" y2="183.58" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="86.31" x2="578.0" y2="97.32" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="97.32" x2="326.65" y2="108.34" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="108.34" x2="723.0" y2="161.56" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="723.0" cy="161.56" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="1080.69" cy="75.3" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="471.66" cy="172.57" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="829.34" cy="86.31" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="220.31" cy="183.58" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="578.0" cy="97.32" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="935.68" cy="194.59" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="326.65" cy="108.34" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="684.34" cy="205.6" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,252.9 88.5,303.5 177.0,303.7 265.5,253.3 354.0,216.5 442.5,240.3 531.0,294.3 619.5,309.7 708.0,266.8" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="203.34" y1="151.87" x2="601.52" y2="169.73" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="402.43" y1="309.6" x2="262.53" y2="327.46" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="601.52" y1="169.73" x2="461.62" y2="187.58" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="262.53" y1="327.46" x2="122.63" y2="345.31" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="461.62" y1="187.58" x2="321.72" y2="205.44" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="321.72" y1="205.44" x2="181.81" y2="223.3" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="203.34" cy="151.87" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="402.43" cy="309.6" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="601.52" cy="169.73" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="262.53" cy="327.46" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="461.62" cy="187.58" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="122.63" cy="345.31" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="321.72" cy="205.44" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="520.8" cy="363.17" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="181.81" cy="223.3" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4C2615" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,164.0 159.0,190.8 318.0,181.9 477.0,148.6 636.0,133.4 795.0,155.7 954.0,187.0 1113.0,187.5 1272.0,156.5" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="200.98" y1="62.46" x2="916.35" y2="73.47" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="159.72" x2="307.32" y2="170.73" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="73.47" x2="665.0" y2="84.48" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="170.73" x2="1022.69" y2="181.74" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="181.74" x2="771.34" y2="192.76" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="192.76" x2="200.98" y2="62.46" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="200.98" cy="62.46" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="558.66" cy="159.72" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="916.35" cy="73.47" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="307.32" cy="170.73" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="665.0" cy="84.48" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="1022.69" cy="181.74" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="413.65" cy="95.49" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="771.34" cy="192.76" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="162.31" cy="106.5" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,148.4 159.0,133.5 318.0,155.9 477.0,187.1 636.0,187.3 795.0,156.2 954.0,133.5 1113.0,148.1 1272.0,181.5" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="684.34" y1="154.22" x2="432.99" y2="165.23" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="67.96" x2="790.68" y2="78.97" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="165.23" x2="181.64" y2="176.24" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="78.97" x2="539.33" y2="89.98" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="89.98" x2="287.98" y2="101.0" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="101.0" x2="684.34" y2="154.22" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="684.34" cy="154.22" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="1042.02" cy="67.96" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="432.99" cy="165.23" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="790.68" cy="78.97" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="181.64" cy="176.24" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="539.33" cy="89.98" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="897.01" cy="187.25" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="287.98" cy="101.0" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="645.67" cy="198.26" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4C2615" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESFJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE8DA" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9844A" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9844A" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4C2615" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,169.1 90.0,208.2 180.0,230.1 270.0,206.8 360.0,168.1 450.0,163.3 540.0,198.6 630.0,228.9 720.0,215.6" fill="none" stroke="#F9844A" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="535.1" y1="243.69" x2="392.83" y2="256.86" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="190.37" y1="140.54" x2="595.3" y2="153.71" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="392.83" y1="256.86" x2="250.56" y2="270.03" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="595.3" y1="153.71" x2="453.02" y2="166.88" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="250.56" y1="270.03" x2="108.29" y2="63.72" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/><line x1="108.29" y1="63.72" x2="513.22" y2="76.89" stroke="#F9844A" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="535.1" cy="243.69" r="3" fill="#F9844A" fill-opacity="0.35"/><circle cx="190.37" cy="140.54" r="4" fill="#F9844A" fill-opacity="0.40"/><circle cx="392.83" cy="256.86" r="5" fill="#F9844A" fill-opacity="0.45"/><circle cx="595.3" cy="153.71" r="3" fill="#F9844A" fill-opacity="0.50"/><circle cx="250.56" cy="270.03" r="4" fill="#F9844A" fill-opacity="0.35"/><circle cx="453.02" cy="166.88" r="5" fill="#F9844A" fill-opacity="0.40"/><circle cx="108.29" cy="63.72" r="3" fill="#F9844A" fill-opacity="0.45"/><circle cx="310.75" cy="180.04" r="4" fill="#F9844A" fill-opacity="0.50"/><circle cx="513.22" cy="76.89" r="5" fill="#F9844A" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F9844A" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4C2615" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4C2615" fill-opacity="0.72">ESFJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4C2615" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,166.3 159.0,191.5 318.0,180.1 477.0,146.7 636.0,133.8 795.0,158.0 954.0,188.3 1113.0,186.1 1272.0,154.2" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="200.98" y1="62.46" x2="916.35" y2="73.47" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="159.72" x2="307.32" y2="170.73" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="73.47" x2="665.0" y2="84.48" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="170.73" x2="1022.69" y2="181.74" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="181.74" x2="771.34" y2="192.76" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="192.76" x2="200.98" y2="62.46" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="200.98" cy="62.46" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="558.66" cy="159.72" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="916.35" cy="73.47" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="307.32" cy="170.73" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="665.0" cy="84.48" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="1022.69" cy="181.74" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="413.65" cy="95.49" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="771.34" cy="192.76" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="162.31" cy="106.5" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,424.3 94.5,362.5 189.0,301.3 283.5,318.8 378.0,392.7 472.5,428.7 567.0,380.9 661.5,310.3 756.0,306.9" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="527.39" y1="429.79" x2="378.0" y2="454.34" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="165.41" y1="237.47" x2="590.59" y2="262.02" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="378.0" y1="454.34" x2="228.61" y2="478.9" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="590.59" y1="262.02" x2="441.2" y2="286.57" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="228.61" y1="478.9" x2="653.79" y2="503.45" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="653.79" y1="503.45" x2="504.4" y2="118.8" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="527.39" cy="429.79" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="165.41" cy="237.47" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="378.0" cy="454.34" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="590.59" cy="262.02" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="228.61" cy="478.9" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="441.2" cy="286.57" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="653.79" cy="503.45" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="291.82" cy="311.12" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="504.4" cy="118.8" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#47370C" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,166.6 159.0,136.8 318.0,140.2 477.0,172.4 636.0,192.4 795.0,174.7 954.0,141.8 1113.0,135.7 1272.0,164.2" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="597.33" y1="137.7" x2="345.98" y2="148.71" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="955.02" y1="234.96" x2="703.67" y2="62.46" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="148.71" x2="1061.36" y2="159.72" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="703.67" y1="62.46" x2="452.32" y2="73.47" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="159.72" x2="810.01" y2="170.73" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="170.73" x2="558.66" y2="181.74" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="597.33" cy="137.7" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="955.02" cy="234.96" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="345.98" cy="148.71" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="703.67" cy="62.46" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="1061.36" cy="159.72" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="452.32" cy="73.47" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="810.01" cy="170.73" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="200.98" cy="84.48" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="558.66" cy="181.74" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,220.2 88.5,266.4 177.0,309.5 265.5,294.6 354.0,240.6 442.5,216.5 531.0,252.9 619.5,303.5 708.0,303.7" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="133.39" y1="113.18" x2="531.57" y2="131.04" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="332.48" y1="270.91" x2="192.58" y2="288.77" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="531.57" y1="131.04" x2="391.67" y2="148.9" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="192.58" y1="288.77" x2="590.76" y2="306.62" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="590.76" y1="306.62" x2="450.85" y2="324.48" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="450.85" y1="324.48" x2="133.39" y2="113.18" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="133.39" cy="113.18" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="332.48" cy="270.91" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="531.57" cy="131.04" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="192.58" cy="288.77" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="391.67" cy="148.9" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="590.76" cy="306.62" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="251.76" cy="166.75" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="450.85" cy="324.48" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="111.86" cy="184.61" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#47370C" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,140.0 159.0,172.2 318.0,192.4 477.0,174.8 636.0,142.0 795.0,135.7 954.0,164.0 1113.0,190.8 1272.0,181.9" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1042.02" y1="222.12" x2="790.68" y2="233.13" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="135.86" x2="181.64" y2="146.88" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="233.13" x2="539.33" y2="60.62" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="181.64" y1="146.88" x2="897.01" y2="157.89" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="60.62" x2="287.98" y2="71.63" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="71.63" x2="1003.35" y2="82.64" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1042.02" cy="222.12" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="432.99" cy="135.86" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="790.68" cy="233.13" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="181.64" cy="146.88" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="539.33" cy="60.62" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="897.01" cy="157.89" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="287.98" cy="71.63" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="645.67" cy="168.9" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="1003.35" cy="82.64" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,174.6 159.0,141.8 318.0,135.7 477.0,164.2 636.0,190.9 795.0,181.7 954.0,148.5 1113.0,133.5 1272.0,155.9" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="558.66" y1="130.36" x2="307.32" y2="141.37" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="227.62" x2="665.0" y2="55.12" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="141.37" x2="1022.69" y2="152.38" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="665.0" y1="55.12" x2="413.65" y2="66.13" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="152.38" x2="771.34" y2="163.39" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="163.39" x2="519.99" y2="174.4" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="558.66" cy="130.36" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="916.35" cy="227.62" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="307.32" cy="141.37" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="665.0" cy="55.12" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="1022.69" cy="152.38" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="413.65" cy="66.13" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="771.34" cy="163.39" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="162.31" cy="77.14" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="519.99" cy="174.4" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,159.7 90.0,177.0 180.0,216.8 270.0,228.5 360.0,197.1 450.0,162.6 540.0,169.1 630.0,208.2 720.0,230.1" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="463.97" y1="215.16" x2="321.7" y2="228.33" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="119.23" y1="112.01" x2="524.16" y2="125.17" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="321.7" y1="228.33" x2="179.42" y2="241.5" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="524.16" y1="125.17" x2="381.89" y2="138.34" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="381.89" y1="138.34" x2="239.62" y2="151.51" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="239.62" y1="151.51" x2="463.97" y2="215.16" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="463.97" cy="215.16" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="119.23" cy="112.01" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="321.7" cy="228.33" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="524.16" cy="125.17" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="179.42" cy="241.5" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="381.89" cy="138.34" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="584.35" cy="254.67" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="239.62" cy="151.51" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="442.08" cy="267.84" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#47370C" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,192.2 159.0,176.5 318.0,143.3 477.0,135.0 636.0,162.1 795.0,190.1 954.0,183.3 1113.0,150.3 1272.0,133.3" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="384.65" y1="97.32" x2="1100.03" y2="108.34" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="742.34" y1="194.59" x2="490.99" y2="205.6" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="108.34" x2="848.68" y2="119.35" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="490.99" y1="205.6" x2="239.64" y2="216.61" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="119.35" x2="597.33" y2="130.36" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="130.36" x2="345.98" y2="141.37" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="384.65" cy="97.32" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="742.34" cy="194.59" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="1100.03" cy="108.34" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="490.99" cy="205.6" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="848.68" cy="119.35" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="239.64" cy="216.61" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="597.33" cy="130.36" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="955.02" cy="227.62" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="345.98" cy="141.37" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,353.2 94.5,298.6 189.0,326.2 283.5,400.7 378.0,427.2 472.5,371.8 567.0,305.2 661.5,312.3 756.0,384.1" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="636.55" y1="507.54" x2="487.17" y2="122.89" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="274.58" y1="315.22" x2="125.19" y2="339.77" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="487.17" y1="122.89" x2="337.78" y2="147.44" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="125.19" y1="339.77" x2="550.37" y2="364.32" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="550.37" y1="364.32" x2="400.98" y2="388.87" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="400.98" y1="388.87" x2="636.55" y2="507.54" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="636.55" cy="507.54" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="274.58" cy="315.22" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="487.17" cy="122.89" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="125.19" cy="339.77" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="337.78" cy="147.44" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="550.37" cy="364.32" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="188.4" cy="172.0" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="400.98" cy="388.87" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="613.57" cy="196.55" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#47370C" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,135.1 159.0,143.1 318.0,176.2 477.0,192.3 636.0,170.7 795.0,139.1 954.0,137.7 1113.0,168.3 1272.0,191.9" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="781.01" y1="172.57" x2="529.66" y2="183.58" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="86.31" x2="887.35" y2="97.32" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="529.66" y1="183.58" x2="278.31" y2="194.59" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="97.32" x2="636.0" y2="108.34" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="108.34" x2="384.65" y2="119.35" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="119.35" x2="781.01" y2="172.57" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="781.01" cy="172.57" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="171.97" cy="86.31" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="529.66" cy="183.58" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="887.35" cy="97.32" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="278.31" cy="194.59" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="636.0" cy="108.34" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="993.69" cy="205.6" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="384.65" cy="119.35" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="742.34" cy="216.61" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,273.1 88.5,311.2 177.0,289.1 265.5,235.0 354.0,217.9 442.5,259.6 531.0,306.9 619.5,299.5 708.0,246.8" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="235.62" y1="169.73" x2="95.72" y2="187.58" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="434.71" y1="327.46" x2="294.81" y2="345.31" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="95.72" y1="187.58" x2="493.9" y2="205.44" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="294.81" y1="345.31" x2="154.91" y2="363.17" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="493.9" y1="205.44" x2="354.0" y2="223.3" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="354.0" y1="223.3" x2="214.1" y2="241.15" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="235.62" cy="169.73" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="434.71" cy="327.46" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="95.72" cy="187.58" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="294.81" cy="345.31" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="493.9" cy="205.44" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="154.91" cy="363.17" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="354.0" cy="223.3" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="553.09" cy="381.02" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="214.1" cy="241.15" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#47370C" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,176.1 159.0,192.3 318.0,170.9 477.0,139.2 636.0,137.6 795.0,168.1 954.0,191.9 1113.0,178.5 1272.0,145.1" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="258.98" y1="73.47" x2="974.35" y2="84.48" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="170.73" x2="365.32" y2="181.74" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="974.35" y1="84.48" x2="723.0" y2="95.49" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="181.74" x2="1080.69" y2="192.76" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="192.76" x2="829.34" y2="203.77" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="203.77" x2="258.98" y2="73.47" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="258.98" cy="73.47" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="616.67" cy="170.73" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="974.35" cy="84.48" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="365.32" cy="181.74" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="723.0" cy="95.49" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="1080.69" cy="192.76" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="471.66" cy="106.5" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="829.34" cy="203.77" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="220.31" cy="117.51" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,139.1 159.0,137.7 318.0,168.3 477.0,191.9 636.0,178.4 795.0,145.0 954.0,134.3 1113.0,160.0 1272.0,189.3" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="742.34" y1="165.23" x2="490.99" y2="176.24" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="78.97" x2="848.68" y2="89.98" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="490.99" y1="176.24" x2="239.64" y2="187.25" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="89.98" x2="597.33" y2="101.0" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="101.0" x2="345.98" y2="112.01" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="112.01" x2="742.34" y2="165.23" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="742.34" cy="165.23" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="1100.03" cy="78.97" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="490.99" cy="176.24" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="848.68" cy="89.98" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="239.64" cy="187.25" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="597.33" cy="101.0" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="955.02" cy="198.26" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="345.98" cy="112.01" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="703.67" cy="209.27" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#47370C" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESFP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFF2C5" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F9C74F" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F9C74F" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#47370C" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,181.4 90.0,220.5 180.0,226.6 270.0,192.1 360.0,160.8 450.0,172.8 540.0,212.7 630.0,229.6 720.0,202.0" fill="none" stroke="#F9C74F" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="567.94" y1="256.86" x2="425.66" y2="270.03" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="223.2" y1="153.71" x2="628.13" y2="166.88" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="425.66" y1="270.03" x2="283.39" y2="63.72" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="628.13" y1="166.88" x2="485.86" y2="180.04" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="283.39" y1="63.72" x2="141.12" y2="76.89" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/><line x1="141.12" y1="76.89" x2="546.05" y2="90.06" stroke="#F9C74F" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="567.94" cy="256.86" r="3" fill="#F9C74F" fill-opacity="0.35"/><circle cx="223.2" cy="153.71" r="4" fill="#F9C74F" fill-opacity="0.40"/><circle cx="425.66" cy="270.03" r="5" fill="#F9C74F" fill-opacity="0.45"/><circle cx="628.13" cy="166.88" r="3" fill="#F9C74F" fill-opacity="0.50"/><circle cx="283.39" cy="63.72" r="4" fill="#F9C74F" fill-opacity="0.35"/><circle cx="485.86" cy="180.04" r="5" fill="#F9C74F" fill-opacity="0.40"/><circle cx="141.12" cy="76.89" r="3" fill="#F9C74F" fill-opacity="0.45"/><circle cx="343.58" cy="193.21" r="4" fill="#F9C74F" fill-opacity="0.50"/><circle cx="546.05" cy="90.06" r="5" fill="#F9C74F" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F9C74F" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#47370C" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#47370C" fill-opacity="0.72">ESFP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#47370C" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,181.5 159.0,191.0 318.0,164.5 477.0,135.9 636.0,141.6 795.0,174.3 954.0,192.4 1113.0,172.7 1272.0,140.4" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="278.31" y1="77.14" x2="993.69" y2="88.15" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="174.4" x2="384.65" y2="185.41" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="993.69" y1="88.15" x2="742.34" y2="99.16" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="185.41" x2="1100.03" y2="196.43" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="196.43" x2="848.68" y2="207.44" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="207.44" x2="278.31" y2="77.14" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="278.31" cy="77.14" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="636.0" cy="174.4" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="993.69" cy="88.15" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="384.65" cy="185.41" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="742.34" cy="99.16" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="1100.03" cy="196.43" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="490.99" cy="110.17" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="848.68" cy="207.44" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="239.64" cy="121.18" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,401.7 94.5,327.2 189.0,298.3 283.5,351.9 378.0,419.6 472.5,415.1 567.0,344.1 661.5,297.2 756.0,334.2" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="573.35" y1="462.53" x2="423.96" y2="487.08" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="211.38" y1="270.2" x2="636.55" y2="294.76" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="423.96" y1="487.08" x2="274.58" y2="511.63" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="636.55" y1="294.76" x2="487.17" y2="319.31" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="274.58" y1="511.63" x2="125.19" y2="126.98" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="125.19" y1="126.98" x2="550.37" y2="151.54" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="573.35" cy="462.53" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="211.38" cy="270.2" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="423.96" cy="487.08" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="636.55" cy="294.76" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="274.58" cy="511.63" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="487.17" cy="319.31" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="125.19" cy="126.98" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="337.78" cy="343.86" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="550.37" cy="151.54" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4A210B" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,150.3 159.0,133.3 318.0,153.9 477.0,185.9 636.0,188.4 795.0,158.3 954.0,133.9 1113.0,146.4 1272.0,179.8" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="674.67" y1="152.38" x2="423.32" y2="163.39" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="1032.36" y1="66.13" x2="781.01" y2="77.14" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="163.39" x2="171.97" y2="174.4" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="781.01" y1="77.14" x2="529.66" y2="88.15" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="174.4" x2="887.35" y2="185.41" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="185.41" x2="636.0" y2="196.43" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="674.67" cy="152.38" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="1032.36" cy="66.13" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="423.32" cy="163.39" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="781.01" cy="77.14" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="171.97" cy="174.4" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="529.66" cy="88.15" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="887.35" cy="185.41" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="278.31" cy="99.16" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="636.0" cy="196.43" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,237.5 88.5,291.7 177.0,310.6 265.5,270.1 354.0,221.8 442.5,227.4 531.0,279.6 619.5,312.0 708.0,283.1" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="176.43" y1="136.99" x2="574.61" y2="154.85" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="375.52" y1="294.72" x2="235.62" y2="312.58" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="574.61" y1="154.85" x2="434.71" y2="172.7" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="235.62" y1="312.58" x2="95.72" y2="330.43" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="95.72" y1="330.43" x2="493.9" y2="348.29" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="493.9" y1="348.29" x2="176.43" y2="136.99" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="176.43" cy="136.99" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="375.52" cy="294.72" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="574.61" cy="154.85" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="235.62" cy="312.58" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="434.71" cy="172.7" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="95.72" cy="330.43" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="294.81" cy="190.56" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="493.9" cy="348.29" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="154.91" cy="208.42" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4A210B" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,153.7 159.0,185.8 318.0,188.5 477.0,158.5 636.0,133.9 795.0,146.2 954.0,179.6 1113.0,191.6 1272.0,166.8" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="152.64" y1="53.28" x2="868.01" y2="64.29" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="510.33" y1="150.55" x2="258.98" y2="161.56" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="64.29" x2="616.67" y2="75.3" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="161.56" x2="974.35" y2="172.57" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="75.3" x2="365.32" y2="86.31" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="86.31" x2="1080.69" y2="97.32" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="152.64" cy="53.28" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="510.33" cy="150.55" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="868.01" cy="64.29" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="258.98" cy="161.56" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="616.67" cy="75.3" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="974.35" cy="172.57" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="365.32" cy="86.31" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="723.0" cy="183.58" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="1080.69" cy="97.32" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,158.3 159.0,133.9 318.0,146.4 477.0,179.8 636.0,191.5 795.0,166.6 954.0,136.8 1113.0,140.2 1272.0,172.4" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="636.0" y1="145.04" x2="384.65" y2="156.05" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="993.69" y1="58.79" x2="742.34" y2="69.8" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="156.05" x2="1100.03" y2="167.06" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="742.34" y1="69.8" x2="490.99" y2="80.81" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="167.06" x2="848.68" y2="178.07" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="178.07" x2="597.33" y2="189.08" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="636.0" cy="145.04" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="993.69" cy="58.79" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="384.65" cy="156.05" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="742.34" cy="69.8" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="1100.03" cy="167.06" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="490.99" cy="80.81" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="848.68" cy="178.07" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="239.64" cy="91.82" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="597.33" cy="189.08" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,162.2 90.0,196.1 180.0,228.2 270.0,217.6 360.0,177.8 450.0,159.6 540.0,186.2 630.0,223.6 720.0,224.2" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="507.74" y1="232.72" x2="365.47" y2="245.89" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="163.01" y1="129.56" x2="567.94" y2="142.73" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="365.47" y1="245.89" x2="223.2" y2="259.06" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="567.94" y1="142.73" x2="425.66" y2="155.9" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="425.66" y1="155.9" x2="283.39" y2="169.07" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="283.39" y1="169.07" x2="507.74" y2="232.72" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="507.74" cy="232.72" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="163.01" cy="129.56" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="365.47" cy="245.89" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="567.94" cy="142.73" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="223.2" cy="259.06" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="425.66" cy="155.9" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="628.13" cy="272.23" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="283.39" cy="169.07" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="485.86" cy="65.91" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4A210B" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,189.4 159.0,160.3 318.0,134.4 477.0,144.7 636.0,178.1 795.0,192.0 954.0,168.7 1113.0,137.9 1272.0,138.9" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="461.99" y1="112.01" x2="210.64" y2="123.02" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="819.68" y1="209.27" x2="568.33" y2="220.28" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="210.64" y1="123.02" x2="926.02" y2="134.03" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="568.33" y1="220.28" x2="316.98" y2="231.29" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="134.03" x2="674.67" y2="145.04" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="145.04" x2="423.32" y2="156.05" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="461.99" cy="112.01" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="819.68" cy="209.27" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="210.64" cy="123.02" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="568.33" cy="220.28" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="926.02" cy="134.03" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="316.98" cy="231.29" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="674.67" cy="145.04" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="1032.36" cy="58.79" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="423.32" cy="156.05" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,319.8 94.5,300.9 189.0,361.2 283.5,423.8 378.0,408.9 472.5,335.4 567.0,297.1 661.5,342.8 756.0,414.3" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="107.96" y1="131.08" x2="533.13" y2="155.63" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="320.54" y1="347.95" x2="171.16" y2="372.5" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="533.13" y1="155.63" x2="383.75" y2="180.18" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="171.16" y1="372.5" x2="596.33" y2="397.06" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="596.33" y1="397.06" x2="446.95" y2="421.61" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="446.95" y1="421.61" x2="107.96" y2="131.08" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="107.96" cy="131.08" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="320.54" cy="347.95" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="533.13" cy="155.63" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="171.16" cy="372.5" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="383.75" cy="180.18" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="596.33" cy="397.06" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="234.36" cy="204.73" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="446.95" cy="421.61" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="659.53" cy="229.28" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4A210B" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.8 159.0,158.0 318.0,188.3 477.0,186.1 636.0,154.2 795.0,133.3 954.0,150.0 1113.0,183.0 1272.0,190.3" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="858.35" y1="187.25" x2="607.0" y2="198.26" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="101.0" x2="964.68" y2="112.01" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="607.0" y1="198.26" x2="355.65" y2="209.27" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="112.01" x2="713.34" y2="123.02" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="123.02" x2="461.99" y2="134.03" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="134.03" x2="858.35" y2="187.25" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="858.35" cy="187.25" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="249.31" cy="101.0" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="607.0" cy="198.26" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="964.68" cy="112.01" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="355.65" cy="209.27" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="713.34" cy="123.02" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="1071.02" cy="220.28" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="461.99" cy="134.03" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="819.68" cy="231.29" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,296.9 88.5,308.5 177.0,263.3 265.5,219.0 354.0,232.1 442.5,285.8 531.0,311.8 619.5,276.8 708.0,225.5" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="278.67" y1="193.54" x2="138.77" y2="211.39" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="477.76" y1="351.26" x2="337.86" y2="369.12" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="138.77" y1="211.39" x2="536.95" y2="229.25" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="337.86" y1="369.12" x2="197.96" y2="89.38" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="536.95" y1="229.25" x2="397.05" y2="247.1" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="397.05" y1="247.1" x2="257.15" y2="264.96" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="278.67" cy="193.54" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="477.76" cy="351.26" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="138.77" cy="211.39" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="337.86" cy="369.12" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="536.95" cy="229.25" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="197.96" cy="89.38" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="397.05" cy="247.1" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="596.14" cy="107.23" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="257.15" cy="264.96" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4A210B" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,188.2 159.0,186.2 318.0,154.4 477.0,133.3 636.0,149.8 795.0,182.9 954.0,190.3 1113.0,162.7 1272.0,135.2" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="336.32" y1="88.15" x2="1051.69" y2="99.16" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="694.0" y1="185.41" x2="442.66" y2="196.43" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="1051.69" y1="99.16" x2="800.34" y2="110.17" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="196.43" x2="191.31" y2="207.44" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="207.44" x2="906.68" y2="218.45" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="218.45" x2="336.32" y2="88.15" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="336.32" cy="88.15" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="694.0" cy="185.41" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="1051.69" cy="99.16" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="442.66" cy="196.43" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="800.34" cy="110.17" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="191.31" cy="207.44" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="549.0" cy="121.18" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="906.68" cy="218.45" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="297.65" cy="132.19" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.3 159.0,150.0 318.0,183.0 477.0,190.3 636.0,162.5 795.0,135.1 954.0,143.1 1113.0,176.2 1272.0,192.3" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="819.68" y1="179.91" x2="568.33" y2="190.92" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="210.64" y1="93.65" x2="926.02" y2="104.67" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="568.33" y1="190.92" x2="316.98" y2="201.93" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="104.67" x2="674.67" y2="115.68" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="115.68" x2="423.32" y2="126.69" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="126.69" x2="819.68" y2="179.91" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="819.68" cy="179.91" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="210.64" cy="93.65" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="568.33" cy="190.92" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="926.02" cy="104.67" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="316.98" cy="201.93" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="674.67" cy="115.68" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="1032.36" cy="212.94" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="423.32" cy="126.69" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="781.01" cy="223.95" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4A210B" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESTJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFE1D0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F3722C" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F3722C" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4A210B" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,201.1 90.0,229.5 180.0,213.5 270.0,173.6 360.0,160.6 450.0,191.1 540.0,226.2 630.0,221.2 720.0,182.4" fill="none" stroke="#F3722C" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="611.71" y1="274.42" x2="469.44" y2="68.11" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="266.98" y1="171.27" x2="124.7" y2="184.43" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="469.44" y1="68.11" x2="327.17" y2="81.28" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="124.7" y1="184.43" x2="529.63" y2="197.6" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="327.17" y1="81.28" x2="184.9" y2="94.45" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/><line x1="184.9" y1="94.45" x2="589.82" y2="107.62" stroke="#F3722C" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="611.71" cy="274.42" r="3" fill="#F3722C" fill-opacity="0.35"/><circle cx="266.98" cy="171.27" r="4" fill="#F3722C" fill-opacity="0.40"/><circle cx="469.44" cy="68.11" r="5" fill="#F3722C" fill-opacity="0.45"/><circle cx="124.7" cy="184.43" r="3" fill="#F3722C" fill-opacity="0.50"/><circle cx="327.17" cy="81.28" r="4" fill="#F3722C" fill-opacity="0.35"/><circle cx="529.63" cy="197.6" r="5" fill="#F3722C" fill-opacity="0.40"/><circle cx="184.9" cy="94.45" r="3" fill="#F3722C" fill-opacity="0.45"/><circle cx="387.36" cy="210.77" r="4" fill="#F3722C" fill-opacity="0.50"/><circle cx="589.82" cy="107.62" r="5" fill="#F3722C" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F3722C" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4A210B" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4A210B" fill-opacity="0.72">ESTJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4A210B" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,189.3 159.0,184.7 318.0,152.2 477.0,133.2 636.0,151.9 795.0,184.5 954.0,189.4 1113.0,160.4 1272.0,134.4" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="336.32" y1="88.15" x2="1051.69" y2="99.16" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="694.0" y1="185.41" x2="442.66" y2="196.43" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="1051.69" y1="99.16" x2="800.34" y2="110.17" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="196.43" x2="191.31" y2="207.44" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="207.44" x2="906.68" y2="218.45" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="218.45" x2="336.32" y2="88.15" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="336.32" cy="88.15" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="694.0" cy="185.41" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="1051.69" cy="99.16" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="442.66" cy="196.43" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="800.34" cy="110.17" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="191.31" cy="207.44" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="549.0" cy="121.18" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="906.68" cy="218.45" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="297.65" cy="132.19" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,376.3 94.5,307.6 189.0,309.5 283.5,379.6 378.0,428.6 472.5,393.9 567.0,319.8 661.5,300.8 756.0,361.1" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="607.82" y1="487.08" x2="458.44" y2="511.63" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="245.85" y1="294.76" x2="96.47" y2="319.31" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="458.44" y1="511.63" x2="309.05" y2="126.98" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="96.47" y1="319.31" x2="521.64" y2="343.86" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="309.05" y1="126.98" x2="159.67" y2="151.54" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="159.67" y1="151.54" x2="584.84" y2="176.09" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="607.82" cy="487.08" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="245.85" cy="294.76" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="458.44" cy="511.63" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="96.47" cy="319.31" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="309.05" cy="126.98" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="521.64" cy="343.86" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="159.67" cy="151.54" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="372.25" cy="368.41" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="584.84" cy="176.09" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4B1011" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,140.4 159.0,136.7 318.0,166.3 477.0,191.5 636.0,180.1 795.0,146.7 954.0,133.8 1113.0,157.9 1272.0,188.2" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="732.67" y1="163.39" x2="481.32" y2="174.4" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="77.14" x2="839.01" y2="88.15" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="174.4" x2="229.98" y2="185.41" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="839.01" y1="88.15" x2="587.66" y2="99.16" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="185.41" x2="945.35" y2="196.43" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="196.43" x2="694.0" y2="207.44" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="732.67" cy="163.39" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="1090.36" cy="77.14" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="481.32" cy="174.4" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="839.01" cy="88.15" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="229.98" cy="185.41" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="587.66" cy="99.16" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="945.35" cy="196.43" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="336.32" cy="110.17" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="694.0" cy="207.44" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,256.3 88.5,305.3 177.0,301.7 265.5,250.0 354.0,216.1 442.5,243.3 531.0,296.9 619.5,308.5 708.0,263.4" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="208.72" y1="154.85" x2="606.9" y2="172.7" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="407.81" y1="312.58" x2="267.91" y2="330.43" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="606.9" y1="172.7" x2="467.0" y2="190.56" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="267.91" y1="330.43" x2="128.01" y2="348.29" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="128.01" y1="348.29" x2="526.19" y2="366.14" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="526.19" y1="366.14" x2="208.72" y2="154.85" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="208.72" cy="154.85" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="407.81" cy="312.58" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="606.9" cy="172.7" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="267.91" cy="330.43" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="467.0" cy="190.56" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="128.01" cy="348.29" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="327.1" cy="208.42" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="526.19" cy="366.14" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="187.2" cy="226.27" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4B1011" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,166.1 159.0,191.4 318.0,180.2 477.0,146.8 636.0,133.8 795.0,157.7 954.0,188.1 1113.0,186.2 1272.0,154.4" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="210.64" y1="64.29" x2="926.02" y2="75.3" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="568.33" y1="161.56" x2="316.98" y2="172.57" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="75.3" x2="674.67" y2="86.31" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="316.98" y1="172.57" x2="1032.36" y2="183.58" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="86.31" x2="423.32" y2="97.32" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="97.32" x2="171.97" y2="108.34" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="210.64" cy="64.29" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="568.33" cy="161.56" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="926.02" cy="75.3" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="316.98" cy="172.57" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="674.67" cy="86.31" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="1032.36" cy="183.58" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="423.32" cy="97.32" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="781.01" cy="194.59" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="171.97" cy="108.34" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,146.7 159.0,133.8 318.0,158.0 477.0,188.3 636.0,186.1 795.0,154.2 954.0,133.3 1113.0,150.0 1272.0,183.0" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="694.0" y1="156.05" x2="442.66" y2="167.06" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="1051.69" y1="69.8" x2="800.34" y2="80.81" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="167.06" x2="191.31" y2="178.07" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="800.34" y1="80.81" x2="549.0" y2="91.82" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="178.07" x2="906.68" y2="189.08" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="189.08" x2="655.33" y2="200.1" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="694.0" cy="156.05" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="1051.69" cy="69.8" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="442.66" cy="167.06" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="800.34" cy="80.81" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="191.31" cy="178.07" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="549.0" cy="91.82" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="906.68" cy="189.08" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="297.65" cy="102.83" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="655.33" cy="200.1" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,170.9 90.0,210.5 180.0,229.9 270.0,204.4 360.0,166.5 450.0,164.5 540.0,201.0 630.0,229.5 720.0,213.5" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="540.58" y1="245.89" x2="398.3" y2="259.06" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="195.84" y1="142.73" x2="600.77" y2="155.9" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="398.3" y1="259.06" x2="256.03" y2="272.23" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="600.77" y1="155.9" x2="458.5" y2="169.07" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="458.5" y1="169.07" x2="316.22" y2="182.24" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="316.22" y1="182.24" x2="540.58" y2="245.89" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="540.58" cy="245.89" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="195.84" cy="142.73" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="398.3" cy="259.06" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="600.77" cy="155.9" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="256.03" cy="272.23" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="458.5" cy="169.07" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="113.76" cy="65.91" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="316.22" cy="182.24" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="518.69" cy="79.08" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4B1011" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,181.7 159.0,148.4 318.0,133.5 477.0,155.9 636.0,187.1 795.0,187.3 954.0,156.2 1113.0,133.5 1272.0,148.1" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="519.99" y1="123.02" x2="268.65" y2="134.03" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="877.68" y1="220.28" x2="626.33" y2="231.29" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="134.03" x2="984.02" y2="145.04" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="626.33" y1="231.29" x2="374.99" y2="58.79" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="145.04" x2="732.67" y2="156.05" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="156.05" x2="481.32" y2="167.06" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="519.99" cy="123.02" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="877.68" cy="220.28" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="268.65" cy="134.03" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="626.33" cy="231.29" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="984.02" cy="145.04" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="374.99" cy="58.79" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="732.67" cy="156.05" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="1090.36" cy="69.8" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="481.32" cy="167.06" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,303.1 94.5,315.5 189.0,388.5 283.5,429.0 378.0,385.4 472.5,313.2 567.0,304.6 661.5,370.4 756.0,426.8" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="142.43" y1="155.63" x2="567.6" y2="180.18" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="355.02" y1="372.5" x2="205.63" y2="397.06" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="567.6" y1="180.18" x2="418.22" y2="204.73" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="205.63" y1="397.06" x2="630.81" y2="421.61" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="630.81" y1="421.61" x2="481.42" y2="446.16" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="481.42" y1="446.16" x2="142.43" y2="155.63" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="142.43" cy="155.63" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="355.02" cy="372.5" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="567.6" cy="180.18" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="205.63" cy="397.06" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="418.22" cy="204.73" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="630.81" cy="421.61" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="268.83" cy="229.28" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="481.42" cy="446.16" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="119.45" cy="253.84" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#4B1011" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,138.9 159.0,170.4 318.0,192.2 477.0,176.5 636.0,143.3 795.0,135.0 954.0,162.1 1113.0,190.1 1272.0,183.3" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="916.35" y1="198.26" x2="665.0" y2="209.27" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="112.01" x2="1022.69" y2="123.02" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="665.0" y1="209.27" x2="413.65" y2="220.28" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="123.02" x2="771.34" y2="134.03" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="134.03" x2="519.99" y2="145.04" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="145.04" x2="916.35" y2="198.26" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="916.35" cy="198.26" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="307.32" cy="112.01" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="665.0" cy="209.27" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="1022.69" cy="123.02" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="413.65" cy="220.28" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="771.34" cy="134.03" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="162.31" cy="231.29" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="519.99" cy="145.04" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="877.68" cy="58.79" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,308.4 88.5,297.2 177.0,243.7 265.5,216.1 354.0,249.6 442.5,301.5 531.0,305.5 619.5,256.6 708.0,217.1" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="310.95" y1="211.39" x2="171.05" y2="229.25" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="510.04" y1="369.12" x2="370.14" y2="89.38" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="171.05" y1="229.25" x2="569.23" y2="247.1" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="370.14" y1="89.38" x2="230.24" y2="107.23" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="569.23" y1="247.1" x2="429.33" y2="264.96" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="429.33" y1="264.96" x2="289.43" y2="282.82" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="310.95" cy="211.39" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="510.04" cy="369.12" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="171.05" cy="229.25" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="370.14" cy="89.38" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="569.23" cy="247.1" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="230.24" cy="107.23" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="429.33" cy="264.96" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="90.34" cy="125.09" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="289.43" cy="282.82" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#4B1011" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,192.2 159.0,176.7 318.0,143.5 477.0,134.9 636.0,161.9 795.0,190.0 954.0,183.5 1113.0,150.5 1272.0,133.2" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="394.32" y1="99.16" x2="1109.69" y2="110.17" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="196.43" x2="500.66" y2="207.44" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="1109.69" y1="110.17" x2="858.35" y2="121.18" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="207.44" x2="249.31" y2="218.45" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="218.45" x2="964.68" y2="229.46" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="229.46" x2="394.32" y2="99.16" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="394.32" cy="99.16" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="752.01" cy="196.43" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="1109.69" cy="110.17" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="500.66" cy="207.44" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="858.35" cy="121.18" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="249.31" cy="218.45" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="607.0" cy="132.19" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="964.68" cy="229.46" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="355.65" cy="143.2" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,135.0 159.0,162.1 318.0,190.1 477.0,183.3 636.0,150.3 795.0,133.3 954.0,153.9 1113.0,185.9 1272.0,188.4" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="877.68" y1="190.92" x2="626.33" y2="201.93" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="104.67" x2="984.02" y2="115.68" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="626.33" y1="201.93" x2="374.99" y2="212.94" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="115.68" x2="732.67" y2="126.69" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="126.69" x2="481.32" y2="137.7" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="137.7" x2="877.68" y2="190.92" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="877.68" cy="190.92" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="268.65" cy="104.67" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="626.33" cy="201.93" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="984.02" cy="115.68" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="374.99" cy="212.94" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="732.67" cy="126.69" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="1090.36" cy="223.95" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="481.32" cy="137.7" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="839.01" cy="234.96" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#4B1011" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ESTP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ESTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#FFDCDC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#F94144" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#F94144" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#4B1011" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,214.8 90.0,229.1 180.0,199.5 270.0,163.8 360.0,167.4 450.0,205.9 540.0,230.1 630.0,209.1 720.0,169.8" fill="none" stroke="#F94144" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="97.34" y1="68.11" x2="502.27" y2="81.28" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="299.81" y1="184.43" x2="157.54" y2="197.6" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="502.27" y1="81.28" x2="360.0" y2="94.45" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="157.54" y1="197.6" x2="562.46" y2="210.77" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="360.0" y1="94.45" x2="217.73" y2="107.62" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/><line x1="217.73" y1="107.62" x2="622.66" y2="120.78" stroke="#F94144" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="97.34" cy="68.11" r="3" fill="#F94144" fill-opacity="0.35"/><circle cx="299.81" cy="184.43" r="4" fill="#F94144" fill-opacity="0.40"/><circle cx="502.27" cy="81.28" r="5" fill="#F94144" fill-opacity="0.45"/><circle cx="157.54" cy="197.6" r="3" fill="#F94144" fill-opacity="0.50"/><circle cx="360.0" cy="94.45" r="4" fill="#F94144" fill-opacity="0.35"/><circle cx="562.46" cy="210.77" r="5" fill="#F94144" fill-opacity="0.40"/><circle cx="217.73" cy="107.62" r="3" fill="#F94144" fill-opacity="0.45"/><circle cx="420.19" cy="223.94" r="4" fill="#F94144" fill-opacity="0.50"/><circle cx="622.66" cy="120.78" r="5" fill="#F94144" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#F94144" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#4B1011" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#4B1011" fill-opacity="0.72">ESTP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#4B1011" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,151.9 159.0,184.5 318.0,189.4 477.0,160.3 636.0,134.4 795.0,144.7 954.0,178.1 1113.0,192.0 1272.0,168.7" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1100.03" y1="233.13" x2="848.68" y2="60.62" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="490.99" y1="146.88" x2="239.64" y2="157.89" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="60.62" x2="597.33" y2="71.63" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="239.64" y1="157.89" x2="955.02" y2="168.9" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="71.63" x2="345.98" y2="82.64" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="82.64" x2="1061.36" y2="93.65" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1100.03" cy="233.13" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="490.99" cy="146.88" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="848.68" cy="60.62" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="239.64" cy="157.89" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="597.33" cy="71.63" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="955.02" cy="168.9" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="345.98" cy="82.64" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="703.67" cy="179.91" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="1061.36" cy="93.65" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,428.6 94.5,393.8 189.0,319.8 283.5,300.9 378.0,361.2 472.5,423.8 567.0,408.9 661.5,335.4 756.0,297.1" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="487.17" y1="401.15" x2="337.78" y2="425.7" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="125.19" y1="208.82" x2="550.37" y2="233.38" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="337.78" y1="425.7" x2="188.4" y2="450.25" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="550.37" y1="233.38" x2="400.98" y2="257.93" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="400.98" y1="257.93" x2="251.6" y2="282.48" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="251.6" y1="282.48" x2="487.17" y2="401.15" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="487.17" cy="401.15" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="125.19" cy="208.82" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="337.78" cy="425.7" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="550.37" cy="233.38" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="188.4" cy="450.25" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="400.98" cy="257.93" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="613.57" cy="474.8" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="251.6" cy="282.48" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="464.18" cy="499.36" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,180.1 159.0,146.7 318.0,133.8 477.0,158.0 636.0,188.3 795.0,186.1 954.0,154.2 1113.0,133.3 1272.0,150.0" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="529.66" y1="124.85" x2="278.31" y2="135.86" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="222.12" x2="636.0" y2="233.13" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="278.31" y1="135.86" x2="993.69" y2="146.88" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="233.13" x2="384.65" y2="60.62" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="60.62" x2="1100.03" y2="71.63" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="71.63" x2="529.66" y2="124.85" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="529.66" cy="124.85" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="887.35" cy="222.12" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="278.31" cy="135.86" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="636.0" cy="233.13" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="993.69" cy="146.88" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="384.65" cy="60.62" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="742.34" cy="157.89" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="1100.03" cy="71.63" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="490.99" cy="168.9" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,216.1 88.5,243.4 177.0,296.9 265.5,308.5 354.0,263.3 442.5,219.0 531.0,232.1 619.5,285.8 708.0,311.8" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="95.72" y1="92.35" x2="493.9" y2="110.21" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="294.81" y1="250.08" x2="154.91" y2="267.94" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="493.9" y1="110.21" x2="354.0" y2="128.06" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="154.91" y1="267.94" x2="553.09" y2="285.79" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="354.0" y1="128.06" x2="214.1" y2="145.92" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="214.1" y1="145.92" x2="612.28" y2="163.78" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="95.72" cy="92.35" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="294.81" cy="250.08" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="493.9" cy="110.21" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="154.91" cy="267.94" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="354.0" cy="128.06" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="553.09" cy="285.79" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="214.1" cy="145.92" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="413.19" cy="303.65" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="612.28" cy="163.78" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.8 159.0,157.8 318.0,188.2 477.0,186.2 636.0,154.4 795.0,133.3 954.0,149.8 1113.0,182.9 1272.0,190.3" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="974.35" y1="209.27" x2="723.0" y2="220.28" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="123.02" x2="1080.69" y2="134.03" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="723.0" y1="220.28" x2="471.66" y2="231.29" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="134.03" x2="829.34" y2="145.04" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="145.04" x2="578.0" y2="156.05" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="156.05" x2="974.35" y2="209.27" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="974.35" cy="209.27" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="365.32" cy="123.02" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="723.0" cy="220.28" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="1080.69" cy="134.03" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="471.66" cy="231.29" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="829.34" cy="145.04" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="220.31" cy="58.79" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="578.0" cy="156.05" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="935.68" cy="69.8" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,186.1 159.0,154.2 318.0,133.3 477.0,150.0 636.0,183.0 795.0,190.3 954.0,162.5 1113.0,135.1 1272.0,143.1" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="490.99" y1="117.51" x2="239.64" y2="128.52" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="214.78" x2="597.33" y2="225.79" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="239.64" y1="128.52" x2="955.02" y2="139.53" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="225.79" x2="345.98" y2="53.28" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="53.28" x2="1061.36" y2="64.29" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="64.29" x2="490.99" y2="117.51" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="490.99" cy="117.51" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="848.68" cy="214.78" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="239.64" cy="128.52" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="597.33" cy="225.79" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="955.02" cy="139.53" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="345.98" cy="53.28" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="703.67" cy="150.55" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="1061.36" cy="64.29" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="452.32" cy="161.56" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,166.5 90.0,164.6 180.0,201.1 270.0,229.5 360.0,213.5 450.0,173.6 540.0,160.6 630.0,191.1 720.0,226.2" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="425.66" y1="199.8" x2="283.39" y2="212.97" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="628.13" y1="96.64" x2="485.86" y2="109.81" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="283.39" y1="212.97" x2="141.12" y2="226.14" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="485.86" y1="109.81" x2="343.58" y2="122.98" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="141.12" y1="226.14" x2="546.05" y2="239.3" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="546.05" y1="239.3" x2="403.78" y2="252.47" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="425.66" cy="199.8" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="628.13" cy="96.64" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="283.39" cy="212.97" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="485.86" cy="109.81" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="141.12" cy="226.14" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="343.58" cy="122.98" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="546.05" cy="239.3" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="201.31" cy="136.15" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="403.78" cy="252.47" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,187.1 159.0,187.3 318.0,156.2 477.0,133.5 636.0,148.2 795.0,181.5 954.0,191.0 1113.0,164.5 1272.0,135.9" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="316.98" y1="84.48" x2="1032.36" y2="95.49" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="181.74" x2="423.32" y2="192.76" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="1032.36" y1="95.49" x2="781.01" y2="106.5" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="192.76" x2="171.97" y2="203.77" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="203.77" x2="887.35" y2="214.78" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="214.78" x2="316.98" y2="84.48" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="316.98" cy="84.48" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="674.67" cy="181.74" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="1032.36" cy="95.49" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="423.32" cy="192.76" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="781.01" cy="106.5" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="171.97" cy="203.77" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="529.66" cy="117.51" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="887.35" cy="214.78" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="278.31" cy="128.52" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,385.3 94.5,313.2 189.0,304.6 283.5,370.5 378.0,426.8 472.5,401.8 567.0,327.3 661.5,298.3 756.0,351.9" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="596.33" y1="478.9" x2="446.95" y2="503.45" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="234.36" y1="286.57" x2="659.53" y2="311.12" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="446.95" y1="503.45" x2="297.56" y2="118.8" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="659.53" y1="311.12" x2="510.15" y2="335.68" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="297.56" y1="118.8" x2="148.18" y2="143.35" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="148.18" y1="143.35" x2="573.35" y2="167.9" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="596.33" cy="478.9" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="234.36" cy="286.57" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="446.95" cy="503.45" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="659.53" cy="311.12" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="297.56" cy="118.8" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="510.15" cy="335.68" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="148.18" cy="143.35" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="360.76" cy="360.23" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="573.35" cy="167.9" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,143.3 159.0,135.0 318.0,162.1 477.0,190.1 636.0,183.3 795.0,150.3 954.0,133.3 1113.0,153.9 1272.0,185.9" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="713.34" y1="159.72" x2="461.99" y2="170.73" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="1071.02" y1="73.47" x2="819.68" y2="84.48" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="170.73" x2="210.64" y2="181.74" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="819.68" y1="84.48" x2="568.33" y2="95.49" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="210.64" y1="181.74" x2="926.02" y2="192.76" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="192.76" x2="674.67" y2="203.77" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="713.34" cy="159.72" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="1071.02" cy="73.47" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="461.99" cy="170.73" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="819.68" cy="84.48" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="210.64" cy="181.74" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="568.33" cy="95.49" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="926.02" cy="192.76" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="316.98" cy="106.5" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="674.67" cy="203.77" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,249.7 88.5,301.5 177.0,305.5 265.5,256.6 354.0,217.1 442.5,237.4 531.0,291.6 619.5,310.6 708.0,270.1" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="197.96" y1="148.9" x2="596.14" y2="166.75" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="397.05" y1="306.62" x2="257.15" y2="324.48" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="596.14" y1="166.75" x2="456.24" y2="184.61" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="257.15" y1="324.48" x2="117.24" y2="342.34" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="117.24" y1="342.34" x2="515.42" y2="360.19" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="515.42" y1="360.19" x2="197.96" y2="148.9" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="197.96" cy="148.9" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="397.05" cy="306.62" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="596.14" cy="166.75" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="257.15" cy="324.48" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="456.24" cy="184.61" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="117.24" cy="342.34" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="316.33" cy="202.46" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="515.42" cy="360.19" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="176.43" cy="220.32" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,161.9 159.0,190.1 318.0,183.4 477.0,150.5 636.0,133.2 795.0,153.7 954.0,185.7 1113.0,188.5 1272.0,158.5" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="191.31" y1="60.62" x2="906.68" y2="71.63" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="549.0" y1="157.89" x2="297.65" y2="168.9" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="71.63" x2="655.33" y2="82.64" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="297.65" y1="168.9" x2="1013.02" y2="179.91" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="82.64" x2="403.99" y2="93.65" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="93.65" x2="152.64" y2="104.67" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="191.31" cy="60.62" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="549.0" cy="157.89" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="906.68" cy="71.63" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="297.65" cy="168.9" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="655.33" cy="82.64" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="1013.02" cy="179.91" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="403.99" cy="93.65" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="761.67" cy="190.92" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="152.64" cy="104.67" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,150.3 159.0,133.3 318.0,153.9 477.0,185.9 636.0,188.4 795.0,158.3 954.0,133.9 1113.0,146.4 1272.0,179.8" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="674.67" y1="152.38" x2="423.32" y2="163.39" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="1032.36" y1="66.13" x2="781.01" y2="77.14" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="163.39" x2="171.97" y2="174.4" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="781.01" y1="77.14" x2="529.66" y2="88.15" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="174.4" x2="887.35" y2="185.41" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="185.41" x2="636.0" y2="196.43" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="674.67" cy="152.38" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="1032.36" cy="66.13" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="423.32" cy="163.39" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="781.01" cy="77.14" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="171.97" cy="174.4" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="529.66" cy="88.15" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="887.35" cy="185.41" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="278.31" cy="99.16" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="636.0" cy="196.43" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INFJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8F5F0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#2EC4B6" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#2EC4B6" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#0F3D3E" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,167.5 90.0,205.9 180.0,230.1 270.0,209.1 360.0,169.8 450.0,162.2 540.0,196.1 630.0,228.2 720.0,217.6" fill="none" stroke="#2EC4B6" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="529.63" y1="241.5" x2="387.36" y2="254.67" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="184.9" y1="138.34" x2="589.82" y2="151.51" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="387.36" y1="254.67" x2="245.09" y2="267.84" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="589.82" y1="151.51" x2="447.55" y2="164.68" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="447.55" y1="164.68" x2="305.28" y2="177.85" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/><line x1="305.28" y1="177.85" x2="529.63" y2="241.5" stroke="#2EC4B6" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="529.63" cy="241.5" r="3" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="184.9" cy="138.34" r="4" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="387.36" cy="254.67" r="5" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="589.82" cy="151.51" r="3" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="245.09" cy="267.84" r="4" fill="#2EC4B6" fill-opacity="0.35"/><circle cx="447.55" cy="164.68" r="5" fill="#2EC4B6" fill-opacity="0.40"/><circle cx="102.82" cy="281.01" r="3" fill="#2EC4B6" fill-opacity="0.45"/><circle cx="305.28" cy="177.85" r="4" fill="#2EC4B6" fill-opacity="0.50"/><circle cx="507.74" cy="74.69" r="5" fill="#2EC4B6" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#2EC4B6" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0F3D3E" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#0F3D3E" fill-opacity="0.72">INFJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#0F3D3E" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,164.2 159.0,190.9 318.0,181.7 477.0,148.4 636.0,133.5 795.0,155.9 954.0,187.1 1113.0,187.3 1272.0,156.2" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="191.31" y1="60.62" x2="906.68" y2="71.63" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="549.0" y1="157.89" x2="297.65" y2="168.9" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="71.63" x2="655.33" y2="82.64" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="297.65" y1="168.9" x2="1013.02" y2="179.91" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="82.64" x2="403.99" y2="93.65" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="93.65" x2="152.64" y2="104.67" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="191.31" cy="60.62" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="549.0" cy="157.89" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="906.68" cy="71.63" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="297.65" cy="168.9" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="655.33" cy="82.64" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="1013.02" cy="179.91" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="403.99" cy="93.65" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="761.67" cy="190.92" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="152.64" cy="104.67" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,425.9 94.5,367.1 189.0,303.1 283.5,315.5 378.0,388.5 472.5,429.0 567.0,385.4 661.5,313.2 756.0,304.6" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="521.64" y1="425.7" x2="372.25" y2="450.25" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="159.67" y1="233.38" x2="584.84" y2="257.93" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="372.25" y1="450.25" x2="222.87" y2="474.8" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="584.84" y1="257.93" x2="435.46" y2="282.48" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="435.46" y1="282.48" x2="286.07" y2="307.03" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="286.07" y1="307.03" x2="521.64" y2="425.7" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="521.64" cy="425.7" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="159.67" cy="233.38" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="372.25" cy="450.25" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="584.84" cy="257.93" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="222.87" cy="474.8" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="435.46" cy="282.48" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="648.04" cy="499.36" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="286.07" cy="307.03" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="498.66" cy="523.91" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#1E5130" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,168.7 159.0,137.9 318.0,138.9 477.0,170.4 636.0,192.2 795.0,176.5 954.0,143.3 1113.0,135.0 1272.0,162.1" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="587.66" y1="135.86" x2="336.32" y2="146.88" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="233.13" x2="694.0" y2="60.62" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="336.32" y1="146.88" x2="1051.69" y2="157.89" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="694.0" y1="60.62" x2="442.66" y2="71.63" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="442.66" y1="71.63" x2="191.31" y2="82.64" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="191.31" y1="82.64" x2="587.66" y2="135.86" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="587.66" cy="135.86" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="945.35" cy="233.13" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="336.32" cy="146.88" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="694.0" cy="60.62" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="1051.69" cy="157.89" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="442.66" cy="71.63" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="800.34" cy="168.9" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="191.31" cy="82.64" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="549.0" cy="179.91" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,218.9 88.5,263.0 177.0,308.4 265.5,297.2 354.0,243.7 442.5,216.1 531.0,249.6 619.5,301.5 708.0,305.5" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="128.01" y1="110.21" x2="526.19" y2="128.06" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="327.1" y1="267.94" x2="187.2" y2="285.79" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="526.19" y1="128.06" x2="386.28" y2="145.92" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="187.2" y1="285.79" x2="585.37" y2="303.65" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="386.28" y1="145.92" x2="246.38" y2="163.78" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="246.38" y1="163.78" x2="106.48" y2="181.63" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="128.01" cy="110.21" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="327.1" cy="267.94" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="526.19" cy="128.06" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="187.2" cy="285.79" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="386.28" cy="145.92" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="585.37" cy="303.65" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="246.38" cy="163.78" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="445.47" cy="321.5" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="106.48" cy="181.63" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#1E5130" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,138.8 159.0,170.2 318.0,192.2 477.0,176.7 636.0,143.5 795.0,134.9 954.0,161.9 1113.0,190.0 1272.0,183.5" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1032.36" y1="220.28" x2="781.01" y2="231.29" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="134.03" x2="171.97" y2="145.04" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="781.01" y1="231.29" x2="529.66" y2="58.79" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="145.04" x2="887.35" y2="156.05" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="156.05" x2="636.0" y2="167.06" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="167.06" x2="1032.36" y2="220.28" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1032.36" cy="220.28" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="423.32" cy="134.03" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="781.01" cy="231.29" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="171.97" cy="145.04" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="529.66" cy="58.79" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="887.35" cy="156.05" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="278.31" cy="69.8" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="636.0" cy="167.06" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="993.69" cy="80.81" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,176.5 159.0,143.3 318.0,135.0 477.0,162.1 636.0,190.1 795.0,183.3 954.0,150.3 1113.0,133.3 1272.0,153.9" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="549.0" y1="128.52" x2="297.65" y2="139.53" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="225.79" x2="655.33" y2="53.28" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="297.65" y1="139.53" x2="1013.02" y2="150.55" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="53.28" x2="403.99" y2="64.29" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="64.29" x2="152.64" y2="75.3" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="152.64" y1="75.3" x2="549.0" y2="128.52" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="549.0" cy="128.52" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="906.68" cy="225.79" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="297.65" cy="139.53" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="655.33" cy="53.28" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="1013.02" cy="150.55" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="403.99" cy="64.29" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="761.67" cy="161.56" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="152.64" cy="75.3" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="510.33" cy="172.57" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,160.2 90.0,174.8 180.0,214.8 270.0,229.1 360.0,199.5 450.0,163.8 540.0,167.4 630.0,205.9 720.0,230.1" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="458.5" y1="212.97" x2="316.22" y2="226.14" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="113.76" y1="109.81" x2="518.69" y2="122.98" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="316.22" y1="226.14" x2="173.95" y2="239.3" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="518.69" y1="122.98" x2="376.42" y2="136.15" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="173.95" y1="239.3" x2="578.88" y2="252.47" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="578.88" y1="252.47" x2="436.61" y2="265.64" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="458.5" cy="212.97" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="113.76" cy="109.81" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="316.22" cy="226.14" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="518.69" cy="122.98" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="173.95" cy="239.3" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="376.42" cy="136.15" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="578.88" cy="252.47" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="234.14" cy="149.32" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="436.61" cy="265.64" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#1E5130" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,191.9 159.0,178.3 318.0,144.9 477.0,134.3 636.0,160.0 795.0,189.3 954.0,184.8 1113.0,152.2 1272.0,133.2" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="374.99" y1="95.49" x2="1090.36" y2="106.5" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="192.76" x2="481.32" y2="203.77" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="106.5" x2="839.01" y2="117.51" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="203.77" x2="229.98" y2="214.78" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="214.78" x2="945.35" y2="225.79" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="225.79" x2="374.99" y2="95.49" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="374.99" cy="95.49" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="732.67" cy="192.76" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="1090.36" cy="106.5" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="481.32" cy="203.77" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="839.01" cy="117.51" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="229.98" cy="214.78" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="587.66" cy="128.52" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="945.35" cy="225.79" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="336.32" cy="139.53" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,357.8 94.5,299.8 189.0,322.4 283.5,396.8 378.0,428.1 472.5,376.4 567.0,307.6 661.5,309.5 756.0,379.6" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="630.81" y1="503.45" x2="481.42" y2="118.8" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="268.83" y1="311.12" x2="119.45" y2="335.68" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="481.42" y1="118.8" x2="332.04" y2="143.35" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="119.45" y1="335.68" x2="544.62" y2="360.23" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="332.04" y1="143.35" x2="182.65" y2="167.9" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="182.65" y1="167.9" x2="607.82" y2="192.46" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="630.81" cy="503.45" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="268.83" cy="311.12" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="481.42" cy="118.8" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="119.45" cy="335.68" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="332.04" cy="143.35" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="544.62" cy="360.23" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="182.65" cy="167.9" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="395.24" cy="384.78" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="607.82" cy="192.46" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#1E5130" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,135.9 159.0,141.6 318.0,174.3 477.0,192.4 636.0,172.7 795.0,140.4 954.0,136.7 1113.0,166.3 1272.0,191.5" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="771.34" y1="170.73" x2="519.99" y2="181.74" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="162.31" y1="84.48" x2="877.68" y2="95.49" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="181.74" x2="268.65" y2="192.76" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="877.68" y1="95.49" x2="626.33" y2="106.5" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="192.76" x2="984.02" y2="203.77" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="203.77" x2="732.67" y2="214.78" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="771.34" cy="170.73" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="162.31" cy="84.48" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="519.99" cy="181.74" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="877.68" cy="95.49" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="268.65" cy="192.76" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="626.33" cy="106.5" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="984.02" cy="203.77" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="374.99" cy="117.51" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="732.67" cy="214.78" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,269.8 88.5,310.5 177.0,291.9 265.5,237.7 354.0,217.0 442.5,256.2 531.0,305.3 619.5,301.7 708.0,250.0" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="230.24" y1="166.75" x2="90.34" y2="184.61" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="429.33" y1="324.48" x2="289.43" y2="342.34" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="90.34" y1="184.61" x2="488.52" y2="202.46" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="289.43" y1="342.34" x2="149.53" y2="360.19" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="149.53" y1="360.19" x2="547.71" y2="378.05" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="547.71" y1="378.05" x2="230.24" y2="166.75" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="230.24" cy="166.75" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="429.33" cy="324.48" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="90.34" cy="184.61" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="289.43" cy="342.34" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="488.52" cy="202.46" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="149.53" cy="360.19" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="348.62" cy="220.32" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="547.71" cy="378.05" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="208.72" cy="238.18" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#1E5130" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,174.2 159.0,192.4 318.0,172.9 477.0,140.5 636.0,136.6 795.0,166.1 954.0,191.4 1113.0,180.3 1272.0,146.9" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="249.31" y1="71.63" x2="964.68" y2="82.64" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="607.0" y1="168.9" x2="355.65" y2="179.91" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="82.64" x2="713.34" y2="93.65" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="355.65" y1="179.91" x2="1071.02" y2="190.92" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="93.65" x2="461.99" y2="104.67" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="104.67" x2="210.64" y2="115.68" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="249.31" cy="71.63" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="607.0" cy="168.9" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="964.68" cy="82.64" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="355.65" cy="179.91" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="713.34" cy="93.65" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="1071.02" cy="190.92" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="461.99" cy="104.67" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="819.68" cy="201.93" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="210.64" cy="115.68" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,140.4 159.0,136.7 318.0,166.3 477.0,191.5 636.0,180.1 795.0,146.7 954.0,133.8 1113.0,157.9 1272.0,188.2" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="732.67" y1="163.39" x2="481.32" y2="174.4" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="77.14" x2="839.01" y2="88.15" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="174.4" x2="229.98" y2="185.41" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="839.01" y1="88.15" x2="587.66" y2="99.16" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="185.41" x2="945.35" y2="196.43" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="196.43" x2="694.0" y2="207.44" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="732.67" cy="163.39" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="1090.36" cy="77.14" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="481.32" cy="174.4" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="839.01" cy="88.15" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="229.98" cy="185.41" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="587.66" cy="99.16" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="945.35" cy="196.43" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="336.32" cy="110.17" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="694.0" cy="207.44" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E5130" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INFP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#E1F7E7" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#7BD389" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#7BD389" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#1E5130" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,179.2 90.0,218.7 180.0,227.6 270.0,194.6 360.0,161.7 450.0,170.9 540.0,210.5 630.0,230.0 720.0,204.5" fill="none" stroke="#7BD389" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="562.46" y1="254.67" x2="420.19" y2="267.84" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="217.73" y1="151.51" x2="622.66" y2="164.68" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="420.19" y1="267.84" x2="277.92" y2="281.01" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="622.66" y1="164.68" x2="480.38" y2="177.85" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="480.38" y1="177.85" x2="338.11" y2="191.02" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/><line x1="338.11" y1="191.02" x2="562.46" y2="254.67" stroke="#7BD389" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="562.46" cy="254.67" r="3" fill="#7BD389" fill-opacity="0.35"/><circle cx="217.73" cy="151.51" r="4" fill="#7BD389" fill-opacity="0.40"/><circle cx="420.19" cy="267.84" r="5" fill="#7BD389" fill-opacity="0.45"/><circle cx="622.66" cy="164.68" r="3" fill="#7BD389" fill-opacity="0.50"/><circle cx="277.92" cy="281.01" r="4" fill="#7BD389" fill-opacity="0.35"/><circle cx="480.38" cy="177.85" r="5" fill="#7BD389" fill-opacity="0.40"/><circle cx="135.65" cy="74.69" r="3" fill="#7BD389" fill-opacity="0.45"/><circle cx="338.11" cy="191.02" r="4" fill="#7BD389" fill-opacity="0.50"/><circle cx="540.58" cy="87.86" r="5" fill="#7BD389" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#7BD389" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E5130" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#1E5130" fill-opacity="0.72">INFP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#1E5130" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,179.8 159.0,191.5 318.0,166.6 477.0,136.8 636.0,140.2 795.0,172.4 954.0,192.4 1113.0,174.7 1272.0,141.8" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="268.65" y1="75.3" x2="984.02" y2="86.31" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="626.33" y1="172.57" x2="374.99" y2="183.58" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="86.31" x2="732.67" y2="97.32" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="374.99" y1="183.58" x2="1090.36" y2="194.59" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="97.32" x2="481.32" y2="108.34" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="108.34" x2="229.98" y2="119.35" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="268.65" cy="75.3" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="626.33" cy="172.57" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="984.02" cy="86.31" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="374.99" cy="183.58" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="732.67" cy="97.32" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="1090.36" cy="194.59" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="481.32" cy="108.34" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="839.01" cy="205.6" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="229.98" cy="119.35" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,405.4 94.5,331.2 189.0,297.6 283.5,347.4 378.0,417.1 472.5,417.8 567.0,348.7 661.5,297.8 756.0,330.1" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="567.6" y1="458.44" x2="418.22" y2="482.99" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="205.63" y1="266.11" x2="630.81" y2="290.66" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="418.22" y1="482.99" x2="268.83" y2="507.54" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="630.81" y1="290.66" x2="481.42" y2="315.22" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="481.42" y1="315.22" x2="332.04" y2="339.77" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="332.04" y1="339.77" x2="567.6" y2="458.44" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="567.6" cy="458.44" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="205.63" cy="266.11" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="418.22" cy="482.99" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="630.81" cy="290.66" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="268.83" cy="507.54" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="481.42" cy="315.22" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="119.45" cy="122.89" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="332.04" cy="339.77" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="544.62" cy="147.44" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,152.2 159.0,133.2 318.0,151.9 477.0,184.5 636.0,189.4 795.0,160.4 954.0,134.4 1113.0,144.7 1272.0,178.0" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="665.0" y1="150.55" x2="413.65" y2="161.56" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="64.29" x2="771.34" y2="75.3" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="413.65" y1="161.56" x2="162.31" y2="172.57" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="75.3" x2="519.99" y2="86.31" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="86.31" x2="268.65" y2="97.32" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="97.32" x2="665.0" y2="150.55" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="665.0" cy="150.55" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="1022.69" cy="64.29" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="413.65" cy="161.56" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="771.34" cy="75.3" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="162.31" cy="172.57" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="519.99" cy="86.31" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="877.68" cy="183.58" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="268.65" cy="97.32" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="626.33" cy="194.59" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,234.7 88.5,288.8 177.0,311.3 265.5,273.4 354.0,223.5 442.5,225.3 531.0,276.4 619.5,311.7 708.0,286.2" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="171.05" y1="134.02" x2="569.23" y2="151.87" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="370.14" y1="291.74" x2="230.24" y2="309.6" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="569.23" y1="151.87" x2="429.33" y2="169.73" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="230.24" y1="309.6" x2="90.34" y2="327.46" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="429.33" y1="169.73" x2="289.43" y2="187.58" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="289.43" y1="187.58" x2="149.53" y2="205.44" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="171.05" cy="134.02" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="370.14" cy="291.74" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="569.23" cy="151.87" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="230.24" cy="309.6" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="429.33" cy="169.73" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="90.34" cy="327.46" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="289.43" cy="187.58" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="488.52" cy="345.31" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="149.53" cy="205.44" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,151.7 159.0,184.4 318.0,189.5 477.0,160.6 636.0,134.5 795.0,144.5 954.0,177.9 1113.0,192.0 1272.0,168.9" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1109.69" y1="234.96" x2="858.35" y2="62.46" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="148.71" x2="249.31" y2="159.72" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="858.35" y1="62.46" x2="607.0" y2="73.47" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="159.72" x2="964.68" y2="170.73" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="170.73" x2="713.34" y2="181.74" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="181.74" x2="1109.69" y2="234.96" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1109.69" cy="234.96" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="500.66" cy="148.71" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="858.35" cy="62.46" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="249.31" cy="159.72" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="607.0" cy="73.47" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="964.68" cy="170.73" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="355.65" cy="84.48" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="713.34" cy="181.74" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="1071.02" cy="95.49" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,160.3 159.0,134.4 318.0,144.7 477.0,178.1 636.0,192.0 795.0,168.7 954.0,137.9 1113.0,138.9 1272.0,170.4" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="626.33" y1="143.2" x2="374.99" y2="154.22" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="56.95" x2="732.67" y2="67.96" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="374.99" y1="154.22" x2="1090.36" y2="165.23" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="67.96" x2="481.32" y2="78.97" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="78.97" x2="229.98" y2="89.98" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="89.98" x2="626.33" y2="143.2" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="626.33" cy="143.2" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="984.02" cy="56.95" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="374.99" cy="154.22" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="732.67" cy="67.96" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="1090.36" cy="165.23" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="481.32" cy="78.97" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="839.01" cy="176.24" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="229.98" cy="89.98" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="587.66" cy="187.25" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,161.3 90.0,193.6 180.0,227.3 270.0,219.4 360.0,180.0 450.0,159.4 540.0,183.8 630.0,222.1 720.0,225.5" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="502.27" y1="230.52" x2="360.0" y2="243.69" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="157.54" y1="127.37" x2="562.46" y2="140.54" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="360.0" y1="243.69" x2="217.73" y2="256.86" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="562.46" y1="140.54" x2="420.19" y2="153.71" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="217.73" y1="256.86" x2="622.66" y2="270.03" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="622.66" y1="270.03" x2="480.38" y2="63.72" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="502.27" cy="230.52" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="157.54" cy="127.37" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="360.0" cy="243.69" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="562.46" cy="140.54" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="217.73" cy="256.86" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="420.19" cy="153.71" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="622.66" cy="270.03" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="277.92" cy="166.88" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="480.38" cy="63.72" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,190.3 159.0,162.4 318.0,135.1 477.0,143.1 636.0,176.2 795.0,192.3 954.0,170.7 1113.0,139.1 1272.0,137.7" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="452.32" y1="110.17" x2="200.98" y2="121.18" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="207.44" x2="558.66" y2="218.45" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="200.98" y1="121.18" x2="916.35" y2="132.19" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="218.45" x2="307.32" y2="229.46" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="229.46" x2="1022.69" y2="56.95" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="56.95" x2="452.32" y2="110.17" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="452.32" cy="110.17" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="810.01" cy="207.44" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="200.98" cy="121.18" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="558.66" cy="218.45" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="916.35" cy="132.19" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="307.32" cy="229.46" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="665.0" cy="143.2" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="1022.69" cy="56.95" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="413.65" cy="154.22" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,323.4 94.5,299.4 189.0,356.5 283.5,421.9 378.0,412.1 472.5,339.7 567.0,297.0 661.5,338.4 756.0,411.2" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="102.21" y1="126.98" x2="527.39" y2="151.54" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="314.8" y1="343.86" x2="165.41" y2="368.41" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="527.39" y1="151.54" x2="378.0" y2="176.09" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="165.41" y1="368.41" x2="590.59" y2="392.96" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="378.0" y1="176.09" x2="228.61" y2="200.64" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="228.61" y1="200.64" x2="653.79" y2="225.19" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="102.21" cy="126.98" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="314.8" cy="343.86" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="527.39" cy="151.54" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="165.41" cy="368.41" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="378.0" cy="176.09" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="590.59" cy="392.96" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="228.61" cy="200.64" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="441.2" cy="417.52" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="653.79" cy="225.19" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.5 159.0,155.9 318.0,187.1 477.0,187.3 636.0,156.2 795.0,133.5 954.0,148.1 1113.0,181.5 1272.0,191.0" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="848.68" y1="185.41" x2="597.33" y2="196.43" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="239.64" y1="99.16" x2="955.02" y2="110.17" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="196.43" x2="345.98" y2="207.44" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="955.02" y1="110.17" x2="703.67" y2="121.18" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="207.44" x2="1061.36" y2="218.45" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="218.45" x2="810.01" y2="229.46" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="848.68" cy="185.41" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="239.64" cy="99.16" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="597.33" cy="196.43" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="955.02" cy="110.17" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="345.98" cy="207.44" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="703.67" cy="121.18" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="1061.36" cy="218.45" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="452.32" cy="132.19" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="810.01" cy="229.46" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,294.4 88.5,309.6 177.0,266.7 265.5,220.3 354.0,229.6 442.5,282.8 531.0,312.0 619.5,280.0 708.0,227.6" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="273.29" y1="190.56" x2="133.39" y2="208.42" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="472.38" y1="348.29" x2="332.48" y2="366.14" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="133.39" y1="208.42" x2="531.57" y2="226.27" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="332.48" y1="366.14" x2="192.58" y2="86.4" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="192.58" y1="86.4" x2="590.76" y2="104.26" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="590.76" y1="104.26" x2="273.29" y2="190.56" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="273.29" cy="190.56" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="472.38" cy="348.29" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="133.39" cy="208.42" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="332.48" cy="366.14" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="531.57" cy="226.27" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="192.58" cy="86.4" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="391.67" cy="244.13" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="590.76" cy="104.26" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="251.76" cy="261.98" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,187.0 159.0,187.4 318.0,156.4 477.0,133.6 636.0,148.0 795.0,181.3 954.0,191.0 1113.0,164.8 1272.0,136.0" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="326.65" y1="86.31" x2="1042.02" y2="97.32" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="684.34" y1="183.58" x2="432.99" y2="194.59" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="97.32" x2="790.68" y2="108.34" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="194.59" x2="181.64" y2="205.6" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="108.34" x2="539.33" y2="119.35" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="119.35" x2="287.98" y2="130.36" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="326.65" cy="86.31" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="684.34" cy="183.58" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="1042.02" cy="97.32" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="432.99" cy="194.59" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="790.68" cy="108.34" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="181.64" cy="205.6" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="539.33" cy="119.35" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="897.01" cy="216.61" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="287.98" cy="130.36" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.5 159.0,148.2 318.0,181.5 477.0,191.0 636.0,164.5 795.0,135.9 954.0,141.6 1113.0,174.3 1272.0,192.4" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="810.01" y1="178.07" x2="558.66" y2="189.08" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="200.98" y1="91.82" x2="916.35" y2="102.83" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="189.08" x2="307.32" y2="200.1" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="102.83" x2="665.0" y2="113.84" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="200.1" x2="1022.69" y2="211.11" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="211.11" x2="771.34" y2="222.12" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="810.01" cy="178.07" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="200.98" cy="91.82" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="558.66" cy="189.08" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="916.35" cy="102.83" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="307.32" cy="200.1" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="665.0" cy="113.84" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="1022.69" cy="211.11" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="413.65" cy="124.85" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="771.34" cy="222.12" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INTJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DDE1FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#6C63FF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#6C63FF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#1D1B4F" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,198.6 90.0,228.9 180.0,215.6 270.0,175.6 360.0,160.0 450.0,188.6 540.0,225.0 630.0,222.7 720.0,184.7" fill="none" stroke="#6C63FF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="606.24" y1="272.23" x2="463.97" y2="65.91" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="261.5" y1="169.07" x2="119.23" y2="182.24" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="463.97" y1="65.91" x2="321.7" y2="79.08" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="119.23" y1="182.24" x2="524.16" y2="195.41" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="524.16" y1="195.41" x2="381.89" y2="208.58" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/><line x1="381.89" y1="208.58" x2="606.24" y2="272.23" stroke="#6C63FF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="606.24" cy="272.23" r="3" fill="#6C63FF" fill-opacity="0.35"/><circle cx="261.5" cy="169.07" r="4" fill="#6C63FF" fill-opacity="0.40"/><circle cx="463.97" cy="65.91" r="5" fill="#6C63FF" fill-opacity="0.45"/><circle cx="119.23" cy="182.24" r="3" fill="#6C63FF" fill-opacity="0.50"/><circle cx="321.7" cy="79.08" r="4" fill="#6C63FF" fill-opacity="0.35"/><circle cx="524.16" cy="195.41" r="5" fill="#6C63FF" fill-opacity="0.40"/><circle cx="179.42" cy="92.25" r="3" fill="#6C63FF" fill-opacity="0.45"/><circle cx="381.89" cy="208.58" r="4" fill="#6C63FF" fill-opacity="0.50"/><circle cx="584.35" cy="105.42" r="5" fill="#6C63FF" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#6C63FF" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1D1B4F" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#1D1B4F" fill-opacity="0.72">INTJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#1D1B4F" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,188.3 159.0,186.1 318.0,154.2 477.0,133.3 636.0,150.0 795.0,183.0 954.0,190.3 1113.0,162.5 1272.0,135.1" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="326.65" y1="86.31" x2="1042.02" y2="97.32" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="684.34" y1="183.58" x2="432.99" y2="194.59" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="97.32" x2="790.68" y2="108.34" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="194.59" x2="181.64" y2="205.6" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="108.34" x2="539.33" y2="119.35" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="119.35" x2="287.98" y2="130.36" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="326.65" cy="86.31" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="684.34" cy="183.58" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="1042.02" cy="97.32" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="432.99" cy="194.59" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="790.68" cy="108.34" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="181.64" cy="205.6" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="539.33" cy="119.35" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="897.01" cy="216.61" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="287.98" cy="130.36" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,380.9 94.5,310.3 189.0,306.9 283.5,375.1 378.0,427.9 472.5,397.9 567.0,323.4 661.5,299.4 756.0,356.5" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="602.08" y1="482.99" x2="452.69" y2="507.54" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="240.11" y1="290.66" x2="90.72" y2="315.22" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="452.69" y1="507.54" x2="303.31" y2="122.89" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="90.72" y1="315.22" x2="515.89" y2="339.77" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="515.89" y1="339.77" x2="366.51" y2="364.32" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="366.51" y1="364.32" x2="602.08" y2="482.99" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="602.08" cy="482.99" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="240.11" cy="290.66" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="452.69" cy="507.54" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="90.72" cy="315.22" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="303.31" cy="122.89" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="515.89" cy="339.77" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="153.92" cy="147.44" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="366.51" cy="364.32" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="579.1" cy="172.0" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#0D284D" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,141.8 159.0,135.7 318.0,164.2 477.0,190.9 636.0,181.7 795.0,148.5 954.0,133.5 1113.0,155.9 1272.0,187.1" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="723.0" y1="161.56" x2="471.66" y2="172.57" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="75.3" x2="829.34" y2="86.31" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="471.66" y1="172.57" x2="220.31" y2="183.58" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="86.31" x2="578.0" y2="97.32" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="97.32" x2="326.65" y2="108.34" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="108.34" x2="723.0" y2="161.56" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="723.0" cy="161.56" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="1080.69" cy="75.3" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="471.66" cy="172.57" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="829.34" cy="86.31" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="220.31" cy="183.58" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="578.0" cy="97.32" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="935.68" cy="194.59" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="326.65" cy="108.34" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="684.34" cy="205.6" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,252.9 88.5,303.5 177.0,303.7 265.5,253.3 354.0,216.5 442.5,240.3 531.0,294.3 619.5,309.7 708.0,266.8" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="203.34" y1="151.87" x2="601.52" y2="169.73" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="402.43" y1="309.6" x2="262.53" y2="327.46" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="601.52" y1="169.73" x2="461.62" y2="187.58" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="262.53" y1="327.46" x2="122.63" y2="345.31" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="461.62" y1="187.58" x2="321.72" y2="205.44" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="321.72" y1="205.44" x2="181.81" y2="223.3" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="203.34" cy="151.87" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="402.43" cy="309.6" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="601.52" cy="169.73" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="262.53" cy="327.46" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="461.62" cy="187.58" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="122.63" cy="345.31" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="321.72" cy="205.44" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="520.8" cy="363.17" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="181.81" cy="223.3" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#0D284D" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,164.0 159.0,190.8 318.0,181.9 477.0,148.6 636.0,133.4 795.0,155.7 954.0,187.0 1113.0,187.5 1272.0,156.5" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="200.98" y1="62.46" x2="916.35" y2="73.47" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="159.72" x2="307.32" y2="170.73" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="73.47" x2="665.0" y2="84.48" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="170.73" x2="1022.69" y2="181.74" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="181.74" x2="771.34" y2="192.76" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="192.76" x2="200.98" y2="62.46" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="200.98" cy="62.46" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="558.66" cy="159.72" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="916.35" cy="73.47" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="307.32" cy="170.73" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="665.0" cy="84.48" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="1022.69" cy="181.74" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="413.65" cy="95.49" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="771.34" cy="192.76" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="162.31" cy="106.5" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,148.4 159.0,133.5 318.0,155.9 477.0,187.1 636.0,187.3 795.0,156.2 954.0,133.5 1113.0,148.1 1272.0,181.5" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="684.34" y1="154.22" x2="432.99" y2="165.23" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="67.96" x2="790.68" y2="78.97" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="432.99" y1="165.23" x2="181.64" y2="176.24" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="78.97" x2="539.33" y2="89.98" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="89.98" x2="287.98" y2="101.0" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="101.0" x2="684.34" y2="154.22" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="684.34" cy="154.22" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="1042.02" cy="67.96" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="432.99" cy="165.23" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="790.68" cy="78.97" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="181.64" cy="176.24" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="539.33" cy="89.98" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="897.01" cy="187.25" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="287.98" cy="101.0" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="645.67" cy="198.26" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,169.1 90.0,208.2 180.0,230.1 270.0,206.8 360.0,168.1 450.0,163.3 540.0,198.6 630.0,228.9 720.0,215.6" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="535.1" y1="243.69" x2="392.83" y2="256.86" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="190.37" y1="140.54" x2="595.3" y2="153.71" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="392.83" y1="256.86" x2="250.56" y2="270.03" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="595.3" y1="153.71" x2="453.02" y2="166.88" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="250.56" y1="270.03" x2="108.29" y2="63.72" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="108.29" y1="63.72" x2="513.22" y2="76.89" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="535.1" cy="243.69" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="190.37" cy="140.54" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="392.83" cy="256.86" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="595.3" cy="153.71" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="250.56" cy="270.03" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="453.02" cy="166.88" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="108.29" cy="63.72" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="310.75" cy="180.04" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="513.22" cy="76.89" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#0D284D" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,183.3 159.0,150.3 318.0,133.3 477.0,153.9 636.0,185.9 795.0,188.4 954.0,158.3 1113.0,133.9 1272.0,146.4" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="510.33" y1="121.18" x2="258.98" y2="132.19" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="218.45" x2="616.67" y2="229.46" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="132.19" x2="974.35" y2="143.2" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="229.46" x2="365.32" y2="56.95" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="56.95" x2="1080.69" y2="67.96" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="67.96" x2="510.33" y2="121.18" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="510.33" cy="121.18" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="868.01" cy="218.45" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="258.98" cy="132.19" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="616.67" cy="229.46" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="974.35" cy="143.2" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="365.32" cy="56.95" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="723.0" cy="154.22" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="1080.69" cy="67.96" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="471.66" cy="165.23" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,305.2 94.5,312.4 189.0,384.1 283.5,428.9 378.0,389.7 472.5,316.4 567.0,302.6 661.5,365.8 756.0,425.5" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="136.68" y1="151.54" x2="561.86" y2="176.09" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="349.27" y1="368.41" x2="199.89" y2="392.96" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="561.86" y1="176.09" x2="412.47" y2="200.64" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="199.89" y1="392.96" x2="625.06" y2="417.52" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="412.47" y1="200.64" x2="263.09" y2="225.19" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="263.09" y1="225.19" x2="113.7" y2="249.74" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="136.68" cy="151.54" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="349.27" cy="368.41" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="561.86" cy="176.09" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="199.89" cy="392.96" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="412.47" cy="200.64" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="625.06" cy="417.52" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="263.09" cy="225.19" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="475.68" cy="442.07" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="113.7" cy="249.74" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#0D284D" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,137.7 159.0,168.3 318.0,191.9 477.0,178.4 636.0,145.0 795.0,134.3 954.0,160.0 1113.0,189.3 1272.0,184.8" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="906.68" y1="196.43" x2="655.33" y2="207.44" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="297.65" y1="110.17" x2="1013.02" y2="121.18" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="207.44" x2="403.99" y2="218.45" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1013.02" y1="121.18" x2="761.67" y2="132.19" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="218.45" x2="152.64" y2="229.46" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="152.64" y1="229.46" x2="868.01" y2="56.95" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="906.68" cy="196.43" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="297.65" cy="110.17" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="655.33" cy="207.44" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="1013.02" cy="121.18" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="403.99" cy="218.45" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="761.67" cy="132.19" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="152.64" cy="229.46" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="510.33" cy="143.2" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="868.01" cy="56.95" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,307.0 88.5,299.5 177.0,246.8 265.5,216.0 354.0,246.4 442.5,299.3 531.0,307.1 619.5,260.0 708.0,218.0" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="305.57" y1="208.42" x2="165.67" y2="226.27" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="504.66" y1="366.14" x2="364.76" y2="86.4" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="165.67" y1="226.27" x2="563.85" y2="244.13" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="364.76" y1="86.4" x2="224.86" y2="104.26" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="224.86" y1="104.26" x2="84.96" y2="122.11" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="84.96" y1="122.11" x2="305.57" y2="208.42" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="305.57" cy="208.42" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="504.66" cy="366.14" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="165.67" cy="226.27" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="364.76" cy="86.4" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="563.85" cy="244.13" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="224.86" cy="104.26" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="423.95" cy="261.98" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="84.96" cy="122.11" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="284.05" cy="279.84" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#0D284D" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,191.9 159.0,178.5 318.0,145.1 477.0,134.3 636.0,159.8 795.0,189.2 954.0,184.9 1113.0,152.5 1272.0,133.2" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="384.65" y1="97.32" x2="1100.03" y2="108.34" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="742.34" y1="194.59" x2="490.99" y2="205.6" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="108.34" x2="848.68" y2="119.35" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="490.99" y1="205.6" x2="239.64" y2="216.61" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="119.35" x2="597.33" y2="130.36" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="130.36" x2="345.98" y2="141.37" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="384.65" cy="97.32" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="742.34" cy="194.59" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="1100.03" cy="108.34" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="490.99" cy="205.6" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="848.68" cy="119.35" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="239.64" cy="216.61" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="597.33" cy="130.36" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="955.02" cy="227.62" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="345.98" cy="141.37" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,134.3 159.0,160.0 318.0,189.3 477.0,184.8 636.0,152.2 795.0,133.2 954.0,151.9 1113.0,184.5 1272.0,189.4" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="868.01" y1="189.08" x2="616.67" y2="200.1" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="258.98" y1="102.83" x2="974.35" y2="113.84" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="200.1" x2="365.32" y2="211.11" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="974.35" y1="113.84" x2="723.0" y2="124.85" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="211.11" x2="1080.69" y2="222.12" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="222.12" x2="829.34" y2="233.13" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="868.01" cy="189.08" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="258.98" cy="102.83" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="616.67" cy="200.1" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="974.35" cy="113.84" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="365.32" cy="211.11" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="723.0" cy="124.85" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="1080.69" cy="222.12" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="471.66" cy="135.86" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="829.34" cy="233.13" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0D284D" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">INTP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the INTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D9E9FF" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#4F8BFF" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#4F8BFF" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#0D284D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,212.7 90.0,229.6 180.0,202.0 270.0,165.1 360.0,165.9 450.0,203.5 540.0,229.8 630.0,211.4 720.0,171.6" fill="none" stroke="#4F8BFF" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="91.87" y1="65.91" x2="496.8" y2="79.08" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="294.34" y1="182.24" x2="152.06" y2="195.41" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="496.8" y1="79.08" x2="354.53" y2="92.25" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="152.06" y1="195.41" x2="556.99" y2="208.58" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="556.99" y1="208.58" x2="414.72" y2="221.75" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/><line x1="414.72" y1="221.75" x2="91.87" y2="65.91" stroke="#4F8BFF" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="91.87" cy="65.91" r="3" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="294.34" cy="182.24" r="4" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="496.8" cy="79.08" r="5" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="152.06" cy="195.41" r="3" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="354.53" cy="92.25" r="4" fill="#4F8BFF" fill-opacity="0.35"/><circle cx="556.99" cy="208.58" r="5" fill="#4F8BFF" fill-opacity="0.40"/><circle cx="212.26" cy="105.42" r="3" fill="#4F8BFF" fill-opacity="0.45"/><circle cx="414.72" cy="221.75" r="4" fill="#4F8BFF" fill-opacity="0.50"/><circle cx="617.18" cy="118.59" r="5" fill="#4F8BFF" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#4F8BFF" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0D284D" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#0D284D" fill-opacity="0.72">INTP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#0D284D" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,162.1 159.0,190.1 318.0,183.3 477.0,150.3 636.0,133.3 795.0,153.9 954.0,185.9 1113.0,188.4 1272.0,158.3" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="181.64" y1="58.79" x2="897.01" y2="69.8" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="156.05" x2="287.98" y2="167.06" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="897.01" y1="69.8" x2="645.67" y2="80.81" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="167.06" x2="1003.35" y2="178.07" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="178.07" x2="752.01" y2="189.08" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="189.08" x2="181.64" y2="58.79" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="181.64" cy="58.79" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="539.33" cy="156.05" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="897.01" cy="69.8" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="287.98" cy="167.06" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="645.67" cy="80.81" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="1003.35" cy="178.07" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="394.32" cy="91.82" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="752.01" cy="189.08" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="1109.69" cy="102.83" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,427.1 94.5,371.7 189.0,305.2 283.5,312.4 378.0,384.1 472.5,428.9 567.0,389.7 661.5,316.4 756.0,302.6" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="515.89" y1="421.61" x2="366.51" y2="446.16" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="153.92" y1="229.28" x2="579.1" y2="253.84" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="366.51" y1="446.16" x2="217.12" y2="470.71" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="579.1" y1="253.84" x2="429.71" y2="278.39" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="217.12" y1="470.71" x2="642.3" y2="495.26" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="642.3" y1="495.26" x2="492.91" y2="519.82" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="515.89" cy="421.61" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="153.92" cy="229.28" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="366.51" cy="446.16" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="579.1" cy="253.84" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="217.12" cy="470.71" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="429.71" cy="278.39" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="642.3" cy="495.26" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="280.32" cy="302.94" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="492.91" cy="519.82" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#143B31" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,170.7 159.0,139.1 318.0,137.7 477.0,168.3 636.0,191.9 795.0,178.4 954.0,145.0 1113.0,134.3 1272.0,160.0" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="578.0" y1="134.03" x2="326.65" y2="145.04" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="935.68" y1="231.29" x2="684.34" y2="58.79" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="145.04" x2="1042.02" y2="156.05" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="684.34" y1="58.79" x2="432.99" y2="69.8" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="1042.02" y1="156.05" x2="790.68" y2="167.06" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="167.06" x2="539.33" y2="178.07" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="578.0" cy="134.03" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="935.68" cy="231.29" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="326.65" cy="145.04" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="684.34" cy="58.79" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="1042.02" cy="156.05" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="432.99" cy="69.8" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="790.68" cy="167.06" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="181.64" cy="80.81" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="539.33" cy="178.07" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,217.9 88.5,259.6 177.0,307.0 265.5,299.5 354.0,246.8 442.5,216.0 531.0,246.4 619.5,299.3 708.0,307.1" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="122.63" y1="107.23" x2="520.8" y2="125.09" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="321.72" y1="264.96" x2="181.81" y2="282.82" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="520.8" y1="125.09" x2="380.9" y2="142.94" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="181.81" y1="282.82" x2="579.99" y2="300.67" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="579.99" y1="300.67" x2="440.09" y2="318.53" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="440.09" y1="318.53" x2="122.63" y2="107.23" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="122.63" cy="107.23" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="321.72" cy="264.96" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="520.8" cy="125.09" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="181.81" cy="282.82" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="380.9" cy="142.94" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="579.99" cy="300.67" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="241.0" cy="160.8" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="440.09" cy="318.53" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="101.1" cy="178.66" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#143B31" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,137.6 159.0,168.2 318.0,191.9 477.0,178.5 636.0,145.1 795.0,134.3 954.0,159.8 1113.0,189.2 1272.0,184.9" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1022.69" y1="218.45" x2="771.34" y2="229.46" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="413.65" y1="132.19" x2="162.31" y2="143.2" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="229.46" x2="519.99" y2="56.95" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="162.31" y1="143.2" x2="877.68" y2="154.22" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="56.95" x2="268.65" y2="67.96" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="67.96" x2="984.02" y2="78.97" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1022.69" cy="218.45" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="413.65" cy="132.19" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="771.34" cy="229.46" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="162.31" cy="143.2" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="519.99" cy="56.95" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="877.68" cy="154.22" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="268.65" cy="67.96" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="626.33" cy="165.23" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="984.02" cy="78.97" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,178.3 159.0,144.9 318.0,134.3 477.0,160.0 636.0,189.3 795.0,184.8 954.0,152.2 1113.0,133.2 1272.0,151.9" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="539.33" y1="126.69" x2="287.98" y2="137.7" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="897.01" y1="223.95" x2="645.67" y2="234.96" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="137.7" x2="1003.35" y2="148.71" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="645.67" y1="234.96" x2="394.32" y2="62.46" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="148.71" x2="752.01" y2="159.72" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="159.72" x2="500.66" y2="170.73" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="539.33" cy="126.69" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="897.01" cy="223.95" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="287.98" cy="137.7" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="645.67" cy="234.96" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="1003.35" cy="148.71" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="394.32" cy="62.46" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="752.01" cy="159.72" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="1109.69" cy="73.47" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="500.66" cy="170.73" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISFJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,160.8 90.0,172.8 180.0,212.7 270.0,229.6 360.0,202.0 450.0,165.1 540.0,165.9 630.0,203.5 720.0,229.8" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="453.02" y1="210.77" x2="310.75" y2="223.94" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="108.29" y1="107.62" x2="513.22" y2="120.78" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="310.75" y1="223.94" x2="168.48" y2="237.11" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="513.22" y1="120.78" x2="370.94" y2="133.95" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="370.94" y1="133.95" x2="228.67" y2="147.12" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="228.67" y1="147.12" x2="453.02" y2="210.77" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="453.02" cy="210.77" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="108.29" cy="107.62" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="310.75" cy="223.94" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="513.22" cy="120.78" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="168.48" cy="237.11" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="370.94" cy="133.95" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="573.41" cy="250.28" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="228.67" cy="147.12" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="431.14" cy="263.45" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#143B31" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,191.5 159.0,180.1 318.0,146.7 477.0,133.8 636.0,158.0 795.0,188.3 954.0,186.1 1113.0,154.2 1272.0,133.3" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="365.32" y1="93.65" x2="1080.69" y2="104.67" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="723.0" y1="190.92" x2="471.66" y2="201.93" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="104.67" x2="829.34" y2="115.68" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="471.66" y1="201.93" x2="220.31" y2="212.94" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="115.68" x2="578.0" y2="126.69" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="126.69" x2="326.65" y2="137.7" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="365.32" cy="93.65" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="723.0" cy="190.92" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="1080.69" cy="104.67" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="471.66" cy="201.93" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="829.34" cy="115.68" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="220.31" cy="212.94" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="578.0" cy="126.69" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="935.68" cy="223.95" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="326.65" cy="137.7" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,362.5 94.5,301.3 189.0,318.8 283.5,392.7 378.0,428.7 472.5,380.9 567.0,310.3 661.5,306.9 756.0,375.0" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="625.06" y1="499.36" x2="475.68" y2="523.91" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="263.09" y1="307.03" x2="113.7" y2="331.58" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="475.68" y1="523.91" x2="326.29" y2="139.26" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="113.7" y1="331.58" x2="538.88" y2="356.14" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="538.88" y1="356.14" x2="389.49" y2="380.69" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="389.49" y1="380.69" x2="625.06" y2="499.36" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="625.06" cy="499.36" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="263.09" cy="307.03" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="475.68" cy="523.91" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="113.7" cy="331.58" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="326.29" cy="139.26" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="538.88" cy="356.14" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="176.9" cy="163.81" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="389.49" cy="380.69" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="602.08" cy="188.36" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#143B31" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,136.8 159.0,140.2 318.0,172.4 477.0,192.4 636.0,174.7 795.0,141.8 954.0,135.7 1113.0,164.2 1272.0,190.9" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="761.67" y1="168.9" x2="510.33" y2="179.91" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="152.64" y1="82.64" x2="868.01" y2="93.65" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="510.33" y1="179.91" x2="258.98" y2="190.92" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="93.65" x2="616.67" y2="104.67" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="616.67" y1="104.67" x2="365.32" y2="115.68" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="365.32" y1="115.68" x2="761.67" y2="168.9" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="761.67" cy="168.9" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="152.64" cy="82.64" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="510.33" cy="179.91" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="868.01" cy="93.65" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="258.98" cy="190.92" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="616.67" cy="104.67" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="974.35" cy="201.93" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="365.32" cy="115.68" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="723.0" cy="212.94" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,266.4 88.5,309.5 177.0,294.6 265.5,240.6 354.0,216.5 442.5,252.9 531.0,303.5 619.5,303.7 708.0,253.3" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="224.86" y1="163.78" x2="84.96" y2="181.63" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="423.95" y1="321.5" x2="284.05" y2="339.36" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="84.96" y1="181.63" x2="483.14" y2="199.49" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="284.05" y1="339.36" x2="144.15" y2="357.22" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="483.14" y1="199.49" x2="343.24" y2="217.34" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="343.24" y1="217.34" x2="203.34" y2="235.2" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="224.86" cy="163.78" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="423.95" cy="321.5" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="84.96" cy="181.63" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="284.05" cy="339.36" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="483.14" cy="199.49" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="144.15" cy="357.22" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="343.24" cy="217.34" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="542.33" cy="375.07" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="203.34" cy="235.2" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#143B31" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,172.2 159.0,192.4 318.0,174.8 477.0,142.0 636.0,135.7 795.0,164.0 954.0,190.8 1113.0,181.9 1272.0,148.7" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="239.64" y1="69.8" x2="955.02" y2="80.81" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="167.06" x2="345.98" y2="178.07" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="955.02" y1="80.81" x2="703.67" y2="91.82" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="178.07" x2="1061.36" y2="189.08" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="189.08" x2="810.01" y2="200.1" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="200.1" x2="239.64" y2="69.8" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="239.64" cy="69.8" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="597.33" cy="167.06" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="955.02" cy="80.81" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="345.98" cy="178.07" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="703.67" cy="91.82" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="1061.36" cy="189.08" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="452.32" cy="102.83" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="810.01" cy="200.1" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="200.98" cy="113.84" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,141.8 159.0,135.7 318.0,164.2 477.0,190.9 636.0,181.7 795.0,148.5 954.0,133.5 1113.0,155.9 1272.0,187.1" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="723.0" y1="161.56" x2="471.66" y2="172.57" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="1080.69" y1="75.3" x2="829.34" y2="86.31" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="471.66" y1="172.57" x2="220.31" y2="183.58" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="86.31" x2="578.0" y2="97.32" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="97.32" x2="326.65" y2="108.34" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="108.34" x2="723.0" y2="161.56" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="723.0" cy="161.56" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="1080.69" cy="75.3" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="471.66" cy="172.57" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="829.34" cy="86.31" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="220.31" cy="183.58" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="578.0" cy="97.32" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="935.68" cy="194.59" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="326.65" cy="108.34" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="684.34" cy="205.6" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#143B31" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISFJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISFJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DEF3EC" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#43AA8B" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#43AA8B" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#143B31" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,177.0 90.0,216.8 180.0,228.5 270.0,197.1 360.0,162.6 450.0,169.1 540.0,208.2 630.0,230.1 720.0,206.8" fill="none" stroke="#43AA8B" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="556.99" y1="252.47" x2="414.72" y2="265.64" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="212.26" y1="149.32" x2="617.18" y2="162.49" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="414.72" y1="265.64" x2="272.45" y2="278.81" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="617.18" y1="162.49" x2="474.91" y2="175.65" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="272.45" y1="278.81" x2="130.18" y2="72.5" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/><line x1="130.18" y1="72.5" x2="535.1" y2="85.67" stroke="#43AA8B" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="556.99" cy="252.47" r="3" fill="#43AA8B" fill-opacity="0.35"/><circle cx="212.26" cy="149.32" r="4" fill="#43AA8B" fill-opacity="0.40"/><circle cx="414.72" cy="265.64" r="5" fill="#43AA8B" fill-opacity="0.45"/><circle cx="617.18" cy="162.49" r="3" fill="#43AA8B" fill-opacity="0.50"/><circle cx="272.45" cy="278.81" r="4" fill="#43AA8B" fill-opacity="0.35"/><circle cx="474.91" cy="175.65" r="5" fill="#43AA8B" fill-opacity="0.40"/><circle cx="130.18" cy="72.5" r="3" fill="#43AA8B" fill-opacity="0.45"/><circle cx="332.64" cy="188.82" r="4" fill="#43AA8B" fill-opacity="0.50"/><circle cx="535.1" cy="85.67" r="5" fill="#43AA8B" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#43AA8B" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#143B31" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#143B31" fill-opacity="0.72">ISFJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#143B31" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,174.4 159.0,192.4 318.0,172.7 477.0,140.4 636.0,136.7 795.0,166.3 954.0,191.5 1113.0,180.1 1272.0,146.7" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="239.64" y1="69.8" x2="955.02" y2="80.81" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="597.33" y1="167.06" x2="345.98" y2="178.07" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="955.02" y1="80.81" x2="703.67" y2="91.82" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="178.07" x2="1061.36" y2="189.08" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="189.08" x2="810.01" y2="200.1" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="200.1" x2="239.64" y2="69.8" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="239.64" cy="69.8" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="597.33" cy="167.06" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="955.02" cy="80.81" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="345.98" cy="178.07" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="703.67" cy="91.82" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="1061.36" cy="189.08" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="452.32" cy="102.83" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="810.01" cy="200.1" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="200.98" cy="113.84" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,415.1 94.5,344.1 189.0,297.2 283.5,334.2 378.0,407.9 472.5,424.3 567.0,362.5 661.5,301.3 756.0,318.8" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="550.37" y1="446.16" x2="400.98" y2="470.71" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="188.4" y1="253.84" x2="613.57" y2="278.39" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="400.98" y1="470.71" x2="251.6" y2="495.26" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="613.57" y1="278.39" x2="464.18" y2="302.94" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="251.6" y1="495.26" x2="102.21" y2="519.82" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="102.21" y1="519.82" x2="527.39" y2="135.17" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="550.37" cy="446.16" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="188.4" cy="253.84" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="400.98" cy="470.71" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="613.57" cy="278.39" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="251.6" cy="495.26" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="464.18" cy="302.94" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="102.21" cy="519.82" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="314.8" cy="327.49" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="527.39" cy="135.17" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#2C421D" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,158.3 159.0,133.9 318.0,146.4 477.0,179.8 636.0,191.5 795.0,166.6 954.0,136.8 1113.0,140.2 1272.0,172.4" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="636.0" y1="145.04" x2="384.65" y2="156.05" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="993.69" y1="58.79" x2="742.34" y2="69.8" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="156.05" x2="1100.03" y2="167.06" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="742.34" y1="69.8" x2="490.99" y2="80.81" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="1100.03" y1="167.06" x2="848.68" y2="178.07" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="848.68" y1="178.07" x2="597.33" y2="189.08" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="636.0" cy="145.04" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="993.69" cy="58.79" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="384.65" cy="156.05" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="742.34" cy="69.8" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="1100.03" cy="167.06" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="490.99" cy="80.81" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="848.68" cy="178.07" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="239.64" cy="91.82" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="597.33" cy="189.08" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,227.4 88.5,279.7 177.0,312.0 265.5,283.1 354.0,229.9 442.5,220.2 531.0,266.3 619.5,309.5 708.0,294.7" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="154.91" y1="125.09" x2="553.09" y2="142.94" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="354.0" y1="282.82" x2="214.1" y2="300.67" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="553.09" y1="142.94" x2="413.19" y2="160.8" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="214.1" y1="300.67" x2="612.28" y2="318.53" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="612.28" y1="318.53" x2="472.38" y2="336.38" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="472.38" y1="336.38" x2="154.91" y2="125.09" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="154.91" cy="125.09" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="354.0" cy="282.82" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="553.09" cy="142.94" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="214.1" cy="300.67" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="413.19" cy="160.8" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="612.28" cy="318.53" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="273.29" cy="178.66" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="472.38" cy="336.38" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="133.39" cy="196.51" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#2C421D" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,146.2 159.0,179.6 318.0,191.6 477.0,166.8 636.0,136.9 795.0,140.0 954.0,172.2 1113.0,192.4 1272.0,174.9" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="1080.69" y1="229.46" x2="829.34" y2="56.95" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="471.66" y1="143.2" x2="220.31" y2="154.22" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="829.34" y1="56.95" x2="578.0" y2="67.96" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="220.31" y1="154.22" x2="935.68" y2="165.23" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="578.0" y1="67.96" x2="326.65" y2="78.97" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="326.65" y1="78.97" x2="1042.02" y2="89.98" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="1080.69" cy="229.46" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="471.66" cy="143.2" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="829.34" cy="56.95" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="220.31" cy="154.22" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="578.0" cy="67.96" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="935.68" cy="165.23" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="326.65" cy="78.97" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="684.34" cy="176.24" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="1042.02" cy="89.98" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,166.6 159.0,136.8 318.0,140.2 477.0,172.4 636.0,192.4 795.0,174.7 954.0,141.8 1113.0,135.7 1272.0,164.2" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="597.33" y1="137.7" x2="345.98" y2="148.71" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="955.02" y1="234.96" x2="703.67" y2="62.46" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="148.71" x2="1061.36" y2="159.72" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="703.67" y1="62.46" x2="452.32" y2="73.47" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="159.72" x2="810.01" y2="170.73" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="170.73" x2="558.66" y2="181.74" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="597.33" cy="137.7" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="955.02" cy="234.96" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="345.98" cy="148.71" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="703.67" cy="62.46" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="1061.36" cy="159.72" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="452.32" cy="73.47" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="810.01" cy="170.73" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="200.98" cy="84.48" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="558.66" cy="181.74" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISFP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,159.6 90.0,186.2 180.0,223.6 270.0,224.2 360.0,187.1 450.0,159.7 540.0,176.9 630.0,216.8 720.0,228.5" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="485.86" y1="223.94" x2="343.58" y2="237.11" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="141.12" y1="120.78" x2="546.05" y2="133.95" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="343.58" y1="237.11" x2="201.31" y2="250.28" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="546.05" y1="133.95" x2="403.78" y2="147.12" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="403.78" y1="147.12" x2="261.5" y2="160.29" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="261.5" y1="160.29" x2="485.86" y2="223.94" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="485.86" cy="223.94" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="141.12" cy="120.78" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="343.58" cy="237.11" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="546.05" cy="133.95" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="201.31" cy="250.28" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="403.78" cy="147.12" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="606.24" cy="263.45" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="261.5" cy="160.29" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="463.97" cy="276.62" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#2C421D" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,192.0 159.0,168.7 318.0,137.9 477.0,138.9 636.0,170.4 795.0,192.2 954.0,176.5 1113.0,143.3 1272.0,135.0" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="423.32" y1="104.67" x2="171.97" y2="115.68" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="781.01" y1="201.93" x2="529.66" y2="212.94" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="115.68" x2="887.35" y2="126.69" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="529.66" y1="212.94" x2="278.31" y2="223.95" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="126.69" x2="636.0" y2="137.7" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="137.7" x2="384.65" y2="148.71" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="423.32" cy="104.67" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="781.01" cy="201.93" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="171.97" cy="115.68" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="529.66" cy="212.94" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="887.35" cy="126.69" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="278.31" cy="223.95" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="636.0" cy="137.7" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="993.69" cy="234.96" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="384.65" cy="148.71" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,335.4 94.5,297.1 189.0,342.9 283.5,414.3 378.0,420.3 472.5,353.2 567.0,298.6 661.5,326.1 756.0,400.6" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="659.53" y1="523.91" x2="510.15" y2="139.26" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="297.56" y1="331.58" x2="148.18" y2="356.14" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="510.15" y1="139.26" x2="360.76" y2="163.81" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="148.18" y1="356.14" x2="573.35" y2="380.69" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="573.35" y1="380.69" x2="423.96" y2="405.24" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="423.96" y1="405.24" x2="659.53" y2="523.91" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="659.53" cy="523.91" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="297.56" cy="331.58" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="510.15" cy="139.26" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="148.18" cy="356.14" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="360.76" cy="163.81" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="573.35" cy="380.69" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="211.38" cy="188.36" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="423.96" cy="405.24" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="636.55" cy="212.92" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#2C421D" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.3 159.0,150.0 318.0,183.0 477.0,190.3 636.0,162.5 795.0,135.1 954.0,143.1 1113.0,176.2 1272.0,192.3" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="819.68" y1="179.91" x2="568.33" y2="190.92" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="210.64" y1="93.65" x2="926.02" y2="104.67" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="568.33" y1="190.92" x2="316.98" y2="201.93" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="104.67" x2="674.67" y2="115.68" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="115.68" x2="423.32" y2="126.69" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="126.69" x2="819.68" y2="179.91" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="819.68" cy="179.91" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="210.64" cy="93.65" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="568.33" cy="190.92" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="926.02" cy="104.67" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="316.98" cy="201.93" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="674.67" cy="115.68" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="1032.36" cy="212.94" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="423.32" cy="126.69" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="781.01" cy="223.95" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,285.9 88.5,311.7 177.0,276.7 265.5,225.5 354.0,223.4 442.5,273.1 531.0,311.2 619.5,289.1 708.0,235.0" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="257.15" y1="181.63" x2="117.24" y2="199.49" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="456.24" y1="339.36" x2="316.33" y2="357.22" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="117.24" y1="199.49" x2="515.42" y2="217.34" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="316.33" y1="357.22" x2="176.43" y2="375.07" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="515.42" y1="217.34" x2="375.52" y2="235.2" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="375.52" y1="235.2" x2="235.62" y2="253.06" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="257.15" cy="181.63" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="456.24" cy="339.36" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="117.24" cy="199.49" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="316.33" cy="357.22" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="515.42" cy="217.34" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="176.43" cy="375.07" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="375.52" cy="235.2" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="574.61" cy="95.33" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="235.62" cy="253.06" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#2C421D" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,182.9 159.0,190.3 318.0,162.7 477.0,135.2 636.0,142.9 795.0,176.0 954.0,192.3 1113.0,170.9 1272.0,139.2" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="297.65" y1="80.81" x2="1013.02" y2="91.82" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="178.07" x2="403.99" y2="189.08" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="1013.02" y1="91.82" x2="761.67" y2="102.83" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="189.08" x2="152.64" y2="200.1" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="152.64" y1="200.1" x2="868.01" y2="211.11" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="868.01" y1="211.11" x2="297.65" y2="80.81" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="297.65" cy="80.81" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="655.33" cy="178.07" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="1013.02" cy="91.82" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="403.99" cy="189.08" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="761.67" cy="102.83" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="152.64" cy="200.1" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="510.33" cy="113.84" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="868.01" cy="211.11" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="258.98" cy="124.85" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,135.1 159.0,143.1 318.0,176.2 477.0,192.3 636.0,170.7 795.0,139.1 954.0,137.7 1113.0,168.3 1272.0,191.9" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="781.01" y1="172.57" x2="529.66" y2="183.58" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="86.31" x2="887.35" y2="97.32" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="529.66" y1="183.58" x2="278.31" y2="194.59" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="97.32" x2="636.0" y2="108.34" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="636.0" y1="108.34" x2="384.65" y2="119.35" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="384.65" y1="119.35" x2="781.01" y2="172.57" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="781.01" cy="172.57" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="171.97" cy="86.31" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="529.66" cy="183.58" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="887.35" cy="97.32" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="278.31" cy="194.59" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="636.0" cy="108.34" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="993.69" cy="205.6" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="384.65" cy="119.35" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="742.34" cy="216.61" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#2C421D" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISFP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISFP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#EAF7DD" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#90BE6D" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#90BE6D" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#2C421D" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,191.1 90.0,226.2 180.0,221.1 270.0,182.3 360.0,159.3 450.0,181.4 540.0,220.5 630.0,226.7 720.0,192.1" fill="none" stroke="#90BE6D" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="589.82" y1="265.64" x2="447.55" y2="278.81" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="245.09" y1="162.49" x2="102.82" y2="175.65" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="447.55" y1="278.81" x2="305.28" y2="72.5" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="102.82" y1="175.65" x2="507.74" y2="188.82" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="305.28" y1="72.5" x2="163.01" y2="85.67" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/><line x1="163.01" y1="85.67" x2="567.94" y2="98.84" stroke="#90BE6D" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="589.82" cy="265.64" r="3" fill="#90BE6D" fill-opacity="0.35"/><circle cx="245.09" cy="162.49" r="4" fill="#90BE6D" fill-opacity="0.40"/><circle cx="447.55" cy="278.81" r="5" fill="#90BE6D" fill-opacity="0.45"/><circle cx="102.82" cy="175.65" r="3" fill="#90BE6D" fill-opacity="0.50"/><circle cx="305.28" cy="72.5" r="4" fill="#90BE6D" fill-opacity="0.35"/><circle cx="507.74" cy="188.82" r="5" fill="#90BE6D" fill-opacity="0.40"/><circle cx="163.01" cy="85.67" r="3" fill="#90BE6D" fill-opacity="0.45"/><circle cx="365.47" cy="201.99" r="4" fill="#90BE6D" fill-opacity="0.50"/><circle cx="567.94" cy="98.84" r="5" fill="#90BE6D" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#90BE6D" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#2C421D" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#2C421D" fill-opacity="0.72">ISFP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#2C421D" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,187.1 159.0,187.3 318.0,156.2 477.0,133.5 636.0,148.2 795.0,181.5 954.0,191.0 1113.0,164.5 1272.0,135.9" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="316.98" y1="84.48" x2="1032.36" y2="95.49" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="674.67" y1="181.74" x2="423.32" y2="192.76" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="1032.36" y1="95.49" x2="781.01" y2="106.5" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="192.76" x2="171.97" y2="203.77" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="203.77" x2="887.35" y2="214.78" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="214.78" x2="316.98" y2="84.48" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="316.98" cy="84.48" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="674.67" cy="181.74" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="1032.36" cy="95.49" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="423.32" cy="192.76" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="781.01" cy="106.5" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="171.97" cy="203.77" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="529.66" cy="117.51" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="887.35" cy="214.78" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="278.31" cy="128.52" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,385.3 94.5,313.2 189.0,304.6 283.5,370.5 378.0,426.8 472.5,401.8 567.0,327.3 661.5,298.3 756.0,351.9" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="596.33" y1="478.9" x2="446.95" y2="503.45" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="234.36" y1="286.57" x2="659.53" y2="311.12" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="446.95" y1="503.45" x2="297.56" y2="118.8" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="659.53" y1="311.12" x2="510.15" y2="335.68" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="297.56" y1="118.8" x2="148.18" y2="143.35" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="148.18" y1="143.35" x2="573.35" y2="167.9" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="596.33" cy="478.9" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="234.36" cy="286.57" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="446.95" cy="503.45" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="659.53" cy="311.12" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="297.56" cy="118.8" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="510.15" cy="335.68" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="148.18" cy="143.35" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="360.76" cy="360.23" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="573.35" cy="167.9" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,143.3 159.0,135.0 318.0,162.1 477.0,190.1 636.0,183.3 795.0,150.3 954.0,133.3 1113.0,153.9 1272.0,185.9" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="713.34" y1="159.72" x2="461.99" y2="170.73" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="1071.02" y1="73.47" x2="819.68" y2="84.48" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="170.73" x2="210.64" y2="181.74" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="819.68" y1="84.48" x2="568.33" y2="95.49" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="210.64" y1="181.74" x2="926.02" y2="192.76" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="926.02" y1="192.76" x2="674.67" y2="203.77" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="713.34" cy="159.72" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="1071.02" cy="73.47" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="461.99" cy="170.73" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="819.68" cy="84.48" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="210.64" cy="181.74" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="568.33" cy="95.49" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="926.02" cy="192.76" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="316.98" cy="106.5" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="674.67" cy="203.77" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,249.7 88.5,301.5 177.0,305.5 265.5,256.6 354.0,217.1 442.5,237.4 531.0,291.6 619.5,310.6 708.0,270.1" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="197.96" y1="148.9" x2="596.14" y2="166.75" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="397.05" y1="306.62" x2="257.15" y2="324.48" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="596.14" y1="166.75" x2="456.24" y2="184.61" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="257.15" y1="324.48" x2="117.24" y2="342.34" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="117.24" y1="342.34" x2="515.42" y2="360.19" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="515.42" y1="360.19" x2="197.96" y2="148.9" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="197.96" cy="148.9" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="397.05" cy="306.62" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="596.14" cy="166.75" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="257.15" cy="324.48" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="456.24" cy="184.61" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="117.24" cy="342.34" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="316.33" cy="202.46" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="515.42" cy="360.19" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="176.43" cy="220.32" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,161.9 159.0,190.1 318.0,183.4 477.0,150.5 636.0,133.2 795.0,153.7 954.0,185.7 1113.0,188.5 1272.0,158.5" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="191.31" y1="60.62" x2="906.68" y2="71.63" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="549.0" y1="157.89" x2="297.65" y2="168.9" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="906.68" y1="71.63" x2="655.33" y2="82.64" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="297.65" y1="168.9" x2="1013.02" y2="179.91" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="655.33" y1="82.64" x2="403.99" y2="93.65" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="403.99" y1="93.65" x2="152.64" y2="104.67" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="191.31" cy="60.62" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="549.0" cy="157.89" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="906.68" cy="71.63" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="297.65" cy="168.9" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="655.33" cy="82.64" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="1013.02" cy="179.91" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="403.99" cy="93.65" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="761.67" cy="190.92" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="152.64" cy="104.67" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,150.3 159.0,133.3 318.0,153.9 477.0,185.9 636.0,188.4 795.0,158.3 954.0,133.9 1113.0,146.4 1272.0,179.8" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="674.67" y1="152.38" x2="423.32" y2="163.39" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="1032.36" y1="66.13" x2="781.01" y2="77.14" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="423.32" y1="163.39" x2="171.97" y2="174.4" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="781.01" y1="77.14" x2="529.66" y2="88.15" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="171.97" y1="174.4" x2="887.35" y2="185.41" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="887.35" y1="185.41" x2="636.0" y2="196.43" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="674.67" cy="152.38" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="1032.36" cy="66.13" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="423.32" cy="163.39" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="781.01" cy="77.14" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="171.97" cy="174.4" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="529.66" cy="88.15" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="887.35" cy="185.41" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="278.31" cy="99.16" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="636.0" cy="196.43" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISTJ-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,167.5 90.0,205.9 180.0,230.1 270.0,209.1 360.0,169.8 450.0,162.2 540.0,196.1 630.0,228.2 720.0,217.6" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="529.63" y1="241.5" x2="387.36" y2="254.67" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="184.9" y1="138.34" x2="589.82" y2="151.51" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="387.36" y1="254.67" x2="245.09" y2="267.84" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="589.82" y1="151.51" x2="447.55" y2="164.68" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="447.55" y1="164.68" x2="305.28" y2="177.85" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="305.28" y1="177.85" x2="529.63" y2="241.5" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="529.63" cy="241.5" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="184.9" cy="138.34" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="387.36" cy="254.67" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="589.82" cy="151.51" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="245.09" cy="267.84" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="447.55" cy="164.68" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="102.82" cy="281.01" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="305.28" cy="177.85" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="507.74" cy="74.69" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,184.7 159.0,152.2 318.0,133.2 477.0,151.9 636.0,184.5 795.0,189.4 954.0,160.4 1113.0,134.4 1272.0,144.7" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="500.66" y1="119.35" x2="249.31" y2="130.36" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="858.35" y1="216.61" x2="607.0" y2="227.62" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="130.36" x2="964.68" y2="141.37" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="607.0" y1="227.62" x2="355.65" y2="55.12" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="141.37" x2="713.34" y2="152.38" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="152.38" x2="461.99" y2="163.39" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="500.66" cy="119.35" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="858.35" cy="216.61" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="249.31" cy="130.36" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="607.0" cy="227.62" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="964.68" cy="141.37" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="355.65" cy="55.12" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="713.34" cy="152.38" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="1071.02" cy="66.13" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="461.99" cy="163.39" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,307.6 94.5,309.5 189.0,379.6 283.5,428.6 378.0,393.9 472.5,319.8 567.0,300.8 661.5,361.1 756.0,423.8" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="130.94" y1="147.44" x2="556.11" y2="172.0" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="343.53" y1="364.32" x2="194.14" y2="388.87" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="556.11" y1="172.0" x2="406.73" y2="196.55" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="194.14" y1="388.87" x2="619.32" y2="413.42" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="619.32" y1="413.42" x2="469.93" y2="437.98" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="469.93" y1="437.98" x2="130.94" y2="147.44" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="130.94" cy="147.44" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="343.53" cy="364.32" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="556.11" cy="172.0" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="194.14" cy="388.87" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="406.73" cy="196.55" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="619.32" cy="413.42" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="257.34" cy="221.1" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="469.93" cy="437.98" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="107.96" cy="245.65" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,136.7 159.0,166.3 318.0,191.5 477.0,180.1 636.0,146.7 795.0,133.8 954.0,157.9 1113.0,188.2 1272.0,186.1" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="897.01" y1="194.59" x2="645.67" y2="205.6" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="108.34" x2="1003.35" y2="119.35" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="645.67" y1="205.6" x2="394.32" y2="216.61" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="119.35" x2="752.01" y2="130.36" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="752.01" y1="130.36" x2="500.66" y2="141.37" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="500.66" y1="141.37" x2="897.01" y2="194.59" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="897.01" cy="194.59" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="287.98" cy="108.34" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="645.67" cy="205.6" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="1003.35" cy="119.35" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="394.32" cy="216.61" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="752.01" cy="130.36" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="1109.69" cy="227.62" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="500.66" cy="141.37" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="858.35" cy="55.12" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,305.3 88.5,301.7 177.0,250.0 265.5,216.1 354.0,243.3 442.5,296.9 531.0,308.5 619.5,263.4 708.0,219.0" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="300.19" y1="205.44" x2="160.29" y2="223.3" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="499.28" y1="363.17" x2="359.38" y2="381.02" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="160.29" y1="223.3" x2="558.47" y2="241.15" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="359.38" y1="381.02" x2="219.48" y2="101.28" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="558.47" y1="241.15" x2="418.57" y2="259.01" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="418.57" y1="259.01" x2="278.67" y2="276.86" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="300.19" cy="205.44" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="499.28" cy="363.17" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="160.29" cy="223.3" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="359.38" cy="381.02" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="558.47" cy="241.15" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="219.48" cy="101.28" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="418.57" cy="259.01" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="617.66" cy="119.14" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="278.67" cy="276.86" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,191.4 159.0,180.2 318.0,146.8 477.0,133.8 636.0,157.7 795.0,188.1 954.0,186.2 1113.0,154.4 1272.0,133.3" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="374.99" y1="95.49" x2="1090.36" y2="106.5" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="192.76" x2="481.32" y2="203.77" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="106.5" x2="839.01" y2="117.51" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="203.77" x2="229.98" y2="214.78" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="214.78" x2="945.35" y2="225.79" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="225.79" x2="374.99" y2="95.49" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="374.99" cy="95.49" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="732.67" cy="192.76" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="1090.36" cy="106.5" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="481.32" cy="203.77" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="839.01" cy="117.51" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="229.98" cy="214.78" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="587.66" cy="128.52" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="945.35" cy="225.79" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="336.32" cy="139.53" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,133.8 159.0,158.0 318.0,188.3 477.0,186.1 636.0,154.2 795.0,133.3 954.0,150.0 1113.0,183.0 1272.0,190.3" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="858.35" y1="187.25" x2="607.0" y2="198.26" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="249.31" y1="101.0" x2="964.68" y2="112.01" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="607.0" y1="198.26" x2="355.65" y2="209.27" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="112.01" x2="713.34" y2="123.02" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="123.02" x2="461.99" y2="134.03" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="134.03" x2="858.35" y2="187.25" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="858.35" cy="187.25" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="249.31" cy="101.0" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="607.0" cy="198.26" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="964.68" cy="112.01" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="355.65" cy="209.27" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="713.34" cy="123.02" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="1071.02" cy="220.28" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="461.99" cy="134.03" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="819.68" cy="231.29" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISTJ-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISTJ-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#DFEAF0" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#577590" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#577590" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#1E2F3A" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,210.5 90.0,229.9 180.0,204.4 270.0,166.5 360.0,164.5 450.0,201.0 540.0,229.5 630.0,213.5 720.0,173.6" fill="none" stroke="#577590" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="86.4" y1="63.72" x2="491.33" y2="76.89" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="288.86" y1="180.04" x2="146.59" y2="193.21" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="491.33" y1="76.89" x2="349.06" y2="90.06" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="146.59" y1="193.21" x2="551.52" y2="206.38" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="349.06" y1="90.06" x2="206.78" y2="103.23" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/><line x1="206.78" y1="103.23" x2="611.71" y2="116.4" stroke="#577590" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="86.4" cy="63.72" r="3" fill="#577590" fill-opacity="0.35"/><circle cx="288.86" cy="180.04" r="4" fill="#577590" fill-opacity="0.40"/><circle cx="491.33" cy="76.89" r="5" fill="#577590" fill-opacity="0.45"/><circle cx="146.59" cy="193.21" r="3" fill="#577590" fill-opacity="0.50"/><circle cx="349.06" cy="90.06" r="4" fill="#577590" fill-opacity="0.35"/><circle cx="551.52" cy="206.38" r="5" fill="#577590" fill-opacity="0.40"/><circle cx="206.78" cy="103.23" r="3" fill="#577590" fill-opacity="0.45"/><circle cx="409.25" cy="219.55" r="4" fill="#577590" fill-opacity="0.50"/><circle cx="611.71" cy="116.4" r="5" fill="#577590" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#577590" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#1E2F3A" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#1E2F3A" fill-opacity="0.72">ISTJ-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#1E2F3A" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,191.9 159.0,178.3 318.0,144.9 477.0,134.3 636.0,160.0 795.0,189.3 954.0,184.8 1113.0,152.2 1272.0,133.2" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="374.99" y1="95.49" x2="1090.36" y2="106.5" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="732.67" y1="192.76" x2="481.32" y2="203.77" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="106.5" x2="839.01" y2="117.51" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="203.77" x2="229.98" y2="214.78" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="214.78" x2="945.35" y2="225.79" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="225.79" x2="374.99" y2="95.49" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="374.99" cy="95.49" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="732.67" cy="192.76" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="1090.36" cy="106.5" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="481.32" cy="203.77" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="839.01" cy="117.51" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="229.98" cy="214.78" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="587.66" cy="128.52" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="945.35" cy="225.79" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="336.32" cy="139.53" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">career path map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,357.8 94.5,299.8 189.0,322.4 283.5,396.8 378.0,428.1 472.5,376.4 567.0,307.6 661.5,309.5 756.0,379.6" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="630.81" y1="503.45" x2="481.42" y2="118.8" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="268.83" y1="311.12" x2="119.45" y2="335.68" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="481.42" y1="118.8" x2="332.04" y2="143.35" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="119.45" y1="335.68" x2="544.62" y2="360.23" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="332.04" y1="143.35" x2="182.65" y2="167.9" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="182.65" y1="167.9" x2="607.82" y2="192.46" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="630.81" cy="503.45" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="268.83" cy="311.12" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="481.42" cy="118.8" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="119.45" cy="335.68" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="332.04" cy="143.35" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="544.62" cy="360.23" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="182.65" cy="167.9" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="395.24" cy="384.78" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="607.82" cy="192.46" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#0E3140" fill-opacity="0.48">report unlock panel · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,135.9 159.0,141.6 318.0,174.3 477.0,192.4 636.0,172.7 795.0,140.4 954.0,136.7 1113.0,166.3 1272.0,191.5" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="771.34" y1="170.73" x2="519.99" y2="181.74" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="162.31" y1="84.48" x2="877.68" y2="95.49" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="181.74" x2="268.65" y2="192.76" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="877.68" y1="95.49" x2="626.33" y2="106.5" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="268.65" y1="192.76" x2="984.02" y2="203.77" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="984.02" y1="203.77" x2="732.67" y2="214.78" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="771.34" cy="170.73" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="162.31" cy="84.48" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="519.99" cy="181.74" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="877.68" cy="95.49" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="268.65" cy="192.76" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="626.33" cy="106.5" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="984.02" cy="203.77" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="374.99" cy="117.51" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="732.67" cy="214.78" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">growth rhythm map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,269.8 88.5,310.5 177.0,291.9 265.5,237.7 354.0,217.0 442.5,256.2 531.0,305.3 619.5,301.7 708.0,250.0" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="230.24" y1="166.75" x2="90.34" y2="184.61" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="429.33" y1="324.48" x2="289.43" y2="342.34" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="90.34" y1="184.61" x2="488.52" y2="202.46" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="289.43" y1="342.34" x2="149.53" y2="360.19" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="149.53" y1="360.19" x2="547.71" y2="378.05" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="547.71" y1="378.05" x2="230.24" y2="166.75" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="230.24" cy="166.75" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="429.33" cy="324.48" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="90.34" cy="184.61" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="289.43" cy="342.34" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="488.52" cy="202.46" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="149.53" cy="360.19" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="348.62" cy="220.32" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="547.71" cy="378.05" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="208.72" cy="238.18" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#0E3140" fill-opacity="0.48">identity lattice · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,174.2 159.0,192.4 318.0,172.9 477.0,140.5 636.0,136.6 795.0,166.1 954.0,191.4 1113.0,180.3 1272.0,146.9" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="249.31" y1="71.63" x2="964.68" y2="82.64" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="607.0" y1="168.9" x2="355.65" y2="179.91" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="964.68" y1="82.64" x2="713.34" y2="93.65" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="355.65" y1="179.91" x2="1071.02" y2="190.92" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="713.34" y1="93.65" x2="461.99" y2="104.67" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="461.99" y1="104.67" x2="210.64" y2="115.68" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="249.31" cy="71.63" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="607.0" cy="168.9" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="964.68" cy="82.64" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="355.65" cy="179.91" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="713.34" cy="93.65" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="1071.02" cy="190.92" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="461.99" cy="104.67" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="819.68" cy="201.93" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="210.64" cy="115.68" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">relationship orbit map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,140.4 159.0,136.7 318.0,166.3 477.0,191.5 636.0,180.1 795.0,146.7 954.0,133.8 1113.0,157.9 1272.0,188.2" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="732.67" y1="163.39" x2="481.32" y2="174.4" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="1090.36" y1="77.14" x2="839.01" y2="88.15" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="481.32" y1="174.4" x2="229.98" y2="185.41" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="839.01" y1="88.15" x2="587.66" y2="99.16" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="229.98" y1="185.41" x2="945.35" y2="196.43" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="945.35" y1="196.43" x2="694.0" y2="207.44" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="732.67" cy="163.39" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="1090.36" cy="77.14" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="481.32" cy="174.4" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="839.01" cy="88.15" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="229.98" cy="185.41" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="587.66" cy="99.16" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="945.35" cy="196.43" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="336.32" cy="110.17" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="694.0" cy="207.44" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">axis map · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-A Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISTP-A MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,179.2 90.0,218.7 180.0,227.6 270.0,194.6 360.0,161.7 450.0,170.9 540.0,210.5 630.0,230.0 720.0,204.5" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="562.46" y1="254.67" x2="420.19" y2="267.84" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="217.73" y1="151.51" x2="622.66" y2="164.68" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="420.19" y1="267.84" x2="277.92" y2="281.01" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="622.66" y1="164.68" x2="480.38" y2="177.85" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="480.38" y1="177.85" x2="338.11" y2="191.02" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="338.11" y1="191.02" x2="562.46" y2="254.67" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="562.46" cy="254.67" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="217.73" cy="151.51" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="420.19" cy="267.84" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="622.66" cy="164.68" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="277.92" cy="281.01" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="480.38" cy="177.85" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="135.65" cy="74.69" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="338.11" cy="191.02" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="540.58" cy="87.86" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-A</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#0E3140" fill-opacity="0.48">trait signal card · A</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/career-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/career-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Career path illustration</title>
+  <desc id="desc">Abstract career path map for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,174.6 159.0,141.8 318.0,135.7 477.0,164.2 636.0,190.9 795.0,181.7 954.0,148.5 1113.0,133.5 1272.0,155.9" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="558.66" y1="130.36" x2="307.32" y2="141.37" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="916.35" y1="227.62" x2="665.0" y2="55.12" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="141.37" x2="1022.69" y2="152.38" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="665.0" y1="55.12" x2="413.65" y2="66.13" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="152.38" x2="771.34" y2="163.39" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="163.39" x2="519.99" y2="174.4" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="558.66" cy="130.36" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="916.35" cy="227.62" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="307.32" cy="141.37" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="665.0" cy="55.12" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="1022.69" cy="152.38" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="413.65" cy="66.13" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="771.34" cy="163.39" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="162.31" cy="77.14" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="519.99" cy="174.4" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">career path map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="756" height="660" viewBox="0 0 756 660" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Final offer illustration</title>
+  <desc id="desc">Abstract report unlock panel for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="756" height="660" rx="22" fill="url(#bg)"/>
+  <circle cx="589.7" cy="224.4" r="211.2" fill="url(#halo)"/>
+  <path d="M 60.5 475.2 C 211.7 165.0, 408.2 567.6, 695.5 184.8" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,297.7 94.5,330.1 189.0,404.4 283.5,425.9 378.0,367.2 472.5,303.1 567.0,315.4 661.5,388.4 756.0,429.0" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="165.41" y1="172.0" x2="590.59" y2="196.55" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="378.0" y1="388.87" x2="228.61" y2="413.42" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="590.59" y1="196.55" x2="441.2" y2="221.1" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="228.61" y1="413.42" x2="653.79" y2="437.98" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="653.79" y1="437.98" x2="504.4" y2="462.53" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="504.4" y1="462.53" x2="165.41" y2="172.0" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="165.41" cy="172.0" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="378.0" cy="388.87" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="590.59" cy="196.55" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="228.61" cy="413.42" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="441.2" cy="221.1" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="653.79" cy="437.98" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="291.82" cy="245.65" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="504.4" cy="462.53" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="142.43" cy="270.2" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="56.7" y="79.2" width="136.1" height="118.8" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="635.0" cy="475.2" r="105.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="60.5" y="580.8" font-family="Inter, Arial, sans-serif" font-size="59" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="60.5" y="654.5" font-family="Inter, Arial, sans-serif" font-size="30" font-weight="500" fill="#0E3140" fill-opacity="0.48">report unlock panel · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/growth-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/growth-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Growth path illustration</title>
+  <desc id="desc">Abstract growth rhythm map for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,144.7 159.0,178.1 318.0,192.0 477.0,168.7 636.0,137.9 795.0,138.9 954.0,170.4 1113.0,192.2 1272.0,176.6" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="955.02" y1="205.6" x2="703.67" y2="216.61" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="345.98" y1="119.35" x2="1061.36" y2="130.36" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="703.67" y1="216.61" x2="452.32" y2="227.62" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="1061.36" y1="130.36" x2="810.01" y2="141.37" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="810.01" y1="141.37" x2="558.66" y2="152.38" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="558.66" y1="152.38" x2="955.02" y2="205.6" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="955.02" cy="205.6" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="345.98" cy="119.35" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="703.67" cy="216.61" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="1061.36" cy="130.36" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="452.32" cy="227.62" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="810.01" cy="141.37" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="200.98" cy="55.12" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="558.66" cy="152.38" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="916.35" cy="66.13" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">growth rhythm map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/hero-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/hero-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="708" height="480" viewBox="0 0 708 480" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Hero identity illustration</title>
+  <desc id="desc">Abstract identity lattice for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="708" height="480" rx="22" fill="url(#bg)"/>
+  <circle cx="552.2" cy="163.2" r="153.6" fill="url(#halo)"/>
+  <path d="M 56.6 345.6 C 198.2 120.0, 382.3 412.8, 651.4 134.4" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,311.7 88.5,286.2 177.0,232.4 265.5,218.9 354.0,263.0 442.5,308.4 531.0,297.2 619.5,243.7 708.0,216.1" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="332.48" y1="223.3" x2="192.58" y2="241.15" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="531.57" y1="381.02" x2="391.67" y2="101.28" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="192.58" y1="241.15" x2="590.76" y2="259.01" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="391.67" y1="101.28" x2="251.76" y2="119.14" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="590.76" y1="259.01" x2="450.85" y2="276.86" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="450.85" y1="276.86" x2="310.95" y2="294.72" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="332.48" cy="223.3" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="531.57" cy="381.02" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="192.58" cy="241.15" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="391.67" cy="101.28" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="590.76" cy="259.01" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="251.76" cy="119.14" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="450.85" cy="276.86" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="111.86" cy="136.99" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="310.95" cy="294.72" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="53.1" y="57.6" width="127.4" height="86.4" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="594.7" cy="345.6" r="76.8" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="56.6" y="422.4" font-family="Inter, Arial, sans-serif" font-size="43" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="56.6" y="476.1" font-family="Inter, Arial, sans-serif" font-size="22" font-weight="500" fill="#0E3140" fill-opacity="0.48">identity lattice · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/relationships-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/relationships-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Relationships illustration</title>
+  <desc id="desc">Abstract relationship orbit map for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,192.0 159.0,168.9 318.0,138.0 477.0,138.7 636.0,170.2 795.0,192.2 954.0,176.7 1113.0,143.5 1272.0,134.9" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="432.99" y1="106.5" x2="181.64" y2="117.51" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="790.68" y1="203.77" x2="539.33" y2="214.78" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="181.64" y1="117.51" x2="897.01" y2="128.52" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="539.33" y1="214.78" x2="287.98" y2="225.79" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="287.98" y1="225.79" x2="1003.35" y2="53.28" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="1003.35" y1="53.28" x2="432.99" y2="106.5" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="432.99" cy="106.5" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="790.68" cy="203.77" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="181.64" cy="117.51" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="539.33" cy="214.78" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="897.01" cy="128.52" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="287.98" cy="225.79" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="645.67" cy="139.53" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="1003.35" cy="53.28" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="394.32" cy="150.55" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">relationship orbit map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/traits-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/traits-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1272" height="296" viewBox="0 0 1272 296" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Traits axis illustration</title>
+  <desc id="desc">Abstract axis map for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="1272" height="296" rx="22" fill="url(#bg)"/>
+  <circle cx="992.2" cy="100.6" r="94.7" fill="url(#halo)"/>
+  <path d="M 101.8 213.1 C 356.2 74.0, 686.9 254.6, 1170.2 82.9" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,138.9 159.0,170.4 318.0,192.2 477.0,176.5 636.0,143.3 795.0,135.0 954.0,162.1 1113.0,190.1 1272.0,183.3" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="916.35" y1="198.26" x2="665.0" y2="209.27" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="307.32" y1="112.01" x2="1022.69" y2="123.02" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="665.0" y1="209.27" x2="413.65" y2="220.28" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="1022.69" y1="123.02" x2="771.34" y2="134.03" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="771.34" y1="134.03" x2="519.99" y2="145.04" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="519.99" y1="145.04" x2="916.35" y2="198.26" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="916.35" cy="198.26" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="307.32" cy="112.01" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="665.0" cy="209.27" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="1022.69" cy="123.02" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="413.65" cy="220.28" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="771.34" cy="134.03" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="162.31" cy="231.29" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="519.99" cy="145.04" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="877.68" cy="58.79" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="95.4" y="35.5" width="229.0" height="53.3" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="1068.5" cy="213.1" r="47.4" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="101.8" y="260.5" font-family="Inter, Arial, sans-serif" font-size="27" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="101.8" y="294.2" font-family="Inter, Arial, sans-serif" font-size="13" font-weight="500" fill="#0E3140" fill-opacity="0.48">axis map · T</text>
+</svg>

--- a/backend/public/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg
+++ b/backend/public/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg
@@ -1,0 +1,26 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="720" height="354" viewBox="0 0 720 354" role="img" aria-labelledby="title desc">
+  <title id="title">ISTP-T Traits summary illustration</title>
+  <desc id="desc">Abstract trait signal card for the ISTP-T MBTI desktop result module.</desc>
+  <defs>
+    <linearGradient id="bg" x1="0" x2="1" y1="0" y2="1">
+      <stop offset="0" stop-color="#D8EEF6" stop-opacity="0.92"/>
+      <stop offset="0.55" stop-color="#FFFFFF" stop-opacity="0.96"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0.14"/>
+    </linearGradient>
+    <radialGradient id="halo" cx="74%" cy="35%" r="48%">
+      <stop offset="0" stop-color="#277DA1" stop-opacity="0.26"/>
+      <stop offset="1" stop-color="#277DA1" stop-opacity="0"/>
+    </radialGradient>
+    <filter id="soft"><feGaussianBlur stdDeviation="18"/></filter>
+  </defs>
+  <rect width="720" height="354" rx="22" fill="url(#bg)"/>
+  <circle cx="561.6" cy="120.4" r="113.3" fill="url(#halo)"/>
+  <path d="M 57.6 254.9 C 201.6 88.5, 388.8 304.4, 662.4 99.1" fill="none" stroke="#0E3140" stroke-opacity="0.16" stroke-width="3"/>
+  <polyline points="0.0,222.1 90.0,225.5 180.0,189.6 270.0,160.2 360.0,174.8 450.0,214.8 540.0,229.1 630.0,199.6 720.0,163.8" fill="none" stroke="#277DA1" stroke-opacity="0.34" stroke-width="4" stroke-linecap="round"/>
+  <line x1="119.23" y1="76.89" x2="524.16" y2="90.06" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="321.7" y1="193.21" x2="179.42" y2="206.38" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="524.16" y1="90.06" x2="381.89" y2="103.23" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="179.42" y1="206.38" x2="584.35" y2="219.55" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="381.89" y1="103.23" x2="239.62" y2="116.4" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/><line x1="239.62" y1="116.4" x2="97.34" y2="129.56" stroke="#277DA1" stroke-opacity="0.24" stroke-width="2"/>
+  <circle cx="119.23" cy="76.89" r="3" fill="#277DA1" fill-opacity="0.35"/><circle cx="321.7" cy="193.21" r="4" fill="#277DA1" fill-opacity="0.40"/><circle cx="524.16" cy="90.06" r="5" fill="#277DA1" fill-opacity="0.45"/><circle cx="179.42" cy="206.38" r="3" fill="#277DA1" fill-opacity="0.50"/><circle cx="381.89" cy="103.23" r="4" fill="#277DA1" fill-opacity="0.35"/><circle cx="584.35" cy="219.55" r="5" fill="#277DA1" fill-opacity="0.40"/><circle cx="239.62" cy="116.4" r="3" fill="#277DA1" fill-opacity="0.45"/><circle cx="442.08" cy="232.72" r="4" fill="#277DA1" fill-opacity="0.50"/><circle cx="97.34" cy="129.56" r="5" fill="#277DA1" fill-opacity="0.35"/>
+  <rect x="54.0" y="42.5" width="129.6" height="63.7" rx="18" fill="#277DA1" fill-opacity="0.16"/>
+  <circle cx="604.8" cy="254.9" r="56.6" fill="#FFFFFF" fill-opacity="0.36" stroke="#0E3140" stroke-opacity="0.10"/>
+  <text x="57.6" y="311.5" font-family="Inter, Arial, sans-serif" font-size="32" font-weight="700" fill="#0E3140" fill-opacity="0.72">ISTP-T</text>
+  <text x="57.6" y="351.5" font-family="Inter, Arial, sans-serif" font-size="16" font-weight="500" fill="#0E3140" fill-opacity="0.48">trait signal card · T</text>
+</svg>

--- a/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+++ b/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
@@ -30,13 +30,13 @@ final class MediaLibraryPublicApiTest extends TestCase
             '--status' => 'published',
             '--source-dir' => '../content_baselines/media_assets',
         ])
-            ->expectsOutputToContain('files_found=1')
-            ->expectsOutputToContain('assets_found=3')
-            ->expectsOutputToContain('will_create=3')
+            ->expectsOutputToContain('files_found=2')
+            ->expectsOutputToContain('assets_found=227')
+            ->expectsOutputToContain('will_create=227')
             ->assertExitCode(0);
 
-        $this->assertSame(3, MediaAsset::query()->withoutGlobalScopes()->count());
-        $this->assertSame(9, MediaVariant::query()->count());
+        $this->assertSame(227, MediaAsset::query()->withoutGlobalScopes()->count());
+        $this->assertSame(233, MediaVariant::query()->count());
     }
 
     public function test_public_and_internal_api_return_media_variant_metadata(): void

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
@@ -134,15 +134,23 @@ final class PersonalityDesktopCloneBaselineImportTest extends TestCase
         $this->assertNotSame('', trim((string) data_get($entjTContent, 'content_json.chapters.growth.what_energizes.title')));
         $this->assertNotSame('', trim((string) data_get($istpAContent, 'content_json.chapters.relationships.superpowers.title')));
 
-        $first = PersonalityProfileVariantCloneContent::query()->orderBy('id')->firstOrFail();
-        $slotIds = array_column((array) $first->asset_slots_json, 'slot_id');
+        $intjAClone = $this->cloneContentModelByRuntimeType('INTJ-A');
+        $slotIds = array_column((array) $intjAClone->asset_slots_json, 'slot_id');
 
         $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds(), $slotIds);
         $this->assertSame(
-            0,
-            collect((array) $first->asset_slots_json)
+            7,
+            collect((array) $intjAClone->asset_slots_json)
                 ->where('status', PersonalityDesktopCloneAssetSlotSupport::STATUS_READY)
                 ->count(),
+        );
+        $this->assertSame(
+            'mbti.desktop_clone.intj-a.hero-illustration',
+            data_get($intjAClone->asset_slots_json, '0.meta.media_library_asset_key'),
+        );
+        $this->assertSame(
+            'https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/hero-illustration.svg',
+            data_get($intjAClone->asset_slots_json, '0.asset_ref.url'),
         );
 
         $this->artisan('personality:import-desktop-clone-baseline', [

--- a/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneMediaAssetBaselineTest.php
+++ b/backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneMediaAssetBaselineTest.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\PersonalityCms;
+
+use App\PersonalityCms\DesktopClone\PersonalityDesktopCloneAssetSlotSupport;
+use Tests\TestCase;
+
+final class PersonalityDesktopCloneMediaAssetBaselineTest extends TestCase
+{
+    public function test_mbti_desktop_clone_baseline_has_ready_media_library_backed_slots(): void
+    {
+        $clone = $this->decodeJson(base_path('../content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json'));
+        $mediaRows = collect($this->decodeJson(base_path('../content_baselines/media_assets/mbti_desktop_clone_assets.v1.json')))
+            ->keyBy(fn (array $row): string => (string) ($row['asset_key'] ?? ''));
+
+        $this->assertCount(32, $clone['variants']);
+        $this->assertCount(224, $mediaRows);
+
+        foreach ($clone['variants'] as $variant) {
+            $fullCode = (string) $variant['full_code'];
+            $fullCodeSlug = strtolower($fullCode);
+            $assetSlots = $variant['asset_slots_json'] ?? [];
+
+            $this->assertCount(7, $assetSlots, $fullCode);
+            $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::allowedSlotIds(), array_column($assetSlots, 'slotId'));
+
+            foreach ($assetSlots as $slot) {
+                $slotId = (string) ($slot['slotId'] ?? '');
+                $assetKey = sprintf('mbti.desktop_clone.%s.%s', $fullCodeSlug, $slotId);
+                $path = sprintf('/static/mbti/desktop-clone/%s/%s.svg', $fullCodeSlug, $slotId);
+
+                $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::STATUS_READY, $slot['status'] ?? null, $assetKey);
+                $this->assertSame($assetKey, data_get($slot, 'meta.media_library_asset_key'));
+                $this->assertSame(PersonalityDesktopCloneAssetSlotSupport::ASSET_PROVIDER_CDN, data_get($slot, 'assetRef.provider'));
+                $this->assertSame($path, data_get($slot, 'assetRef.path'));
+                $this->assertSame('https://assets.fermatmind.com'.$path, data_get($slot, 'assetRef.url'));
+                $this->assertStringStartsWith('sha256:', (string) data_get($slot, 'assetRef.checksum'));
+                $this->assertNotSame('', trim((string) ($slot['alt'] ?? '')));
+
+                $this->assertTrue($mediaRows->has($assetKey), $assetKey);
+                $media = $mediaRows->get($assetKey);
+                $this->assertSame($path, $media['path'] ?? null);
+                $this->assertSame('https://assets.fermatmind.com'.$path, $media['url'] ?? null);
+                $this->assertSame('image/svg+xml', $media['mime_type'] ?? null);
+                $this->assertSame($slot['alt'], $media['alt'] ?? null);
+                $this->assertFileExists(base_path('public'.$path), $path);
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>|list<array<string, mixed>>
+     */
+    private function decodeJson(string $path): array
+    {
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/content_baselines/media_assets/mbti_desktop_clone_assets.v1.json
+++ b/content_baselines/media_assets/mbti_desktop_clone_assets.v1.json
@@ -1,0 +1,8066 @@
+[
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3200,
+    "alt": "INTJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:0c2ebbaab5d67bb4a45b1de0dd6e7f254dbdc8cc21932fd088d3e48dcfcc5f70"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:0c2ebbaab5d67bb4a45b1de0dd6e7f254dbdc8cc21932fd088d3e48dcfcc5f70"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3183,
+    "alt": "INTJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:a41faa228975e58975191446aa4f9c0c2d0b9e5bf7da5a610507398e54efd6d7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3183,
+        "payload_json": {
+          "checksum": "sha256:a41faa228975e58975191446aa4f9c0c2d0b9e5bf7da5a610507398e54efd6d7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3201,
+    "alt": "INTJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:e28c448ffd746118fa80f33845968b0fdb5bc767ae155fe4304ad64efd3c392a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:e28c448ffd746118fa80f33845968b0fdb5bc767ae155fe4304ad64efd3c392a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3200,
+    "alt": "INTJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:a1030e7de221a2411f10485feba24dfbf26cef79bf4cd9709bc731f8cf2b7c1c"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:a1030e7de221a2411f10485feba24dfbf26cef79bf4cd9709bc731f8cf2b7c1c"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3198,
+    "alt": "INTJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:168e6a6ab3722085975034eda827fe921421dc594c7a805229e2a549f0a38ac4"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:168e6a6ab3722085975034eda827fe921421dc594c7a805229e2a549f0a38ac4"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3220,
+    "alt": "INTJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:1dee508359eca3ee52d9008c0b6fe1b5ebe1a1e99cfaf1241838693bb1d1e61e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3220,
+        "payload_json": {
+          "checksum": "sha256:1dee508359eca3ee52d9008c0b6fe1b5ebe1a1e99cfaf1241838693bb1d1e61e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3208,
+    "alt": "INTJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:acb2bd016a7897700d2c43a0d700e344f4c3d988c1b5bc65b135645df0b57929"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3208,
+        "payload_json": {
+          "checksum": "sha256:acb2bd016a7897700d2c43a0d700e344f4c3d988c1b5bc65b135645df0b57929"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3199,
+    "alt": "INTJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:f8888bcb5dee5e147231e95e181e40e243bb9e678e7d7a90c0e2d9c6142fa597"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:f8888bcb5dee5e147231e95e181e40e243bb9e678e7d7a90c0e2d9c6142fa597"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3191,
+    "alt": "INTJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:3dc4470fbafc20573a7b1fa90346e21e3b53ca0c26c7e407cb2a410492036328"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3191,
+        "payload_json": {
+          "checksum": "sha256:3dc4470fbafc20573a7b1fa90346e21e3b53ca0c26c7e407cb2a410492036328"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3196,
+    "alt": "INTJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:3aec5d0f64b5636a6d021b5183f6f84550dab128fa7d65e4459fd90101ab22cb"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:3aec5d0f64b5636a6d021b5183f6f84550dab128fa7d65e4459fd90101ab22cb"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3207,
+    "alt": "INTJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:2372c6225f3379717a1c32d1e367d244d47a83a36c8e900ad6fd6744a3d41417"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:2372c6225f3379717a1c32d1e367d244d47a83a36c8e900ad6fd6744a3d41417"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3214,
+    "alt": "INTJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:b4b59d4a448f5076e2e279833e56c5dfd67f0598ddaef2b36d7026275436afaf"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3214,
+        "payload_json": {
+          "checksum": "sha256:b4b59d4a448f5076e2e279833e56c5dfd67f0598ddaef2b36d7026275436afaf"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3221,
+    "alt": "INTJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:2c8e0aca447d6c35ab2f0393e0351d14d3166d5416bd91c2ad71a556d92b8de4"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3221,
+        "payload_json": {
+          "checksum": "sha256:2c8e0aca447d6c35ab2f0393e0351d14d3166d5416bd91c2ad71a556d92b8de4"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3205,
+    "alt": "INTJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:ba36a04fe0f3e4c4528cd9fea49b703f567b1c9da28057e1e3839d9e2543fade"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:ba36a04fe0f3e4c4528cd9fea49b703f567b1c9da28057e1e3839d9e2543fade"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3200,
+    "alt": "INTP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:841984b763560ac5bc8023e420e3a84e5ca241087c3c0dd85cbcc8175c558452"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:841984b763560ac5bc8023e420e3a84e5ca241087c3c0dd85cbcc8175c558452"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3186,
+    "alt": "INTP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:71ec536512626f99ac6e6533d876f571c878cf786a4b9b6e9f2778e622a8aef8"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3186,
+        "payload_json": {
+          "checksum": "sha256:71ec536512626f99ac6e6533d876f571c878cf786a4b9b6e9f2778e622a8aef8"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3196,
+    "alt": "INTP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:b7b3c110a5557488fc2ff9dc2e50c47953ad94eaf90be6209347fb00f6236261"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:b7b3c110a5557488fc2ff9dc2e50c47953ad94eaf90be6209347fb00f6236261"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3205,
+    "alt": "INTP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:fc0edc5ae730df25ebda79c5177db784d170203db3b077a2d556f5ad3912fad9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:fc0edc5ae730df25ebda79c5177db784d170203db3b077a2d556f5ad3912fad9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3198,
+    "alt": "INTP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:d490a654def86a0c76ca766bee6c0003b627649e7c156407a5933402c76d452b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:d490a654def86a0c76ca766bee6c0003b627649e7c156407a5933402c76d452b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3216,
+    "alt": "INTP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:c46d77efff21dd8a04f48cf26d5d019c73d44b5e563ea0505a50961826bd38cc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3216,
+        "payload_json": {
+          "checksum": "sha256:c46d77efff21dd8a04f48cf26d5d019c73d44b5e563ea0505a50961826bd38cc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3206,
+    "alt": "INTP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:5e9d43634d03dd4db7d0bf0d7b0c3d99a41ef49484fc7a147bd0af09ae02bc85"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:5e9d43634d03dd4db7d0bf0d7b0c3d99a41ef49484fc7a147bd0af09ae02bc85"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3196,
+    "alt": "INTP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:a01e7a0bbbec601cf78c50477227951aa780da3c2c2c803c106a0feaa9e9dad4"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:a01e7a0bbbec601cf78c50477227951aa780da3c2c2c803c106a0feaa9e9dad4"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3193,
+    "alt": "INTP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:86c15405b36c0422843a8f2d959c2cbe7a0b2947936920af78c1fbdc608fefe5"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3193,
+        "payload_json": {
+          "checksum": "sha256:86c15405b36c0422843a8f2d959c2cbe7a0b2947936920af78c1fbdc608fefe5"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3192,
+    "alt": "INTP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:b82e42c64a541cdf8534a9d200403e17f39f3f399ad056c8435d805a06069d78"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3192,
+        "payload_json": {
+          "checksum": "sha256:b82e42c64a541cdf8534a9d200403e17f39f3f399ad056c8435d805a06069d78"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "INTP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:8cf8b940a4c07dedab7040874b50b99dab2ded9382b86f1ff0fc116777766a81"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:8cf8b940a4c07dedab7040874b50b99dab2ded9382b86f1ff0fc116777766a81"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3213,
+    "alt": "INTP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:2b18b49d6b88e9ae821bf58d21acaa9463fee00a8f87e49d7f9fc5ca170a67cf"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3213,
+        "payload_json": {
+          "checksum": "sha256:2b18b49d6b88e9ae821bf58d21acaa9463fee00a8f87e49d7f9fc5ca170a67cf"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3223,
+    "alt": "INTP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:fa700757de767089a4cd3bb4c752b9cb0f1f0c0f6f1cfdc2748801dd44bae54f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3223,
+        "payload_json": {
+          "checksum": "sha256:fa700757de767089a4cd3bb4c752b9cb0f1f0c0f6f1cfdc2748801dd44bae54f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.intp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3209,
+    "alt": "INTP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INTP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:0ae71c22d8b2921ffd967b572052724efdc56bfc8c7bd7f566163aaf301bff95"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:0ae71c22d8b2921ffd967b572052724efdc56bfc8c7bd7f566163aaf301bff95"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3199,
+    "alt": "ENTJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:5813d192d772b156c425866b0360edac72c7eb25e0b5ab6f3d9a3409bd462760"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:5813d192d772b156c425866b0360edac72c7eb25e0b5ab6f3d9a3409bd462760"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3183,
+    "alt": "ENTJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:f837e218f06a5a71a098ddcf6605b18b7a07606b227e83eb0d52b1c8ab343a0d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3183,
+        "payload_json": {
+          "checksum": "sha256:f837e218f06a5a71a098ddcf6605b18b7a07606b227e83eb0d52b1c8ab343a0d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3201,
+    "alt": "ENTJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:bf7be8c55e871d5eff4e6b5bd785bf3b3c267afbf33c02ee886aef087e0c6024"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:bf7be8c55e871d5eff4e6b5bd785bf3b3c267afbf33c02ee886aef087e0c6024"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3197,
+    "alt": "ENTJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:2e8be2acb5e8ce290fd14339b1d51c56c7624990cf601d816c804ba680df9767"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3197,
+        "payload_json": {
+          "checksum": "sha256:2e8be2acb5e8ce290fd14339b1d51c56c7624990cf601d816c804ba680df9767"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3201,
+    "alt": "ENTJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:fe22f58af251a389f2f7565d39b17e5c40de632fcf050ef7401b34f0c788a3de"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:fe22f58af251a389f2f7565d39b17e5c40de632fcf050ef7401b34f0c788a3de"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3219,
+    "alt": "ENTJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:f110716a89685af35c10212a28cb57b356e73812dbfd2415d0a12022dfa90949"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3219,
+        "payload_json": {
+          "checksum": "sha256:f110716a89685af35c10212a28cb57b356e73812dbfd2415d0a12022dfa90949"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3204,
+    "alt": "ENTJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:64fa2ac3f84fd63a970c2c5e72d521ad4af38d83a089fb93ee97d1c766ab5447"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:64fa2ac3f84fd63a970c2c5e72d521ad4af38d83a089fb93ee97d1c766ab5447"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3199,
+    "alt": "ENTJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:733eca9f2a017d54f97ddcdb409ec2e27a8546e5b85c267c2d82e2962f8f0a06"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:733eca9f2a017d54f97ddcdb409ec2e27a8546e5b85c267c2d82e2962f8f0a06"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3188,
+    "alt": "ENTJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:b8531745bcffbadbdf9dd71674a743115c53a56f486f629e5b2858dfc1a160dc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3188,
+        "payload_json": {
+          "checksum": "sha256:b8531745bcffbadbdf9dd71674a743115c53a56f486f629e5b2858dfc1a160dc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3191,
+    "alt": "ENTJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:4588e8f6a3bd75dcd6bfbd25af97d0a0fa17272d887a2974c460dca329f06686"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3191,
+        "payload_json": {
+          "checksum": "sha256:4588e8f6a3bd75dcd6bfbd25af97d0a0fa17272d887a2974c460dca329f06686"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3207,
+    "alt": "ENTJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:919fd75124d9c2bb0d2b3a1006fefdaeaef3e179eae74f82c5e782da4b9e314b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:919fd75124d9c2bb0d2b3a1006fefdaeaef3e179eae74f82c5e782da4b9e314b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3209,
+    "alt": "ENTJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:a455eacd866ebf108b7f3d49cdb40fc35bdd4b4e343757fca16cf73a11e95bab"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:a455eacd866ebf108b7f3d49cdb40fc35bdd4b4e343757fca16cf73a11e95bab"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3222,
+    "alt": "ENTJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:ad9187c1067e364ea9dc81c953f2031603d690c06a67016744f255566b79849d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3222,
+        "payload_json": {
+          "checksum": "sha256:ad9187c1067e364ea9dc81c953f2031603d690c06a67016744f255566b79849d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3204,
+    "alt": "ENTJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:b73db72db5a18c0a292812bb20580c8fcc5a787ec065f0d8637e8193309434e5"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:b73db72db5a18c0a292812bb20580c8fcc5a787ec065f0d8637e8193309434e5"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3196,
+    "alt": "ENTP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:389bccb3ec1d125c05634b7ad225410077cda0639035382f932a93f2a1b4bb86"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:389bccb3ec1d125c05634b7ad225410077cda0639035382f932a93f2a1b4bb86"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3185,
+    "alt": "ENTP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:99da98816848ec5b4519083f6ca10795bd161a9372d183bef3d46dc5317ee04e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3185,
+        "payload_json": {
+          "checksum": "sha256:99da98816848ec5b4519083f6ca10795bd161a9372d183bef3d46dc5317ee04e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3196,
+    "alt": "ENTP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:d1826fad230fe2bc68afa2bf422687de2852df18df38026c0cc58403cfebd566"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:d1826fad230fe2bc68afa2bf422687de2852df18df38026c0cc58403cfebd566"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "ENTP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:74fbf4311d9ce70b43d0fe2d940292437477ee47e016ee1f21c24065af2a9ffd"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:74fbf4311d9ce70b43d0fe2d940292437477ee47e016ee1f21c24065af2a9ffd"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "ENTP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:fb15480ee840b367b52d457e7b759dc5075e104e0d7cf1f7a51c7640bad75c86"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:fb15480ee840b367b52d457e7b759dc5075e104e0d7cf1f7a51c7640bad75c86"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3213,
+    "alt": "ENTP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:1a44b99fbbebc26334d39711cbce54d877854f908fbf2944532748e0e92c0860"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3213,
+        "payload_json": {
+          "checksum": "sha256:1a44b99fbbebc26334d39711cbce54d877854f908fbf2944532748e0e92c0860"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3200,
+    "alt": "ENTP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:b80ca40f83b24e440c82112d0d127aaf43dcf47d4ba2120e0b4d9d9796f84795"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:b80ca40f83b24e440c82112d0d127aaf43dcf47d4ba2120e0b4d9d9796f84795"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3199,
+    "alt": "ENTP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:4c8e7befc850db91a8ee31e478543f2fdb6a7249738105450909c0b5f404a3b1"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:4c8e7befc850db91a8ee31e478543f2fdb6a7249738105450909c0b5f404a3b1"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3190,
+    "alt": "ENTP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:77dd530522721053fe3c42eded95ceab391af499adcfb2f6954eed3cebcb7bcd"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3190,
+        "payload_json": {
+          "checksum": "sha256:77dd530522721053fe3c42eded95ceab391af499adcfb2f6954eed3cebcb7bcd"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3190,
+    "alt": "ENTP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:a23bd0b7a2e8de053be7545bead9c000335a23a7a0d3068bf0309064c4f4635c"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3190,
+        "payload_json": {
+          "checksum": "sha256:a23bd0b7a2e8de053be7545bead9c000335a23a7a0d3068bf0309064c4f4635c"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "ENTP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:f65581f56c76d6c0c6233ddfdb11c665e10914089ff49a43ad51eb53cc1e5284"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:f65581f56c76d6c0c6233ddfdb11c665e10914089ff49a43ad51eb53cc1e5284"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3211,
+    "alt": "ENTP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:947a69e52fda1164e6a97cff51c3282d65efde24708ad31ec30a6ac9ac2986e8"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:947a69e52fda1164e6a97cff51c3282d65efde24708ad31ec30a6ac9ac2986e8"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3223,
+    "alt": "ENTP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:613b480311ee1517aed644f8b9d82d46e5b043f43001733aa9270418289edd7d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3223,
+        "payload_json": {
+          "checksum": "sha256:613b480311ee1517aed644f8b9d82d46e5b043f43001733aa9270418289edd7d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.entp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3200,
+    "alt": "ENTP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENTP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:c944d487a5862dc01a732de479da73864a06f805f7545c9bd5ed123b36d2edef"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:c944d487a5862dc01a732de479da73864a06f805f7545c9bd5ed123b36d2edef"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3192,
+    "alt": "INFJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:6c649fd5f3d7e451085dace36b67592ab0de0675086b31bad621a2b9b3fcc14e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3192,
+        "payload_json": {
+          "checksum": "sha256:6c649fd5f3d7e451085dace36b67592ab0de0675086b31bad621a2b9b3fcc14e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3192,
+    "alt": "INFJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:a9d67ffa529d75bac556b584ea000bc8e16638b68abf17369183ca2bee9a361a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3192,
+        "payload_json": {
+          "checksum": "sha256:a9d67ffa529d75bac556b584ea000bc8e16638b68abf17369183ca2bee9a361a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3199,
+    "alt": "INFJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:1b697eacdacb60d49d3ce802c4f830cc20bae61626e6bf758aeed2d6d2e566b7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:1b697eacdacb60d49d3ce802c4f830cc20bae61626e6bf758aeed2d6d2e566b7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3200,
+    "alt": "INFJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:27077d5c912002b83555e61a845911b2fdea0e51fa9d0334102f61c0cdaa11b2"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:27077d5c912002b83555e61a845911b2fdea0e51fa9d0334102f61c0cdaa11b2"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "INFJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:3ff73e8453981bff8ee942865d07c353c07dbae554214d1a3b4b9476d9ed2295"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:3ff73e8453981bff8ee942865d07c353c07dbae554214d1a3b4b9476d9ed2295"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3219,
+    "alt": "INFJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:2eb5cd51b538c9125190952337ac05f043a687cdc1b53e8bb1d140e11511a922"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3219,
+        "payload_json": {
+          "checksum": "sha256:2eb5cd51b538c9125190952337ac05f043a687cdc1b53e8bb1d140e11511a922"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3202,
+    "alt": "INFJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:1e5fa9c3b588b12e93899e9aa5cd21ad1ec641f51b385f2c65a2a19fafe66d3d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:1e5fa9c3b588b12e93899e9aa5cd21ad1ec641f51b385f2c65a2a19fafe66d3d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3202,
+    "alt": "INFJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:fdfc630e1d23b293c285c13833fa6366890a36c9c3324e33ee1d8002fead7096"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:fdfc630e1d23b293c285c13833fa6366890a36c9c3324e33ee1d8002fead7096"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3184,
+    "alt": "INFJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:f7432dbec7c51aa1b3caa1496c6e8f656f6bf6b35bb206594354f7c72bf35bdf"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3184,
+        "payload_json": {
+          "checksum": "sha256:f7432dbec7c51aa1b3caa1496c6e8f656f6bf6b35bb206594354f7c72bf35bdf"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3200,
+    "alt": "INFJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:c769620764d42fc12d127c923c9961026127fbd6660bb9a7373a84334f20a9e2"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:c769620764d42fc12d127c923c9961026127fbd6660bb9a7373a84334f20a9e2"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "INFJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:9e2dc2efc5d3c4e01d34963e1ac954a99cb673f8224884f0ab6221ba6cde2017"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:9e2dc2efc5d3c4e01d34963e1ac954a99cb673f8224884f0ab6221ba6cde2017"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3207,
+    "alt": "INFJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:611f330bb94d6e4f12caabf8f6b4cc1fec65c6567b618fc15ff290c87824a52a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:611f330bb94d6e4f12caabf8f6b4cc1fec65c6567b618fc15ff290c87824a52a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3211,
+    "alt": "INFJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:af31f793201035e2efab434bcbd66277d447ee292e42ca4de4e1390afbfdd836"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:af31f793201035e2efab434bcbd66277d447ee292e42ca4de4e1390afbfdd836"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3204,
+    "alt": "INFJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:3248ec0f66c12c5b8411c65104e350d8dbf8722bf82befe24cd087d8b9f4f4b6"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:3248ec0f66c12c5b8411c65104e350d8dbf8722bf82befe24cd087d8b9f4f4b6"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3199,
+    "alt": "INFP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:f48e42bc204a7ac9fdaf47a69ec8441fb1cc925f9d51736c70f0417eef32bdf7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:f48e42bc204a7ac9fdaf47a69ec8441fb1cc925f9d51736c70f0417eef32bdf7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3182,
+    "alt": "INFP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:d38e8b2af31c2bf45b957f46ca23781e16b527c049756968c0d424a59182a43b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3182,
+        "payload_json": {
+          "checksum": "sha256:d38e8b2af31c2bf45b957f46ca23781e16b527c049756968c0d424a59182a43b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3201,
+    "alt": "INFP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:049f016241d68e2b89555f82cabb6aa29608c068fbb9296918ebce725a99eb22"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:049f016241d68e2b89555f82cabb6aa29608c068fbb9296918ebce725a99eb22"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3195,
+    "alt": "INFP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:851fb610e7ae5a6b76fe2d8ffa1a19b1b0389258071dfd45a9815e98d5880563"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3195,
+        "payload_json": {
+          "checksum": "sha256:851fb610e7ae5a6b76fe2d8ffa1a19b1b0389258071dfd45a9815e98d5880563"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3201,
+    "alt": "INFP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:36c16e716edaf2678cd9f9958898c679f6ce524c734d8573f5a8bea37f634d0f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:36c16e716edaf2678cd9f9958898c679f6ce524c734d8573f5a8bea37f634d0f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3220,
+    "alt": "INFP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:89ca487aa953c670163b7df318a5b369645db6747b1500937842f40105ee2197"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3220,
+        "payload_json": {
+          "checksum": "sha256:89ca487aa953c670163b7df318a5b369645db6747b1500937842f40105ee2197"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3206,
+    "alt": "INFP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:1d75f66adee61c68e965bdbe5137d01b26fa95605fb4d47152c40a2644301175"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:1d75f66adee61c68e965bdbe5137d01b26fa95605fb4d47152c40a2644301175"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3202,
+    "alt": "INFP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:071dcbb0f90b4b9ffeb3ffb6d56b2a9b8ddca8b4c1487a2e23708a379d786e58"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:071dcbb0f90b4b9ffeb3ffb6d56b2a9b8ddca8b4c1487a2e23708a379d786e58"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3185,
+    "alt": "INFP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:b1d08e87171574dfa5094062f0b1ccacf8866532f0abc9f58f7f6014694a9226"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3185,
+        "payload_json": {
+          "checksum": "sha256:b1d08e87171574dfa5094062f0b1ccacf8866532f0abc9f58f7f6014694a9226"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3204,
+    "alt": "INFP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:df488e7be09f2e4af2a99a709d04ab718be7e6153a9ed465394f268561515fc8"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:df488e7be09f2e4af2a99a709d04ab718be7e6153a9ed465394f268561515fc8"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "INFP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:438bd14dc4d2c77bdd4d8d5cf7c4ec48c18d28b2136a7b0dfe5fedd864bec2a6"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:438bd14dc4d2c77bdd4d8d5cf7c4ec48c18d28b2136a7b0dfe5fedd864bec2a6"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "INFP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:e2c071ca085f4376f820101e88f962392f556465b42358ead4b9b2eec2d73f44"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:e2c071ca085f4376f820101e88f962392f556465b42358ead4b9b2eec2d73f44"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3215,
+    "alt": "INFP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:886ea44cad6a35b5bbc6313c1cf0caff62e1e79af8542c67f7818c387918f2ee"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3215,
+        "payload_json": {
+          "checksum": "sha256:886ea44cad6a35b5bbc6313c1cf0caff62e1e79af8542c67f7818c387918f2ee"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.infp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3205,
+    "alt": "INFP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for INFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "INFP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:d87fce15f6dea194259e9f6b632bf27695fab395887c7b0161af57685b6050f9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:d87fce15f6dea194259e9f6b632bf27695fab395887c7b0161af57685b6050f9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3199,
+    "alt": "ENFJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:5f00c8b4dba61b80314b7fb43db6afc92ea9aac4c1d810c114cfd798d9fc9dcc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:5f00c8b4dba61b80314b7fb43db6afc92ea9aac4c1d810c114cfd798d9fc9dcc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3193,
+    "alt": "ENFJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:6fbfcf606badba59863f830366d26a5bc3b3efd421c3ca87b1d09f7fcdaaf6e9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3193,
+        "payload_json": {
+          "checksum": "sha256:6fbfcf606badba59863f830366d26a5bc3b3efd421c3ca87b1d09f7fcdaaf6e9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3197,
+    "alt": "ENFJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:f146f3b73fb35f1902fd41f29c5088c4091f823c711a1ffdf26fb7dd64904fe6"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3197,
+        "payload_json": {
+          "checksum": "sha256:f146f3b73fb35f1902fd41f29c5088c4091f823c711a1ffdf26fb7dd64904fe6"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3198,
+    "alt": "ENFJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:9a95c81e215ff4db4427a871f563c9f20cbe8ab8c8c637cb47e33829f1f977b9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:9a95c81e215ff4db4427a871f563c9f20cbe8ab8c8c637cb47e33829f1f977b9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3210,
+    "alt": "ENFJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:3cf7a98f1938d2e804753023b994c0eb2ee73c45897e9fd84901dfced9e2aea5"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3210,
+        "payload_json": {
+          "checksum": "sha256:3cf7a98f1938d2e804753023b994c0eb2ee73c45897e9fd84901dfced9e2aea5"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3224,
+    "alt": "ENFJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:8a59ef158cb4830c2dd05ad1edc729aea42f69d4e0af0f23675cdb6dbae87607"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3224,
+        "payload_json": {
+          "checksum": "sha256:8a59ef158cb4830c2dd05ad1edc729aea42f69d4e0af0f23675cdb6dbae87607"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3204,
+    "alt": "ENFJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:ca7e82dc26a075a1933f495829eb343a2344af3db8e25444b0a64fcf35a724ea"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:ca7e82dc26a075a1933f495829eb343a2344af3db8e25444b0a64fcf35a724ea"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3197,
+    "alt": "ENFJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:94d658da60ab0463b7ccde16cc0f6a11a3cb1b1c7d6ee3f96ffcdd717b07243f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3197,
+        "payload_json": {
+          "checksum": "sha256:94d658da60ab0463b7ccde16cc0f6a11a3cb1b1c7d6ee3f96ffcdd717b07243f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3185,
+    "alt": "ENFJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:55d23b50df18c9f917cf0af66d0936c8c8a380a4c30153d82b883f5782f9da29"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3185,
+        "payload_json": {
+          "checksum": "sha256:55d23b50df18c9f917cf0af66d0936c8c8a380a4c30153d82b883f5782f9da29"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3200,
+    "alt": "ENFJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:8a5ae843a1400ab0ef83abf8ce38dfa74f710294a4d629c8f7c88c0ad0eb9533"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:8a5ae843a1400ab0ef83abf8ce38dfa74f710294a4d629c8f7c88c0ad0eb9533"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3200,
+    "alt": "ENFJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:af1032340aa53bb05bccc1c44f5ca807996fe4c00671d73517046e75bf579ee9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:af1032340aa53bb05bccc1c44f5ca807996fe4c00671d73517046e75bf579ee9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3202,
+    "alt": "ENFJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:c918d239769ae4947f321a607bb4658e74f49d81d843636f6592baea22f0f792"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:c918d239769ae4947f321a607bb4658e74f49d81d843636f6592baea22f0f792"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3210,
+    "alt": "ENFJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:6006c15e3ce72f740648423c8232e731d17a7e05ff56cef9cf61a271b72470aa"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3210,
+        "payload_json": {
+          "checksum": "sha256:6006c15e3ce72f740648423c8232e731d17a7e05ff56cef9cf61a271b72470aa"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3209,
+    "alt": "ENFJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:189016963c20eeaf9462967e141fa0db554d9d74ae643cd1e8f52fbf729107b7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:189016963c20eeaf9462967e141fa0db554d9d74ae643cd1e8f52fbf729107b7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3198,
+    "alt": "ENFP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:501b98e773af8517cd40256177dc0093f38e3568adcfd2329fdac789c1665bdc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:501b98e773af8517cd40256177dc0093f38e3568adcfd2329fdac789c1665bdc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3189,
+    "alt": "ENFP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:83d13c90fef92f14c7d764b111bb03c3b1825b679640f87236530d20cd5fd312"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3189,
+        "payload_json": {
+          "checksum": "sha256:83d13c90fef92f14c7d764b111bb03c3b1825b679640f87236530d20cd5fd312"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3198,
+    "alt": "ENFP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:b71b5a18d13cadcda6423c861d6f9b04e2ec2780a246a2b77d76117392bcd72e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:b71b5a18d13cadcda6423c861d6f9b04e2ec2780a246a2b77d76117392bcd72e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3194,
+    "alt": "ENFP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:0d0a27384b17502999f671ac6e81c96e50dfc63a0fabca616a7c29e7255aba51"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3194,
+        "payload_json": {
+          "checksum": "sha256:0d0a27384b17502999f671ac6e81c96e50dfc63a0fabca616a7c29e7255aba51"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3200,
+    "alt": "ENFP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:412455d6aa214a90db4eae3ca17c4be69f7733510aaa743cdded957847446536"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:412455d6aa214a90db4eae3ca17c4be69f7733510aaa743cdded957847446536"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3223,
+    "alt": "ENFP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:0b9d8209ad656d03c1923d2348831a0b532cdd7e00008e45ff8e3a724c2bff00"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3223,
+        "payload_json": {
+          "checksum": "sha256:0b9d8209ad656d03c1923d2348831a0b532cdd7e00008e45ff8e3a724c2bff00"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3211,
+    "alt": "ENFP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:30a9574b9e8f1c40ad05316294f1afadd89c162eac530ae96b61afb750aff9d0"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:30a9574b9e8f1c40ad05316294f1afadd89c162eac530ae96b61afb750aff9d0"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3195,
+    "alt": "ENFP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:d445284ac7a2f8cead21bf05d9f5f693d64347d4f62cac85a615fc53de88bc0f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3195,
+        "payload_json": {
+          "checksum": "sha256:d445284ac7a2f8cead21bf05d9f5f693d64347d4f62cac85a615fc53de88bc0f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3182,
+    "alt": "ENFP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:c1aa108885916da9cf335ad1fea4135e2f9d929c371311148652019d2dd0ac9a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3182,
+        "payload_json": {
+          "checksum": "sha256:c1aa108885916da9cf335ad1fea4135e2f9d929c371311148652019d2dd0ac9a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3195,
+    "alt": "ENFP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:7dc019e0a6593d4a93445b46b18d90cdc1a6574497adff186949d562cd89e026"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3195,
+        "payload_json": {
+          "checksum": "sha256:7dc019e0a6593d4a93445b46b18d90cdc1a6574497adff186949d562cd89e026"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ENFP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:44745e43b93e4c0150327bbb5453348933ceaa333d2bd7a2a121e9fce5ed154d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:44745e43b93e4c0150327bbb5453348933ceaa333d2bd7a2a121e9fce5ed154d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ENFP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:fbe0a9fc78986e110c0c092e5438969835776cdf395d36cdb46eedbce2742a69"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:fbe0a9fc78986e110c0c092e5438969835776cdf395d36cdb46eedbce2742a69"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3213,
+    "alt": "ENFP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:129134139901c17a79fd6a13b63ef685e3efa3388938f0b835b4d0264dbff2c9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3213,
+        "payload_json": {
+          "checksum": "sha256:129134139901c17a79fd6a13b63ef685e3efa3388938f0b835b4d0264dbff2c9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.enfp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3208,
+    "alt": "ENFP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ENFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ENFP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:aa6a6c1f65fc13725812c6e400acac6a06a029ddf6ada9e19748b0184599fde2"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3208,
+        "payload_json": {
+          "checksum": "sha256:aa6a6c1f65fc13725812c6e400acac6a06a029ddf6ada9e19748b0184599fde2"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3202,
+    "alt": "ISTJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:89b0be4e82c54ede78178033697ef13942b78cf8df782da0200f0d35ac2ecb4e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:89b0be4e82c54ede78178033697ef13942b78cf8df782da0200f0d35ac2ecb4e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3184,
+    "alt": "ISTJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:ea0c43dfffb21c353506bef636ea0ad8668c7313cf2837510ddab23533cbd02a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3184,
+        "payload_json": {
+          "checksum": "sha256:ea0c43dfffb21c353506bef636ea0ad8668c7313cf2837510ddab23533cbd02a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3200,
+    "alt": "ISTJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:e74d722c4bc0086aac262cddb588dfd442fabe8ec08e191f5f9a4c960f33287a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:e74d722c4bc0086aac262cddb588dfd442fabe8ec08e191f5f9a4c960f33287a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "ISTJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:5e6101115ee4fec3be97d7b62a1a235df72b0b5296a3fe24487e06151fd3104e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:5e6101115ee4fec3be97d7b62a1a235df72b0b5296a3fe24487e06151fd3104e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3207,
+    "alt": "ISTJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:9c6b6375c4599845ff1d8232f692a52c51745e3e653cfe428d4155759cf9d1ee"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:9c6b6375c4599845ff1d8232f692a52c51745e3e653cfe428d4155759cf9d1ee"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3211,
+    "alt": "ISTJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:d98772dda6ecfebadcde355f6f1515e6640fab85545f6cb12a230d623f4675e2"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:d98772dda6ecfebadcde355f6f1515e6640fab85545f6cb12a230d623f4675e2"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3204,
+    "alt": "ISTJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:a4943e12282e80e817fdd4038db5e8f22704bcc2ad3cee9317a8f9547cdfda53"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:a4943e12282e80e817fdd4038db5e8f22704bcc2ad3cee9317a8f9547cdfda53"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3202,
+    "alt": "ISTJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:77a1baa2f6dbb7604c95446565244682963f697ef8c7989721ad3831d536cbbe"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:77a1baa2f6dbb7604c95446565244682963f697ef8c7989721ad3831d536cbbe"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3191,
+    "alt": "ISTJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:5f000586299bed4c4c302b8e792b28c6da4805f4557710f43aa5a67d8506dd04"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3191,
+        "payload_json": {
+          "checksum": "sha256:5f000586299bed4c4c302b8e792b28c6da4805f4557710f43aa5a67d8506dd04"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3192,
+    "alt": "ISTJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:78e69620e50fcd7084b51307810fe988e4870d75787427d33064ef6c9c832c40"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3192,
+        "payload_json": {
+          "checksum": "sha256:78e69620e50fcd7084b51307810fe988e4870d75787427d33064ef6c9c832c40"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "ISTJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:c58958e17836b9e893b5974bdbe76492b0af671834c517906ad347f273de7a37"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:c58958e17836b9e893b5974bdbe76492b0af671834c517906ad347f273de7a37"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3213,
+    "alt": "ISTJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:0e9511ef3ace4f3912990a338bf44e48b363e99d34a37757c2d6e08a3070fa57"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3213,
+        "payload_json": {
+          "checksum": "sha256:0e9511ef3ace4f3912990a338bf44e48b363e99d34a37757c2d6e08a3070fa57"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3222,
+    "alt": "ISTJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:3867a8b1a6a73d171d68b70de980fad2375029607c0b10104fdd49c069f6eb0d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3222,
+        "payload_json": {
+          "checksum": "sha256:3867a8b1a6a73d171d68b70de980fad2375029607c0b10104fdd49c069f6eb0d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3207,
+    "alt": "ISTJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:3c25fd36a5cfde658eb5ab2a02a332bc72f07dddfba5f33dbd7432ce7bbdaaa8"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:3c25fd36a5cfde658eb5ab2a02a332bc72f07dddfba5f33dbd7432ce7bbdaaa8"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3197,
+    "alt": "ISFJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:e1bf14d79f93b43d6618169e29f7ffd2a5fce121c018499aef72823043458434"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3197,
+        "payload_json": {
+          "checksum": "sha256:e1bf14d79f93b43d6618169e29f7ffd2a5fce121c018499aef72823043458434"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3193,
+    "alt": "ISFJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:a680dcbf3b89f74bd92356aeed84c228f2b1cd7d87821e905bd6798b4f7f20df"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3193,
+        "payload_json": {
+          "checksum": "sha256:a680dcbf3b89f74bd92356aeed84c228f2b1cd7d87821e905bd6798b4f7f20df"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3206,
+    "alt": "ISFJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:b9443a411d9f04c24f63b2d634625e283a283c588f4a37149934222c9e969c8e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:b9443a411d9f04c24f63b2d634625e283a283c588f4a37149934222c9e969c8e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3201,
+    "alt": "ISFJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:4657378b855723d21ae5d305649b7563070fc85225b667b5ee8906abede06220"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:4657378b855723d21ae5d305649b7563070fc85225b667b5ee8906abede06220"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "ISFJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:e59f90c2420a70574b7a897c38a734daae839918e1aee025f5d1247e65e95fe3"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:e59f90c2420a70574b7a897c38a734daae839918e1aee025f5d1247e65e95fe3"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3216,
+    "alt": "ISFJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:3a1536f066f5b27ff9c7283ce62e0dbeac9ec6633727797332ec6eee32256f63"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3216,
+        "payload_json": {
+          "checksum": "sha256:3a1536f066f5b27ff9c7283ce62e0dbeac9ec6633727797332ec6eee32256f63"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3205,
+    "alt": "ISFJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:e522abd3b0520cffd6f16e8f515b13385a15ccbab1dcaa7b5e5cbb7f82104a71"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:e522abd3b0520cffd6f16e8f515b13385a15ccbab1dcaa7b5e5cbb7f82104a71"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3198,
+    "alt": "ISFJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:c07553b588c7d249767afde2aec59e2ef0e8bbd9e8a79a1ed1c70a809c733d3b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:c07553b588c7d249767afde2aec59e2ef0e8bbd9e8a79a1ed1c70a809c733d3b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3180,
+    "alt": "ISFJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:5d576af70ac5445747ad18e6ee512983f2a9d9a4a62e9d5a965cf982bfae62ed"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3180,
+        "payload_json": {
+          "checksum": "sha256:5d576af70ac5445747ad18e6ee512983f2a9d9a4a62e9d5a965cf982bfae62ed"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3196,
+    "alt": "ISFJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:f370ea3781d685c094b5f1de6cd0fddcdbd91611719b94bdc94bd7021e28f136"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:f370ea3781d685c094b5f1de6cd0fddcdbd91611719b94bdc94bd7021e28f136"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ISFJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:b3a3d254abb64a7c840c4d39e4852cbad9faca740b63db1df4c859f1d43746d3"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:b3a3d254abb64a7c840c4d39e4852cbad9faca740b63db1df4c859f1d43746d3"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "ISFJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:e7383f1ee5a3134cbbc0165dddb63d3957a170b3ae3e9cba30dc1aecd907811d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:e7383f1ee5a3134cbbc0165dddb63d3957a170b3ae3e9cba30dc1aecd907811d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3214,
+    "alt": "ISFJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:ae2b60457f822b714ec82af6dc07c46b109db93104a74034af7cbd7fb077b57f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3214,
+        "payload_json": {
+          "checksum": "sha256:ae2b60457f822b714ec82af6dc07c46b109db93104a74034af7cbd7fb077b57f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3207,
+    "alt": "ISFJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:291d22a879d2d9c9e6b34e175b18ab5ec22787796c673115b8967e7c5b53b972"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:291d22a879d2d9c9e6b34e175b18ab5ec22787796c673115b8967e7c5b53b972"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3197,
+    "alt": "ESTJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:5d16293231f8f034dfbed9dfc93dd66b6c76255161ecb14f681dfd7844ba5e82"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3197,
+        "payload_json": {
+          "checksum": "sha256:5d16293231f8f034dfbed9dfc93dd66b6c76255161ecb14f681dfd7844ba5e82"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3185,
+    "alt": "ESTJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:77c6897c7415d244198f9e4c6642071a3953003c9177807e7f03997647a1b19b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3185,
+        "payload_json": {
+          "checksum": "sha256:77c6897c7415d244198f9e4c6642071a3953003c9177807e7f03997647a1b19b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3200,
+    "alt": "ESTJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:24f00000ff63fffcef36742d8341dd609b11ed81dabfb8709ed2669fc9533d9b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:24f00000ff63fffcef36742d8341dd609b11ed81dabfb8709ed2669fc9533d9b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3200,
+    "alt": "ESTJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:6fea31d87733a2ae36522ba7929fd2eebf3e555b0e622223a3199954dedf4037"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:6fea31d87733a2ae36522ba7929fd2eebf3e555b0e622223a3199954dedf4037"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3202,
+    "alt": "ESTJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:e6bb3c3a1cc659f6494ce524b9f2538661342c1c9c19705b01b1cc6e5aa26c51"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:e6bb3c3a1cc659f6494ce524b9f2538661342c1c9c19705b01b1cc6e5aa26c51"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3210,
+    "alt": "ESTJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:4f5d0652a40ab937655c85037318ef2bc0faef420af4988a90fc03976bda6113"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3210,
+        "payload_json": {
+          "checksum": "sha256:4f5d0652a40ab937655c85037318ef2bc0faef420af4988a90fc03976bda6113"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3209,
+    "alt": "ESTJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESTJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:efad94fd5ab6567303e78cf5137d11e3ee539b8eedbf94bc7c0d6d07e52971bb"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:efad94fd5ab6567303e78cf5137d11e3ee539b8eedbf94bc7c0d6d07e52971bb"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3200,
+    "alt": "ESTJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:abaaa89087b50ba5e05990237d565c9fba50929fd9d2fb534f5de906bebe8003"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:abaaa89087b50ba5e05990237d565c9fba50929fd9d2fb534f5de906bebe8003"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3194,
+    "alt": "ESTJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:e4054ede22cd09f9107979faaec2fc711b0ec8a0a9e2998f539b059f018eb2f1"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3194,
+        "payload_json": {
+          "checksum": "sha256:e4054ede22cd09f9107979faaec2fc711b0ec8a0a9e2998f539b059f018eb2f1"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3189,
+    "alt": "ESTJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:023e133d637ca9972d181c3badde31e72fd384f48bc26dda5c33bba14803b5bd"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3189,
+        "payload_json": {
+          "checksum": "sha256:023e133d637ca9972d181c3badde31e72fd384f48bc26dda5c33bba14803b5bd"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3209,
+    "alt": "ESTJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:6eb084318c745e4d7d68dbebad3685133e95ae041745df78c267c26badbc1d8a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:6eb084318c745e4d7d68dbebad3685133e95ae041745df78c267c26badbc1d8a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3209,
+    "alt": "ESTJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:5f23b773d664164d64cfca4c5e41c0016de1976326526d9f6b115f8bde20bae3"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:5f23b773d664164d64cfca4c5e41c0016de1976326526d9f6b115f8bde20bae3"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3219,
+    "alt": "ESTJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:de4176a223594ae8edecbba703af75a763f590d32c7019f5486aa1d4f4353d0f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3219,
+        "payload_json": {
+          "checksum": "sha256:de4176a223594ae8edecbba703af75a763f590d32c7019f5486aa1d4f4353d0f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3208,
+    "alt": "ESTJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESTJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:565acf819dc8c3f61a2b0111b6d6e79b0a06d768f9788f375b2b9a99e11b88b1"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3208,
+        "payload_json": {
+          "checksum": "sha256:565acf819dc8c3f61a2b0111b6d6e79b0a06d768f9788f375b2b9a99e11b88b1"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3198,
+    "alt": "ESFJ-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:21e62b6eb96a57506147e77ddd72dd06067b07f67535379f89ea436b1cd9df14"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:21e62b6eb96a57506147e77ddd72dd06067b07f67535379f89ea436b1cd9df14"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3190,
+    "alt": "ESFJ-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:9ab0f9f0f0a4e5ff147422730df7639a85013be6d5815d899c80a7cc61208287"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3190,
+        "payload_json": {
+          "checksum": "sha256:9ab0f9f0f0a4e5ff147422730df7639a85013be6d5815d899c80a7cc61208287"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3199,
+    "alt": "ESFJ-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:b4d88e114812cb9fc539aa1c1e97ac6ff732ab060e727bbcc9530098db9ecffb"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:b4d88e114812cb9fc539aa1c1e97ac6ff732ab060e727bbcc9530098db9ecffb"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "ESFJ-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:077cba9ea16619750bcaa01f63e4915f80415759f829eeeaddc1fa0224baabc4"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:077cba9ea16619750bcaa01f63e4915f80415759f829eeeaddc1fa0224baabc4"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3211,
+    "alt": "ESFJ-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:d3c00f69ee066dd607b0136b36e74fc3ca38c6ce23e44bc08baf17eddabe0c79"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:d3c00f69ee066dd607b0136b36e74fc3ca38c6ce23e44bc08baf17eddabe0c79"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3223,
+    "alt": "ESFJ-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:0f91ea7f6c869bf2f93afac0a8fb327ff5ca4412d689108facd6112fbaa5c4dc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3223,
+        "payload_json": {
+          "checksum": "sha256:0f91ea7f6c869bf2f93afac0a8fb327ff5ca4412d689108facd6112fbaa5c4dc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3208,
+    "alt": "ESFJ-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESFJ-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:d2f63ff8f7b3fd864f40a7eb660eaa9e05c7b992c9be13a00dfea983ac64e8f2"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3208,
+        "payload_json": {
+          "checksum": "sha256:d2f63ff8f7b3fd864f40a7eb660eaa9e05c7b992c9be13a00dfea983ac64e8f2"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3200,
+    "alt": "ESFJ-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:857a5a5a2433217ce6924192cd1ae5b300f7888736e22a0c177b000f1fe040ed"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:857a5a5a2433217ce6924192cd1ae5b300f7888736e22a0c177b000f1fe040ed"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3186,
+    "alt": "ESFJ-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:d92e494bacdc8bf7c01a5ab4b6317e931274bb95800f0127864a0776ead7a8ad"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3186,
+        "payload_json": {
+          "checksum": "sha256:d92e494bacdc8bf7c01a5ab4b6317e931274bb95800f0127864a0776ead7a8ad"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3196,
+    "alt": "ESFJ-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:5c7079e4b86b129f795ee8e8787ac0e6234b3cf0f833fffe328c40d3a208e9d9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:5c7079e4b86b129f795ee8e8787ac0e6234b3cf0f833fffe328c40d3a208e9d9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3205,
+    "alt": "ESFJ-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:1d8162a3d695db30a92c2ada696b7f07f935a7db881de00b0be5119d10a18c6e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:1d8162a3d695db30a92c2ada696b7f07f935a7db881de00b0be5119d10a18c6e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3198,
+    "alt": "ESFJ-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:49d16dc941589145ab6e6c9d7a25293f35507ba2efdf621723a7faeb97345029"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:49d16dc941589145ab6e6c9d7a25293f35507ba2efdf621723a7faeb97345029"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3216,
+    "alt": "ESFJ-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:5ebf45165e524fd512ec12816dc626ef0e1b08e9f0bf2c166c805578c44e9d96"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3216,
+        "payload_json": {
+          "checksum": "sha256:5ebf45165e524fd512ec12816dc626ef0e1b08e9f0bf2c166c805578c44e9d96"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfj-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3206,
+    "alt": "ESFJ-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESFJ-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFJ-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:3cc0e24d927adb9b8205affec0df78f3156510c4798e83a1501db4a0a6977399"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:3cc0e24d927adb9b8205affec0df78f3156510c4798e83a1501db4a0a6977399"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3202,
+    "alt": "ISTP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:0b77cbb9a2c10f869031e56a1412cd80132a83d19d243bb1c9c2810b9967b5c4"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3202,
+        "payload_json": {
+          "checksum": "sha256:0b77cbb9a2c10f869031e56a1412cd80132a83d19d243bb1c9c2810b9967b5c4"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3185,
+    "alt": "ISTP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:e0cdc136833552b93b2620f88631f189aef080f61712acf8675d5a9dea4a834d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3185,
+        "payload_json": {
+          "checksum": "sha256:e0cdc136833552b93b2620f88631f189aef080f61712acf8675d5a9dea4a834d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3204,
+    "alt": "ISTP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:d859ed440e02f5f8fda8e0fcc5e3312bb2387b41db1ed6273bb86ab1fe6dcd20"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:d859ed440e02f5f8fda8e0fcc5e3312bb2387b41db1ed6273bb86ab1fe6dcd20"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "ISTP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:63b68462196028ee87bc2aacee86acd87741e1b02d96ca08fea175b8e3d9d4b7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:63b68462196028ee87bc2aacee86acd87741e1b02d96ca08fea175b8e3d9d4b7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "ISTP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:c658597dc0c322fbbf90d2d6550930631632abb009d76a229ab54b3a422519fd"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:c658597dc0c322fbbf90d2d6550930631632abb009d76a229ab54b3a422519fd"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3215,
+    "alt": "ISTP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:af6344a7accd3e87fb443fba629d86d6aeb47af52f08ad9c1e97677196c60983"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3215,
+        "payload_json": {
+          "checksum": "sha256:af6344a7accd3e87fb443fba629d86d6aeb47af52f08ad9c1e97677196c60983"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3205,
+    "alt": "ISTP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:deaac2d641ffa85cd6541477a467316eec125076159bba58dd46988fd57f0bbc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:deaac2d641ffa85cd6541477a467316eec125076159bba58dd46988fd57f0bbc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3203,
+    "alt": "ISTP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:46912ec1da34c7e4634dc573415183e1126ad38e4fd29e668bcc622b05a37c9b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:46912ec1da34c7e4634dc573415183e1126ad38e4fd29e668bcc622b05a37c9b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3194,
+    "alt": "ISTP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:96e9a5fec3c6c270bdeff4b8d9e6d8bc332c4e84f453816f92d46844f468ea43"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3194,
+        "payload_json": {
+          "checksum": "sha256:96e9a5fec3c6c270bdeff4b8d9e6d8bc332c4e84f453816f92d46844f468ea43"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3194,
+    "alt": "ISTP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:728eb2e773a00368771cc8135ac03206880931b69695019a1169e74915efd429"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3194,
+        "payload_json": {
+          "checksum": "sha256:728eb2e773a00368771cc8135ac03206880931b69695019a1169e74915efd429"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3201,
+    "alt": "ISTP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:b573eff519745390b23b0ec11ce4ebabbdab62803eda42f8cd2169e047c4f07e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:b573eff519745390b23b0ec11ce4ebabbdab62803eda42f8cd2169e047c4f07e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3211,
+    "alt": "ISTP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:95e6ea7e2a51bb0c48599ff8841270f444efc8707e4f4f481522ac88c43f261d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:95e6ea7e2a51bb0c48599ff8841270f444efc8707e4f4f481522ac88c43f261d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3222,
+    "alt": "ISTP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:c7361c24b32635487a602cacca410cfde9082a93a4f92d887fa8188a0cb5f68f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3222,
+        "payload_json": {
+          "checksum": "sha256:c7361c24b32635487a602cacca410cfde9082a93a4f92d887fa8188a0cb5f68f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.istp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3198,
+    "alt": "ISTP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISTP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:4f6772284ea4c37b5a8bdfcefa1c983a0863050edcaea8fa967555feba78a6f4"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:4f6772284ea4c37b5a8bdfcefa1c983a0863050edcaea8fa967555feba78a6f4"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3198,
+    "alt": "ISFP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:20421c2ac147a772df26bbf1ea7b3adeb19256a3502caf31ddbdb73d48a21e0f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:20421c2ac147a772df26bbf1ea7b3adeb19256a3502caf31ddbdb73d48a21e0f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3190,
+    "alt": "ISFP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:2f8bf7b083396a87c6f4a63913c6e018e78921af0102591a20b3fd8f55f218dc"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3190,
+        "payload_json": {
+          "checksum": "sha256:2f8bf7b083396a87c6f4a63913c6e018e78921af0102591a20b3fd8f55f218dc"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3203,
+    "alt": "ISFP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:2587d4f7a46c232b3e38bca4dadb830d0003af3ca15fffca024de6a36542bdb9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:2587d4f7a46c232b3e38bca4dadb830d0003af3ca15fffca024de6a36542bdb9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3198,
+    "alt": "ISFP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:0a5128b593b220fc3087746effca812442a6371608c5c44203ec41eeccc87b7a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:0a5128b593b220fc3087746effca812442a6371608c5c44203ec41eeccc87b7a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ISFP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:db531eef599654bf66398fa9ff6171af9c693e6b843b04a06ff88e76f892ef9f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:db531eef599654bf66398fa9ff6171af9c693e6b843b04a06ff88e76f892ef9f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3213,
+    "alt": "ISFP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:6d91cd03c1b7d1108b42d5bdf66589563055b8368c17dd2255881afe433898ff"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3213,
+        "payload_json": {
+          "checksum": "sha256:6d91cd03c1b7d1108b42d5bdf66589563055b8368c17dd2255881afe433898ff"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3205,
+    "alt": "ISFP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:d23ff6a16cd0d96552f1ec7988cbf28de0498fe47e70b787a1a8cb66e6258b2f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3205,
+        "payload_json": {
+          "checksum": "sha256:d23ff6a16cd0d96552f1ec7988cbf28de0498fe47e70b787a1a8cb66e6258b2f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3201,
+    "alt": "ISFP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:a007a064223d82a8db8372075e303c59c6409c99beda9e916d60ac036cf1fb8d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:a007a064223d82a8db8372075e303c59c6409c99beda9e916d60ac036cf1fb8d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3186,
+    "alt": "ISFP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:d432277e06a6181580bfef99459f3983ef427f1df3788fca55ef855919d4500b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3186,
+        "payload_json": {
+          "checksum": "sha256:d432277e06a6181580bfef99459f3983ef427f1df3788fca55ef855919d4500b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3195,
+    "alt": "ISFP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:2b345734669d6acf1c0ad4d6c5249d054b332d222d1a1b590310000a55b7d45e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3195,
+        "payload_json": {
+          "checksum": "sha256:2b345734669d6acf1c0ad4d6c5249d054b332d222d1a1b590310000a55b7d45e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ISFP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:944aa054613b1c8f2065fd58a806bb223c554b955c248fdff929e6de99c13ef7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:944aa054613b1c8f2065fd58a806bb223c554b955c248fdff929e6de99c13ef7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3212,
+    "alt": "ISFP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:a1302fc776ba2517414bff14d8a3e460a7787012ed23c720962fc8e01b3bf742"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3212,
+        "payload_json": {
+          "checksum": "sha256:a1302fc776ba2517414bff14d8a3e460a7787012ed23c720962fc8e01b3bf742"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3219,
+    "alt": "ISFP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:5ca2865c38a20468d4890896982c355b2b88bc153f1fc4417a9688583adc4230"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3219,
+        "payload_json": {
+          "checksum": "sha256:5ca2865c38a20468d4890896982c355b2b88bc153f1fc4417a9688583adc4230"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.isfp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3211,
+    "alt": "ISFP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ISFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ISFP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:e7c8fbff67df8c2f3076a7b43c30f1e63723c2c0e49a63e903d4338a5084520d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3211,
+        "payload_json": {
+          "checksum": "sha256:e7c8fbff67df8c2f3076a7b43c30f1e63723c2c0e49a63e903d4338a5084520d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3195,
+    "alt": "ESTP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:8f4c29381467d6a4cef737ea9c0345b1275330058dc1d141b97934cf62cdc50a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3195,
+        "payload_json": {
+          "checksum": "sha256:8f4c29381467d6a4cef737ea9c0345b1275330058dc1d141b97934cf62cdc50a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3182,
+    "alt": "ESTP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:a3075ee82b487ad9f61c33ef80f246661ebfff6453c817ceb08e4d19aa45eafd"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3182,
+        "payload_json": {
+          "checksum": "sha256:a3075ee82b487ad9f61c33ef80f246661ebfff6453c817ceb08e4d19aa45eafd"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3195,
+    "alt": "ESTP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:ea7c3f35cbb610e9907d6e98a528dfce17719e26e4af811024d37ddbfae68655"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3195,
+        "payload_json": {
+          "checksum": "sha256:ea7c3f35cbb610e9907d6e98a528dfce17719e26e4af811024d37ddbfae68655"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ESTP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:33983e8b4776033cc2960a43c3969b3cdb7eca3ba15652c669ffcb0a7d952f7d"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:33983e8b4776033cc2960a43c3969b3cdb7eca3ba15652c669ffcb0a7d952f7d"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3203,
+    "alt": "ESTP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:85973f72bdf2c0465c3f67239932f37275383a21b3ac62a73c5eb9d91e8673e7"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:85973f72bdf2c0465c3f67239932f37275383a21b3ac62a73c5eb9d91e8673e7"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3213,
+    "alt": "ESTP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:619fcb2c2c1a819dced05f0550d0bb24f6d6189fb8cbba8e01e58c76642ba5b2"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3213,
+        "payload_json": {
+          "checksum": "sha256:619fcb2c2c1a819dced05f0550d0bb24f6d6189fb8cbba8e01e58c76642ba5b2"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3208,
+    "alt": "ESTP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESTP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:b53b0b90808d98058c37389620b304675d2fece7fd78813550133fc5309f1c58"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3208,
+        "payload_json": {
+          "checksum": "sha256:b53b0b90808d98058c37389620b304675d2fece7fd78813550133fc5309f1c58"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3198,
+    "alt": "ESTP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:84e914528bfd32c4cdeb3e6fa1307b35ff79d0164d774ee21f7802f2359e328a"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3198,
+        "payload_json": {
+          "checksum": "sha256:84e914528bfd32c4cdeb3e6fa1307b35ff79d0164d774ee21f7802f2359e328a"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3193,
+    "alt": "ESTP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:236c485e55bd9c2d982f4db491101fc38c0a91ac0ead81f03092e46a42534a18"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3193,
+        "payload_json": {
+          "checksum": "sha256:236c485e55bd9c2d982f4db491101fc38c0a91ac0ead81f03092e46a42534a18"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3190,
+    "alt": "ESTP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:9be08603824dd11fdaf5a8c65c2767219dec380c385d535b269e18c7c3d0630f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3190,
+        "payload_json": {
+          "checksum": "sha256:9be08603824dd11fdaf5a8c65c2767219dec380c385d535b269e18c7c3d0630f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3206,
+    "alt": "ESTP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:327aae359b28839805534cf5c5c9f4ad992e99f1663a30422ca506fdf8a9c40b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:327aae359b28839805534cf5c5c9f4ad992e99f1663a30422ca506fdf8a9c40b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3212,
+    "alt": "ESTP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:ebb5017b4f2f188a5216e4bd7a281a6fdb7e94955eeaf66ca3faffb1a386e41e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3212,
+        "payload_json": {
+          "checksum": "sha256:ebb5017b4f2f188a5216e4bd7a281a6fdb7e94955eeaf66ca3faffb1a386e41e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3223,
+    "alt": "ESTP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:a08c84e8e450baaf1e4176c175fa0af397d92e5a23d6aa42fca3462ae8f7aac1"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3223,
+        "payload_json": {
+          "checksum": "sha256:a08c84e8e450baaf1e4176c175fa0af397d92e5a23d6aa42fca3462ae8f7aac1"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.estp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3206,
+    "alt": "ESTP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESTP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESTP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:6dd1f8a94266532c7aa30cf0a5418436d281e24070880941facafb135eadc194"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3206,
+        "payload_json": {
+          "checksum": "sha256:6dd1f8a94266532c7aa30cf0a5418436d281e24070880941facafb135eadc194"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3203,
+    "alt": "ESFP-A MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:dfe9ba7ccfc1e14f1468fa0e6b99748e5fd076b336ce1dc00101236b0bed5d6e"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3203,
+        "payload_json": {
+          "checksum": "sha256:dfe9ba7ccfc1e14f1468fa0e6b99748e5fd076b336ce1dc00101236b0bed5d6e"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3187,
+    "alt": "ESFP-A MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:ecd1e188f81fcad1ec57decb52e2aa0a1f04afec41a404ce6da364f8ea90c01b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3187,
+        "payload_json": {
+          "checksum": "sha256:ecd1e188f81fcad1ec57decb52e2aa0a1f04afec41a404ce6da364f8ea90c01b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3201,
+    "alt": "ESFP-A MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:1c613b76c94e08f8d3086ad3629d6828f946eeee9e92f9d5e2d9c545e4c0db1f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3201,
+        "payload_json": {
+          "checksum": "sha256:1c613b76c94e08f8d3086ad3629d6828f946eeee9e92f9d5e2d9c545e4c0db1f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3200,
+    "alt": "ESFP-A MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:efeb7bdec316d73b548abd9c4a61d5457425a60c867d34d79c920bd0a28cf19f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3200,
+        "payload_json": {
+          "checksum": "sha256:efeb7bdec316d73b548abd9c4a61d5457425a60c867d34d79c920bd0a28cf19f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3208,
+    "alt": "ESFP-A MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:bbed4c764ac0dc00b2344fdbfb8cfc97472001ca7cac62992aed967f2906e78f"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3208,
+        "payload_json": {
+          "checksum": "sha256:bbed4c764ac0dc00b2344fdbfb8cfc97472001ca7cac62992aed967f2906e78f"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3220,
+    "alt": "ESFP-A MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:6759470376625c289bd11d44bf28da563bb64b2877bbd9d22a7334cf3708321b"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3220,
+        "payload_json": {
+          "checksum": "sha256:6759470376625c289bd11d44bf28da563bb64b2877bbd9d22a7334cf3708321b"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-a.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3199,
+    "alt": "ESFP-A MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESFP-A.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-A",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:86b32869d45d99573c7ffbea58282ef5389b13f1756fdb3bd658cd4886e766fd"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3199,
+        "payload_json": {
+          "checksum": "sha256:86b32869d45d99573c7ffbea58282ef5389b13f1756fdb3bd658cd4886e766fd"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.hero-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/hero-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/hero-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 708,
+    "height": 480,
+    "bytes": 3191,
+    "alt": "ESFP-T MBTI desktop clone hero identity illustration.",
+    "caption": "Repo-backed MBTI desktop clone hero identity illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "hero-illustration",
+      "version": "v1",
+      "checksum": "sha256:d147a4a81c7d5527a9e402ade2039a6a9cfe0abeb2ce12a23c0a3e2bbeb74b13"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/hero-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/hero-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 708,
+        "height": 480,
+        "bytes": 3191,
+        "payload_json": {
+          "checksum": "sha256:d147a4a81c7d5527a9e402ade2039a6a9cfe0abeb2ce12a23c0a3e2bbeb74b13"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.traits-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/traits-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/traits-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3189,
+    "alt": "ESFP-T MBTI desktop clone traits axis illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits axis illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "traits-illustration",
+      "version": "v1",
+      "checksum": "sha256:4504d018ca7c52c1764724a2910305d57472b224333966aeebac456ec8e833d9"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/traits-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/traits-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3189,
+        "payload_json": {
+          "checksum": "sha256:4504d018ca7c52c1764724a2910305d57472b224333966aeebac456ec8e833d9"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.traits-summary-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 720,
+    "height": 354,
+    "bytes": 3196,
+    "alt": "ESFP-T MBTI desktop clone traits summary illustration.",
+    "caption": "Repo-backed MBTI desktop clone traits summary illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "traits-summary-illustration",
+      "version": "v1",
+      "checksum": "sha256:8bd693e6a3a7077a859f7ab5994e040ed6f843505db1dae1da02a2307c509916"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 720,
+        "height": 354,
+        "bytes": 3196,
+        "payload_json": {
+          "checksum": "sha256:8bd693e6a3a7077a859f7ab5994e040ed6f843505db1dae1da02a2307c509916"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.career-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/career-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/career-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3207,
+    "alt": "ESFP-T MBTI desktop clone career path illustration.",
+    "caption": "Repo-backed MBTI desktop clone career path illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "career-illustration",
+      "version": "v1",
+      "checksum": "sha256:d02994f2aef413f18aa2bafdb9d88ef4fdf6353680afa40d1a902d952f5cd313"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/career-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/career-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3207,
+        "payload_json": {
+          "checksum": "sha256:d02994f2aef413f18aa2bafdb9d88ef4fdf6353680afa40d1a902d952f5cd313"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.growth-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/growth-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/growth-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3204,
+    "alt": "ESFP-T MBTI desktop clone growth path illustration.",
+    "caption": "Repo-backed MBTI desktop clone growth path illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "growth-illustration",
+      "version": "v1",
+      "checksum": "sha256:8215fdbca8051e1516f55dad663ffbe05d826f2733a98dadab64cfdc9ff951ca"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/growth-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/growth-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3204,
+        "payload_json": {
+          "checksum": "sha256:8215fdbca8051e1516f55dad663ffbe05d826f2733a98dadab64cfdc9ff951ca"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.relationships-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 1272,
+    "height": 296,
+    "bytes": 3217,
+    "alt": "ESFP-T MBTI desktop clone relationships illustration.",
+    "caption": "Repo-backed MBTI desktop clone relationships illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "relationships-illustration",
+      "version": "v1",
+      "checksum": "sha256:e09e19d9b843020eef88e9057dae4222d80d5aad22571a7df19ba80736975374"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 1272,
+        "height": 296,
+        "bytes": 3217,
+        "payload_json": {
+          "checksum": "sha256:e09e19d9b843020eef88e9057dae4222d80d5aad22571a7df19ba80736975374"
+        }
+      }
+    ]
+  },
+  {
+    "asset_key": "mbti.desktop_clone.esfp-t.final-offer-illustration",
+    "disk": "public_static",
+    "path": "/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg",
+    "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg",
+    "mime_type": "image/svg+xml",
+    "width": 756,
+    "height": 660,
+    "bytes": 3209,
+    "alt": "ESFP-T MBTI desktop clone final offer illustration.",
+    "caption": "Repo-backed MBTI desktop clone final offer illustration for ESFP-T.",
+    "credit": "FermatMind generated system asset",
+    "status": "published",
+    "is_public": true,
+    "payload_json": {
+      "surface": "mbti_desktop_clone",
+      "full_code": "ESFP-T",
+      "slot_id": "final-offer-illustration",
+      "version": "v1",
+      "checksum": "sha256:f2c026c07811c60c873187d732eeab80b171df05e152a71abf1c9e1106a2e9ad"
+    },
+    "variants": [
+      {
+        "variant_key": "original",
+        "path": "/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg",
+        "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg",
+        "mime_type": "image/svg+xml",
+        "width": 756,
+        "height": 660,
+        "bytes": 3209,
+        "payload_json": {
+          "checksum": "sha256:f2c026c07811c60c873187d732eeab80b171df05e152a71abf1c9e1106a2e9ad"
+        }
+      }
+    ]
+  }
+]

--- a/content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
+++ b/content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
@@ -1170,66 +1170,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0c2ebbaab5d67bb4a45b1de0dd6e7f254dbdc8cc21932fd088d3e48dcfcc5f70"
+          },
+          "alt": "INTJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a41faa228975e58975191446aa4f9c0c2d0b9e5bf7da5a610507398e54efd6d7"
+          },
+          "alt": "INTJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e28c448ffd746118fa80f33845968b0fdb5bc767ae155fe4304ad64efd3c392a"
+          },
+          "alt": "INTJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a1030e7de221a2411f10485feba24dfbf26cef79bf4cd9709bc731f8cf2b7c1c"
+          },
+          "alt": "INTJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:168e6a6ab3722085975034eda827fe921421dc594c7a805229e2a549f0a38ac4"
+          },
+          "alt": "INTJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1dee508359eca3ee52d9008c0b6fe1b5ebe1a1e99cfaf1241838693bb1d1e61e"
+          },
+          "alt": "INTJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:acb2bd016a7897700d2c43a0d700e344f4c3d988c1b5bc65b135645df0b57929"
+          },
+          "alt": "INTJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -2397,66 +2488,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f8888bcb5dee5e147231e95e181e40e243bb9e678e7d7a90c0e2d9c6142fa597"
+          },
+          "alt": "INTJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3dc4470fbafc20573a7b1fa90346e21e3b53ca0c26c7e407cb2a410492036328"
+          },
+          "alt": "INTJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3aec5d0f64b5636a6d021b5183f6f84550dab128fa7d65e4459fd90101ab22cb"
+          },
+          "alt": "INTJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2372c6225f3379717a1c32d1e367d244d47a83a36c8e900ad6fd6744a3d41417"
+          },
+          "alt": "INTJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b4b59d4a448f5076e2e279833e56c5dfd67f0598ddaef2b36d7026275436afaf"
+          },
+          "alt": "INTJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2c8e0aca447d6c35ab2f0393e0351d14d3166d5416bd91c2ad71a556d92b8de4"
+          },
+          "alt": "INTJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ba36a04fe0f3e4c4528cd9fea49b703f567b1c9da28057e1e3839d9e2543fade"
+          },
+          "alt": "INTJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -3624,66 +3806,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:841984b763560ac5bc8023e420e3a84e5ca241087c3c0dd85cbcc8175c558452"
+          },
+          "alt": "INTP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:71ec536512626f99ac6e6533d876f571c878cf786a4b9b6e9f2778e622a8aef8"
+          },
+          "alt": "INTP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b7b3c110a5557488fc2ff9dc2e50c47953ad94eaf90be6209347fb00f6236261"
+          },
+          "alt": "INTP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:fc0edc5ae730df25ebda79c5177db784d170203db3b077a2d556f5ad3912fad9"
+          },
+          "alt": "INTP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d490a654def86a0c76ca766bee6c0003b627649e7c156407a5933402c76d452b"
+          },
+          "alt": "INTP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c46d77efff21dd8a04f48cf26d5d019c73d44b5e563ea0505a50961826bd38cc"
+          },
+          "alt": "INTP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5e9d43634d03dd4db7d0bf0d7b0c3d99a41ef49484fc7a147bd0af09ae02bc85"
+          },
+          "alt": "INTP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -4851,66 +5124,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a01e7a0bbbec601cf78c50477227951aa780da3c2c2c803c106a0feaa9e9dad4"
+          },
+          "alt": "INTP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:86c15405b36c0422843a8f2d959c2cbe7a0b2947936920af78c1fbdc608fefe5"
+          },
+          "alt": "INTP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b82e42c64a541cdf8534a9d200403e17f39f3f399ad056c8435d805a06069d78"
+          },
+          "alt": "INTP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:8cf8b940a4c07dedab7040874b50b99dab2ded9382b86f1ff0fc116777766a81"
+          },
+          "alt": "INTP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2b18b49d6b88e9ae821bf58d21acaa9463fee00a8f87e49d7f9fc5ca170a67cf"
+          },
+          "alt": "INTP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:fa700757de767089a4cd3bb4c752b9cb0f1f0c0f6f1cfdc2748801dd44bae54f"
+          },
+          "alt": "INTP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/intp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0ae71c22d8b2921ffd967b572052724efdc56bfc8c7bd7f566163aaf301bff95"
+          },
+          "alt": "INTP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.intp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -6078,66 +6442,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5813d192d772b156c425866b0360edac72c7eb25e0b5ab6f3d9a3409bd462760"
+          },
+          "alt": "ENTJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f837e218f06a5a71a098ddcf6605b18b7a07606b227e83eb0d52b1c8ab343a0d"
+          },
+          "alt": "ENTJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:bf7be8c55e871d5eff4e6b5bd785bf3b3c267afbf33c02ee886aef087e0c6024"
+          },
+          "alt": "ENTJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2e8be2acb5e8ce290fd14339b1d51c56c7624990cf601d816c804ba680df9767"
+          },
+          "alt": "ENTJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:fe22f58af251a389f2f7565d39b17e5c40de632fcf050ef7401b34f0c788a3de"
+          },
+          "alt": "ENTJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f110716a89685af35c10212a28cb57b356e73812dbfd2415d0a12022dfa90949"
+          },
+          "alt": "ENTJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:64fa2ac3f84fd63a970c2c5e72d521ad4af38d83a089fb93ee97d1c766ab5447"
+          },
+          "alt": "ENTJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -7305,66 +7760,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:733eca9f2a017d54f97ddcdb409ec2e27a8546e5b85c267c2d82e2962f8f0a06"
+          },
+          "alt": "ENTJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b8531745bcffbadbdf9dd71674a743115c53a56f486f629e5b2858dfc1a160dc"
+          },
+          "alt": "ENTJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:4588e8f6a3bd75dcd6bfbd25af97d0a0fa17272d887a2974c460dca329f06686"
+          },
+          "alt": "ENTJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:919fd75124d9c2bb0d2b3a1006fefdaeaef3e179eae74f82c5e782da4b9e314b"
+          },
+          "alt": "ENTJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a455eacd866ebf108b7f3d49cdb40fc35bdd4b4e343757fca16cf73a11e95bab"
+          },
+          "alt": "ENTJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ad9187c1067e364ea9dc81c953f2031603d690c06a67016744f255566b79849d"
+          },
+          "alt": "ENTJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b73db72db5a18c0a292812bb20580c8fcc5a787ec065f0d8637e8193309434e5"
+          },
+          "alt": "ENTJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -8532,66 +9078,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:389bccb3ec1d125c05634b7ad225410077cda0639035382f932a93f2a1b4bb86"
+          },
+          "alt": "ENTP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:99da98816848ec5b4519083f6ca10795bd161a9372d183bef3d46dc5317ee04e"
+          },
+          "alt": "ENTP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d1826fad230fe2bc68afa2bf422687de2852df18df38026c0cc58403cfebd566"
+          },
+          "alt": "ENTP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:74fbf4311d9ce70b43d0fe2d940292437477ee47e016ee1f21c24065af2a9ffd"
+          },
+          "alt": "ENTP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:fb15480ee840b367b52d457e7b759dc5075e104e0d7cf1f7a51c7640bad75c86"
+          },
+          "alt": "ENTP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1a44b99fbbebc26334d39711cbce54d877854f908fbf2944532748e0e92c0860"
+          },
+          "alt": "ENTP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b80ca40f83b24e440c82112d0d127aaf43dcf47d4ba2120e0b4d9d9796f84795"
+          },
+          "alt": "ENTP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -9759,66 +10396,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:4c8e7befc850db91a8ee31e478543f2fdb6a7249738105450909c0b5f404a3b1"
+          },
+          "alt": "ENTP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:77dd530522721053fe3c42eded95ceab391af499adcfb2f6954eed3cebcb7bcd"
+          },
+          "alt": "ENTP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a23bd0b7a2e8de053be7545bead9c000335a23a7a0d3068bf0309064c4f4635c"
+          },
+          "alt": "ENTP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f65581f56c76d6c0c6233ddfdb11c665e10914089ff49a43ad51eb53cc1e5284"
+          },
+          "alt": "ENTP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:947a69e52fda1164e6a97cff51c3282d65efde24708ad31ec30a6ac9ac2986e8"
+          },
+          "alt": "ENTP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:613b480311ee1517aed644f8b9d82d46e5b043f43001733aa9270418289edd7d"
+          },
+          "alt": "ENTP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/entp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c944d487a5862dc01a732de479da73864a06f805f7545c9bd5ed123b36d2edef"
+          },
+          "alt": "ENTP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.entp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -10986,66 +11714,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6c649fd5f3d7e451085dace36b67592ab0de0675086b31bad621a2b9b3fcc14e"
+          },
+          "alt": "INFJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a9d67ffa529d75bac556b584ea000bc8e16638b68abf17369183ca2bee9a361a"
+          },
+          "alt": "INFJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1b697eacdacb60d49d3ce802c4f830cc20bae61626e6bf758aeed2d6d2e566b7"
+          },
+          "alt": "INFJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:27077d5c912002b83555e61a845911b2fdea0e51fa9d0334102f61c0cdaa11b2"
+          },
+          "alt": "INFJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3ff73e8453981bff8ee942865d07c353c07dbae554214d1a3b4b9476d9ed2295"
+          },
+          "alt": "INFJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2eb5cd51b538c9125190952337ac05f043a687cdc1b53e8bb1d140e11511a922"
+          },
+          "alt": "INFJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1e5fa9c3b588b12e93899e9aa5cd21ad1ec641f51b385f2c65a2a19fafe66d3d"
+          },
+          "alt": "INFJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -12213,66 +13032,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:fdfc630e1d23b293c285c13833fa6366890a36c9c3324e33ee1d8002fead7096"
+          },
+          "alt": "INFJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f7432dbec7c51aa1b3caa1496c6e8f656f6bf6b35bb206594354f7c72bf35bdf"
+          },
+          "alt": "INFJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c769620764d42fc12d127c923c9961026127fbd6660bb9a7373a84334f20a9e2"
+          },
+          "alt": "INFJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:9e2dc2efc5d3c4e01d34963e1ac954a99cb673f8224884f0ab6221ba6cde2017"
+          },
+          "alt": "INFJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:611f330bb94d6e4f12caabf8f6b4cc1fec65c6567b618fc15ff290c87824a52a"
+          },
+          "alt": "INFJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:af31f793201035e2efab434bcbd66277d447ee292e42ca4de4e1390afbfdd836"
+          },
+          "alt": "INFJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3248ec0f66c12c5b8411c65104e350d8dbf8722bf82befe24cd087d8b9f4f4b6"
+          },
+          "alt": "INFJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -13440,66 +14350,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f48e42bc204a7ac9fdaf47a69ec8441fb1cc925f9d51736c70f0417eef32bdf7"
+          },
+          "alt": "INFP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d38e8b2af31c2bf45b957f46ca23781e16b527c049756968c0d424a59182a43b"
+          },
+          "alt": "INFP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:049f016241d68e2b89555f82cabb6aa29608c068fbb9296918ebce725a99eb22"
+          },
+          "alt": "INFP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:851fb610e7ae5a6b76fe2d8ffa1a19b1b0389258071dfd45a9815e98d5880563"
+          },
+          "alt": "INFP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:36c16e716edaf2678cd9f9958898c679f6ce524c734d8573f5a8bea37f634d0f"
+          },
+          "alt": "INFP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:89ca487aa953c670163b7df318a5b369645db6747b1500937842f40105ee2197"
+          },
+          "alt": "INFP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1d75f66adee61c68e965bdbe5137d01b26fa95605fb4d47152c40a2644301175"
+          },
+          "alt": "INFP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -14667,66 +15668,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:071dcbb0f90b4b9ffeb3ffb6d56b2a9b8ddca8b4c1487a2e23708a379d786e58"
+          },
+          "alt": "INFP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b1d08e87171574dfa5094062f0b1ccacf8866532f0abc9f58f7f6014694a9226"
+          },
+          "alt": "INFP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:df488e7be09f2e4af2a99a709d04ab718be7e6153a9ed465394f268561515fc8"
+          },
+          "alt": "INFP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:438bd14dc4d2c77bdd4d8d5cf7c4ec48c18d28b2136a7b0dfe5fedd864bec2a6"
+          },
+          "alt": "INFP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e2c071ca085f4376f820101e88f962392f556465b42358ead4b9b2eec2d73f44"
+          },
+          "alt": "INFP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:886ea44cad6a35b5bbc6313c1cf0caff62e1e79af8542c67f7818c387918f2ee"
+          },
+          "alt": "INFP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/infp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d87fce15f6dea194259e9f6b632bf27695fab395887c7b0161af57685b6050f9"
+          },
+          "alt": "INFP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.infp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -15894,66 +16986,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5f00c8b4dba61b80314b7fb43db6afc92ea9aac4c1d810c114cfd798d9fc9dcc"
+          },
+          "alt": "ENFJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6fbfcf606badba59863f830366d26a5bc3b3efd421c3ca87b1d09f7fcdaaf6e9"
+          },
+          "alt": "ENFJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f146f3b73fb35f1902fd41f29c5088c4091f823c711a1ffdf26fb7dd64904fe6"
+          },
+          "alt": "ENFJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:9a95c81e215ff4db4427a871f563c9f20cbe8ab8c8c637cb47e33829f1f977b9"
+          },
+          "alt": "ENFJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3cf7a98f1938d2e804753023b994c0eb2ee73c45897e9fd84901dfced9e2aea5"
+          },
+          "alt": "ENFJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:8a59ef158cb4830c2dd05ad1edc729aea42f69d4e0af0f23675cdb6dbae87607"
+          },
+          "alt": "ENFJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ca7e82dc26a075a1933f495829eb343a2344af3db8e25444b0a64fcf35a724ea"
+          },
+          "alt": "ENFJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -17121,66 +18304,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:94d658da60ab0463b7ccde16cc0f6a11a3cb1b1c7d6ee3f96ffcdd717b07243f"
+          },
+          "alt": "ENFJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:55d23b50df18c9f917cf0af66d0936c8c8a380a4c30153d82b883f5782f9da29"
+          },
+          "alt": "ENFJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:8a5ae843a1400ab0ef83abf8ce38dfa74f710294a4d629c8f7c88c0ad0eb9533"
+          },
+          "alt": "ENFJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:af1032340aa53bb05bccc1c44f5ca807996fe4c00671d73517046e75bf579ee9"
+          },
+          "alt": "ENFJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c918d239769ae4947f321a607bb4658e74f49d81d843636f6592baea22f0f792"
+          },
+          "alt": "ENFJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6006c15e3ce72f740648423c8232e731d17a7e05ff56cef9cf61a271b72470aa"
+          },
+          "alt": "ENFJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:189016963c20eeaf9462967e141fa0db554d9d74ae643cd1e8f52fbf729107b7"
+          },
+          "alt": "ENFJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -18348,66 +19622,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:501b98e773af8517cd40256177dc0093f38e3568adcfd2329fdac789c1665bdc"
+          },
+          "alt": "ENFP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:83d13c90fef92f14c7d764b111bb03c3b1825b679640f87236530d20cd5fd312"
+          },
+          "alt": "ENFP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b71b5a18d13cadcda6423c861d6f9b04e2ec2780a246a2b77d76117392bcd72e"
+          },
+          "alt": "ENFP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0d0a27384b17502999f671ac6e81c96e50dfc63a0fabca616a7c29e7255aba51"
+          },
+          "alt": "ENFP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:412455d6aa214a90db4eae3ca17c4be69f7733510aaa743cdded957847446536"
+          },
+          "alt": "ENFP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0b9d8209ad656d03c1923d2348831a0b532cdd7e00008e45ff8e3a724c2bff00"
+          },
+          "alt": "ENFP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:30a9574b9e8f1c40ad05316294f1afadd89c162eac530ae96b61afb750aff9d0"
+          },
+          "alt": "ENFP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -19575,66 +20940,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d445284ac7a2f8cead21bf05d9f5f693d64347d4f62cac85a615fc53de88bc0f"
+          },
+          "alt": "ENFP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c1aa108885916da9cf335ad1fea4135e2f9d929c371311148652019d2dd0ac9a"
+          },
+          "alt": "ENFP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:7dc019e0a6593d4a93445b46b18d90cdc1a6574497adff186949d562cd89e026"
+          },
+          "alt": "ENFP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:44745e43b93e4c0150327bbb5453348933ceaa333d2bd7a2a121e9fce5ed154d"
+          },
+          "alt": "ENFP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:fbe0a9fc78986e110c0c092e5438969835776cdf395d36cdb46eedbce2742a69"
+          },
+          "alt": "ENFP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:129134139901c17a79fd6a13b63ef685e3efa3388938f0b835b4d0264dbff2c9"
+          },
+          "alt": "ENFP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/enfp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:aa6a6c1f65fc13725812c6e400acac6a06a029ddf6ada9e19748b0184599fde2"
+          },
+          "alt": "ENFP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.enfp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -20802,66 +22258,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:89b0be4e82c54ede78178033697ef13942b78cf8df782da0200f0d35ac2ecb4e"
+          },
+          "alt": "ISTJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ea0c43dfffb21c353506bef636ea0ad8668c7313cf2837510ddab23533cbd02a"
+          },
+          "alt": "ISTJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e74d722c4bc0086aac262cddb588dfd442fabe8ec08e191f5f9a4c960f33287a"
+          },
+          "alt": "ISTJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5e6101115ee4fec3be97d7b62a1a235df72b0b5296a3fe24487e06151fd3104e"
+          },
+          "alt": "ISTJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:9c6b6375c4599845ff1d8232f692a52c51745e3e653cfe428d4155759cf9d1ee"
+          },
+          "alt": "ISTJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d98772dda6ecfebadcde355f6f1515e6640fab85545f6cb12a230d623f4675e2"
+          },
+          "alt": "ISTJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a4943e12282e80e817fdd4038db5e8f22704bcc2ad3cee9317a8f9547cdfda53"
+          },
+          "alt": "ISTJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -22029,66 +23576,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:77a1baa2f6dbb7604c95446565244682963f697ef8c7989721ad3831d536cbbe"
+          },
+          "alt": "ISTJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5f000586299bed4c4c302b8e792b28c6da4805f4557710f43aa5a67d8506dd04"
+          },
+          "alt": "ISTJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:78e69620e50fcd7084b51307810fe988e4870d75787427d33064ef6c9c832c40"
+          },
+          "alt": "ISTJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c58958e17836b9e893b5974bdbe76492b0af671834c517906ad347f273de7a37"
+          },
+          "alt": "ISTJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0e9511ef3ace4f3912990a338bf44e48b363e99d34a37757c2d6e08a3070fa57"
+          },
+          "alt": "ISTJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3867a8b1a6a73d171d68b70de980fad2375029607c0b10104fdd49c069f6eb0d"
+          },
+          "alt": "ISTJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3c25fd36a5cfde658eb5ab2a02a332bc72f07dddfba5f33dbd7432ce7bbdaaa8"
+          },
+          "alt": "ISTJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -23256,66 +24894,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e1bf14d79f93b43d6618169e29f7ffd2a5fce121c018499aef72823043458434"
+          },
+          "alt": "ISFJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a680dcbf3b89f74bd92356aeed84c228f2b1cd7d87821e905bd6798b4f7f20df"
+          },
+          "alt": "ISFJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b9443a411d9f04c24f63b2d634625e283a283c588f4a37149934222c9e969c8e"
+          },
+          "alt": "ISFJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:4657378b855723d21ae5d305649b7563070fc85225b667b5ee8906abede06220"
+          },
+          "alt": "ISFJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e59f90c2420a70574b7a897c38a734daae839918e1aee025f5d1247e65e95fe3"
+          },
+          "alt": "ISFJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3a1536f066f5b27ff9c7283ce62e0dbeac9ec6633727797332ec6eee32256f63"
+          },
+          "alt": "ISFJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e522abd3b0520cffd6f16e8f515b13385a15ccbab1dcaa7b5e5cbb7f82104a71"
+          },
+          "alt": "ISFJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -24483,66 +26212,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c07553b588c7d249767afde2aec59e2ef0e8bbd9e8a79a1ed1c70a809c733d3b"
+          },
+          "alt": "ISFJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5d576af70ac5445747ad18e6ee512983f2a9d9a4a62e9d5a965cf982bfae62ed"
+          },
+          "alt": "ISFJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f370ea3781d685c094b5f1de6cd0fddcdbd91611719b94bdc94bd7021e28f136"
+          },
+          "alt": "ISFJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b3a3d254abb64a7c840c4d39e4852cbad9faca740b63db1df4c859f1d43746d3"
+          },
+          "alt": "ISFJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e7383f1ee5a3134cbbc0165dddb63d3957a170b3ae3e9cba30dc1aecd907811d"
+          },
+          "alt": "ISFJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ae2b60457f822b714ec82af6dc07c46b109db93104a74034af7cbd7fb077b57f"
+          },
+          "alt": "ISFJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:291d22a879d2d9c9e6b34e175b18ab5ec22787796c673115b8967e7c5b53b972"
+          },
+          "alt": "ISFJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -25710,66 +27530,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5d16293231f8f034dfbed9dfc93dd66b6c76255161ecb14f681dfd7844ba5e82"
+          },
+          "alt": "ESTJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:77c6897c7415d244198f9e4c6642071a3953003c9177807e7f03997647a1b19b"
+          },
+          "alt": "ESTJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:24f00000ff63fffcef36742d8341dd609b11ed81dabfb8709ed2669fc9533d9b"
+          },
+          "alt": "ESTJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6fea31d87733a2ae36522ba7929fd2eebf3e555b0e622223a3199954dedf4037"
+          },
+          "alt": "ESTJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e6bb3c3a1cc659f6494ce524b9f2538661342c1c9c19705b01b1cc6e5aa26c51"
+          },
+          "alt": "ESTJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:4f5d0652a40ab937655c85037318ef2bc0faef420af4988a90fc03976bda6113"
+          },
+          "alt": "ESTJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:efad94fd5ab6567303e78cf5137d11e3ee539b8eedbf94bc7c0d6d07e52971bb"
+          },
+          "alt": "ESTJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -26937,66 +28848,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:abaaa89087b50ba5e05990237d565c9fba50929fd9d2fb534f5de906bebe8003"
+          },
+          "alt": "ESTJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e4054ede22cd09f9107979faaec2fc711b0ec8a0a9e2998f539b059f018eb2f1"
+          },
+          "alt": "ESTJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:023e133d637ca9972d181c3badde31e72fd384f48bc26dda5c33bba14803b5bd"
+          },
+          "alt": "ESTJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6eb084318c745e4d7d68dbebad3685133e95ae041745df78c267c26badbc1d8a"
+          },
+          "alt": "ESTJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5f23b773d664164d64cfca4c5e41c0016de1976326526d9f6b115f8bde20bae3"
+          },
+          "alt": "ESTJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:de4176a223594ae8edecbba703af75a763f590d32c7019f5486aa1d4f4353d0f"
+          },
+          "alt": "ESTJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:565acf819dc8c3f61a2b0111b6d6e79b0a06d768f9788f375b2b9a99e11b88b1"
+          },
+          "alt": "ESTJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -28164,66 +30166,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:21e62b6eb96a57506147e77ddd72dd06067b07f67535379f89ea436b1cd9df14"
+          },
+          "alt": "ESFJ-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:9ab0f9f0f0a4e5ff147422730df7639a85013be6d5815d899c80a7cc61208287"
+          },
+          "alt": "ESFJ-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b4d88e114812cb9fc539aa1c1e97ac6ff732ab060e727bbcc9530098db9ecffb"
+          },
+          "alt": "ESFJ-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:077cba9ea16619750bcaa01f63e4915f80415759f829eeeaddc1fa0224baabc4"
+          },
+          "alt": "ESFJ-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d3c00f69ee066dd607b0136b36e74fc3ca38c6ce23e44bc08baf17eddabe0c79"
+          },
+          "alt": "ESFJ-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0f91ea7f6c869bf2f93afac0a8fb327ff5ca4412d689108facd6112fbaa5c4dc"
+          },
+          "alt": "ESFJ-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d2f63ff8f7b3fd864f40a7eb660eaa9e05c7b992c9be13a00dfea983ac64e8f2"
+          },
+          "alt": "ESFJ-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -29391,66 +31484,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:857a5a5a2433217ce6924192cd1ae5b300f7888736e22a0c177b000f1fe040ed"
+          },
+          "alt": "ESFJ-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d92e494bacdc8bf7c01a5ab4b6317e931274bb95800f0127864a0776ead7a8ad"
+          },
+          "alt": "ESFJ-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5c7079e4b86b129f795ee8e8787ac0e6234b3cf0f833fffe328c40d3a208e9d9"
+          },
+          "alt": "ESFJ-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1d8162a3d695db30a92c2ada696b7f07f935a7db881de00b0be5119d10a18c6e"
+          },
+          "alt": "ESFJ-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:49d16dc941589145ab6e6c9d7a25293f35507ba2efdf621723a7faeb97345029"
+          },
+          "alt": "ESFJ-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5ebf45165e524fd512ec12816dc626ef0e1b08e9f0bf2c166c805578c44e9d96"
+          },
+          "alt": "ESFJ-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfj-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:3cc0e24d927adb9b8205affec0df78f3156510c4798e83a1501db4a0a6977399"
+          },
+          "alt": "ESFJ-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfj-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -30618,66 +32802,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0b77cbb9a2c10f869031e56a1412cd80132a83d19d243bb1c9c2810b9967b5c4"
+          },
+          "alt": "ISTP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e0cdc136833552b93b2620f88631f189aef080f61712acf8675d5a9dea4a834d"
+          },
+          "alt": "ISTP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d859ed440e02f5f8fda8e0fcc5e3312bb2387b41db1ed6273bb86ab1fe6dcd20"
+          },
+          "alt": "ISTP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:63b68462196028ee87bc2aacee86acd87741e1b02d96ca08fea175b8e3d9d4b7"
+          },
+          "alt": "ISTP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c658597dc0c322fbbf90d2d6550930631632abb009d76a229ab54b3a422519fd"
+          },
+          "alt": "ISTP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:af6344a7accd3e87fb443fba629d86d6aeb47af52f08ad9c1e97677196c60983"
+          },
+          "alt": "ISTP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:deaac2d641ffa85cd6541477a467316eec125076159bba58dd46988fd57f0bbc"
+          },
+          "alt": "ISTP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -31845,66 +34120,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:46912ec1da34c7e4634dc573415183e1126ad38e4fd29e668bcc622b05a37c9b"
+          },
+          "alt": "ISTP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:96e9a5fec3c6c270bdeff4b8d9e6d8bc332c4e84f453816f92d46844f468ea43"
+          },
+          "alt": "ISTP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:728eb2e773a00368771cc8135ac03206880931b69695019a1169e74915efd429"
+          },
+          "alt": "ISTP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b573eff519745390b23b0ec11ce4ebabbdab62803eda42f8cd2169e047c4f07e"
+          },
+          "alt": "ISTP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:95e6ea7e2a51bb0c48599ff8841270f444efc8707e4f4f481522ac88c43f261d"
+          },
+          "alt": "ISTP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:c7361c24b32635487a602cacca410cfde9082a93a4f92d887fa8188a0cb5f68f"
+          },
+          "alt": "ISTP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/istp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:4f6772284ea4c37b5a8bdfcefa1c983a0863050edcaea8fa967555feba78a6f4"
+          },
+          "alt": "ISTP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.istp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -33072,66 +35438,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:20421c2ac147a772df26bbf1ea7b3adeb19256a3502caf31ddbdb73d48a21e0f"
+          },
+          "alt": "ISFP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2f8bf7b083396a87c6f4a63913c6e018e78921af0102591a20b3fd8f55f218dc"
+          },
+          "alt": "ISFP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2587d4f7a46c232b3e38bca4dadb830d0003af3ca15fffca024de6a36542bdb9"
+          },
+          "alt": "ISFP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:0a5128b593b220fc3087746effca812442a6371608c5c44203ec41eeccc87b7a"
+          },
+          "alt": "ISFP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:db531eef599654bf66398fa9ff6171af9c693e6b843b04a06ff88e76f892ef9f"
+          },
+          "alt": "ISFP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6d91cd03c1b7d1108b42d5bdf66589563055b8368c17dd2255881afe433898ff"
+          },
+          "alt": "ISFP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d23ff6a16cd0d96552f1ec7988cbf28de0498fe47e70b787a1a8cb66e6258b2f"
+          },
+          "alt": "ISFP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -34299,66 +36756,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a007a064223d82a8db8372075e303c59c6409c99beda9e916d60ac036cf1fb8d"
+          },
+          "alt": "ISFP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d432277e06a6181580bfef99459f3983ef427f1df3788fca55ef855919d4500b"
+          },
+          "alt": "ISFP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:2b345734669d6acf1c0ad4d6c5249d054b332d222d1a1b590310000a55b7d45e"
+          },
+          "alt": "ISFP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:944aa054613b1c8f2065fd58a806bb223c554b955c248fdff929e6de99c13ef7"
+          },
+          "alt": "ISFP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a1302fc776ba2517414bff14d8a3e460a7787012ed23c720962fc8e01b3bf742"
+          },
+          "alt": "ISFP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:5ca2865c38a20468d4890896982c355b2b88bc153f1fc4417a9688583adc4230"
+          },
+          "alt": "ISFP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/isfp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e7c8fbff67df8c2f3076a7b43c30f1e63723c2c0e49a63e903d4338a5084520d"
+          },
+          "alt": "ISFP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.isfp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -35526,66 +38074,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:8f4c29381467d6a4cef737ea9c0345b1275330058dc1d141b97934cf62cdc50a"
+          },
+          "alt": "ESTP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a3075ee82b487ad9f61c33ef80f246661ebfff6453c817ceb08e4d19aa45eafd"
+          },
+          "alt": "ESTP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ea7c3f35cbb610e9907d6e98a528dfce17719e26e4af811024d37ddbfae68655"
+          },
+          "alt": "ESTP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:33983e8b4776033cc2960a43c3969b3cdb7eca3ba15652c669ffcb0a7d952f7d"
+          },
+          "alt": "ESTP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:85973f72bdf2c0465c3f67239932f37275383a21b3ac62a73c5eb9d91e8673e7"
+          },
+          "alt": "ESTP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:619fcb2c2c1a819dced05f0550d0bb24f6d6189fb8cbba8e01e58c76642ba5b2"
+          },
+          "alt": "ESTP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:b53b0b90808d98058c37389620b304675d2fece7fd78813550133fc5309f1c58"
+          },
+          "alt": "ESTP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -36753,66 +39392,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:84e914528bfd32c4cdeb3e6fa1307b35ff79d0164d774ee21f7802f2359e328a"
+          },
+          "alt": "ESTP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:236c485e55bd9c2d982f4db491101fc38c0a91ac0ead81f03092e46a42534a18"
+          },
+          "alt": "ESTP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:9be08603824dd11fdaf5a8c65c2767219dec380c385d535b269e18c7c3d0630f"
+          },
+          "alt": "ESTP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:327aae359b28839805534cf5c5c9f4ad992e99f1663a30422ca506fdf8a9c40b"
+          },
+          "alt": "ESTP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ebb5017b4f2f188a5216e4bd7a281a6fdb7e94955eeaf66ca3faffb1a386e41e"
+          },
+          "alt": "ESTP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:a08c84e8e450baaf1e4176c175fa0af397d92e5a23d6aa42fca3462ae8f7aac1"
+          },
+          "alt": "ESTP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/estp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6dd1f8a94266532c7aa30cf0a5418436d281e24070880941facafb135eadc194"
+          },
+          "alt": "ESTP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.estp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -37980,66 +40710,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:dfe9ba7ccfc1e14f1468fa0e6b99748e5fd076b336ce1dc00101236b0bed5d6e"
+          },
+          "alt": "ESFP-A MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:ecd1e188f81fcad1ec57decb52e2aa0a1f04afec41a404ce6da364f8ea90c01b"
+          },
+          "alt": "ESFP-A MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:1c613b76c94e08f8d3086ad3629d6828f946eeee9e92f9d5e2d9c545e4c0db1f"
+          },
+          "alt": "ESFP-A MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:efeb7bdec316d73b548abd9c4a61d5457425a60c867d34d79c920bd0a28cf19f"
+          },
+          "alt": "ESFP-A MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:bbed4c764ac0dc00b2344fdbfb8cfc97472001ca7cac62992aed967f2906e78f"
+          },
+          "alt": "ESFP-A MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:6759470376625c289bd11d44bf28da563bb64b2877bbd9d22a7334cf3708321b"
+          },
+          "alt": "ESFP-A MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-a/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:86b32869d45d99573c7ffbea58282ef5389b13f1756fdb3bd658cd4886e766fd"
+          },
+          "alt": "ESFP-A MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-a.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {
@@ -39207,66 +42028,157 @@
       "asset_slots_json": [
         {
           "slotId": "hero-illustration",
-          "label": "illustration-slot placeholder",
+          "label": "Hero identity illustration",
           "aspectRatio": "236:160",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/hero-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/hero-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d147a4a81c7d5527a9e402ade2039a6a9cfe0abeb2ce12a23c0a3e2bbeb74b13"
+          },
+          "alt": "ESFP-T MBTI desktop clone hero identity illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.hero-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 708,
+            "height": 480,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "traits-illustration",
-          "label": "traits illustration-slot placeholder",
+          "label": "Traits axis illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/traits-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/traits-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:4504d018ca7c52c1764724a2910305d57472b224333966aeebac456ec8e833d9"
+          },
+          "alt": "ESFP-T MBTI desktop clone traits axis illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.traits-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "traits-summary-asset",
-          "label": "illustration-slot placeholder",
+          "slotId": "traits-summary-illustration",
+          "label": "Traits summary illustration",
           "aspectRatio": "240:118",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/traits-summary-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:8bd693e6a3a7077a859f7ab5994e040ed6f843505db1dae1da02a2307c509916"
+          },
+          "alt": "ESFP-T MBTI desktop clone traits summary illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.traits-summary-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 720,
+            "height": 354,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "career-illustration",
-          "label": "career illustration-slot placeholder",
+          "label": "Career path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/career-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/career-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:d02994f2aef413f18aa2bafdb9d88ef4fdf6353680afa40d1a902d952f5cd313"
+          },
+          "alt": "ESFP-T MBTI desktop clone career path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.career-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "growth-illustration",
-          "label": "growth illustration-slot placeholder",
+          "label": "Growth path illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/growth-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/growth-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:8215fdbca8051e1516f55dad663ffbe05d826f2733a98dadab64cfdc9ff951ca"
+          },
+          "alt": "ESFP-T MBTI desktop clone growth path illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.growth-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
           "slotId": "relationships-illustration",
-          "label": "relationships illustration-slot placeholder",
+          "label": "Relationships illustration",
           "aspectRatio": "636:148",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/relationships-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:e09e19d9b843020eef88e9057dae4222d80d5aad22571a7df19ba80736975374"
+          },
+          "alt": "ESFP-T MBTI desktop clone relationships illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.relationships-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 1272,
+            "height": 296,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         },
         {
-          "slotId": "final-offer-asset",
-          "label": "feature image placeholder",
+          "slotId": "final-offer-illustration",
+          "label": "Final offer illustration",
           "aspectRatio": "252:220",
-          "status": "placeholder",
-          "assetRef": null,
-          "alt": null,
-          "meta": null
+          "status": "ready",
+          "assetRef": {
+            "provider": "cdn",
+            "path": "/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg",
+            "url": "https://assets.fermatmind.com/static/mbti/desktop-clone/esfp-t/final-offer-illustration.svg",
+            "version": "v1",
+            "checksum": "sha256:f2c026c07811c60c873187d732eeab80b171df05e152a71abf1c9e1106a2e9ad"
+          },
+          "alt": "ESFP-T MBTI desktop clone final offer illustration.",
+          "meta": {
+            "media_library_asset_key": "mbti.desktop_clone.esfp-t.final-offer-illustration",
+            "mime_type": "image/svg+xml",
+            "width": 756,
+            "height": 660,
+            "source": "repo_static_media_baseline",
+            "human_visual_review_required": false
+          }
         }
       ],
       "meta_json": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-27T23:38:00+08:00",
+  "updated_at": "2026-05-28T00:23:36+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -20853,6 +20853,101 @@
           "at": "2026-05-27T00:00:00+08:00",
           "event": "ci_failure_fixed_locally",
           "details": "GitHub verify-mbti-legacy and verify-mbti-v2 failed because the Big Five runtime freeze guard flagged the scoped article metadata backfill migration. Added a narrow classifier allowlist and regression test for this migration; BigFiveResultPageV2CoreBodyPreviewTest now passes locally."
+        }
+      ]
+    },
+    "MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01": {
+      "id": "MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01",
+      "repo": "fap-api",
+      "branch": "codex/mbti-desktop-clone-media-assets-01",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01 MBTI desktop clone media asset baseline",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01 manifest/state updates for the current PR only."
+        },
+        "asset_baseline": {
+          "status": "pass",
+          "evidence": "Generated 224 static SVG assets and 224 Media Library baseline rows for 32 MBTI fullCode variants x 7 desktop clone asset slots."
+        },
+        "focused_tests": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=PersonalityDesktopCloneBaselineImportTest --no-ansi",
+            "cd backend && php artisan test --filter=PersonalityDesktopCloneMediaAssetBaselineTest --no-ansi",
+            "cd backend && php artisan test --filter=MediaLibraryPublicApiTest --no-ansi",
+            "cd backend && php artisan test --filter=PersonalityDesktopClonePublicApiTest --no-ansi",
+            "cd backend && php artisan test --filter=PersonalityDesktopCloneAssetSlotSupportTest --no-ansi"
+          ],
+          "evidence": "All focused tests exited 0. PHPUnit reported warning-marked output in the isolated environment, but no failures occurred."
+        },
+        "common_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json >/dev/null",
+            "python3 -m json.tool content_baselines/media_assets/mbti_desktop_clone_assets.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "evidence": "route:list, Pint, composer validate/audit, JSON/YAML parse, and diff checks passed locally."
+        },
+        "scope": {
+          "status": "pass",
+          "allowed_files": [
+            "backend/docs/mbti-desktop-clone-owner.md",
+            "backend/public/static/mbti/desktop-clone/**",
+            "backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php",
+            "backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php",
+            "backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneMediaAssetBaselineTest.php",
+            "content_baselines/media_assets/mbti_desktop_clone_assets.v1.json",
+            "content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json",
+            "docs/codex/pr-train.yaml",
+            "docs/codex/pr-train-state.json"
+          ],
+          "evidence": "Changes are confined to MBTI desktop clone media baselines, static repo-backed assets, focused tests, owner documentation, and current PR ledger metadata."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "evidence": "PR not opened yet."
+        }
+      },
+      "scope": {
+        "cms_mutation": false,
+        "media_upload": false,
+        "publish": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "url_submission": false,
+        "fap_web_modified": false,
+        "frontend_fallback_authority": false,
+        "paid_content_gate_change": false,
+        "repo_backed_media_baseline_only": true
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "DEPLOY-READINESS",
+      "events": [
+        {
+          "at": "2026-05-28T00:23:36+08:00",
+          "status": "manifest_registered",
+          "summary": "Registered current MBTI desktop clone media asset baseline PR after explicit user authorization."
+        },
+        {
+          "at": "2026-05-28T00:23:36+08:00",
+          "status": "local_validation_passed",
+          "summary": "Generated CDN-ready repo-backed Media Library baseline and static SVG assets for 224 MBTI desktop clone slots; focused tests and common validation passed locally."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-28T00:23:36+08:00",
+  "updated_at": "2026-05-28T00:31:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -20861,10 +20861,10 @@
       "repo": "fap-api",
       "branch": "codex/mbti-desktop-clone-media-assets-01",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "pr_opened",
       "title": "MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01 MBTI desktop clone media asset baseline",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "eeeb271d",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1735",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -20918,7 +20918,8 @@
         },
         "github_required_checks": {
           "status": "pending",
-          "evidence": "PR not opened yet."
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1735",
+          "evidence": "PR opened; checks pending."
         }
       },
       "scope": {
@@ -20948,6 +20949,11 @@
           "at": "2026-05-28T00:23:36+08:00",
           "status": "local_validation_passed",
           "summary": "Generated CDN-ready repo-backed Media Library baseline and static SVG assets for 224 MBTI desktop clone slots; focused tests and common validation passed locally."
+        },
+        {
+          "at": "2026-05-28T00:31:00+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1735 after local validation passed."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15105,3 +15105,54 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03
+
+  - id: MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01
+    repo: fap-api
+    branch: codex/mbti-desktop-clone-media-assets-01
+    base: main
+    title: "MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01 MBTI desktop clone media asset baseline"
+    train_scope: mbti_result_desktop_clone_media_assets
+    risk_level: p1_media_library_baseline
+    allowed_paths:
+      - backend/docs/mbti-desktop-clone-owner.md
+      - backend/public/static/mbti/desktop-clone/**
+      - backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+      - backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneBaselineImportTest.php
+      - backend/tests/Feature/PersonalityCms/PersonalityDesktopCloneMediaAssetBaselineTest.php
+      - content_baselines/media_assets/mbti_desktop_clone_assets.v1.json
+      - content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Upgrade MBTI desktop clone 32 fullCode x 7 visual asset slots from placeholder metadata to Media Library/CDN-ready baseline references.
+      - Add repo-backed static SVG asset files and Media Library baseline rows for each desktop clone slot without mutating production CMS or uploading assets.
+      - Add focused tests proving all 224 desktop clone asset slots are ready, checksummed, alt-backed, and linked to Media Library asset keys.
+      - Do not change fap-web runtime, result unlock behavior, paid content gates, Search Channel, sitemap, llms, deploy state, or production CMS.
+    validation:
+      - cd backend && php artisan test --filter=PersonalityDesktopCloneBaselineImportTest --no-ansi
+      - cd backend && php artisan test --filter=PersonalityDesktopCloneMediaAssetBaselineTest --no-ansi
+      - cd backend && php artisan test --filter=MediaLibraryPublicApiTest --no-ansi
+      - cd backend && php artisan test --filter=PersonalityDesktopClonePublicApiTest --no-ansi
+      - cd backend && php artisan test --filter=PersonalityDesktopCloneAssetSlotSupportTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json >/dev/null
+      - python3 -m json.tool content_baselines/media_assets/mbti_desktop_clone_assets.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    media_upload: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    paid_content_gate_change: false
+    next_task: DEPLOY-READINESS


### PR DESCRIPTION
## What changed
- Added repo-backed Media Library baseline rows for MBTI desktop clone visual assets: 32 fullCode variants x 7 canonical slots = 224 assets.
- Added static SVG asset files under `backend/public/static/mbti/desktop-clone/{fullCode}/{slot}.svg` for CDN/OSS readiness.
- Updated `content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json` so every desktop clone `asset_slots_json` entry is `ready`, checksummed, alt-backed, and linked to a Media Library asset key.
- Added focused coverage for desktop clone media asset completeness and updated existing baseline/import tests.
- Registered only the current PR train entry `MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01` after explicit user authorization.

## Why
The previous MBTI desktop clone result shell could hydrate public/redacted text, but its visual asset slots still pointed at placeholder metadata. This PR makes the backend authority package ready for Media Library / OSS / CDN activation without changing fap-web runtime or publishing anything.

## Validation
- `cd backend && php artisan test --filter=PersonalityDesktopCloneBaselineImportTest --no-ansi`
- `cd backend && php artisan test --filter=PersonalityDesktopCloneMediaAssetBaselineTest --no-ansi`
- `cd backend && php artisan test --filter=MediaLibraryPublicApiTest --no-ansi`
- `cd backend && php artisan test --filter=PersonalityDesktopClonePublicApiTest --no-ansi`
- `cd backend && php artisan test --filter=PersonalityDesktopCloneAssetSlotSupportTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool content_baselines/personality_clone/mbti_desktop_clone.zh-CN.json >/dev/null`
- `python3 -m json.tool content_baselines/media_assets/mbti_desktop_clone_assets.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production CMS mutation.
- No Media Library production import.
- No OSS/CDN upload or sync.
- No deploy.
- No fap-web changes.
- No Search Channel action or URL submission.
- Human art-grade replacement artwork remains a later creative/brand review task; this PR provides operational baseline assets and authority references.

## Repository rule impact
This keeps MBTI desktop clone media under backend authority through content baselines and Media Library metadata. The frontend remains a consumer and must not treat local placeholder/fallback visuals as authority.
