### PR TITLE
ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 Enneagram forced-choice English question pack

### DIFF
--- a/backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json
+++ b/backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json
@@ -1,10 +1,10 @@
 {
-  "compiled_hash": "9e6fc333a244abb72ea5b71831608a0312f385eeb9ddeb422814bd1d14d577ea",
+  "compiled_hash": "f121379f9a45404e2c9a64aa50d9b01bff41cda221eef86506941c7003a3b4e8",
   "form_code": "enneagram_forced_choice_144",
   "form_kind": "forced_choice",
   "hashes": {
     "policy.compiled.json": "8583b7f2cab09aab89ab77c9a5db23e5e87e029ea72e857205ebd6216dfc82e4",
-    "questions.compiled.json": "bdd6055164176f82ccc7cf90ea72aa48251414180a2ed10685d24175c35b8c6a"
+    "questions.compiled.json": "59fcb1d078370ad6af3e01fff3060e45e07e409cd8cb654afde33e839bf27209"
   },
   "pack_id": "ENNEAGRAM",
   "pack_version": "v1-forced-choice-144",

--- a/backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json
+++ b/backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json
@@ -1452,15 +1452,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会留意哪里还能再改进。",
-              "text_en": "我会留意哪里还能再改进。",
+              "text": "I notice where things could still be improved.",
+              "text_en": "I notice where things could still be improved.",
               "text_zh": "我会留意哪里还能再改进。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我做决定时会把“万一呢”也考虑进去。",
-              "text_en": "我做决定时会把“万一呢”也考虑进去。",
+              "text": "When I make decisions, I also consider what could go wrong.",
+              "text_en": "When I make decisions, I also consider what could go wrong.",
               "text_zh": "我做决定时会把“万一呢”也考虑进去。",
               "type_code": "T6"
             }
@@ -1477,15 +1477,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更希望人生是充满选项和可能性的。",
-              "text_en": "我更希望人生是充满选项和可能性的。",
+              "text": "I would rather life feel full of options and possibilities.",
+              "text_en": "I would rather life feel full of options and possibilities.",
               "text_zh": "我更希望人生是充满选项和可能性的。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我会主动拉近人与人之间的距离。",
-              "text_en": "我会主动拉近人与人之间的距离。",
+              "text": "I actively try to bring people closer together.",
+              "text_en": "I actively try to bring people closer together.",
               "text_zh": "我会主动拉近人与人之间的距离。",
               "type_code": "T2"
             }
@@ -1502,15 +1502,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我对“这件事到底是怎么运作的”很有兴趣。",
-              "text_en": "我对“这件事到底是怎么运作的”很有兴趣。",
+              "text": "I am very interested in how something actually works.",
+              "text_en": "I am very interested in how something actually works.",
               "text_zh": "我对“这件事到底是怎么运作的”很有兴趣。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我会努力让自己表现得专业、能干。",
-              "text_en": "我会努力让自己表现得专业、能干。",
+              "text": "I work to come across as professional and capable.",
+              "text_en": "I work to come across as professional and capable.",
               "text_zh": "我会努力让自己表现得专业、能干。",
               "type_code": "T3"
             }
@@ -1527,15 +1527,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢把自己压进过于普通的模板里。",
-              "text_en": "我不太喜欢把自己压进过于普通的模板里。",
+              "text": "I do not like forcing myself into an overly ordinary template.",
+              "text_en": "I do not like forcing myself into an overly ordinary template.",
               "text_zh": "我不太喜欢把自己压进过于普通的模板里。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我偶尔会因为想省心而拖一拖。",
-              "text_en": "我偶尔会因为想省心而拖一拖。",
+              "text": "Sometimes I put things off because I want to avoid extra hassle.",
+              "text_en": "Sometimes I put things off because I want to avoid extra hassle.",
               "text_zh": "我偶尔会因为想省心而拖一拖。",
               "type_code": "T9"
             }
@@ -1552,15 +1552,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢一边走一边打开新的可能。",
-              "text_en": "我喜欢一边走一边打开新的可能。",
+              "text": "I like opening new possibilities as I move forward.",
+              "text_en": "I like opening new possibilities as I move forward.",
               "text_zh": "我喜欢一边走一边打开新的可能。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我喜欢事情朝着明确方向推进。",
-              "text_en": "我喜欢事情朝着明确方向推进。",
+              "text": "I like things to move in a clear direction.",
+              "text_en": "I like things to move in a clear direction.",
               "text_zh": "我喜欢事情朝着明确方向推进。",
               "type_code": "T8"
             }
@@ -1577,15 +1577,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我希望自己是个可靠、讲规矩的人。",
-              "text_en": "我希望自己是个可靠、讲规矩的人。",
+              "text": "I want to be reliable and principled.",
+              "text_en": "I want to be reliable and principled.",
               "text_zh": "我希望自己是个可靠、讲规矩的人。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我喜欢先把事情想清楚，再决定怎么做。",
-              "text_en": "我喜欢先把事情想清楚，再决定怎么做。",
+              "text": "I like to think things through before deciding what to do.",
+              "text_en": "I like to think things through before deciding what to do.",
               "text_zh": "我喜欢先把事情想清楚，再决定怎么做。",
               "type_code": "T5"
             }
@@ -1602,15 +1602,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我做选择时常会想还有没有更好的可能。",
-              "text_en": "我做选择时常会想还有没有更好的可能。",
+              "text": "When choosing, I often wonder whether there is a better possibility.",
+              "text_en": "When choosing, I often wonder whether there is a better possibility.",
               "text_zh": "我做选择时常会想还有没有更好的可能。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我希望自己在别人心里是有分量的。",
-              "text_en": "我希望自己在别人心里是有分量的。",
+              "text": "I want to matter to the people around me.",
+              "text_en": "I want to matter to the people around me.",
               "text_zh": "我希望自己在别人心里是有分量的。",
               "type_code": "T2"
             }
@@ -1627,15 +1627,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常能很快进入“把事办成”的模式。",
-              "text_en": "我通常能很快进入“把事办成”的模式。",
+              "text": "I can usually switch quickly into getting-things-done mode.",
+              "text_en": "I can usually switch quickly into getting-things-done mode.",
               "text_zh": "我通常能很快进入“把事办成”的模式。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我通常不怕表明自己的态度。",
-              "text_en": "我通常不怕表明自己的态度。",
+              "text": "I am usually not afraid to make my position clear.",
+              "text_en": "I am usually not afraid to make my position clear.",
               "text_zh": "我通常不怕表明自己的态度。",
               "type_code": "T8"
             }
@@ -1652,15 +1652,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我在人群里常会自然地扮演支持者。",
-              "text_en": "我在人群里常会自然地扮演支持者。",
+              "text": "In groups, I naturally tend to play a supportive role.",
+              "text_en": "In groups, I naturally tend to play a supportive role.",
               "text_zh": "我在人群里常会自然地扮演支持者。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我喜欢给自己留出安静思考的空间。",
-              "text_en": "我喜欢给自己留出安静思考的空间。",
+              "text": "I like to leave myself quiet space to think.",
+              "text_en": "I like to leave myself quiet space to think.",
               "text_zh": "我喜欢给自己留出安静思考的空间。",
               "type_code": "T5"
             }
@@ -1677,15 +1677,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会把独特感看成自我价值的一部分。",
-              "text_en": "我会把独特感看成自我价值的一部分。",
+              "text": "I see a sense of uniqueness as part of my self-worth.",
+              "text_en": "I see a sense of uniqueness as part of my self-worth.",
               "text_zh": "我会把独特感看成自我价值的一部分。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我习惯把人生当成一场需要持续升级的赛程。",
-              "text_en": "我习惯把人生当成一场需要持续升级的赛程。",
+              "text": "I tend to see life as a course that needs continual improvement.",
+              "text_en": "I tend to see life as a course that needs continual improvement.",
               "text_zh": "我习惯把人生当成一场需要持续升级的赛程。",
               "type_code": "T3"
             }
@@ -1702,15 +1702,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢简单、安稳、没有太多拉扯的状态。",
-              "text_en": "我喜欢简单、安稳、没有太多拉扯的状态。",
+              "text": "I like states that feel simple, steady, and low-conflict.",
+              "text_en": "I like states that feel simple, steady, and low-conflict.",
               "text_zh": "我喜欢简单、安稳、没有太多拉扯的状态。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我会自然地往轻松、积极的方向看。",
-              "text_en": "我会自然地往轻松、积极的方向看。",
+              "text": "I naturally look toward the lighter, more positive side.",
+              "text_en": "I naturally look toward the lighter, more positive side.",
               "text_zh": "我会自然地往轻松、积极的方向看。",
               "type_code": "T7"
             }
@@ -1727,15 +1727,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会和周围的人保持较远的距离。",
-              "text_en": "我偶尔会和周围的人保持较远的距离。",
+              "text": "Sometimes I keep a fair amount of distance from the people around me.",
+              "text_en": "Sometimes I keep a fair amount of distance from the people around me.",
               "text_zh": "我偶尔会和周围的人保持较远的距离。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我有时会因为顾着别人而忽略自己。",
-              "text_en": "我有时会因为顾着别人而忽略自己。",
+              "text": "Sometimes I neglect myself because I am taking care of others.",
+              "text_en": "Sometimes I neglect myself because I am taking care of others.",
               "text_zh": "我有时会因为顾着别人而忽略自己。",
               "type_code": "T2"
             }
@@ -1752,15 +1752,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我习惯用期待未来来给自己打气。",
-              "text_en": "我习惯用期待未来来给自己打气。",
+              "text": "I tend to encourage myself by looking forward to the future.",
+              "text_en": "I tend to encourage myself by looking forward to the future.",
               "text_zh": "我习惯用期待未来来给自己打气。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我会把长期保障看得比一时痛快更重要。",
-              "text_en": "我会把长期保障看得比一时痛快更重要。",
+              "text": "I value long-term security more than short-term satisfaction.",
+              "text_en": "I value long-term security more than short-term satisfaction.",
               "text_zh": "我会把长期保障看得比一时痛快更重要。",
               "type_code": "T6"
             }
@@ -1777,15 +1777,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常能让自己保持比较平稳的状态。",
-              "text_en": "我通常能让自己保持比较平稳的状态。",
+              "text": "I can usually keep myself fairly steady.",
+              "text_en": "I can usually keep myself fairly steady.",
               "text_zh": "我通常能让自己保持比较平稳的状态。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我会为了把事情做好而自我要求。",
-              "text_en": "我会为了把事情做好而自我要求。",
+              "text": "I hold myself to standards because I want to do things well.",
+              "text_en": "I hold myself to standards because I want to do things well.",
               "text_zh": "我会为了把事情做好而自我要求。",
               "type_code": "T1"
             }
@@ -1802,15 +1802,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我希望自己在群体中是有影响力的人。",
-              "text_en": "我希望自己在群体中是有影响力的人。",
+              "text": "I want to be an influential person in a group.",
+              "text_en": "I want to be an influential person in a group.",
               "text_zh": "我希望自己在群体中是有影响力的人。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我做判断时会先看证据和逻辑。",
-              "text_en": "我做判断时会先看证据和逻辑。",
+              "text": "When I judge something, I look first at evidence and logic.",
+              "text_en": "When I judge something, I look first at evidence and logic.",
               "text_zh": "我做判断时会先看证据和逻辑。",
               "type_code": "T5"
             }
@@ -1827,15 +1827,15 @@
           "options": [
             {
               "code": "A",
-              "text": "当生活太平淡时，我会觉得少了点什么。",
-              "text_en": "当生活太平淡时，我会觉得少了点什么。",
+              "text": "When life feels too plain, I feel something is missing.",
+              "text_en": "When life feels too plain, I feel something is missing.",
               "text_zh": "当生活太平淡时，我会觉得少了点什么。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我偶尔会把强硬当成保护自己的方式。",
-              "text_en": "我偶尔会把强硬当成保护自己的方式。",
+              "text": "Sometimes I use toughness as a way to protect myself.",
+              "text_en": "Sometimes I use toughness as a way to protect myself.",
               "text_zh": "我偶尔会把强硬当成保护自己的方式。",
               "type_code": "T8"
             }
@@ -1852,15 +1852,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更容易先从关系的角度理解问题。",
-              "text_en": "我更容易先从关系的角度理解问题。",
+              "text": "I am more likely to understand a problem first through relationships.",
+              "text_en": "I am more likely to understand a problem first through relationships.",
               "text_zh": "我更容易先从关系的角度理解问题。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我更愿意把时间花在能带来产出的事上。",
-              "text_en": "我更愿意把时间花在能带来产出的事上。",
+              "text": "I would rather spend time on things that produce results.",
+              "text_en": "I would rather spend time on things that produce results.",
               "text_zh": "我更愿意把时间花在能带来产出的事上。",
               "type_code": "T3"
             }
@@ -1877,15 +1877,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会自然地关注接下来可能发生什么。",
-              "text_en": "我会自然地关注接下来可能发生什么。",
+              "text": "I naturally pay attention to what might happen next.",
+              "text_en": "I naturally pay attention to what might happen next.",
               "text_zh": "我会自然地关注接下来可能发生什么。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我会在意一件事是否足够真、足够有感觉。",
-              "text_en": "我会在意一件事是否足够真、足够有感觉。",
+              "text": "I care whether something feels real enough and emotionally alive.",
+              "text_en": "I care whether something feels real enough and emotionally alive.",
               "text_zh": "我会在意一件事是否足够真、足够有感觉。",
               "type_code": "T4"
             }
@@ -1902,15 +1902,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢拐弯抹角。",
-              "text_en": "我不太喜欢拐弯抹角。",
+              "text": "I do not like beating around the bush.",
+              "text_en": "I do not like beating around the bush.",
               "text_zh": "我不太喜欢拐弯抹角。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我会因为弄懂一件事而感到满足。",
-              "text_en": "我会因为弄懂一件事而感到满足。",
+              "text": "I feel satisfied when I understand something clearly.",
+              "text_en": "I feel satisfied when I understand something clearly.",
               "text_zh": "我会因为弄懂一件事而感到满足。",
               "type_code": "T5"
             }
@@ -1927,15 +1927,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更看重长期的规范，而不是一时的省事。",
-              "text_en": "我更看重长期的规范，而不是一时的省事。",
+              "text": "I value lasting standards more than short-term convenience.",
+              "text_en": "I value lasting standards more than short-term convenience.",
               "text_zh": "我更看重长期的规范，而不是一时的省事。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "比起抢先出头，我更希望大家都能舒服一点。",
-              "text_en": "比起抢先出头，我更希望大家都能舒服一点。",
+              "text": "Rather than pushing myself forward first, I want everyone to feel comfortable.",
+              "text_en": "Rather than pushing myself forward first, I want everyone to feel comfortable.",
               "text_zh": "比起抢先出头，我更希望大家都能舒服一点。",
               "type_code": "T9"
             }
@@ -1952,15 +1952,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会因为不想错过而分散了注意力。",
-              "text_en": "我偶尔会因为不想错过而分散了注意力。",
+              "text": "Sometimes my attention scatters because I do not want to miss out.",
+              "text_en": "Sometimes my attention scatters because I do not want to miss out.",
               "text_zh": "我偶尔会因为不想错过而分散了注意力。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "别人退缩不表态时，我会忍不住先出头。",
-              "text_en": "别人退缩不表态时，我会忍不住先出头。",
+              "text": "When others hold back and do not take a stand, I tend to step forward first.",
+              "text_en": "When others hold back and do not take a stand, I tend to step forward first.",
               "text_zh": "别人退缩不表态时，我会忍不住先出头。",
               "type_code": "T8"
             }
@@ -1977,15 +1977,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更习惯先观察，再参与。",
-              "text_en": "我更习惯先观察，再参与。",
+              "text": "I am more used to observing first, then participating.",
+              "text_en": "I am more used to observing first, then participating.",
               "text_zh": "我更习惯先观察，再参与。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我更偏好清晰、有标准的做事方式。",
-              "text_en": "我更偏好清晰、有标准的做事方式。",
+              "text": "I prefer a clear way of doing things with standards.",
+              "text_en": "I prefer a clear way of doing things with standards.",
               "text_zh": "我更偏好清晰、有标准的做事方式。",
               "type_code": "T1"
             }
@@ -2002,15 +2002,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更相信行动和担当，而不只是讨论。",
-              "text_en": "我更相信行动和担当，而不只是讨论。",
+              "text": "I trust action and responsibility more than discussion alone.",
+              "text_en": "I trust action and responsibility more than discussion alone.",
               "text_zh": "我更相信行动和担当，而不只是讨论。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我很看重自己是否对身边人有帮助。",
-              "text_en": "我很看重自己是否对身边人有帮助。",
+              "text": "I care a lot about whether I am helpful to the people around me.",
+              "text_en": "I care a lot about whether I am helpful to the people around me.",
               "text_zh": "我很看重自己是否对身边人有帮助。",
               "type_code": "T2"
             }
@@ -2027,15 +2027,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会因为想得太多而行动得慢一点。",
-              "text_en": "我有时会因为想得太多而行动得慢一点。",
+              "text": "Sometimes I act more slowly because I am thinking too much.",
+              "text_en": "Sometimes I act more slowly because I am thinking too much.",
               "text_zh": "我有时会因为想得太多而行动得慢一点。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "别人太随意时，我心里会有点别扭。",
-              "text_en": "别人太随意时，我心里会有点别扭。",
+              "text": "When others are too casual, I feel a bit uneasy inside.",
+              "text_en": "When others are too casual, I feel a bit uneasy inside.",
               "text_zh": "别人太随意时，我心里会有点别扭。",
               "type_code": "T1"
             }
@@ -2052,15 +2052,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我待人时一般比较温和、好相处。",
-              "text_en": "我待人时一般比较温和、好相处。",
+              "text": "I am generally gentle and easy to get along with.",
+              "text_en": "I am generally gentle and easy to get along with.",
               "text_zh": "我待人时一般比较温和、好相处。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我待人时会比较体贴和主动。",
-              "text_en": "我待人时会比较体贴和主动。",
+              "text": "I tend to be considerate and proactive with people.",
+              "text_en": "I tend to be considerate and proactive with people.",
               "text_zh": "我待人时会比较体贴和主动。",
               "type_code": "T2"
             }
@@ -2077,15 +2077,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我觉得守住边界和规则很重要。",
-              "text_en": "我觉得守住边界和规则很重要。",
+              "text": "I think it is important to maintain boundaries and rules.",
+              "text_en": "I think it is important to maintain boundaries and rules.",
               "text_zh": "我觉得守住边界和规则很重要。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我不太喜欢别人替我做主。",
-              "text_en": "我不太喜欢别人替我做主。",
+              "text": "I do not like other people deciding for me.",
+              "text_en": "I do not like other people deciding for me.",
               "text_zh": "我不太喜欢别人替我做主。",
               "type_code": "T8"
             }
@@ -2102,15 +2102,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我常通过付出来表达在意。",
-              "text_en": "我常通过付出来表达在意。",
+              "text": "I often express care by giving to others.",
+              "text_en": "I often express care by giving to others.",
               "text_zh": "我常通过付出来表达在意。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我更容易把时间花在研究问题，而不是经营场面。",
-              "text_en": "我更容易把时间花在研究问题，而不是经营场面。",
+              "text": "I am more likely to spend time studying a problem than managing appearances.",
+              "text_en": "I am more likely to spend time studying a problem than managing appearances.",
               "text_zh": "我更容易把时间花在研究问题，而不是经营场面。",
               "type_code": "T5"
             }
@@ -2127,15 +2127,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会让自己一直处在冲刺状态。",
-              "text_en": "我有时会让自己一直处在冲刺状态。",
+              "text": "Sometimes I keep myself in a constant sprint.",
+              "text_en": "Sometimes I keep myself in a constant sprint.",
               "text_zh": "我有时会让自己一直处在冲刺状态。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "有些情绪一上来，会让我很难一下子抽离。",
-              "text_en": "有些情绪一上来，会让我很难一下子抽离。",
+              "text": "When certain emotions arise, it is hard for me to step away at once.",
+              "text_en": "When certain emotions arise, it is hard for me to step away at once.",
               "text_zh": "有些情绪一上来，会让我很难一下子抽离。",
               "type_code": "T4"
             }
@@ -2152,15 +2152,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢把气氛搞得太紧张。",
-              "text_en": "我不太喜欢把气氛搞得太紧张。",
+              "text": "I do not like making the atmosphere too tense.",
+              "text_en": "I do not like making the atmosphere too tense.",
               "text_zh": "我不太喜欢把气氛搞得太紧张。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我喜欢让一天里有些让人兴奋的东西。",
-              "text_en": "我喜欢让一天里有些让人兴奋的东西。",
+              "text": "I like having something exciting in the day.",
+              "text_en": "I like having something exciting in the day.",
               "text_zh": "我喜欢让一天里有些让人兴奋的东西。",
               "type_code": "T7"
             }
@@ -2177,15 +2177,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会把维护关系看得比较重要。",
-              "text_en": "我会把维护关系看得比较重要。",
+              "text": "I place a lot of importance on maintaining relationships.",
+              "text_en": "I place a lot of importance on maintaining relationships.",
               "text_zh": "我会把维护关系看得比较重要。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我更安心于有规则、有结构的环境。",
-              "text_en": "我更安心于有规则、有结构的环境。",
+              "text": "I feel safer in an environment with rules and structure.",
+              "text_en": "I feel safer in an environment with rules and structure.",
               "text_zh": "我更安心于有规则、有结构的环境。",
               "type_code": "T6"
             }
@@ -2202,15 +2202,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我对情绪和氛围通常很敏感。",
-              "text_en": "我对情绪和氛围通常很敏感。",
+              "text": "I am usually sensitive to emotions and atmosphere.",
+              "text_en": "I am usually sensitive to emotions and atmosphere.",
               "text_zh": "我对情绪和氛围通常很敏感。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我做事时通常很有分寸和原则。",
-              "text_en": "我做事时通常很有分寸和原则。",
+              "text": "I usually act with restraint and principles.",
+              "text_en": "I usually act with restraint and principles.",
               "text_zh": "我做事时通常很有分寸和原则。",
               "type_code": "T1"
             }
@@ -2227,15 +2227,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢被沉重的情绪困太久。",
-              "text_en": "我不太喜欢被沉重的情绪困太久。",
+              "text": "I do not like being trapped in heavy emotions for too long.",
+              "text_en": "I do not like being trapped in heavy emotions for too long.",
               "text_zh": "我不太喜欢被沉重的情绪困太久。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我偶尔会把效率看得比感受更重要。",
-              "text_en": "我偶尔会把效率看得比感受更重要。",
+              "text": "Sometimes I value efficiency more than feelings.",
+              "text_en": "Sometimes I value efficiency more than feelings.",
               "text_zh": "我偶尔会把效率看得比感受更重要。",
               "type_code": "T3"
             }
@@ -2252,15 +2252,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我希望自己能成为让人感觉温暖的人。",
-              "text_en": "我希望自己能成为让人感觉温暖的人。",
+              "text": "I want to be someone who feels warm to others.",
+              "text_en": "I want to be someone who feels warm to others.",
               "text_zh": "我希望自己能成为让人感觉温暖的人。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我宁可慢一点，也想找到真正契合自己的东西。",
-              "text_en": "我宁可慢一点，也想找到真正契合自己的东西。",
+              "text": "I would rather go slower and find what truly fits me.",
+              "text_en": "I would rather go slower and find what truly fits me.",
               "text_zh": "我宁可慢一点，也想找到真正契合自己的东西。",
               "type_code": "T4"
             }
@@ -2277,15 +2277,15 @@
           "options": [
             {
               "code": "A",
-              "text": "没做出成绩时，我会对自己不太满意。",
-              "text_en": "没做出成绩时，我会对自己不太满意。",
+              "text": "When I have not achieved results, I feel dissatisfied with myself.",
+              "text_en": "When I have not achieved results, I feel dissatisfied with myself.",
               "text_zh": "没做出成绩时，我会对自己不太满意。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "没做到自己标准时，我会对自己不太满意。",
-              "text_en": "没做到自己标准时，我会对自己不太满意。",
+              "text": "When I do not meet my own standards, I feel dissatisfied with myself.",
+              "text_en": "When I do not meet my own standards, I feel dissatisfied with myself.",
               "text_zh": "没做到自己标准时，我会对自己不太满意。",
               "type_code": "T1"
             }
@@ -2302,15 +2302,15 @@
           "options": [
             {
               "code": "A",
-              "text": "对我来说，理解自己的心，比尽快给出结论更重要。",
-              "text_en": "对我来说，理解自己的心，比尽快给出结论更重要。",
+              "text": "For me, understanding my own heart matters more than reaching a quick conclusion.",
+              "text_en": "For me, understanding my own heart matters more than reaching a quick conclusion.",
               "text_zh": "对我来说，理解自己的心，比尽快给出结论更重要。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我通常会把力量感看得很重要。",
-              "text_en": "我通常会把力量感看得很重要。",
+              "text": "I usually place a lot of importance on feeling strong.",
+              "text_en": "I usually place a lot of importance on feeling strong.",
               "text_zh": "我通常会把力量感看得很重要。",
               "type_code": "T8"
             }
@@ -2327,15 +2327,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢停留在空想里，更想尽快行动。",
-              "text_en": "我不太喜欢停留在空想里，更想尽快行动。",
+              "text": "I do not like staying in daydreams; I want to act as soon as possible.",
+              "text_en": "I do not like staying in daydreams; I want to act as soon as possible.",
               "text_zh": "我不太喜欢停留在空想里，更想尽快行动。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我常会主动询问别人需要什么。",
-              "text_en": "我常会主动询问别人需要什么。",
+              "text": "I often proactively ask what others need.",
+              "text_en": "I often proactively ask what others need.",
               "text_zh": "我常会主动询问别人需要什么。",
               "type_code": "T2"
             }
@@ -2352,15 +2352,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更容易通过行动争取空间，而不是等别人给。",
-              "text_en": "我更容易通过行动争取空间，而不是等别人给。",
+              "text": "I am more likely to claim space through action than wait for others to give it.",
+              "text_en": "I am more likely to claim space through action than wait for others to give it.",
               "text_zh": "我更容易通过行动争取空间，而不是等别人给。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我更在意整体是不是和谐，而不只是我个人有没有赢。",
-              "text_en": "我更在意整体是不是和谐，而不只是我个人有没有赢。",
+              "text": "I care more about whether the whole situation is harmonious than whether I personally win.",
+              "text_en": "I care more about whether the whole situation is harmonious than whether I personally win.",
               "text_zh": "我更在意整体是不是和谐，而不只是我个人有没有赢。",
               "type_code": "T9"
             }
@@ -2377,15 +2377,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常会朝着明确目标推进。",
-              "text_en": "我通常会朝着明确目标推进。",
+              "text": "I usually move toward clear goals.",
+              "text_en": "I usually move toward clear goals.",
               "text_zh": "我通常会朝着明确目标推进。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "别人需要帮忙时，我通常愿意搭把手。",
-              "text_en": "别人需要帮忙时，我通常愿意搭把手。",
+              "text": "When others need help, I am usually willing to lend a hand.",
+              "text_en": "When others need help, I am usually willing to lend a hand.",
               "text_zh": "别人需要帮忙时，我通常愿意搭把手。",
               "type_code": "T2"
             }
@@ -2402,15 +2402,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我做事通常按计划和步骤推进。",
-              "text_en": "我做事通常按计划和步骤推进。",
+              "text": "I usually work according to a plan and steps.",
+              "text_en": "I usually work according to a plan and steps.",
               "text_zh": "我做事通常按计划和步骤推进。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我不太喜欢把自己困在单一选项里。",
-              "text_en": "我不太喜欢把自己困在单一选项里。",
+              "text": "I do not like trapping myself in a single option.",
+              "text_en": "I do not like trapping myself in a single option.",
               "text_zh": "我不太喜欢把自己困在单一选项里。",
               "type_code": "T7"
             }
@@ -2427,15 +2427,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会希望自己的付出能被看见。",
-              "text_en": "我会希望自己的付出能被看见。",
+              "text": "I want my efforts to be seen.",
+              "text_en": "I want my efforts to be seen.",
               "text_zh": "我会希望自己的付出能被看见。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我会在意别人是否把我看成有能力的人。",
-              "text_en": "我会在意别人是否把我看成有能力的人。",
+              "text": "I care whether others see me as capable.",
+              "text_en": "I care whether others see me as capable.",
               "text_zh": "我会在意别人是否把我看成有能力的人。",
               "type_code": "T3"
             }
@@ -2452,15 +2452,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意按照内心感受来理解自己。",
-              "text_en": "我更愿意按照内心感受来理解自己。",
+              "text": "I prefer to understand myself through my inner feelings.",
+              "text_en": "I prefer to understand myself through my inner feelings.",
               "text_zh": "我更愿意按照内心感受来理解自己。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "当事情变得沉闷时，我会想办法换个节奏。",
-              "text_en": "当事情变得沉闷时，我会想办法换个节奏。",
+              "text": "When things become dull, I look for a way to change the pace.",
+              "text_en": "When things become dull, I look for a way to change the pace.",
               "text_zh": "当事情变得沉闷时，我会想办法换个节奏。",
               "type_code": "T7"
             }
@@ -2477,15 +2477,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我希望自己能成为值得信赖的人。",
-              "text_en": "我希望自己能成为值得信赖的人。",
+              "text": "I want to become someone trustworthy.",
+              "text_en": "I want to become someone trustworthy.",
               "text_zh": "我希望自己能成为值得信赖的人。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "遇到机会时，我通常会想办法抓住它。",
-              "text_en": "遇到机会时，我通常会想办法抓住它。",
+              "text": "When an opportunity appears, I usually try to seize it.",
+              "text_en": "When an opportunity appears, I usually try to seize it.",
               "text_zh": "遇到机会时，我通常会想办法抓住它。",
               "type_code": "T3"
             }
@@ -2502,15 +2502,15 @@
           "options": [
             {
               "code": "A",
-              "text": "对我来说，保留精力和边界很重要。",
-              "text_en": "对我来说，保留精力和边界很重要。",
+              "text": "For me, preserving energy and boundaries is important.",
+              "text_en": "For me, preserving energy and boundaries is important.",
               "text_zh": "对我来说，保留精力和边界很重要。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我会想避开让我感到压抑的人和场景。",
-              "text_en": "我会想避开让我感到压抑的人和场景。",
+              "text": "I want to avoid people and situations that feel oppressive.",
+              "text_en": "I want to avoid people and situations that feel oppressive.",
               "text_zh": "我会想避开让我感到压抑的人和场景。",
               "type_code": "T7"
             }
@@ -2527,15 +2527,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意维持一种顺畅、没有太多摩擦的状态。",
-              "text_en": "我更愿意维持一种顺畅、没有太多摩擦的状态。",
+              "text": "I prefer to maintain a smooth state with little friction.",
+              "text_en": "I prefer to maintain a smooth state with little friction.",
               "text_zh": "我更愿意维持一种顺畅、没有太多摩擦的状态。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "对我来说，成就感往往来自被证明“我做到了”。",
-              "text_en": "对我来说，成就感往往来自被证明“我做到了”。",
+              "text": "For me, achievement often comes from proving that I did it.",
+              "text_en": "For me, achievement often comes from proving that I did it.",
               "text_zh": "对我来说，成就感往往来自被证明“我做到了”。",
               "type_code": "T3"
             }
@@ -2552,15 +2552,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常更尊重真实的力量，而不是表面的客套。",
-              "text_en": "我通常更尊重真实的力量，而不是表面的客套。",
+              "text": "I usually respect real strength more than surface politeness.",
+              "text_en": "I usually respect real strength more than surface politeness.",
               "text_zh": "我通常更尊重真实的力量，而不是表面的客套。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我比较看重长期的稳定感。",
-              "text_en": "我比较看重长期的稳定感。",
+              "text": "I value long-term stability.",
+              "text_en": "I value long-term stability.",
               "text_zh": "我比较看重长期的稳定感。",
               "type_code": "T6"
             }
@@ -2577,15 +2577,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更在意人心有没有被照顾到，而不只是事情有没有完成。",
-              "text_en": "我更在意人心有没有被照顾到，而不只是事情有没有完成。",
+              "text": "I care whether people's feelings are cared for, not only whether the task is finished.",
+              "text_en": "I care whether people's feelings are cared for, not only whether the task is finished.",
               "text_zh": "我更在意人心有没有被照顾到，而不只是事情有没有完成。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我通常把平静和安稳看得很重要。",
-              "text_en": "我通常把平静和安稳看得很重要。",
+              "text": "I usually value calm and steadiness.",
+              "text_en": "I usually value calm and steadiness.",
               "text_zh": "我通常把平静和安稳看得很重要。",
               "type_code": "T9"
             }
@@ -2602,15 +2602,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会担心自己准备得还不够。",
-              "text_en": "我偶尔会担心自己准备得还不够。",
+              "text": "Sometimes I worry that I am not prepared enough.",
+              "text_en": "Sometimes I worry that I am not prepared enough.",
               "text_zh": "我偶尔会担心自己准备得还不够。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我有时会觉得自己像个旁观者，融不进眼前的圈子。",
-              "text_en": "我有时会觉得自己像个旁观者，融不进眼前的圈子。",
+              "text": "Sometimes I feel like an observer who cannot fit into the group in front of me.",
+              "text_en": "Sometimes I feel like an observer who cannot fit into the group in front of me.",
               "text_zh": "我有时会觉得自己像个旁观者，融不进眼前的圈子。",
               "type_code": "T4"
             }
@@ -2627,15 +2627,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更想让日子过得有趣、有活力。",
-              "text_en": "我更想让日子过得有趣、有活力。",
+              "text": "I want life to feel interesting and energetic.",
+              "text_en": "I want life to feel interesting and energetic.",
               "text_zh": "我更想让日子过得有趣、有活力。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我希望和世界保持一种可观察、可理解的距离。",
-              "text_en": "我希望和世界保持一种可观察、可理解的距离。",
+              "text": "I want to keep an observable and understandable distance from the world.",
+              "text_en": "I want to keep an observable and understandable distance from the world.",
               "text_zh": "我希望和世界保持一种可观察、可理解的距离。",
               "type_code": "T5"
             }
@@ -2652,15 +2652,15 @@
           "options": [
             {
               "code": "A",
-              "text": "别人态度强一点时，我可能就让过去了。",
-              "text_en": "别人态度强一点时，我可能就让过去了。",
+              "text": "When others take a stronger attitude, I may just let it pass.",
+              "text_en": "When others take a stronger attitude, I may just let it pass.",
               "text_zh": "别人态度强一点时，我可能就让过去了。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我偶尔会把“被需要”看得太重要。",
-              "text_en": "我偶尔会把“被需要”看得太重要。",
+              "text": "Sometimes I place too much importance on being needed.",
+              "text_en": "Sometimes I place too much importance on being needed.",
               "text_zh": "我偶尔会把“被需要”看得太重要。",
               "type_code": "T2"
             }
@@ -2677,15 +2677,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我宁可慢一点，也希望事情更稳妥、更到位。",
-              "text_en": "我宁可慢一点，也希望事情更稳妥、更到位。",
+              "text": "I would rather move slower so things are more stable and complete.",
+              "text_en": "I would rather move slower so things are more stable and complete.",
               "text_zh": "我宁可慢一点，也希望事情更稳妥、更到位。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "比起过程是否舒服，我更在意结果是否漂亮。",
-              "text_en": "比起过程是否舒服，我更在意结果是否漂亮。",
+              "text": "I care more about whether the result is strong than whether the process is comfortable.",
+              "text_en": "I care more about whether the result is strong than whether the process is comfortable.",
               "text_zh": "比起过程是否舒服，我更在意结果是否漂亮。",
               "type_code": "T3"
             }
@@ -2702,15 +2702,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常给人一种稳定、不折腾的感觉。",
-              "text_en": "我通常给人一种稳定、不折腾的感觉。",
+              "text": "I usually give people a sense of being stable and low-drama.",
+              "text_en": "I usually give people a sense of being stable and low-drama.",
               "text_zh": "我通常给人一种稳定、不折腾的感觉。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我身上有一股往前冲的劲儿。",
-              "text_en": "我身上有一股往前冲的劲儿。",
+              "text": "I have a drive to push forward.",
+              "text_en": "I have a drive to push forward.",
               "text_zh": "我身上有一股往前冲的劲儿。",
               "type_code": "T8"
             }
@@ -2727,15 +2727,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会花时间确认一个人或一件事是否值得信任。",
-              "text_en": "我会花时间确认一个人或一件事是否值得信任。",
+              "text": "I spend time confirming whether a person or situation is trustworthy.",
+              "text_en": "I spend time confirming whether a person or situation is trustworthy.",
               "text_zh": "我会花时间确认一个人或一件事是否值得信任。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我更容易被好玩的事吸引，而不是被责任吓住。",
-              "text_en": "我更容易被好玩的事吸引，而不是被责任吓住。",
+              "text": "I am more easily drawn by fun things than intimidated by responsibility.",
+              "text_en": "I am more easily drawn by fun things than intimidated by responsibility.",
               "text_zh": "我更容易被好玩的事吸引，而不是被责任吓住。",
               "type_code": "T7"
             }
@@ -2752,15 +2752,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢被逼着很快做决定。",
-              "text_en": "我不太喜欢被逼着很快做决定。",
+              "text": "I do not like being forced to make decisions quickly.",
+              "text_en": "I do not like being forced to make decisions quickly.",
               "text_zh": "我不太喜欢被逼着很快做决定。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我有时会给自己很强的赢的压力。",
-              "text_en": "我有时会给自己很强的赢的压力。",
+              "text": "Sometimes I put strong pressure on myself to win.",
+              "text_en": "Sometimes I put strong pressure on myself to win.",
               "text_zh": "我有时会给自己很强的赢的压力。",
               "type_code": "T3"
             }
@@ -2777,15 +2777,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更容易被有个性、有味道的人事物吸引。",
-              "text_en": "我更容易被有个性、有味道的人事物吸引。",
+              "text": "I am more easily attracted to people and things with character and flavor.",
+              "text_en": "I am more easily attracted to people and things with character and flavor.",
               "text_zh": "我更容易被有个性、有味道的人事物吸引。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我更容易注意到别人的情绪变化。",
-              "text_en": "我更容易注意到别人的情绪变化。",
+              "text": "I more easily notice changes in other people's emotions.",
+              "text_en": "I more easily notice changes in other people's emotions.",
               "text_zh": "我更容易注意到别人的情绪变化。",
               "type_code": "T2"
             }
@@ -2802,15 +2802,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢让别人看到自己不擅长的一面。",
-              "text_en": "我不太喜欢让别人看到自己不擅长的一面。",
+              "text": "I do not like letting others see what I am not good at.",
+              "text_en": "I do not like letting others see what I am not good at.",
               "text_zh": "我不太喜欢让别人看到自己不擅长的一面。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我会反复检查，是因为不想出差错。",
-              "text_en": "我会反复检查，是因为不想出差错。",
+              "text": "I check repeatedly because I do not want mistakes.",
+              "text_en": "I check repeatedly because I do not want mistakes.",
               "text_zh": "我会反复检查，是因为不想出差错。",
               "type_code": "T6"
             }
@@ -2827,15 +2827,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意凭理解来建立安全感。",
-              "text_en": "我更愿意凭理解来建立安全感。",
+              "text": "I prefer to build a sense of security through understanding.",
+              "text_en": "I prefer to build a sense of security through understanding.",
               "text_zh": "我更愿意凭理解来建立安全感。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我希望自己的人生带着鲜明的个人色彩。",
-              "text_en": "我希望自己的人生带着鲜明的个人色彩。",
+              "text": "I want my life to carry a distinct personal color.",
+              "text_en": "I want my life to carry a distinct personal color.",
               "text_zh": "我希望自己的人生带着鲜明的个人色彩。",
               "type_code": "T4"
             }
@@ -2852,15 +2852,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢先确认计划是否足够周全。",
-              "text_en": "我喜欢先确认计划是否足够周全。",
+              "text": "I like to confirm first that a plan is thorough enough.",
+              "text_en": "I like to confirm first that a plan is thorough enough.",
               "text_zh": "我喜欢先确认计划是否足够周全。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我在意自己是否给人留下能干的印象。",
-              "text_en": "我在意自己是否给人留下能干的印象。",
+              "text": "I care whether I leave an impression of competence.",
+              "text_en": "I care whether I leave an impression of competence.",
               "text_zh": "我在意自己是否给人留下能干的印象。",
               "type_code": "T3"
             }
@@ -2877,15 +2877,15 @@
           "options": [
             {
               "code": "A",
-              "text": "对我来说，“差不多就行”并不容易。",
-              "text_en": "对我来说，“差不多就行”并不容易。",
+              "text": "For me, good enough is not easy to accept.",
+              "text_en": "For me, good enough is not easy to accept.",
               "text_zh": "对我来说，“差不多就行”并不容易。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我有时会为了维持和气而不太表达自己。",
-              "text_en": "我有时会为了维持和气而不太表达自己。",
+              "text": "Sometimes I hold back from expressing myself to keep the peace.",
+              "text_en": "Sometimes I hold back from expressing myself to keep the peace.",
               "text_zh": "我有时会为了维持和气而不太表达自己。",
               "type_code": "T9"
             }
@@ -2902,15 +2902,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我对“别人都这样”这类理由并不太买账。",
-              "text_en": "我对“别人都这样”这类理由并不太买账。",
+              "text": "I am not very convinced by reasons like everyone does it this way.",
+              "text_en": "I am not very convinced by reasons like everyone does it this way.",
               "text_zh": "我对“别人都这样”这类理由并不太买账。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我常会通过规划和准备来让自己安心。",
-              "text_en": "我常会通过规划和准备来让自己安心。",
+              "text": "I often use planning and preparation to reassure myself.",
+              "text_en": "I often use planning and preparation to reassure myself.",
               "text_zh": "我常会通过规划和准备来让自己安心。",
               "type_code": "T6"
             }
@@ -2927,15 +2927,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢保持头脑上的清晰和客观。",
-              "text_en": "我喜欢保持头脑上的清晰和客观。",
+              "text": "I like to stay mentally clear and objective.",
+              "text_en": "I like to stay mentally clear and objective.",
               "text_zh": "我喜欢保持头脑上的清晰和客观。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我更倾向于用平和的方式处理问题。",
-              "text_en": "我更倾向于用平和的方式处理问题。",
+              "text": "I tend to handle problems in a calm way.",
+              "text_en": "I tend to handle problems in a calm way.",
               "text_zh": "我更倾向于用平和的方式处理问题。",
               "type_code": "T9"
             }
@@ -2952,15 +2952,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会觉得自己和周围的人不太一样。",
-              "text_en": "我偶尔会觉得自己和周围的人不太一样。",
+              "text": "Sometimes I feel different from the people around me.",
+              "text_en": "Sometimes I feel different from the people around me.",
               "text_zh": "我偶尔会觉得自己和周围的人不太一样。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "别人不需要我时，我偶尔会有点失落。",
-              "text_en": "别人不需要我时，我偶尔会有点失落。",
+              "text": "Sometimes I feel a little disappointed when others do not need me.",
+              "text_en": "Sometimes I feel a little disappointed when others do not need me.",
               "text_zh": "别人不需要我时，我偶尔会有点失落。",
               "type_code": "T2"
             }
@@ -2977,15 +2977,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢把问题拆开来看。",
-              "text_en": "我喜欢把问题拆开来看。",
+              "text": "I like to break problems apart and examine them.",
+              "text_en": "I like to break problems apart and examine them.",
               "text_zh": "我喜欢把问题拆开来看。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我习惯在不确定时尽快做出判断。",
-              "text_en": "我习惯在不确定时尽快做出判断。",
+              "text": "When things are uncertain, I tend to make a judgment quickly.",
+              "text_en": "When things are uncertain, I tend to make a judgment quickly.",
               "text_zh": "我习惯在不确定时尽快做出判断。",
               "type_code": "T8"
             }
@@ -3002,15 +3002,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我内心的体验通常比较丰富。",
-              "text_en": "我内心的体验通常比较丰富。",
+              "text": "My inner experience is usually quite rich.",
+              "text_en": "My inner experience is usually quite rich.",
               "text_zh": "我内心的体验通常比较丰富。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我通常会为不确定的情况先做准备。",
-              "text_en": "我通常会为不确定的情况先做准备。",
+              "text": "I usually prepare in advance for uncertain situations.",
+              "text_en": "I usually prepare in advance for uncertain situations.",
               "text_zh": "我通常会为不确定的情况先做准备。",
               "type_code": "T6"
             }
@@ -3027,15 +3027,15 @@
           "options": [
             {
               "code": "A",
-              "text": "如果别人对我冷淡，我会有点在意。",
-              "text_en": "如果别人对我冷淡，我会有点在意。",
+              "text": "If others are cold toward me, I care about it.",
+              "text_en": "If others are cold toward me, I care about it.",
               "text_zh": "如果别人对我冷淡，我会有点在意。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "看到不规范的地方，我会忍不住想纠正。",
-              "text_en": "看到不规范的地方，我会忍不住想纠正。",
+              "text": "When I see something irregular, I cannot help wanting to correct it.",
+              "text_en": "When I see something irregular, I cannot help wanting to correct it.",
               "text_zh": "看到不规范的地方，我会忍不住想纠正。",
               "type_code": "T1"
             }
@@ -3052,15 +3052,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更容易去适应环境，而不是强行改变环境。",
-              "text_en": "我更容易去适应环境，而不是强行改变环境。",
+              "text": "I am more likely to adapt to an environment than force it to change.",
+              "text_en": "I am more likely to adapt to an environment than force it to change.",
               "text_zh": "我更容易去适应环境，而不是强行改变环境。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我更愿意主动掌控，而不是被动等待。",
-              "text_en": "我更愿意主动掌控，而不是被动等待。",
+              "text": "I prefer to take control proactively rather than wait passively.",
+              "text_en": "I prefer to take control proactively rather than wait passively.",
               "text_zh": "我更愿意主动掌控，而不是被动等待。",
               "type_code": "T8"
             }
@@ -3077,15 +3077,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我往往能在事情里看到值得期待的一面。",
-              "text_en": "我往往能在事情里看到值得期待的一面。",
+              "text": "I can often see something worth looking forward to in a situation.",
+              "text_en": "I can often see something worth looking forward to in a situation.",
               "text_zh": "我往往能在事情里看到值得期待的一面。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我愿意承认自己复杂的一面。",
-              "text_en": "我愿意承认自己复杂的一面。",
+              "text": "I am willing to acknowledge the complex side of myself.",
+              "text_en": "I am willing to acknowledge the complex side of myself.",
               "text_zh": "我愿意承认自己复杂的一面。",
               "type_code": "T4"
             }
@@ -3102,15 +3102,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我宁可忙一点，也不想长期停滞不前。",
-              "text_en": "我宁可忙一点，也不想长期停滞不前。",
+              "text": "I would rather be a little busy than remain stuck for a long time.",
+              "text_en": "I would rather be a little busy than remain stuck for a long time.",
               "text_zh": "我宁可忙一点，也不想长期停滞不前。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我希望自己是能扛事、能做主的人。",
-              "text_en": "我希望自己是能扛事、能做主的人。",
+              "text": "I want to be someone who can carry responsibility and make decisions.",
+              "text_en": "I want to be someone who can carry responsibility and make decisions.",
               "text_zh": "我希望自己是能扛事、能做主的人。",
               "type_code": "T8"
             }
@@ -3127,15 +3127,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我习惯先完成分内该做的事。",
-              "text_en": "我习惯先完成分内该做的事。",
+              "text": "I tend to finish what is my responsibility first.",
+              "text_en": "I tend to finish what is my responsibility first.",
               "text_zh": "我习惯先完成分内该做的事。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我不太喜欢太过千篇一律的状态。",
-              "text_en": "我不太喜欢太过千篇一律的状态。",
+              "text": "I do not like states that feel too uniform or repetitive.",
+              "text_en": "I do not like states that feel too uniform or repetitive.",
               "text_zh": "我不太喜欢太过千篇一律的状态。",
               "type_code": "T4"
             }
@@ -3152,15 +3152,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢从复杂信息里梳理出规律。",
-              "text_en": "我喜欢从复杂信息里梳理出规律。",
+              "text": "I like finding patterns in complex information.",
+              "text_en": "I like finding patterns in complex information.",
               "text_zh": "我喜欢从复杂信息里梳理出规律。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我会认真守住自己该负的责任。",
-              "text_en": "我会认真守住自己该负的责任。",
+              "text": "I take seriously the responsibilities I should carry.",
+              "text_en": "I take seriously the responsibilities I should carry.",
               "text_zh": "我会认真守住自己该负的责任。",
               "type_code": "T6"
             }
@@ -3177,15 +3177,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会把责任扛得太满。",
-              "text_en": "我有时会把责任扛得太满。",
+              "text": "Sometimes I take on too much responsibility.",
+              "text_en": "Sometimes I take on too much responsibility.",
               "text_zh": "我有时会把责任扛得太满。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我有时会因为太直接而让人有压力。",
-              "text_en": "我有时会因为太直接而让人有压力。",
+              "text": "Sometimes I put pressure on others by being too direct.",
+              "text_en": "Sometimes I put pressure on others by being too direct.",
               "text_zh": "我有时会因为太直接而让人有压力。",
               "type_code": "T8"
             }
@@ -3202,15 +3202,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢成为别人可以依靠的人。",
-              "text_en": "我喜欢成为别人可以依靠的人。",
+              "text": "I like being someone others can rely on.",
+              "text_en": "I like being someone others can rely on.",
               "text_zh": "我喜欢成为别人可以依靠的人。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我做事时通常不急着抢主导权。",
-              "text_en": "我做事时通常不急着抢主导权。",
+              "text": "When doing things, I usually do not rush to take the lead.",
+              "text_en": "When doing things, I usually do not rush to take the lead.",
               "text_zh": "我做事时通常不急着抢主导权。",
               "type_code": "T9"
             }
@@ -3227,15 +3227,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我很看重一个人是否活得真诚、有自我。",
-              "text_en": "我很看重一个人是否活得真诚、有自我。",
+              "text": "I care a lot about whether a person lives sincerely and with a sense of self.",
+              "text_en": "I care a lot about whether a person lives sincerely and with a sense of self.",
               "text_zh": "我很看重一个人是否活得真诚、有自我。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我希望自己是高效、能成事的人。",
-              "text_en": "我希望自己是高效、能成事的人。",
+              "text": "I want to be efficient and able to make things happen.",
+              "text_en": "I want to be efficient and able to make things happen.",
               "text_zh": "我希望自己是高效、能成事的人。",
               "type_code": "T3"
             }
@@ -3252,15 +3252,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会先追求感觉好，再考虑别的。",
-              "text_en": "我有时会先追求感觉好，再考虑别的。",
+              "text": "Sometimes I pursue what feels good first and consider other things later.",
+              "text_en": "Sometimes I pursue what feels good first and consider other things later.",
               "text_zh": "我有时会先追求感觉好，再考虑别的。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我有时会先想到最坏的可能。",
-              "text_en": "我有时会先想到最坏的可能。",
+              "text": "Sometimes I think of the worst possibility first.",
+              "text_en": "Sometimes I think of the worst possibility first.",
               "text_zh": "我有时会先想到最坏的可能。",
               "type_code": "T6"
             }
@@ -3277,15 +3277,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更希望被理解成真正的我，而不只是一个标签。",
-              "text_en": "我更希望被理解成真正的我，而不只是一个标签。",
+              "text": "I want to be understood as my real self, not just as a label.",
+              "text_en": "I want to be understood as my real self, not just as a label.",
               "text_zh": "我更希望被理解成真正的我，而不只是一个标签。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我不太喜欢被卷进强烈的对立里。",
-              "text_en": "我不太喜欢被卷进强烈的对立里。",
+              "text": "I do not like being pulled into intense opposition.",
+              "text_en": "I do not like being pulled into intense opposition.",
               "text_zh": "我不太喜欢被卷进强烈的对立里。",
               "type_code": "T9"
             }
@@ -3302,15 +3302,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意把话摊开说清楚。",
-              "text_en": "我更愿意把话摊开说清楚。",
+              "text": "I would rather put things on the table and speak clearly.",
+              "text_en": "I would rather put things on the table and speak clearly.",
               "text_zh": "我更愿意把话摊开说清楚。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我会主动寻找让自己更进一步的机会。",
-              "text_en": "我会主动寻找让自己更进一步的机会。",
+              "text": "I actively look for opportunities to move myself further.",
+              "text_en": "I actively look for opportunities to move myself further.",
               "text_zh": "我会主动寻找让自己更进一步的机会。",
               "type_code": "T3"
             }
@@ -3327,15 +3327,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意把注意力放在下一件值得期待的事上。",
-              "text_en": "我更愿意把注意力放在下一件值得期待的事上。",
+              "text": "I prefer to put my attention on the next thing worth looking forward to.",
+              "text_en": "I prefer to put my attention on the next thing worth looking forward to.",
               "text_zh": "我更愿意把注意力放在下一件值得期待的事上。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "对我来说，心里没那么多波澜本身就是一种舒服。",
-              "text_en": "对我来说，心里没那么多波澜本身就是一种舒服。",
+              "text": "For me, having fewer emotional waves inside is comfortable in itself.",
+              "text_en": "For me, having fewer emotional waves inside is comfortable in itself.",
               "text_zh": "对我来说，心里没那么多波澜本身就是一种舒服。",
               "type_code": "T9"
             }
@@ -3352,15 +3352,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常愿意为关系多付出一点。",
-              "text_en": "我通常愿意为关系多付出一点。",
+              "text": "I am usually willing to give a little more for relationships.",
+              "text_en": "I am usually willing to give a little more for relationships.",
               "text_zh": "我通常愿意为关系多付出一点。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "遇到问题时，我往往会主动顶上去。",
-              "text_en": "遇到问题时，我往往会主动顶上去。",
+              "text": "When problems arise, I tend to step up proactively.",
+              "text_en": "When problems arise, I tend to step up proactively.",
               "text_zh": "遇到问题时，我往往会主动顶上去。",
               "type_code": "T8"
             }
@@ -3377,15 +3377,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会先评估自己是否有足够的信息再表态。",
-              "text_en": "我会先评估自己是否有足够的信息再表态。",
+              "text": "I first assess whether I have enough information before taking a position.",
+              "text_en": "I first assess whether I have enough information before taking a position.",
               "text_zh": "我会先评估自己是否有足够的信息再表态。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我通常不想在低落情绪里停太久。",
-              "text_en": "我通常不想在低落情绪里停太久。",
+              "text": "I usually do not want to stay in low moods for too long.",
+              "text_en": "I usually do not want to stay in low moods for too long.",
               "text_zh": "我通常不想在低落情绪里停太久。",
               "type_code": "T7"
             }
@@ -3402,15 +3402,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我做事前会习惯先看风险和后果。",
-              "text_en": "我做事前会习惯先看风险和后果。",
+              "text": "Before acting, I tend to look at risks and consequences first.",
+              "text_en": "Before acting, I tend to look at risks and consequences first.",
               "text_zh": "我做事前会习惯先看风险和后果。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我很重视人与人之间的温度。",
-              "text_en": "我很重视人与人之间的温度。",
+              "text": "I care a lot about warmth between people.",
+              "text_en": "I care a lot about warmth between people.",
               "text_zh": "我很重视人与人之间的温度。",
               "type_code": "T2"
             }
@@ -3427,15 +3427,15 @@
           "options": [
             {
               "code": "A",
-              "text": "对我来说，知道为什么，往往和知道做什么一样重要。",
-              "text_en": "对我来说，知道为什么，往往和知道做什么一样重要。",
+              "text": "For me, knowing why is often as important as knowing what to do.",
+              "text_en": "For me, knowing why is often as important as knowing what to do.",
               "text_zh": "对我来说，知道为什么，往往和知道做什么一样重要。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我更愿意正面碰撞，也不想委屈着绕过去。",
-              "text_en": "我更愿意正面碰撞，也不想委屈着绕过去。",
+              "text": "I would rather face things directly than bend around them while feeling wronged.",
+              "text_en": "I would rather face things directly than bend around them while feeling wronged.",
               "text_zh": "我更愿意正面碰撞，也不想委屈着绕过去。",
               "type_code": "T8"
             }
@@ -3452,15 +3452,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会为重要目标持续投入精力。",
-              "text_en": "我会为重要目标持续投入精力。",
+              "text": "I keep investing energy in important goals.",
+              "text_en": "I keep investing energy in important goals.",
               "text_zh": "我会为重要目标持续投入精力。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我不喜欢把关系弄得很僵。",
-              "text_en": "我不喜欢把关系弄得很僵。",
+              "text": "I do not like making relationships become rigid or strained.",
+              "text_en": "I do not like making relationships become rigid or strained.",
               "text_zh": "我不喜欢把关系弄得很僵。",
               "type_code": "T9"
             }
@@ -3477,15 +3477,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我希望自己活得端正、有标准。",
-              "text_en": "我希望自己活得端正、有标准。",
+              "text": "I want to live with integrity and standards.",
+              "text_en": "I want to live with integrity and standards.",
               "text_zh": "我希望自己活得端正、有标准。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "比起先看风险，我更容易先看机会。",
-              "text_en": "比起先看风险，我更容易先看机会。",
+              "text": "Rather than looking at risks first, I more easily see opportunities first.",
+              "text_en": "Rather than looking at risks first, I more easily see opportunities first.",
               "text_zh": "比起先看风险，我更容易先看机会。",
               "type_code": "T7"
             }
@@ -3502,15 +3502,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常能察觉哪里可能不太对劲。",
-              "text_en": "我通常能察觉哪里可能不太对劲。",
+              "text": "I can usually sense where something may not be right.",
+              "text_en": "I can usually sense where something may not be right.",
               "text_zh": "我通常能察觉哪里可能不太对劲。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我通常会在关键时刻站出来。",
-              "text_en": "我通常会在关键时刻站出来。",
+              "text": "I usually stand up at key moments.",
+              "text_en": "I usually stand up at key moments.",
               "text_zh": "我通常会在关键时刻站出来。",
               "type_code": "T8"
             }
@@ -3527,15 +3527,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会习惯给自己设定阶段性目标。",
-              "text_en": "我会习惯给自己设定阶段性目标。",
+              "text": "I tend to set staged goals for myself.",
+              "text_en": "I tend to set staged goals for myself.",
               "text_zh": "我会习惯给自己设定阶段性目标。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我希望表达出来的东西是有我自己痕迹的。",
-              "text_en": "我希望表达出来的东西是有我自己痕迹的。",
+              "text": "I want what I express to carry my own mark.",
+              "text_en": "I want what I express to carry my own mark.",
               "text_zh": "我希望表达出来的东西是有我自己痕迹的。",
               "type_code": "T4"
             }
@@ -3552,15 +3552,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我说话做事通常比较直接。",
-              "text_en": "我说话做事通常比较直接。",
+              "text": "I usually speak and act directly.",
+              "text_en": "I usually speak and act directly.",
               "text_zh": "我说话做事通常比较直接。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我不太能接受明知不对还将就。",
-              "text_en": "我不太能接受明知不对还将就。",
+              "text": "I have trouble accepting something I know is wrong and settling for it anyway.",
+              "text_en": "I have trouble accepting something I know is wrong and settling for it anyway.",
               "text_zh": "我不太能接受明知不对还将就。",
               "type_code": "T1"
             }
@@ -3577,15 +3577,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢频繁改变已经熟悉的做法。",
-              "text_en": "我不太喜欢频繁改变已经熟悉的做法。",
+              "text": "I do not like frequently changing ways of doing things that are already familiar.",
+              "text_en": "I do not like frequently changing ways of doing things that are already familiar.",
               "text_zh": "我不太喜欢频繁改变已经熟悉的做法。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我不太想把自己活成一个“标准答案”。",
-              "text_en": "我不太想把自己活成一个“标准答案”。",
+              "text": "I do not want to live as a standard answer.",
+              "text_en": "I do not want to live as a standard answer.",
               "text_zh": "我不太想把自己活成一个“标准答案”。",
               "type_code": "T4"
             }
@@ -3602,15 +3602,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太喜欢自己在关系里是可有可无的。",
-              "text_en": "我不太喜欢自己在关系里是可有可无的。",
+              "text": "I do not like feeling optional in a relationship.",
+              "text_en": "I do not like feeling optional in a relationship.",
               "text_zh": "我不太喜欢自己在关系里是可有可无的。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "面对不确定时，我心里会先拉起警报。",
-              "text_en": "面对不确定时，我心里会先拉起警报。",
+              "text": "When facing uncertainty, an alarm goes off inside me first.",
+              "text_en": "When facing uncertainty, an alarm goes off inside me first.",
               "text_zh": "面对不确定时，我心里会先拉起警报。",
               "type_code": "T6"
             }
@@ -3627,15 +3627,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常会把自由感看得很重要。",
-              "text_en": "我通常会把自由感看得很重要。",
+              "text": "I usually place a lot of importance on a sense of freedom.",
+              "text_en": "I usually place a lot of importance on a sense of freedom.",
               "text_zh": "我通常会把自由感看得很重要。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我更容易被内心的共鸣打动，而不是表面的标准答案。",
-              "text_en": "我更容易被内心的共鸣打动，而不是表面的标准答案。",
+              "text": "I am more moved by inner resonance than by surface-level standard answers.",
+              "text_en": "I am more moved by inner resonance than by surface-level standard answers.",
               "text_zh": "我更容易被内心的共鸣打动，而不是表面的标准答案。",
               "type_code": "T4"
             }
@@ -3652,15 +3652,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢先把流程理顺再行动。",
-              "text_en": "我喜欢先把流程理顺再行动。",
+              "text": "I like to sort out the process before acting.",
+              "text_en": "I like to sort out the process before acting.",
               "text_zh": "我喜欢先把流程理顺再行动。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我做事时会先考虑这会不会影响别人。",
-              "text_en": "我做事时会先考虑这会不会影响别人。",
+              "text": "When I do things, I first consider whether they will affect others.",
+              "text_en": "When I do things, I first consider whether they will affect others.",
               "text_zh": "我做事时会先考虑这会不会影响别人。",
               "type_code": "T2"
             }
@@ -3677,15 +3677,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太习惯把脆弱轻易露出来。",
-              "text_en": "我不太习惯把脆弱轻易露出来。",
+              "text": "I am not used to showing vulnerability easily.",
+              "text_en": "I am not used to showing vulnerability easily.",
               "text_zh": "我不太习惯把脆弱轻易露出来。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我会希望自己的努力是被看见、被认可的。",
-              "text_en": "我会希望自己的努力是被看见、被认可的。",
+              "text": "I want my efforts to be seen and recognized.",
+              "text_en": "I want my efforts to be seen and recognized.",
               "text_zh": "我会希望自己的努力是被看见、被认可的。",
               "type_code": "T3"
             }
@@ -3702,15 +3702,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我能感受到别人不太会留意到的细微情绪。",
-              "text_en": "我能感受到别人不太会留意到的细微情绪。",
+              "text": "I can sense subtle emotions that others may not notice.",
+              "text_en": "I can sense subtle emotions that others may not notice.",
               "text_zh": "我能感受到别人不太会留意到的细微情绪。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我能长时间专注在自己感兴趣的问题上。",
-              "text_en": "我能长时间专注在自己感兴趣的问题上。",
+              "text": "I can focus for a long time on problems that interest me.",
+              "text_en": "I can focus for a long time on problems that interest me.",
               "text_zh": "我能长时间专注在自己感兴趣的问题上。",
               "type_code": "T5"
             }
@@ -3727,15 +3727,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不太愿意把自己长期困在无聊和受限里。",
-              "text_en": "我不太愿意把自己长期困在无聊和受限里。",
+              "text": "I am not willing to keep myself trapped in boredom and restriction for long.",
+              "text_en": "I am not willing to keep myself trapped in boredom and restriction for long.",
               "text_zh": "我不太愿意把自己长期困在无聊和受限里。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "面对分歧时，我会先想办法缓一缓。",
-              "text_en": "面对分歧时，我会先想办法缓一缓。",
+              "text": "When facing disagreement, I first try to slow things down.",
+              "text_en": "When facing disagreement, I first try to slow things down.",
               "text_zh": "面对分歧时，我会先想办法缓一缓。",
               "type_code": "T9"
             }
@@ -3752,15 +3752,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我很自然地会去照顾身边的人。",
-              "text_en": "我很自然地会去照顾身边的人。",
+              "text": "I naturally take care of the people around me.",
+              "text_en": "I naturally take care of the people around me.",
               "text_zh": "我很自然地会去照顾身边的人。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我很在意把事情做对。",
-              "text_en": "我很在意把事情做对。",
+              "text": "I care a lot about doing things correctly.",
+              "text_en": "I care a lot about doing things correctly.",
               "text_zh": "我很在意把事情做对。",
               "type_code": "T1"
             }
@@ -3777,15 +3777,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会顺着别人走，却没那么清楚自己想要什么。",
-              "text_en": "我有时会顺着别人走，却没那么清楚自己想要什么。",
+              "text": "Sometimes I go along with others without being very clear about what I want.",
+              "text_en": "Sometimes I go along with others without being very clear about what I want.",
               "text_zh": "我有时会顺着别人走，却没那么清楚自己想要什么。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "如果没有想明白，我不太愿意仓促表态。",
-              "text_en": "如果没有想明白，我不太愿意仓促表态。",
+              "text": "If I have not thought it through, I do not like taking a position in a hurry.",
+              "text_en": "If I have not thought it through, I do not like taking a position in a hurry.",
               "text_zh": "如果没有想明白，我不太愿意仓促表态。",
               "type_code": "T5"
             }
@@ -3802,15 +3802,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我遇到冲突时，通常不会退得太快。",
-              "text_en": "我遇到冲突时，通常不会退得太快。",
+              "text": "When I encounter conflict, I usually do not back down too quickly.",
+              "text_en": "When I encounter conflict, I usually do not back down too quickly.",
               "text_zh": "我遇到冲突时，通常不会退得太快。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我常会把他人的需要放进自己的安排里。",
-              "text_en": "我常会把他人的需要放进自己的安排里。",
+              "text": "I often include other people's needs in my own plans.",
+              "text_en": "I often include other people's needs in my own plans.",
               "text_zh": "我常会把他人的需要放进自己的安排里。",
               "type_code": "T2"
             }
@@ -3827,15 +3827,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢看到自己不断向上移动。",
-              "text_en": "我喜欢看到自己不断向上移动。",
+              "text": "I like seeing myself keep moving upward.",
+              "text_en": "I like seeing myself keep moving upward.",
               "text_zh": "我喜欢看到自己不断向上移动。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我宁可往前试一试，也不太想被困在原地。",
-              "text_en": "我宁可往前试一试，也不太想被困在原地。",
+              "text": "I would rather try moving forward than stay stuck in place.",
+              "text_en": "I would rather try moving forward than stay stuck in place.",
               "text_zh": "我宁可往前试一试，也不太想被困在原地。",
               "type_code": "T7"
             }
@@ -3852,15 +3852,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会对失去的人或事停留很久。",
-              "text_en": "我会对失去的人或事停留很久。",
+              "text": "I may linger for a long time on people or things I have lost.",
+              "text_en": "I may linger for a long time on people or things I have lost.",
               "text_zh": "我会对失去的人或事停留很久。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我不太喜欢别人突然闯进我的节奏里。",
-              "text_en": "我不太喜欢别人突然闯进我的节奏里。",
+              "text": "I do not like others suddenly intruding into my rhythm.",
+              "text_en": "I do not like others suddenly intruding into my rhythm.",
               "text_zh": "我不太喜欢别人突然闯进我的节奏里。",
               "type_code": "T5"
             }
@@ -3877,15 +3877,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常会先看怎么避免冲突升级。",
-              "text_en": "我通常会先看怎么避免冲突升级。",
+              "text": "I usually first look for how to prevent conflict from escalating.",
+              "text_en": "I usually first look for how to prevent conflict from escalating.",
               "text_zh": "我通常会先看怎么避免冲突升级。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我会把保护已有的东西看得很重要。",
-              "text_en": "我会把保护已有的东西看得很重要。",
+              "text": "I place a lot of importance on protecting what already exists.",
+              "text_en": "I place a lot of importance on protecting what already exists.",
               "text_zh": "我会把保护已有的东西看得很重要。",
               "type_code": "T6"
             }
@@ -3902,15 +3902,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢让别人感到被关心、被照顾。",
-              "text_en": "我喜欢让别人感到被关心、被照顾。",
+              "text": "I like helping others feel cared for and looked after.",
+              "text_en": "I like helping others feel cared for and looked after.",
               "text_zh": "我喜欢让别人感到被关心、被照顾。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我会认真对待自己内心真实的感受。",
-              "text_en": "我会认真对待自己内心真实的感受。",
+              "text": "I take my genuine inner feelings seriously.",
+              "text_en": "I take my genuine inner feelings seriously.",
               "text_zh": "我会认真对待自己内心真实的感受。",
               "type_code": "T4"
             }
@@ -3927,15 +3927,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会更愿意旁观，而不是立刻卷进去。",
-              "text_en": "我有时会更愿意旁观，而不是立刻卷进去。",
+              "text": "Sometimes I would rather observe than get involved immediately.",
+              "text_en": "Sometimes I would rather observe than get involved immediately.",
               "text_zh": "我有时会更愿意旁观，而不是立刻卷进去。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我不太容易对风险掉以轻心。",
-              "text_en": "我不太容易对风险掉以轻心。",
+              "text": "I do not easily take risks lightly.",
+              "text_en": "I do not easily take risks lightly.",
               "text_zh": "我不太容易对风险掉以轻心。",
               "type_code": "T6"
             }
@@ -3952,15 +3952,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更习惯掌握局面，而不是被局面推着走。",
-              "text_en": "我更习惯掌握局面，而不是被局面推着走。",
+              "text": "I am more used to taking charge of a situation than being pushed by it.",
+              "text_en": "I am more used to taking charge of a situation than being pushed by it.",
               "text_zh": "我更习惯掌握局面，而不是被局面推着走。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我很容易被可能性和新点子点燃。",
-              "text_en": "我很容易被可能性和新点子点燃。",
+              "text": "I am easily energized by possibilities and new ideas.",
+              "text_en": "I am easily energized by possibilities and new ideas.",
               "text_zh": "我很容易被可能性和新点子点燃。",
               "type_code": "T7"
             }
@@ -3977,15 +3977,15 @@
           "options": [
             {
               "code": "A",
-              "text": "当进展不明显时，我会有点焦躁。",
-              "text_en": "当进展不明显时，我会有点焦躁。",
+              "text": "When progress is not visible, I get a bit restless.",
+              "text_en": "When progress is not visible, I get a bit restless.",
               "text_zh": "当进展不明显时，我会有点焦躁。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "当外界太吵或要求太多时，我会想退回自己的空间。",
-              "text_en": "当外界太吵或要求太多时，我会想退回自己的空间。",
+              "text": "When the outside world is too noisy or demanding, I want to retreat to my own space.",
+              "text_en": "When the outside world is too noisy or demanding, I want to retreat to my own space.",
               "text_zh": "当外界太吵或要求太多时，我会想退回自己的空间。",
               "type_code": "T5"
             }
@@ -4002,15 +4002,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会自然地去维护自己认定的人或事。",
-              "text_en": "我会自然地去维护自己认定的人或事。",
+              "text": "I naturally protect the people or things I believe in.",
+              "text_en": "I naturally protect the people or things I believe in.",
               "text_zh": "我会自然地去维护自己认定的人或事。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我会花时间体会自己的情绪变化。",
-              "text_en": "我会花时间体会自己的情绪变化。",
+              "text": "I spend time experiencing changes in my emotions.",
+              "text_en": "I spend time experiencing changes in my emotions.",
               "text_zh": "我会花时间体会自己的情绪变化。",
               "type_code": "T4"
             }
@@ -4027,15 +4027,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我很容易被有趣的新体验吸引。",
-              "text_en": "我很容易被有趣的新体验吸引。",
+              "text": "I am easily attracted to interesting new experiences.",
+              "text_en": "I am easily attracted to interesting new experiences.",
               "text_zh": "我很容易被有趣的新体验吸引。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我对细节和质量比较敏感。",
-              "text_en": "我对细节和质量比较敏感。",
+              "text": "I am sensitive to details and quality.",
+              "text_en": "I am sensitive to details and quality.",
               "text_zh": "我对细节和质量比较敏感。",
               "type_code": "T1"
             }
@@ -4052,15 +4052,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更容易把“安全”和“责任”放在前面。",
-              "text_en": "我更容易把“安全”和“责任”放在前面。",
+              "text": "I am more likely to put safety and responsibility first.",
+              "text_en": "I am more likely to put safety and responsibility first.",
               "text_zh": "我更容易把“安全”和“责任”放在前面。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "在团体里，我愿意承担照应别人的角色。",
-              "text_en": "在团体里，我愿意承担照应别人的角色。",
+              "text": "In a group, I am willing to take on the role of looking after others.",
+              "text_en": "In a group, I am willing to take on the role of looking after others.",
               "text_zh": "在团体里，我愿意承担照应别人的角色。",
               "type_code": "T2"
             }
@@ -4077,15 +4077,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我常能把气氛带得更轻松一些。",
-              "text_en": "我常能把气氛带得更轻松一些。",
+              "text": "I can often make the atmosphere feel lighter.",
+              "text_en": "I can often make the atmosphere feel lighter.",
               "text_zh": "我常能把气氛带得更轻松一些。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我喜欢让自己处在有进展的状态里。",
-              "text_en": "我喜欢让自己处在有进展的状态里。",
+              "text": "I like keeping myself in a state of progress.",
+              "text_en": "I like keeping myself in a state of progress.",
               "text_zh": "我喜欢让自己处在有进展的状态里。",
               "type_code": "T3"
             }
@@ -4102,15 +4102,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我不喜欢自己被限制、被压着走。",
-              "text_en": "我不喜欢自己被限制、被压着走。",
+              "text": "I do not like being restricted or pushed down.",
+              "text_en": "I do not like being restricted or pushed down.",
               "text_zh": "我不喜欢自己被限制、被压着走。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我偶尔会显得有点冷淡或抽离。",
-              "text_en": "我偶尔会显得有点冷淡或抽离。",
+              "text": "Sometimes I may seem a little cold or detached.",
+              "text_en": "Sometimes I may seem a little cold or detached.",
               "text_zh": "我偶尔会显得有点冷淡或抽离。",
               "type_code": "T5"
             }
@@ -4127,15 +4127,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我做事时很看重结果和成效。",
-              "text_en": "我做事时很看重结果和成效。",
+              "text": "When doing things, I value results and effectiveness.",
+              "text_en": "When doing things, I value results and effectiveness.",
               "text_zh": "我做事时很看重结果和成效。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我很重视可靠、稳妥和可预期。",
-              "text_en": "我很重视可靠、稳妥和可预期。",
+              "text": "I value reliability, steadiness, and predictability.",
+              "text_en": "I value reliability, steadiness, and predictability.",
               "text_zh": "我很重视可靠、稳妥和可预期。",
               "type_code": "T6"
             }
@@ -4152,15 +4152,15 @@
           "options": [
             {
               "code": "A",
-              "text": "比起顾虑太多，我更想先把事推动起来。",
-              "text_en": "比起顾虑太多，我更想先把事推动起来。",
+              "text": "Rather than worrying too much, I want to get things moving first.",
+              "text_en": "Rather than worrying too much, I want to get things moving first.",
               "text_zh": "比起顾虑太多，我更想先把事推动起来。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "遇到分歧时，我会坚持自己认为对的做法。",
-              "text_en": "遇到分歧时，我会坚持自己认为对的做法。",
+              "text": "When there is disagreement, I stick to what I believe is right.",
+              "text_en": "When there is disagreement, I stick to what I believe is right.",
               "text_zh": "遇到分歧时，我会坚持自己认为对的做法。",
               "type_code": "T1"
             }
@@ -4177,15 +4177,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我对安全边界和底线比较敏感。",
-              "text_en": "我对安全边界和底线比较敏感。",
+              "text": "I am sensitive to safety boundaries and bottom lines.",
+              "text_en": "I am sensitive to safety boundaries and bottom lines.",
               "text_zh": "我对安全边界和底线比较敏感。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我通常带着好奇心去接近新事物。",
-              "text_en": "我通常带着好奇心去接近新事物。",
+              "text": "I usually approach new things with curiosity.",
+              "text_en": "I usually approach new things with curiosity.",
               "text_zh": "我通常带着好奇心去接近新事物。",
               "type_code": "T7"
             }
@@ -4202,15 +4202,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更倾向于从本质层面理解问题。",
-              "text_en": "我更倾向于从本质层面理解问题。",
+              "text": "I tend to understand problems at the level of their essence.",
+              "text_en": "I tend to understand problems at the level of their essence.",
               "text_zh": "我更倾向于从本质层面理解问题。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我常会思考自己真正想要的是什么。",
-              "text_en": "我常会思考自己真正想要的是什么。",
+              "text": "I often think about what I truly want.",
+              "text_en": "I often think about what I truly want.",
               "text_zh": "我常会思考自己真正想要的是什么。",
               "type_code": "T4"
             }
@@ -4227,15 +4227,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我会留心别人是否认可我、接纳我。",
-              "text_en": "我会留心别人是否认可我、接纳我。",
+              "text": "I pay attention to whether others recognize and accept me.",
+              "text_en": "I pay attention to whether others recognize and accept me.",
               "text_zh": "我会留心别人是否认可我、接纳我。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "当生活太重复时，我会有点坐不住。",
-              "text_en": "当生活太重复时，我会有点坐不住。",
+              "text": "When life becomes too repetitive, I get a bit restless.",
+              "text_en": "When life becomes too repetitive, I get a bit restless.",
               "text_zh": "当生活太重复时，我会有点坐不住。",
               "type_code": "T7"
             }
@@ -4252,15 +4252,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我能和不同类型的人相处得比较自然。",
-              "text_en": "我能和不同类型的人相处得比较自然。",
+              "text": "I can get along fairly naturally with different kinds of people.",
+              "text_en": "I can get along fairly naturally with different kinds of people.",
               "text_zh": "我能和不同类型的人相处得比较自然。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我会努力让自己和身边的人更有保障。",
-              "text_en": "我会努力让自己和身边的人更有保障。",
+              "text": "I work to make myself and the people around me feel more secure.",
+              "text_en": "I work to make myself and the people around me feel more secure.",
               "text_zh": "我会努力让自己和身边的人更有保障。",
               "type_code": "T6"
             }
@@ -4277,15 +4277,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意做正确的事，而不只是轻松的事。",
-              "text_en": "我更愿意做正确的事，而不只是轻松的事。",
+              "text": "I would rather do the right thing than just the easy thing.",
+              "text_en": "I would rather do the right thing than just the easy thing.",
               "text_zh": "我更愿意做正确的事，而不只是轻松的事。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "比起立刻行动，我更希望先建立清楚的理解。",
-              "text_en": "比起立刻行动，我更希望先建立清楚的理解。",
+              "text": "Rather than act immediately, I want to build clear understanding first.",
+              "text_en": "Rather than act immediately, I want to build clear understanding first.",
               "text_zh": "比起立刻行动，我更希望先建立清楚的理解。",
               "type_code": "T5"
             }
@@ -4302,15 +4302,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会因为顾虑太多而变得谨慎过头。",
-              "text_en": "我偶尔会因为顾虑太多而变得谨慎过头。",
+              "text": "Sometimes I become overly cautious because I consider too many concerns.",
+              "text_en": "Sometimes I become overly cautious because I consider too many concerns.",
               "text_zh": "我偶尔会因为顾虑太多而变得谨慎过头。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我不太想让关系因为立场不同变得紧张。",
-              "text_en": "我不太想让关系因为立场不同变得紧张。",
+              "text": "I do not want relationships to become tense because of different positions.",
+              "text_en": "I do not want relationships to become tense because of different positions.",
               "text_zh": "我不太想让关系因为立场不同变得紧张。",
               "type_code": "T9"
             }
@@ -4327,15 +4327,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意用结果来证明自己。",
-              "text_en": "我更愿意用结果来证明自己。",
+              "text": "I prefer to prove myself through results.",
+              "text_en": "I prefer to prove myself through results.",
               "text_zh": "我更愿意用结果来证明自己。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我喜欢给未来留出弹性和空间。",
-              "text_en": "我喜欢给未来留出弹性和空间。",
+              "text": "I like leaving flexibility and space for the future.",
+              "text_en": "I like leaving flexibility and space for the future.",
               "text_zh": "我喜欢给未来留出弹性和空间。",
               "type_code": "T7"
             }
@@ -4352,15 +4352,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常会被知识、原理和系统吸引。",
-              "text_en": "我通常会被知识、原理和系统吸引。",
+              "text": "I am usually drawn to knowledge, principles, and systems.",
+              "text_en": "I am usually drawn to knowledge, principles, and systems.",
               "text_zh": "我通常会被知识、原理和系统吸引。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我会留意别人有没有被忽略。",
-              "text_en": "我会留意别人有没有被忽略。",
+              "text": "I notice whether someone is being overlooked.",
+              "text_en": "I notice whether someone is being overlooked.",
               "text_zh": "我会留意别人有没有被忽略。",
               "type_code": "T2"
             }
@@ -4377,15 +4377,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常先看一件事是否合理，再看它是否方便。",
-              "text_en": "我通常先看一件事是否合理，再看它是否方便。",
+              "text": "I usually first ask whether something is reasonable, then whether it is convenient.",
+              "text_en": "I usually first ask whether something is reasonable, then whether it is convenient.",
               "text_zh": "我通常先看一件事是否合理，再看它是否方便。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "比起看起来合群，我更在意自己是不是真实。",
-              "text_en": "比起看起来合群，我更在意自己是不是真实。",
+              "text": "I care more about being real than about appearing to fit in.",
+              "text_en": "I care more about being real than about appearing to fit in.",
               "text_zh": "比起看起来合群，我更在意自己是不是真实。",
               "type_code": "T4"
             }
@@ -4402,15 +4402,15 @@
           "options": [
             {
               "code": "A",
-              "text": "让别人因为我而轻松一点，会让我很满足。",
-              "text_en": "让别人因为我而轻松一点，会让我很满足。",
+              "text": "It satisfies me when others feel a little more at ease because of me.",
+              "text_en": "It satisfies me when others feel a little more at ease because of me.",
               "text_zh": "让别人因为我而轻松一点，会让我很满足。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "我通常会主动给生活找点新鲜感。",
-              "text_en": "我通常会主动给生活找点新鲜感。",
+              "text": "I usually take initiative to bring freshness into life.",
+              "text_en": "I usually take initiative to bring freshness into life.",
               "text_zh": "我通常会主动给生活找点新鲜感。",
               "type_code": "T7"
             }
@@ -4427,15 +4427,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更愿意把精力投向真正值得研究的事情。",
-              "text_en": "我更愿意把精力投向真正值得研究的事情。",
+              "text": "I prefer to put my energy into things that are truly worth studying.",
+              "text_en": "I prefer to put my energy into things that are truly worth studying.",
               "text_zh": "我更愿意把精力投向真正值得研究的事情。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我更在意事情能否平稳推进。",
-              "text_en": "我更在意事情能否平稳推进。",
+              "text": "I care more about whether things can move forward smoothly.",
+              "text_en": "I care more about whether things can move forward smoothly.",
               "text_zh": "我更在意事情能否平稳推进。",
               "type_code": "T9"
             }
@@ -4452,15 +4452,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会因为想得太周全而迟迟定不下来。",
-              "text_en": "我有时会因为想得太周全而迟迟定不下来。",
+              "text": "Sometimes I cannot decide for a long time because I am trying to think too thoroughly.",
+              "text_en": "Sometimes I cannot decide for a long time because I am trying to think too thoroughly.",
               "text_zh": "我有时会因为想得太周全而迟迟定不下来。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我会反复检查，怕自己哪里没做好。",
-              "text_en": "我会反复检查，怕自己哪里没做好。",
+              "text": "I check repeatedly because I worry I may not have done something well enough.",
+              "text_en": "I check repeatedly because I worry I may not have done something well enough.",
               "text_zh": "我会反复检查，怕自己哪里没做好。",
               "type_code": "T1"
             }
@@ -4477,15 +4477,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我习惯把注意力放在下一步怎么赢。",
-              "text_en": "我习惯把注意力放在下一步怎么赢。",
+              "text": "I tend to focus on how to win the next step.",
+              "text_en": "I tend to focus on how to win the next step.",
               "text_zh": "我习惯把注意力放在下一步怎么赢。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我常会先顺着整体的安排走。",
-              "text_en": "我常会先顺着整体的安排走。",
+              "text": "I often first go along with the overall arrangement.",
+              "text_en": "I often first go along with the overall arrangement.",
               "text_zh": "我常会先顺着整体的安排走。",
               "type_code": "T9"
             }
@@ -4502,15 +4502,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我做决定时往往比较果断。",
-              "text_en": "我做决定时往往比较果断。",
+              "text": "I tend to be decisive when making decisions.",
+              "text_en": "I tend to be decisive when making decisions.",
               "text_zh": "我做决定时往往比较果断。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我对美感和独特性比较有感觉。",
-              "text_en": "我对美感和独特性比较有感觉。",
+              "text": "I have a strong feel for aesthetics and uniqueness.",
+              "text_en": "I have a strong feel for aesthetics and uniqueness.",
               "text_zh": "我对美感和独特性比较有感觉。",
               "type_code": "T4"
             }
@@ -4527,15 +4527,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我做决定时常会考虑什么最有效。",
-              "text_en": "我做决定时常会考虑什么最有效。",
+              "text": "When making decisions, I often consider what will be most effective.",
+              "text_en": "When making decisions, I often consider what will be most effective.",
               "text_zh": "我做决定时常会考虑什么最有效。",
               "type_code": "T3"
             },
             {
               "code": "B",
-              "text": "我做决定时会考虑是否合乎原则。",
-              "text_en": "我做决定时会考虑是否合乎原则。",
+              "text": "When making decisions, I consider whether they align with principles.",
+              "text_en": "When making decisions, I consider whether they align with principles.",
               "text_zh": "我做决定时会考虑是否合乎原则。",
               "type_code": "T1"
             }
@@ -4552,15 +4552,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常愿意给别人留余地。",
-              "text_en": "我通常愿意给别人留余地。",
+              "text": "I am usually willing to leave room for others.",
+              "text_en": "I am usually willing to leave room for others.",
               "text_zh": "我通常愿意给别人留余地。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我喜欢那些有个人气质、有灵魂的东西。",
-              "text_en": "我喜欢那些有个人气质、有灵魂的东西。",
+              "text": "I like things that have personal character and soul.",
+              "text_en": "I like things that have personal character and soul.",
               "text_zh": "我喜欢那些有个人气质、有灵魂的东西。",
               "type_code": "T4"
             }
@@ -4577,15 +4577,15 @@
           "options": [
             {
               "code": "A",
-              "text": "对我来说，立场清楚比讨所有人喜欢更重要。",
-              "text_en": "对我来说，立场清楚比讨所有人喜欢更重要。",
+              "text": "For me, having a clear position matters more than pleasing everyone.",
+              "text_en": "For me, having a clear position matters more than pleasing everyone.",
               "text_zh": "对我来说，立场清楚比讨所有人喜欢更重要。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "对我来说，快乐常常来自探索和展开。",
-              "text_en": "对我来说，快乐常常来自探索和展开。",
+              "text": "For me, joy often comes from exploration and expansion.",
+              "text_en": "For me, joy often comes from exploration and expansion.",
               "text_zh": "对我来说，快乐常常来自探索和展开。",
               "type_code": "T7"
             }
@@ -4602,15 +4602,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更喜欢按照熟悉、舒服的节奏来。",
-              "text_en": "我更喜欢按照熟悉、舒服的节奏来。",
+              "text": "I prefer to follow a familiar, comfortable rhythm.",
+              "text_en": "I prefer to follow a familiar, comfortable rhythm.",
               "text_zh": "我更喜欢按照熟悉、舒服的节奏来。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我常把“应该怎么做”放在心上。",
-              "text_en": "我常把“应该怎么做”放在心上。",
+              "text": "I often keep in mind what should be done.",
+              "text_en": "I often keep in mind what should be done.",
               "text_zh": "我常把“应该怎么做”放在心上。",
               "type_code": "T1"
             }
@@ -4627,15 +4627,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常先追求洞见，而不是声量。",
-              "text_en": "我通常先追求洞见，而不是声量。",
+              "text": "I usually pursue insight before visibility.",
+              "text_en": "I usually pursue insight before visibility.",
               "text_zh": "我通常先追求洞见，而不是声量。",
               "type_code": "T5"
             },
             {
               "code": "B",
-              "text": "我希望自己是别人会佩服、会关注的人。",
-              "text_en": "我希望自己是别人会佩服、会关注的人。",
+              "text": "I want to be someone others admire and pay attention to.",
+              "text_en": "I want to be someone others admire and pay attention to.",
               "text_zh": "我希望自己是别人会佩服、会关注的人。",
               "type_code": "T3"
             }
@@ -4652,15 +4652,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会因为太想推进而显得强势。",
-              "text_en": "我有时会因为太想推进而显得强势。",
+              "text": "Sometimes I seem forceful because I want to move things forward so much.",
+              "text_en": "Sometimes I seem forceful because I want to move things forward so much.",
               "text_zh": "我有时会因为太想推进而显得强势。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "如果缺乏清晰支持，我会不太踏实。",
-              "text_en": "如果缺乏清晰支持，我会不太踏实。",
+              "text": "If clear support is lacking, I feel uneasy.",
+              "text_en": "If clear support is lacking, I feel uneasy.",
               "text_zh": "如果缺乏清晰支持，我会不太踏实。",
               "type_code": "T6"
             }
@@ -4677,15 +4677,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更倾向于在现有基础上慢慢调整。",
-              "text_en": "我更倾向于在现有基础上慢慢调整。",
+              "text": "I tend to adjust gradually based on what already exists.",
+              "text_en": "I tend to adjust gradually based on what already exists.",
               "text_zh": "我更倾向于在现有基础上慢慢调整。",
               "type_code": "T9"
             },
             {
               "code": "B",
-              "text": "我更偏好深度而不是热闹。",
-              "text_en": "我更偏好深度而不是热闹。",
+              "text": "I prefer depth over buzz.",
+              "text_en": "I prefer depth over buzz.",
               "text_zh": "我更偏好深度而不是热闹。",
               "type_code": "T5"
             }
@@ -4702,15 +4702,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我常会主动把事情整理得更规范。",
-              "text_en": "我常会主动把事情整理得更规范。",
+              "text": "I often proactively make things more orderly and standardized.",
+              "text_en": "I often proactively make things more orderly and standardized.",
               "text_zh": "我常会主动把事情整理得更规范。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我通常会提前想到可能出问题的地方。",
-              "text_en": "我通常会提前想到可能出问题的地方。",
+              "text": "I usually think ahead about where problems may arise.",
+              "text_en": "I usually think ahead about where problems may arise.",
               "text_zh": "我通常会提前想到可能出问题的地方。",
               "type_code": "T6"
             }
@@ -4727,15 +4727,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会宁愿强一点，也不想显得软弱。",
-              "text_en": "我偶尔会宁愿强一点，也不想显得软弱。",
+              "text": "Sometimes I would rather be stronger than appear weak.",
+              "text_en": "Sometimes I would rather be stronger than appear weak.",
               "text_zh": "我偶尔会宁愿强一点，也不想显得软弱。",
               "type_code": "T8"
             },
             {
               "code": "B",
-              "text": "我偶尔会把“别起冲突”放得太前面。",
-              "text_en": "我偶尔会把“别起冲突”放得太前面。",
+              "text": "Sometimes I put avoiding conflict too far ahead of other concerns.",
+              "text_en": "Sometimes I put avoiding conflict too far ahead of other concerns.",
               "text_zh": "我偶尔会把“别起冲突”放得太前面。",
               "type_code": "T9"
             }
@@ -4752,15 +4752,15 @@
           "options": [
             {
               "code": "A",
-              "text": "比起冒险一把，我更看重稳稳地走下去。",
-              "text_en": "比起冒险一把，我更看重稳稳地走下去。",
+              "text": "Rather than taking a big risk, I value moving forward steadily.",
+              "text_en": "Rather than taking a big risk, I value moving forward steadily.",
               "text_zh": "比起冒险一把，我更看重稳稳地走下去。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我会把自我完善当成长期课题。",
-              "text_en": "我会把自我完善当成长期课题。",
+              "text": "I treat self-improvement as a long-term project.",
+              "text_en": "I treat self-improvement as a long-term project.",
               "text_zh": "我会把自我完善当成长期课题。",
               "type_code": "T1"
             }
@@ -4777,15 +4777,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我喜欢让生活保持流动和变化。",
-              "text_en": "我喜欢让生活保持流动和变化。",
+              "text": "I like keeping life fluid and changing.",
+              "text_en": "I like keeping life fluid and changing.",
               "text_zh": "我喜欢让生活保持流动和变化。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我通常愿意独立思考，不急着跟风。",
-              "text_en": "我通常愿意独立思考，不急着跟风。",
+              "text": "I am usually willing to think independently instead of rushing to follow the crowd.",
+              "text_en": "I am usually willing to think independently instead of rushing to follow the crowd.",
               "text_zh": "我通常愿意独立思考，不急着跟风。",
               "type_code": "T5"
             }
@@ -4802,15 +4802,15 @@
           "options": [
             {
               "code": "A",
-              "text": "比起讨好别人，我更在意问心无愧。",
-              "text_en": "比起讨好别人，我更在意问心无愧。",
+              "text": "Rather than pleasing others, I care more about having a clear conscience.",
+              "text_en": "Rather than pleasing others, I care more about having a clear conscience.",
               "text_zh": "比起讨好别人，我更在意问心无愧。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "比起把事情做得漂亮，我更在意人是不是被照顾到。",
-              "text_en": "比起把事情做得漂亮，我更在意人是不是被照顾到。",
+              "text": "Rather than making things look impressive, I care more about whether people are cared for.",
+              "text_en": "Rather than making things look impressive, I care more about whether people are cared for.",
               "text_zh": "比起把事情做得漂亮，我更在意人是不是被照顾到。",
               "type_code": "T2"
             }
@@ -4827,15 +4827,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我偶尔会因为太在意感受而变得敏感。",
-              "text_en": "我偶尔会因为太在意感受而变得敏感。",
+              "text": "Sometimes I become sensitive because I care too much about feelings.",
+              "text_en": "Sometimes I become sensitive because I care too much about feelings.",
               "text_zh": "我偶尔会因为太在意感受而变得敏感。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我偶尔会一下子铺开太多计划。",
-              "text_en": "我偶尔会一下子铺开太多计划。",
+              "text": "Sometimes I spread out too many plans at once.",
+              "text_en": "Sometimes I spread out too many plans at once.",
               "text_zh": "我偶尔会一下子铺开太多计划。",
               "type_code": "T7"
             }
@@ -4852,15 +4852,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我通常先问“会不会有问题”，再问“能不能更快”。",
-              "text_en": "我通常先问“会不会有问题”，再问“能不能更快”。",
+              "text": "I usually ask whether there will be a problem before asking whether it can be faster.",
+              "text_en": "I usually ask whether there will be a problem before asking whether it can be faster.",
               "text_zh": "我通常先问“会不会有问题”，再问“能不能更快”。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我宁可直一点，也不太想把真实意思藏着。",
-              "text_en": "我宁可直一点，也不太想把真实意思藏着。",
+              "text": "I would rather be direct than hide what I really mean.",
+              "text_en": "I would rather be direct than hide what I really mean.",
               "text_zh": "我宁可直一点，也不太想把真实意思藏着。",
               "type_code": "T8"
             }
@@ -4877,15 +4877,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我愿意为更高标准多花一点力气。",
-              "text_en": "我愿意为更高标准多花一点力气。",
+              "text": "I am willing to put in extra effort for a higher standard.",
+              "text_en": "I am willing to put in extra effort for a higher standard.",
               "text_zh": "我愿意为更高标准多花一点力气。",
               "type_code": "T1"
             },
             {
               "code": "B",
-              "text": "我喜欢把事情做出看得见的成果。",
-              "text_en": "我喜欢把事情做出看得见的成果。",
+              "text": "I like producing visible results.",
+              "text_en": "I like producing visible results.",
               "text_zh": "我喜欢把事情做出看得见的成果。",
               "type_code": "T3"
             }
@@ -4902,15 +4902,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我习惯准备备用方案。",
-              "text_en": "我习惯准备备用方案。",
+              "text": "I am used to preparing backup plans.",
+              "text_en": "I am used to preparing backup plans.",
               "text_zh": "我习惯准备备用方案。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我不太喜欢被过度打扰或被迫社交。",
-              "text_en": "我不太喜欢被过度打扰或被迫社交。",
+              "text": "I do not like being overly interrupted or forced to socialize.",
+              "text_en": "I do not like being overly interrupted or forced to socialize.",
               "text_zh": "我不太喜欢被过度打扰或被迫社交。",
               "type_code": "T5"
             }
@@ -4927,15 +4927,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时很难拒绝别人提出的请求。",
-              "text_en": "我有时很难拒绝别人提出的请求。",
+              "text": "Sometimes it is hard for me to refuse other people's requests.",
+              "text_en": "Sometimes it is hard for me to refuse other people's requests.",
               "text_zh": "我有时很难拒绝别人提出的请求。",
               "type_code": "T2"
             },
             {
               "code": "B",
-              "text": "当别人含糊不清时，我会有点不耐烦。",
-              "text_en": "当别人含糊不清时，我会有点不耐烦。",
+              "text": "When others are vague, I get a bit impatient.",
+              "text_en": "When others are vague, I get a bit impatient.",
               "text_zh": "当别人含糊不清时，我会有点不耐烦。",
               "type_code": "T8"
             }
@@ -4952,15 +4952,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我更倾向于先确认基础稳不稳，再往前冲。",
-              "text_en": "我更倾向于先确认基础稳不稳，再往前冲。",
+              "text": "I tend to confirm that the foundation is stable before rushing forward.",
+              "text_en": "I tend to confirm that the foundation is stable before rushing forward.",
               "text_zh": "我更倾向于先确认基础稳不稳，再往前冲。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我很看重自己思想上的独立性。",
-              "text_en": "我很看重自己思想上的独立性。",
+              "text": "I place a lot of importance on intellectual independence.",
+              "text_en": "I place a lot of importance on intellectual independence.",
               "text_zh": "我很看重自己思想上的独立性。",
               "type_code": "T5"
             }
@@ -4977,15 +4977,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会为了不难受而赶紧转移注意力。",
-              "text_en": "我有时会为了不难受而赶紧转移注意力。",
+              "text": "Sometimes I quickly shift my attention so I do not feel bad.",
+              "text_en": "Sometimes I quickly shift my attention so I do not feel bad.",
               "text_zh": "我有时会为了不难受而赶紧转移注意力。",
               "type_code": "T7"
             },
             {
               "code": "B",
-              "text": "我不容易对明显的错误视而不见。",
-              "text_en": "我不容易对明显的错误视而不见。",
+              "text": "I do not easily ignore obvious mistakes.",
+              "text_en": "I do not easily ignore obvious mistakes.",
               "text_zh": "我不容易对明显的错误视而不见。",
               "type_code": "T1"
             }
@@ -5002,15 +5002,15 @@
           "options": [
             {
               "code": "A",
-              "text": "对我来说，安心感往往来自可预见和有准备。",
-              "text_en": "对我来说，安心感往往来自可预见和有准备。",
+              "text": "For me, peace of mind often comes from predictability and preparation.",
+              "text_en": "For me, peace of mind often comes from predictability and preparation.",
               "text_zh": "对我来说，安心感往往来自可预见和有准备。",
               "type_code": "T6"
             },
             {
               "code": "B",
-              "text": "我希望生活能有熟悉感和可延续性。",
-              "text_en": "我希望生活能有熟悉感和可延续性。",
+              "text": "I want life to have familiarity and continuity.",
+              "text_en": "I want life to have familiarity and continuity.",
               "text_zh": "我希望生活能有熟悉感和可延续性。",
               "type_code": "T9"
             }
@@ -5027,15 +5027,15 @@
           "options": [
             {
               "code": "A",
-              "text": "我有时会觉得别人并不真正懂我。",
-              "text_en": "我有时会觉得别人并不真正懂我。",
+              "text": "Sometimes I feel that others do not truly understand me.",
+              "text_en": "Sometimes I feel that others do not truly understand me.",
               "text_zh": "我有时会觉得别人并不真正懂我。",
               "type_code": "T4"
             },
             {
               "code": "B",
-              "text": "我有时会因为太想做好而绷得很紧。",
-              "text_en": "我有时会因为太想做好而绷得很紧。",
+              "text": "Sometimes I become tense because I want to do things too well.",
+              "text_en": "Sometimes I become tense because I want to do things too well.",
               "text_zh": "我有时会因为太想做好而绷得很紧。",
               "type_code": "T1"
             }
@@ -5058,14 +5058,14 @@
             {
               "code": "A",
               "text": "我会留意哪里还能再改进。",
-              "text_en": "我会留意哪里还能再改进。",
+              "text_en": "I notice where things could still be improved.",
               "text_zh": "我会留意哪里还能再改进。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我做决定时会把“万一呢”也考虑进去。",
-              "text_en": "我做决定时会把“万一呢”也考虑进去。",
+              "text_en": "When I make decisions, I also consider what could go wrong.",
               "text_zh": "我做决定时会把“万一呢”也考虑进去。",
               "type_code": "T6"
             }
@@ -5083,14 +5083,14 @@
             {
               "code": "A",
               "text": "我更希望人生是充满选项和可能性的。",
-              "text_en": "我更希望人生是充满选项和可能性的。",
+              "text_en": "I would rather life feel full of options and possibilities.",
               "text_zh": "我更希望人生是充满选项和可能性的。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我会主动拉近人与人之间的距离。",
-              "text_en": "我会主动拉近人与人之间的距离。",
+              "text_en": "I actively try to bring people closer together.",
               "text_zh": "我会主动拉近人与人之间的距离。",
               "type_code": "T2"
             }
@@ -5108,14 +5108,14 @@
             {
               "code": "A",
               "text": "我对“这件事到底是怎么运作的”很有兴趣。",
-              "text_en": "我对“这件事到底是怎么运作的”很有兴趣。",
+              "text_en": "I am very interested in how something actually works.",
               "text_zh": "我对“这件事到底是怎么运作的”很有兴趣。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我会努力让自己表现得专业、能干。",
-              "text_en": "我会努力让自己表现得专业、能干。",
+              "text_en": "I work to come across as professional and capable.",
               "text_zh": "我会努力让自己表现得专业、能干。",
               "type_code": "T3"
             }
@@ -5133,14 +5133,14 @@
             {
               "code": "A",
               "text": "我不太喜欢把自己压进过于普通的模板里。",
-              "text_en": "我不太喜欢把自己压进过于普通的模板里。",
+              "text_en": "I do not like forcing myself into an overly ordinary template.",
               "text_zh": "我不太喜欢把自己压进过于普通的模板里。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我偶尔会因为想省心而拖一拖。",
-              "text_en": "我偶尔会因为想省心而拖一拖。",
+              "text_en": "Sometimes I put things off because I want to avoid extra hassle.",
               "text_zh": "我偶尔会因为想省心而拖一拖。",
               "type_code": "T9"
             }
@@ -5158,14 +5158,14 @@
             {
               "code": "A",
               "text": "我喜欢一边走一边打开新的可能。",
-              "text_en": "我喜欢一边走一边打开新的可能。",
+              "text_en": "I like opening new possibilities as I move forward.",
               "text_zh": "我喜欢一边走一边打开新的可能。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我喜欢事情朝着明确方向推进。",
-              "text_en": "我喜欢事情朝着明确方向推进。",
+              "text_en": "I like things to move in a clear direction.",
               "text_zh": "我喜欢事情朝着明确方向推进。",
               "type_code": "T8"
             }
@@ -5183,14 +5183,14 @@
             {
               "code": "A",
               "text": "我希望自己是个可靠、讲规矩的人。",
-              "text_en": "我希望自己是个可靠、讲规矩的人。",
+              "text_en": "I want to be reliable and principled.",
               "text_zh": "我希望自己是个可靠、讲规矩的人。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我喜欢先把事情想清楚，再决定怎么做。",
-              "text_en": "我喜欢先把事情想清楚，再决定怎么做。",
+              "text_en": "I like to think things through before deciding what to do.",
               "text_zh": "我喜欢先把事情想清楚，再决定怎么做。",
               "type_code": "T5"
             }
@@ -5208,14 +5208,14 @@
             {
               "code": "A",
               "text": "我做选择时常会想还有没有更好的可能。",
-              "text_en": "我做选择时常会想还有没有更好的可能。",
+              "text_en": "When choosing, I often wonder whether there is a better possibility.",
               "text_zh": "我做选择时常会想还有没有更好的可能。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我希望自己在别人心里是有分量的。",
-              "text_en": "我希望自己在别人心里是有分量的。",
+              "text_en": "I want to matter to the people around me.",
               "text_zh": "我希望自己在别人心里是有分量的。",
               "type_code": "T2"
             }
@@ -5233,14 +5233,14 @@
             {
               "code": "A",
               "text": "我通常能很快进入“把事办成”的模式。",
-              "text_en": "我通常能很快进入“把事办成”的模式。",
+              "text_en": "I can usually switch quickly into getting-things-done mode.",
               "text_zh": "我通常能很快进入“把事办成”的模式。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我通常不怕表明自己的态度。",
-              "text_en": "我通常不怕表明自己的态度。",
+              "text_en": "I am usually not afraid to make my position clear.",
               "text_zh": "我通常不怕表明自己的态度。",
               "type_code": "T8"
             }
@@ -5258,14 +5258,14 @@
             {
               "code": "A",
               "text": "我在人群里常会自然地扮演支持者。",
-              "text_en": "我在人群里常会自然地扮演支持者。",
+              "text_en": "In groups, I naturally tend to play a supportive role.",
               "text_zh": "我在人群里常会自然地扮演支持者。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我喜欢给自己留出安静思考的空间。",
-              "text_en": "我喜欢给自己留出安静思考的空间。",
+              "text_en": "I like to leave myself quiet space to think.",
               "text_zh": "我喜欢给自己留出安静思考的空间。",
               "type_code": "T5"
             }
@@ -5283,14 +5283,14 @@
             {
               "code": "A",
               "text": "我会把独特感看成自我价值的一部分。",
-              "text_en": "我会把独特感看成自我价值的一部分。",
+              "text_en": "I see a sense of uniqueness as part of my self-worth.",
               "text_zh": "我会把独特感看成自我价值的一部分。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我习惯把人生当成一场需要持续升级的赛程。",
-              "text_en": "我习惯把人生当成一场需要持续升级的赛程。",
+              "text_en": "I tend to see life as a course that needs continual improvement.",
               "text_zh": "我习惯把人生当成一场需要持续升级的赛程。",
               "type_code": "T3"
             }
@@ -5308,14 +5308,14 @@
             {
               "code": "A",
               "text": "我喜欢简单、安稳、没有太多拉扯的状态。",
-              "text_en": "我喜欢简单、安稳、没有太多拉扯的状态。",
+              "text_en": "I like states that feel simple, steady, and low-conflict.",
               "text_zh": "我喜欢简单、安稳、没有太多拉扯的状态。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我会自然地往轻松、积极的方向看。",
-              "text_en": "我会自然地往轻松、积极的方向看。",
+              "text_en": "I naturally look toward the lighter, more positive side.",
               "text_zh": "我会自然地往轻松、积极的方向看。",
               "type_code": "T7"
             }
@@ -5333,14 +5333,14 @@
             {
               "code": "A",
               "text": "我偶尔会和周围的人保持较远的距离。",
-              "text_en": "我偶尔会和周围的人保持较远的距离。",
+              "text_en": "Sometimes I keep a fair amount of distance from the people around me.",
               "text_zh": "我偶尔会和周围的人保持较远的距离。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我有时会因为顾着别人而忽略自己。",
-              "text_en": "我有时会因为顾着别人而忽略自己。",
+              "text_en": "Sometimes I neglect myself because I am taking care of others.",
               "text_zh": "我有时会因为顾着别人而忽略自己。",
               "type_code": "T2"
             }
@@ -5358,14 +5358,14 @@
             {
               "code": "A",
               "text": "我习惯用期待未来来给自己打气。",
-              "text_en": "我习惯用期待未来来给自己打气。",
+              "text_en": "I tend to encourage myself by looking forward to the future.",
               "text_zh": "我习惯用期待未来来给自己打气。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我会把长期保障看得比一时痛快更重要。",
-              "text_en": "我会把长期保障看得比一时痛快更重要。",
+              "text_en": "I value long-term security more than short-term satisfaction.",
               "text_zh": "我会把长期保障看得比一时痛快更重要。",
               "type_code": "T6"
             }
@@ -5383,14 +5383,14 @@
             {
               "code": "A",
               "text": "我通常能让自己保持比较平稳的状态。",
-              "text_en": "我通常能让自己保持比较平稳的状态。",
+              "text_en": "I can usually keep myself fairly steady.",
               "text_zh": "我通常能让自己保持比较平稳的状态。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我会为了把事情做好而自我要求。",
-              "text_en": "我会为了把事情做好而自我要求。",
+              "text_en": "I hold myself to standards because I want to do things well.",
               "text_zh": "我会为了把事情做好而自我要求。",
               "type_code": "T1"
             }
@@ -5408,14 +5408,14 @@
             {
               "code": "A",
               "text": "我希望自己在群体中是有影响力的人。",
-              "text_en": "我希望自己在群体中是有影响力的人。",
+              "text_en": "I want to be an influential person in a group.",
               "text_zh": "我希望自己在群体中是有影响力的人。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我做判断时会先看证据和逻辑。",
-              "text_en": "我做判断时会先看证据和逻辑。",
+              "text_en": "When I judge something, I look first at evidence and logic.",
               "text_zh": "我做判断时会先看证据和逻辑。",
               "type_code": "T5"
             }
@@ -5433,14 +5433,14 @@
             {
               "code": "A",
               "text": "当生活太平淡时，我会觉得少了点什么。",
-              "text_en": "当生活太平淡时，我会觉得少了点什么。",
+              "text_en": "When life feels too plain, I feel something is missing.",
               "text_zh": "当生活太平淡时，我会觉得少了点什么。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我偶尔会把强硬当成保护自己的方式。",
-              "text_en": "我偶尔会把强硬当成保护自己的方式。",
+              "text_en": "Sometimes I use toughness as a way to protect myself.",
               "text_zh": "我偶尔会把强硬当成保护自己的方式。",
               "type_code": "T8"
             }
@@ -5458,14 +5458,14 @@
             {
               "code": "A",
               "text": "我更容易先从关系的角度理解问题。",
-              "text_en": "我更容易先从关系的角度理解问题。",
+              "text_en": "I am more likely to understand a problem first through relationships.",
               "text_zh": "我更容易先从关系的角度理解问题。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我更愿意把时间花在能带来产出的事上。",
-              "text_en": "我更愿意把时间花在能带来产出的事上。",
+              "text_en": "I would rather spend time on things that produce results.",
               "text_zh": "我更愿意把时间花在能带来产出的事上。",
               "type_code": "T3"
             }
@@ -5483,14 +5483,14 @@
             {
               "code": "A",
               "text": "我会自然地关注接下来可能发生什么。",
-              "text_en": "我会自然地关注接下来可能发生什么。",
+              "text_en": "I naturally pay attention to what might happen next.",
               "text_zh": "我会自然地关注接下来可能发生什么。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我会在意一件事是否足够真、足够有感觉。",
-              "text_en": "我会在意一件事是否足够真、足够有感觉。",
+              "text_en": "I care whether something feels real enough and emotionally alive.",
               "text_zh": "我会在意一件事是否足够真、足够有感觉。",
               "type_code": "T4"
             }
@@ -5508,14 +5508,14 @@
             {
               "code": "A",
               "text": "我不太喜欢拐弯抹角。",
-              "text_en": "我不太喜欢拐弯抹角。",
+              "text_en": "I do not like beating around the bush.",
               "text_zh": "我不太喜欢拐弯抹角。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我会因为弄懂一件事而感到满足。",
-              "text_en": "我会因为弄懂一件事而感到满足。",
+              "text_en": "I feel satisfied when I understand something clearly.",
               "text_zh": "我会因为弄懂一件事而感到满足。",
               "type_code": "T5"
             }
@@ -5533,14 +5533,14 @@
             {
               "code": "A",
               "text": "我更看重长期的规范，而不是一时的省事。",
-              "text_en": "我更看重长期的规范，而不是一时的省事。",
+              "text_en": "I value lasting standards more than short-term convenience.",
               "text_zh": "我更看重长期的规范，而不是一时的省事。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "比起抢先出头，我更希望大家都能舒服一点。",
-              "text_en": "比起抢先出头，我更希望大家都能舒服一点。",
+              "text_en": "Rather than pushing myself forward first, I want everyone to feel comfortable.",
               "text_zh": "比起抢先出头，我更希望大家都能舒服一点。",
               "type_code": "T9"
             }
@@ -5558,14 +5558,14 @@
             {
               "code": "A",
               "text": "我偶尔会因为不想错过而分散了注意力。",
-              "text_en": "我偶尔会因为不想错过而分散了注意力。",
+              "text_en": "Sometimes my attention scatters because I do not want to miss out.",
               "text_zh": "我偶尔会因为不想错过而分散了注意力。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "别人退缩不表态时，我会忍不住先出头。",
-              "text_en": "别人退缩不表态时，我会忍不住先出头。",
+              "text_en": "When others hold back and do not take a stand, I tend to step forward first.",
               "text_zh": "别人退缩不表态时，我会忍不住先出头。",
               "type_code": "T8"
             }
@@ -5583,14 +5583,14 @@
             {
               "code": "A",
               "text": "我更习惯先观察，再参与。",
-              "text_en": "我更习惯先观察，再参与。",
+              "text_en": "I am more used to observing first, then participating.",
               "text_zh": "我更习惯先观察，再参与。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我更偏好清晰、有标准的做事方式。",
-              "text_en": "我更偏好清晰、有标准的做事方式。",
+              "text_en": "I prefer a clear way of doing things with standards.",
               "text_zh": "我更偏好清晰、有标准的做事方式。",
               "type_code": "T1"
             }
@@ -5608,14 +5608,14 @@
             {
               "code": "A",
               "text": "我更相信行动和担当，而不只是讨论。",
-              "text_en": "我更相信行动和担当，而不只是讨论。",
+              "text_en": "I trust action and responsibility more than discussion alone.",
               "text_zh": "我更相信行动和担当，而不只是讨论。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我很看重自己是否对身边人有帮助。",
-              "text_en": "我很看重自己是否对身边人有帮助。",
+              "text_en": "I care a lot about whether I am helpful to the people around me.",
               "text_zh": "我很看重自己是否对身边人有帮助。",
               "type_code": "T2"
             }
@@ -5633,14 +5633,14 @@
             {
               "code": "A",
               "text": "我有时会因为想得太多而行动得慢一点。",
-              "text_en": "我有时会因为想得太多而行动得慢一点。",
+              "text_en": "Sometimes I act more slowly because I am thinking too much.",
               "text_zh": "我有时会因为想得太多而行动得慢一点。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "别人太随意时，我心里会有点别扭。",
-              "text_en": "别人太随意时，我心里会有点别扭。",
+              "text_en": "When others are too casual, I feel a bit uneasy inside.",
               "text_zh": "别人太随意时，我心里会有点别扭。",
               "type_code": "T1"
             }
@@ -5658,14 +5658,14 @@
             {
               "code": "A",
               "text": "我待人时一般比较温和、好相处。",
-              "text_en": "我待人时一般比较温和、好相处。",
+              "text_en": "I am generally gentle and easy to get along with.",
               "text_zh": "我待人时一般比较温和、好相处。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我待人时会比较体贴和主动。",
-              "text_en": "我待人时会比较体贴和主动。",
+              "text_en": "I tend to be considerate and proactive with people.",
               "text_zh": "我待人时会比较体贴和主动。",
               "type_code": "T2"
             }
@@ -5683,14 +5683,14 @@
             {
               "code": "A",
               "text": "我觉得守住边界和规则很重要。",
-              "text_en": "我觉得守住边界和规则很重要。",
+              "text_en": "I think it is important to maintain boundaries and rules.",
               "text_zh": "我觉得守住边界和规则很重要。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我不太喜欢别人替我做主。",
-              "text_en": "我不太喜欢别人替我做主。",
+              "text_en": "I do not like other people deciding for me.",
               "text_zh": "我不太喜欢别人替我做主。",
               "type_code": "T8"
             }
@@ -5708,14 +5708,14 @@
             {
               "code": "A",
               "text": "我常通过付出来表达在意。",
-              "text_en": "我常通过付出来表达在意。",
+              "text_en": "I often express care by giving to others.",
               "text_zh": "我常通过付出来表达在意。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我更容易把时间花在研究问题，而不是经营场面。",
-              "text_en": "我更容易把时间花在研究问题，而不是经营场面。",
+              "text_en": "I am more likely to spend time studying a problem than managing appearances.",
               "text_zh": "我更容易把时间花在研究问题，而不是经营场面。",
               "type_code": "T5"
             }
@@ -5733,14 +5733,14 @@
             {
               "code": "A",
               "text": "我有时会让自己一直处在冲刺状态。",
-              "text_en": "我有时会让自己一直处在冲刺状态。",
+              "text_en": "Sometimes I keep myself in a constant sprint.",
               "text_zh": "我有时会让自己一直处在冲刺状态。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "有些情绪一上来，会让我很难一下子抽离。",
-              "text_en": "有些情绪一上来，会让我很难一下子抽离。",
+              "text_en": "When certain emotions arise, it is hard for me to step away at once.",
               "text_zh": "有些情绪一上来，会让我很难一下子抽离。",
               "type_code": "T4"
             }
@@ -5758,14 +5758,14 @@
             {
               "code": "A",
               "text": "我不太喜欢把气氛搞得太紧张。",
-              "text_en": "我不太喜欢把气氛搞得太紧张。",
+              "text_en": "I do not like making the atmosphere too tense.",
               "text_zh": "我不太喜欢把气氛搞得太紧张。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我喜欢让一天里有些让人兴奋的东西。",
-              "text_en": "我喜欢让一天里有些让人兴奋的东西。",
+              "text_en": "I like having something exciting in the day.",
               "text_zh": "我喜欢让一天里有些让人兴奋的东西。",
               "type_code": "T7"
             }
@@ -5783,14 +5783,14 @@
             {
               "code": "A",
               "text": "我会把维护关系看得比较重要。",
-              "text_en": "我会把维护关系看得比较重要。",
+              "text_en": "I place a lot of importance on maintaining relationships.",
               "text_zh": "我会把维护关系看得比较重要。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我更安心于有规则、有结构的环境。",
-              "text_en": "我更安心于有规则、有结构的环境。",
+              "text_en": "I feel safer in an environment with rules and structure.",
               "text_zh": "我更安心于有规则、有结构的环境。",
               "type_code": "T6"
             }
@@ -5808,14 +5808,14 @@
             {
               "code": "A",
               "text": "我对情绪和氛围通常很敏感。",
-              "text_en": "我对情绪和氛围通常很敏感。",
+              "text_en": "I am usually sensitive to emotions and atmosphere.",
               "text_zh": "我对情绪和氛围通常很敏感。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我做事时通常很有分寸和原则。",
-              "text_en": "我做事时通常很有分寸和原则。",
+              "text_en": "I usually act with restraint and principles.",
               "text_zh": "我做事时通常很有分寸和原则。",
               "type_code": "T1"
             }
@@ -5833,14 +5833,14 @@
             {
               "code": "A",
               "text": "我不太喜欢被沉重的情绪困太久。",
-              "text_en": "我不太喜欢被沉重的情绪困太久。",
+              "text_en": "I do not like being trapped in heavy emotions for too long.",
               "text_zh": "我不太喜欢被沉重的情绪困太久。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我偶尔会把效率看得比感受更重要。",
-              "text_en": "我偶尔会把效率看得比感受更重要。",
+              "text_en": "Sometimes I value efficiency more than feelings.",
               "text_zh": "我偶尔会把效率看得比感受更重要。",
               "type_code": "T3"
             }
@@ -5858,14 +5858,14 @@
             {
               "code": "A",
               "text": "我希望自己能成为让人感觉温暖的人。",
-              "text_en": "我希望自己能成为让人感觉温暖的人。",
+              "text_en": "I want to be someone who feels warm to others.",
               "text_zh": "我希望自己能成为让人感觉温暖的人。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我宁可慢一点，也想找到真正契合自己的东西。",
-              "text_en": "我宁可慢一点，也想找到真正契合自己的东西。",
+              "text_en": "I would rather go slower and find what truly fits me.",
               "text_zh": "我宁可慢一点，也想找到真正契合自己的东西。",
               "type_code": "T4"
             }
@@ -5883,14 +5883,14 @@
             {
               "code": "A",
               "text": "没做出成绩时，我会对自己不太满意。",
-              "text_en": "没做出成绩时，我会对自己不太满意。",
+              "text_en": "When I have not achieved results, I feel dissatisfied with myself.",
               "text_zh": "没做出成绩时，我会对自己不太满意。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "没做到自己标准时，我会对自己不太满意。",
-              "text_en": "没做到自己标准时，我会对自己不太满意。",
+              "text_en": "When I do not meet my own standards, I feel dissatisfied with myself.",
               "text_zh": "没做到自己标准时，我会对自己不太满意。",
               "type_code": "T1"
             }
@@ -5908,14 +5908,14 @@
             {
               "code": "A",
               "text": "对我来说，理解自己的心，比尽快给出结论更重要。",
-              "text_en": "对我来说，理解自己的心，比尽快给出结论更重要。",
+              "text_en": "For me, understanding my own heart matters more than reaching a quick conclusion.",
               "text_zh": "对我来说，理解自己的心，比尽快给出结论更重要。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我通常会把力量感看得很重要。",
-              "text_en": "我通常会把力量感看得很重要。",
+              "text_en": "I usually place a lot of importance on feeling strong.",
               "text_zh": "我通常会把力量感看得很重要。",
               "type_code": "T8"
             }
@@ -5933,14 +5933,14 @@
             {
               "code": "A",
               "text": "我不太喜欢停留在空想里，更想尽快行动。",
-              "text_en": "我不太喜欢停留在空想里，更想尽快行动。",
+              "text_en": "I do not like staying in daydreams; I want to act as soon as possible.",
               "text_zh": "我不太喜欢停留在空想里，更想尽快行动。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我常会主动询问别人需要什么。",
-              "text_en": "我常会主动询问别人需要什么。",
+              "text_en": "I often proactively ask what others need.",
               "text_zh": "我常会主动询问别人需要什么。",
               "type_code": "T2"
             }
@@ -5958,14 +5958,14 @@
             {
               "code": "A",
               "text": "我更容易通过行动争取空间，而不是等别人给。",
-              "text_en": "我更容易通过行动争取空间，而不是等别人给。",
+              "text_en": "I am more likely to claim space through action than wait for others to give it.",
               "text_zh": "我更容易通过行动争取空间，而不是等别人给。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我更在意整体是不是和谐，而不只是我个人有没有赢。",
-              "text_en": "我更在意整体是不是和谐，而不只是我个人有没有赢。",
+              "text_en": "I care more about whether the whole situation is harmonious than whether I personally win.",
               "text_zh": "我更在意整体是不是和谐，而不只是我个人有没有赢。",
               "type_code": "T9"
             }
@@ -5983,14 +5983,14 @@
             {
               "code": "A",
               "text": "我通常会朝着明确目标推进。",
-              "text_en": "我通常会朝着明确目标推进。",
+              "text_en": "I usually move toward clear goals.",
               "text_zh": "我通常会朝着明确目标推进。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "别人需要帮忙时，我通常愿意搭把手。",
-              "text_en": "别人需要帮忙时，我通常愿意搭把手。",
+              "text_en": "When others need help, I am usually willing to lend a hand.",
               "text_zh": "别人需要帮忙时，我通常愿意搭把手。",
               "type_code": "T2"
             }
@@ -6008,14 +6008,14 @@
             {
               "code": "A",
               "text": "我做事通常按计划和步骤推进。",
-              "text_en": "我做事通常按计划和步骤推进。",
+              "text_en": "I usually work according to a plan and steps.",
               "text_zh": "我做事通常按计划和步骤推进。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我不太喜欢把自己困在单一选项里。",
-              "text_en": "我不太喜欢把自己困在单一选项里。",
+              "text_en": "I do not like trapping myself in a single option.",
               "text_zh": "我不太喜欢把自己困在单一选项里。",
               "type_code": "T7"
             }
@@ -6033,14 +6033,14 @@
             {
               "code": "A",
               "text": "我会希望自己的付出能被看见。",
-              "text_en": "我会希望自己的付出能被看见。",
+              "text_en": "I want my efforts to be seen.",
               "text_zh": "我会希望自己的付出能被看见。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我会在意别人是否把我看成有能力的人。",
-              "text_en": "我会在意别人是否把我看成有能力的人。",
+              "text_en": "I care whether others see me as capable.",
               "text_zh": "我会在意别人是否把我看成有能力的人。",
               "type_code": "T3"
             }
@@ -6058,14 +6058,14 @@
             {
               "code": "A",
               "text": "我更愿意按照内心感受来理解自己。",
-              "text_en": "我更愿意按照内心感受来理解自己。",
+              "text_en": "I prefer to understand myself through my inner feelings.",
               "text_zh": "我更愿意按照内心感受来理解自己。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "当事情变得沉闷时，我会想办法换个节奏。",
-              "text_en": "当事情变得沉闷时，我会想办法换个节奏。",
+              "text_en": "When things become dull, I look for a way to change the pace.",
               "text_zh": "当事情变得沉闷时，我会想办法换个节奏。",
               "type_code": "T7"
             }
@@ -6083,14 +6083,14 @@
             {
               "code": "A",
               "text": "我希望自己能成为值得信赖的人。",
-              "text_en": "我希望自己能成为值得信赖的人。",
+              "text_en": "I want to become someone trustworthy.",
               "text_zh": "我希望自己能成为值得信赖的人。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "遇到机会时，我通常会想办法抓住它。",
-              "text_en": "遇到机会时，我通常会想办法抓住它。",
+              "text_en": "When an opportunity appears, I usually try to seize it.",
               "text_zh": "遇到机会时，我通常会想办法抓住它。",
               "type_code": "T3"
             }
@@ -6108,14 +6108,14 @@
             {
               "code": "A",
               "text": "对我来说，保留精力和边界很重要。",
-              "text_en": "对我来说，保留精力和边界很重要。",
+              "text_en": "For me, preserving energy and boundaries is important.",
               "text_zh": "对我来说，保留精力和边界很重要。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我会想避开让我感到压抑的人和场景。",
-              "text_en": "我会想避开让我感到压抑的人和场景。",
+              "text_en": "I want to avoid people and situations that feel oppressive.",
               "text_zh": "我会想避开让我感到压抑的人和场景。",
               "type_code": "T7"
             }
@@ -6133,14 +6133,14 @@
             {
               "code": "A",
               "text": "我更愿意维持一种顺畅、没有太多摩擦的状态。",
-              "text_en": "我更愿意维持一种顺畅、没有太多摩擦的状态。",
+              "text_en": "I prefer to maintain a smooth state with little friction.",
               "text_zh": "我更愿意维持一种顺畅、没有太多摩擦的状态。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "对我来说，成就感往往来自被证明“我做到了”。",
-              "text_en": "对我来说，成就感往往来自被证明“我做到了”。",
+              "text_en": "For me, achievement often comes from proving that I did it.",
               "text_zh": "对我来说，成就感往往来自被证明“我做到了”。",
               "type_code": "T3"
             }
@@ -6158,14 +6158,14 @@
             {
               "code": "A",
               "text": "我通常更尊重真实的力量，而不是表面的客套。",
-              "text_en": "我通常更尊重真实的力量，而不是表面的客套。",
+              "text_en": "I usually respect real strength more than surface politeness.",
               "text_zh": "我通常更尊重真实的力量，而不是表面的客套。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我比较看重长期的稳定感。",
-              "text_en": "我比较看重长期的稳定感。",
+              "text_en": "I value long-term stability.",
               "text_zh": "我比较看重长期的稳定感。",
               "type_code": "T6"
             }
@@ -6183,14 +6183,14 @@
             {
               "code": "A",
               "text": "我更在意人心有没有被照顾到，而不只是事情有没有完成。",
-              "text_en": "我更在意人心有没有被照顾到，而不只是事情有没有完成。",
+              "text_en": "I care whether people's feelings are cared for, not only whether the task is finished.",
               "text_zh": "我更在意人心有没有被照顾到，而不只是事情有没有完成。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我通常把平静和安稳看得很重要。",
-              "text_en": "我通常把平静和安稳看得很重要。",
+              "text_en": "I usually value calm and steadiness.",
               "text_zh": "我通常把平静和安稳看得很重要。",
               "type_code": "T9"
             }
@@ -6208,14 +6208,14 @@
             {
               "code": "A",
               "text": "我偶尔会担心自己准备得还不够。",
-              "text_en": "我偶尔会担心自己准备得还不够。",
+              "text_en": "Sometimes I worry that I am not prepared enough.",
               "text_zh": "我偶尔会担心自己准备得还不够。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我有时会觉得自己像个旁观者，融不进眼前的圈子。",
-              "text_en": "我有时会觉得自己像个旁观者，融不进眼前的圈子。",
+              "text_en": "Sometimes I feel like an observer who cannot fit into the group in front of me.",
               "text_zh": "我有时会觉得自己像个旁观者，融不进眼前的圈子。",
               "type_code": "T4"
             }
@@ -6233,14 +6233,14 @@
             {
               "code": "A",
               "text": "我更想让日子过得有趣、有活力。",
-              "text_en": "我更想让日子过得有趣、有活力。",
+              "text_en": "I want life to feel interesting and energetic.",
               "text_zh": "我更想让日子过得有趣、有活力。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我希望和世界保持一种可观察、可理解的距离。",
-              "text_en": "我希望和世界保持一种可观察、可理解的距离。",
+              "text_en": "I want to keep an observable and understandable distance from the world.",
               "text_zh": "我希望和世界保持一种可观察、可理解的距离。",
               "type_code": "T5"
             }
@@ -6258,14 +6258,14 @@
             {
               "code": "A",
               "text": "别人态度强一点时，我可能就让过去了。",
-              "text_en": "别人态度强一点时，我可能就让过去了。",
+              "text_en": "When others take a stronger attitude, I may just let it pass.",
               "text_zh": "别人态度强一点时，我可能就让过去了。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我偶尔会把“被需要”看得太重要。",
-              "text_en": "我偶尔会把“被需要”看得太重要。",
+              "text_en": "Sometimes I place too much importance on being needed.",
               "text_zh": "我偶尔会把“被需要”看得太重要。",
               "type_code": "T2"
             }
@@ -6283,14 +6283,14 @@
             {
               "code": "A",
               "text": "我宁可慢一点，也希望事情更稳妥、更到位。",
-              "text_en": "我宁可慢一点，也希望事情更稳妥、更到位。",
+              "text_en": "I would rather move slower so things are more stable and complete.",
               "text_zh": "我宁可慢一点，也希望事情更稳妥、更到位。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "比起过程是否舒服，我更在意结果是否漂亮。",
-              "text_en": "比起过程是否舒服，我更在意结果是否漂亮。",
+              "text_en": "I care more about whether the result is strong than whether the process is comfortable.",
               "text_zh": "比起过程是否舒服，我更在意结果是否漂亮。",
               "type_code": "T3"
             }
@@ -6308,14 +6308,14 @@
             {
               "code": "A",
               "text": "我通常给人一种稳定、不折腾的感觉。",
-              "text_en": "我通常给人一种稳定、不折腾的感觉。",
+              "text_en": "I usually give people a sense of being stable and low-drama.",
               "text_zh": "我通常给人一种稳定、不折腾的感觉。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我身上有一股往前冲的劲儿。",
-              "text_en": "我身上有一股往前冲的劲儿。",
+              "text_en": "I have a drive to push forward.",
               "text_zh": "我身上有一股往前冲的劲儿。",
               "type_code": "T8"
             }
@@ -6333,14 +6333,14 @@
             {
               "code": "A",
               "text": "我会花时间确认一个人或一件事是否值得信任。",
-              "text_en": "我会花时间确认一个人或一件事是否值得信任。",
+              "text_en": "I spend time confirming whether a person or situation is trustworthy.",
               "text_zh": "我会花时间确认一个人或一件事是否值得信任。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我更容易被好玩的事吸引，而不是被责任吓住。",
-              "text_en": "我更容易被好玩的事吸引，而不是被责任吓住。",
+              "text_en": "I am more easily drawn by fun things than intimidated by responsibility.",
               "text_zh": "我更容易被好玩的事吸引，而不是被责任吓住。",
               "type_code": "T7"
             }
@@ -6358,14 +6358,14 @@
             {
               "code": "A",
               "text": "我不太喜欢被逼着很快做决定。",
-              "text_en": "我不太喜欢被逼着很快做决定。",
+              "text_en": "I do not like being forced to make decisions quickly.",
               "text_zh": "我不太喜欢被逼着很快做决定。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我有时会给自己很强的赢的压力。",
-              "text_en": "我有时会给自己很强的赢的压力。",
+              "text_en": "Sometimes I put strong pressure on myself to win.",
               "text_zh": "我有时会给自己很强的赢的压力。",
               "type_code": "T3"
             }
@@ -6383,14 +6383,14 @@
             {
               "code": "A",
               "text": "我更容易被有个性、有味道的人事物吸引。",
-              "text_en": "我更容易被有个性、有味道的人事物吸引。",
+              "text_en": "I am more easily attracted to people and things with character and flavor.",
               "text_zh": "我更容易被有个性、有味道的人事物吸引。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我更容易注意到别人的情绪变化。",
-              "text_en": "我更容易注意到别人的情绪变化。",
+              "text_en": "I more easily notice changes in other people's emotions.",
               "text_zh": "我更容易注意到别人的情绪变化。",
               "type_code": "T2"
             }
@@ -6408,14 +6408,14 @@
             {
               "code": "A",
               "text": "我不太喜欢让别人看到自己不擅长的一面。",
-              "text_en": "我不太喜欢让别人看到自己不擅长的一面。",
+              "text_en": "I do not like letting others see what I am not good at.",
               "text_zh": "我不太喜欢让别人看到自己不擅长的一面。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我会反复检查，是因为不想出差错。",
-              "text_en": "我会反复检查，是因为不想出差错。",
+              "text_en": "I check repeatedly because I do not want mistakes.",
               "text_zh": "我会反复检查，是因为不想出差错。",
               "type_code": "T6"
             }
@@ -6433,14 +6433,14 @@
             {
               "code": "A",
               "text": "我更愿意凭理解来建立安全感。",
-              "text_en": "我更愿意凭理解来建立安全感。",
+              "text_en": "I prefer to build a sense of security through understanding.",
               "text_zh": "我更愿意凭理解来建立安全感。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我希望自己的人生带着鲜明的个人色彩。",
-              "text_en": "我希望自己的人生带着鲜明的个人色彩。",
+              "text_en": "I want my life to carry a distinct personal color.",
               "text_zh": "我希望自己的人生带着鲜明的个人色彩。",
               "type_code": "T4"
             }
@@ -6458,14 +6458,14 @@
             {
               "code": "A",
               "text": "我喜欢先确认计划是否足够周全。",
-              "text_en": "我喜欢先确认计划是否足够周全。",
+              "text_en": "I like to confirm first that a plan is thorough enough.",
               "text_zh": "我喜欢先确认计划是否足够周全。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我在意自己是否给人留下能干的印象。",
-              "text_en": "我在意自己是否给人留下能干的印象。",
+              "text_en": "I care whether I leave an impression of competence.",
               "text_zh": "我在意自己是否给人留下能干的印象。",
               "type_code": "T3"
             }
@@ -6483,14 +6483,14 @@
             {
               "code": "A",
               "text": "对我来说，“差不多就行”并不容易。",
-              "text_en": "对我来说，“差不多就行”并不容易。",
+              "text_en": "For me, good enough is not easy to accept.",
               "text_zh": "对我来说，“差不多就行”并不容易。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我有时会为了维持和气而不太表达自己。",
-              "text_en": "我有时会为了维持和气而不太表达自己。",
+              "text_en": "Sometimes I hold back from expressing myself to keep the peace.",
               "text_zh": "我有时会为了维持和气而不太表达自己。",
               "type_code": "T9"
             }
@@ -6508,14 +6508,14 @@
             {
               "code": "A",
               "text": "我对“别人都这样”这类理由并不太买账。",
-              "text_en": "我对“别人都这样”这类理由并不太买账。",
+              "text_en": "I am not very convinced by reasons like everyone does it this way.",
               "text_zh": "我对“别人都这样”这类理由并不太买账。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我常会通过规划和准备来让自己安心。",
-              "text_en": "我常会通过规划和准备来让自己安心。",
+              "text_en": "I often use planning and preparation to reassure myself.",
               "text_zh": "我常会通过规划和准备来让自己安心。",
               "type_code": "T6"
             }
@@ -6533,14 +6533,14 @@
             {
               "code": "A",
               "text": "我喜欢保持头脑上的清晰和客观。",
-              "text_en": "我喜欢保持头脑上的清晰和客观。",
+              "text_en": "I like to stay mentally clear and objective.",
               "text_zh": "我喜欢保持头脑上的清晰和客观。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我更倾向于用平和的方式处理问题。",
-              "text_en": "我更倾向于用平和的方式处理问题。",
+              "text_en": "I tend to handle problems in a calm way.",
               "text_zh": "我更倾向于用平和的方式处理问题。",
               "type_code": "T9"
             }
@@ -6558,14 +6558,14 @@
             {
               "code": "A",
               "text": "我偶尔会觉得自己和周围的人不太一样。",
-              "text_en": "我偶尔会觉得自己和周围的人不太一样。",
+              "text_en": "Sometimes I feel different from the people around me.",
               "text_zh": "我偶尔会觉得自己和周围的人不太一样。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "别人不需要我时，我偶尔会有点失落。",
-              "text_en": "别人不需要我时，我偶尔会有点失落。",
+              "text_en": "Sometimes I feel a little disappointed when others do not need me.",
               "text_zh": "别人不需要我时，我偶尔会有点失落。",
               "type_code": "T2"
             }
@@ -6583,14 +6583,14 @@
             {
               "code": "A",
               "text": "我喜欢把问题拆开来看。",
-              "text_en": "我喜欢把问题拆开来看。",
+              "text_en": "I like to break problems apart and examine them.",
               "text_zh": "我喜欢把问题拆开来看。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我习惯在不确定时尽快做出判断。",
-              "text_en": "我习惯在不确定时尽快做出判断。",
+              "text_en": "When things are uncertain, I tend to make a judgment quickly.",
               "text_zh": "我习惯在不确定时尽快做出判断。",
               "type_code": "T8"
             }
@@ -6608,14 +6608,14 @@
             {
               "code": "A",
               "text": "我内心的体验通常比较丰富。",
-              "text_en": "我内心的体验通常比较丰富。",
+              "text_en": "My inner experience is usually quite rich.",
               "text_zh": "我内心的体验通常比较丰富。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我通常会为不确定的情况先做准备。",
-              "text_en": "我通常会为不确定的情况先做准备。",
+              "text_en": "I usually prepare in advance for uncertain situations.",
               "text_zh": "我通常会为不确定的情况先做准备。",
               "type_code": "T6"
             }
@@ -6633,14 +6633,14 @@
             {
               "code": "A",
               "text": "如果别人对我冷淡，我会有点在意。",
-              "text_en": "如果别人对我冷淡，我会有点在意。",
+              "text_en": "If others are cold toward me, I care about it.",
               "text_zh": "如果别人对我冷淡，我会有点在意。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "看到不规范的地方，我会忍不住想纠正。",
-              "text_en": "看到不规范的地方，我会忍不住想纠正。",
+              "text_en": "When I see something irregular, I cannot help wanting to correct it.",
               "text_zh": "看到不规范的地方，我会忍不住想纠正。",
               "type_code": "T1"
             }
@@ -6658,14 +6658,14 @@
             {
               "code": "A",
               "text": "我更容易去适应环境，而不是强行改变环境。",
-              "text_en": "我更容易去适应环境，而不是强行改变环境。",
+              "text_en": "I am more likely to adapt to an environment than force it to change.",
               "text_zh": "我更容易去适应环境，而不是强行改变环境。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我更愿意主动掌控，而不是被动等待。",
-              "text_en": "我更愿意主动掌控，而不是被动等待。",
+              "text_en": "I prefer to take control proactively rather than wait passively.",
               "text_zh": "我更愿意主动掌控，而不是被动等待。",
               "type_code": "T8"
             }
@@ -6683,14 +6683,14 @@
             {
               "code": "A",
               "text": "我往往能在事情里看到值得期待的一面。",
-              "text_en": "我往往能在事情里看到值得期待的一面。",
+              "text_en": "I can often see something worth looking forward to in a situation.",
               "text_zh": "我往往能在事情里看到值得期待的一面。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我愿意承认自己复杂的一面。",
-              "text_en": "我愿意承认自己复杂的一面。",
+              "text_en": "I am willing to acknowledge the complex side of myself.",
               "text_zh": "我愿意承认自己复杂的一面。",
               "type_code": "T4"
             }
@@ -6708,14 +6708,14 @@
             {
               "code": "A",
               "text": "我宁可忙一点，也不想长期停滞不前。",
-              "text_en": "我宁可忙一点，也不想长期停滞不前。",
+              "text_en": "I would rather be a little busy than remain stuck for a long time.",
               "text_zh": "我宁可忙一点，也不想长期停滞不前。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我希望自己是能扛事、能做主的人。",
-              "text_en": "我希望自己是能扛事、能做主的人。",
+              "text_en": "I want to be someone who can carry responsibility and make decisions.",
               "text_zh": "我希望自己是能扛事、能做主的人。",
               "type_code": "T8"
             }
@@ -6733,14 +6733,14 @@
             {
               "code": "A",
               "text": "我习惯先完成分内该做的事。",
-              "text_en": "我习惯先完成分内该做的事。",
+              "text_en": "I tend to finish what is my responsibility first.",
               "text_zh": "我习惯先完成分内该做的事。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我不太喜欢太过千篇一律的状态。",
-              "text_en": "我不太喜欢太过千篇一律的状态。",
+              "text_en": "I do not like states that feel too uniform or repetitive.",
               "text_zh": "我不太喜欢太过千篇一律的状态。",
               "type_code": "T4"
             }
@@ -6758,14 +6758,14 @@
             {
               "code": "A",
               "text": "我喜欢从复杂信息里梳理出规律。",
-              "text_en": "我喜欢从复杂信息里梳理出规律。",
+              "text_en": "I like finding patterns in complex information.",
               "text_zh": "我喜欢从复杂信息里梳理出规律。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我会认真守住自己该负的责任。",
-              "text_en": "我会认真守住自己该负的责任。",
+              "text_en": "I take seriously the responsibilities I should carry.",
               "text_zh": "我会认真守住自己该负的责任。",
               "type_code": "T6"
             }
@@ -6783,14 +6783,14 @@
             {
               "code": "A",
               "text": "我有时会把责任扛得太满。",
-              "text_en": "我有时会把责任扛得太满。",
+              "text_en": "Sometimes I take on too much responsibility.",
               "text_zh": "我有时会把责任扛得太满。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我有时会因为太直接而让人有压力。",
-              "text_en": "我有时会因为太直接而让人有压力。",
+              "text_en": "Sometimes I put pressure on others by being too direct.",
               "text_zh": "我有时会因为太直接而让人有压力。",
               "type_code": "T8"
             }
@@ -6808,14 +6808,14 @@
             {
               "code": "A",
               "text": "我喜欢成为别人可以依靠的人。",
-              "text_en": "我喜欢成为别人可以依靠的人。",
+              "text_en": "I like being someone others can rely on.",
               "text_zh": "我喜欢成为别人可以依靠的人。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我做事时通常不急着抢主导权。",
-              "text_en": "我做事时通常不急着抢主导权。",
+              "text_en": "When doing things, I usually do not rush to take the lead.",
               "text_zh": "我做事时通常不急着抢主导权。",
               "type_code": "T9"
             }
@@ -6833,14 +6833,14 @@
             {
               "code": "A",
               "text": "我很看重一个人是否活得真诚、有自我。",
-              "text_en": "我很看重一个人是否活得真诚、有自我。",
+              "text_en": "I care a lot about whether a person lives sincerely and with a sense of self.",
               "text_zh": "我很看重一个人是否活得真诚、有自我。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我希望自己是高效、能成事的人。",
-              "text_en": "我希望自己是高效、能成事的人。",
+              "text_en": "I want to be efficient and able to make things happen.",
               "text_zh": "我希望自己是高效、能成事的人。",
               "type_code": "T3"
             }
@@ -6858,14 +6858,14 @@
             {
               "code": "A",
               "text": "我有时会先追求感觉好，再考虑别的。",
-              "text_en": "我有时会先追求感觉好，再考虑别的。",
+              "text_en": "Sometimes I pursue what feels good first and consider other things later.",
               "text_zh": "我有时会先追求感觉好，再考虑别的。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我有时会先想到最坏的可能。",
-              "text_en": "我有时会先想到最坏的可能。",
+              "text_en": "Sometimes I think of the worst possibility first.",
               "text_zh": "我有时会先想到最坏的可能。",
               "type_code": "T6"
             }
@@ -6883,14 +6883,14 @@
             {
               "code": "A",
               "text": "我更希望被理解成真正的我，而不只是一个标签。",
-              "text_en": "我更希望被理解成真正的我，而不只是一个标签。",
+              "text_en": "I want to be understood as my real self, not just as a label.",
               "text_zh": "我更希望被理解成真正的我，而不只是一个标签。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我不太喜欢被卷进强烈的对立里。",
-              "text_en": "我不太喜欢被卷进强烈的对立里。",
+              "text_en": "I do not like being pulled into intense opposition.",
               "text_zh": "我不太喜欢被卷进强烈的对立里。",
               "type_code": "T9"
             }
@@ -6908,14 +6908,14 @@
             {
               "code": "A",
               "text": "我更愿意把话摊开说清楚。",
-              "text_en": "我更愿意把话摊开说清楚。",
+              "text_en": "I would rather put things on the table and speak clearly.",
               "text_zh": "我更愿意把话摊开说清楚。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我会主动寻找让自己更进一步的机会。",
-              "text_en": "我会主动寻找让自己更进一步的机会。",
+              "text_en": "I actively look for opportunities to move myself further.",
               "text_zh": "我会主动寻找让自己更进一步的机会。",
               "type_code": "T3"
             }
@@ -6933,14 +6933,14 @@
             {
               "code": "A",
               "text": "我更愿意把注意力放在下一件值得期待的事上。",
-              "text_en": "我更愿意把注意力放在下一件值得期待的事上。",
+              "text_en": "I prefer to put my attention on the next thing worth looking forward to.",
               "text_zh": "我更愿意把注意力放在下一件值得期待的事上。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "对我来说，心里没那么多波澜本身就是一种舒服。",
-              "text_en": "对我来说，心里没那么多波澜本身就是一种舒服。",
+              "text_en": "For me, having fewer emotional waves inside is comfortable in itself.",
               "text_zh": "对我来说，心里没那么多波澜本身就是一种舒服。",
               "type_code": "T9"
             }
@@ -6958,14 +6958,14 @@
             {
               "code": "A",
               "text": "我通常愿意为关系多付出一点。",
-              "text_en": "我通常愿意为关系多付出一点。",
+              "text_en": "I am usually willing to give a little more for relationships.",
               "text_zh": "我通常愿意为关系多付出一点。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "遇到问题时，我往往会主动顶上去。",
-              "text_en": "遇到问题时，我往往会主动顶上去。",
+              "text_en": "When problems arise, I tend to step up proactively.",
               "text_zh": "遇到问题时，我往往会主动顶上去。",
               "type_code": "T8"
             }
@@ -6983,14 +6983,14 @@
             {
               "code": "A",
               "text": "我会先评估自己是否有足够的信息再表态。",
-              "text_en": "我会先评估自己是否有足够的信息再表态。",
+              "text_en": "I first assess whether I have enough information before taking a position.",
               "text_zh": "我会先评估自己是否有足够的信息再表态。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我通常不想在低落情绪里停太久。",
-              "text_en": "我通常不想在低落情绪里停太久。",
+              "text_en": "I usually do not want to stay in low moods for too long.",
               "text_zh": "我通常不想在低落情绪里停太久。",
               "type_code": "T7"
             }
@@ -7008,14 +7008,14 @@
             {
               "code": "A",
               "text": "我做事前会习惯先看风险和后果。",
-              "text_en": "我做事前会习惯先看风险和后果。",
+              "text_en": "Before acting, I tend to look at risks and consequences first.",
               "text_zh": "我做事前会习惯先看风险和后果。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我很重视人与人之间的温度。",
-              "text_en": "我很重视人与人之间的温度。",
+              "text_en": "I care a lot about warmth between people.",
               "text_zh": "我很重视人与人之间的温度。",
               "type_code": "T2"
             }
@@ -7033,14 +7033,14 @@
             {
               "code": "A",
               "text": "对我来说，知道为什么，往往和知道做什么一样重要。",
-              "text_en": "对我来说，知道为什么，往往和知道做什么一样重要。",
+              "text_en": "For me, knowing why is often as important as knowing what to do.",
               "text_zh": "对我来说，知道为什么，往往和知道做什么一样重要。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我更愿意正面碰撞，也不想委屈着绕过去。",
-              "text_en": "我更愿意正面碰撞，也不想委屈着绕过去。",
+              "text_en": "I would rather face things directly than bend around them while feeling wronged.",
               "text_zh": "我更愿意正面碰撞，也不想委屈着绕过去。",
               "type_code": "T8"
             }
@@ -7058,14 +7058,14 @@
             {
               "code": "A",
               "text": "我会为重要目标持续投入精力。",
-              "text_en": "我会为重要目标持续投入精力。",
+              "text_en": "I keep investing energy in important goals.",
               "text_zh": "我会为重要目标持续投入精力。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我不喜欢把关系弄得很僵。",
-              "text_en": "我不喜欢把关系弄得很僵。",
+              "text_en": "I do not like making relationships become rigid or strained.",
               "text_zh": "我不喜欢把关系弄得很僵。",
               "type_code": "T9"
             }
@@ -7083,14 +7083,14 @@
             {
               "code": "A",
               "text": "我希望自己活得端正、有标准。",
-              "text_en": "我希望自己活得端正、有标准。",
+              "text_en": "I want to live with integrity and standards.",
               "text_zh": "我希望自己活得端正、有标准。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "比起先看风险，我更容易先看机会。",
-              "text_en": "比起先看风险，我更容易先看机会。",
+              "text_en": "Rather than looking at risks first, I more easily see opportunities first.",
               "text_zh": "比起先看风险，我更容易先看机会。",
               "type_code": "T7"
             }
@@ -7108,14 +7108,14 @@
             {
               "code": "A",
               "text": "我通常能察觉哪里可能不太对劲。",
-              "text_en": "我通常能察觉哪里可能不太对劲。",
+              "text_en": "I can usually sense where something may not be right.",
               "text_zh": "我通常能察觉哪里可能不太对劲。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我通常会在关键时刻站出来。",
-              "text_en": "我通常会在关键时刻站出来。",
+              "text_en": "I usually stand up at key moments.",
               "text_zh": "我通常会在关键时刻站出来。",
               "type_code": "T8"
             }
@@ -7133,14 +7133,14 @@
             {
               "code": "A",
               "text": "我会习惯给自己设定阶段性目标。",
-              "text_en": "我会习惯给自己设定阶段性目标。",
+              "text_en": "I tend to set staged goals for myself.",
               "text_zh": "我会习惯给自己设定阶段性目标。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我希望表达出来的东西是有我自己痕迹的。",
-              "text_en": "我希望表达出来的东西是有我自己痕迹的。",
+              "text_en": "I want what I express to carry my own mark.",
               "text_zh": "我希望表达出来的东西是有我自己痕迹的。",
               "type_code": "T4"
             }
@@ -7158,14 +7158,14 @@
             {
               "code": "A",
               "text": "我说话做事通常比较直接。",
-              "text_en": "我说话做事通常比较直接。",
+              "text_en": "I usually speak and act directly.",
               "text_zh": "我说话做事通常比较直接。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我不太能接受明知不对还将就。",
-              "text_en": "我不太能接受明知不对还将就。",
+              "text_en": "I have trouble accepting something I know is wrong and settling for it anyway.",
               "text_zh": "我不太能接受明知不对还将就。",
               "type_code": "T1"
             }
@@ -7183,14 +7183,14 @@
             {
               "code": "A",
               "text": "我不太喜欢频繁改变已经熟悉的做法。",
-              "text_en": "我不太喜欢频繁改变已经熟悉的做法。",
+              "text_en": "I do not like frequently changing ways of doing things that are already familiar.",
               "text_zh": "我不太喜欢频繁改变已经熟悉的做法。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我不太想把自己活成一个“标准答案”。",
-              "text_en": "我不太想把自己活成一个“标准答案”。",
+              "text_en": "I do not want to live as a standard answer.",
               "text_zh": "我不太想把自己活成一个“标准答案”。",
               "type_code": "T4"
             }
@@ -7208,14 +7208,14 @@
             {
               "code": "A",
               "text": "我不太喜欢自己在关系里是可有可无的。",
-              "text_en": "我不太喜欢自己在关系里是可有可无的。",
+              "text_en": "I do not like feeling optional in a relationship.",
               "text_zh": "我不太喜欢自己在关系里是可有可无的。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "面对不确定时，我心里会先拉起警报。",
-              "text_en": "面对不确定时，我心里会先拉起警报。",
+              "text_en": "When facing uncertainty, an alarm goes off inside me first.",
               "text_zh": "面对不确定时，我心里会先拉起警报。",
               "type_code": "T6"
             }
@@ -7233,14 +7233,14 @@
             {
               "code": "A",
               "text": "我通常会把自由感看得很重要。",
-              "text_en": "我通常会把自由感看得很重要。",
+              "text_en": "I usually place a lot of importance on a sense of freedom.",
               "text_zh": "我通常会把自由感看得很重要。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我更容易被内心的共鸣打动，而不是表面的标准答案。",
-              "text_en": "我更容易被内心的共鸣打动，而不是表面的标准答案。",
+              "text_en": "I am more moved by inner resonance than by surface-level standard answers.",
               "text_zh": "我更容易被内心的共鸣打动，而不是表面的标准答案。",
               "type_code": "T4"
             }
@@ -7258,14 +7258,14 @@
             {
               "code": "A",
               "text": "我喜欢先把流程理顺再行动。",
-              "text_en": "我喜欢先把流程理顺再行动。",
+              "text_en": "I like to sort out the process before acting.",
               "text_zh": "我喜欢先把流程理顺再行动。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我做事时会先考虑这会不会影响别人。",
-              "text_en": "我做事时会先考虑这会不会影响别人。",
+              "text_en": "When I do things, I first consider whether they will affect others.",
               "text_zh": "我做事时会先考虑这会不会影响别人。",
               "type_code": "T2"
             }
@@ -7283,14 +7283,14 @@
             {
               "code": "A",
               "text": "我不太习惯把脆弱轻易露出来。",
-              "text_en": "我不太习惯把脆弱轻易露出来。",
+              "text_en": "I am not used to showing vulnerability easily.",
               "text_zh": "我不太习惯把脆弱轻易露出来。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我会希望自己的努力是被看见、被认可的。",
-              "text_en": "我会希望自己的努力是被看见、被认可的。",
+              "text_en": "I want my efforts to be seen and recognized.",
               "text_zh": "我会希望自己的努力是被看见、被认可的。",
               "type_code": "T3"
             }
@@ -7308,14 +7308,14 @@
             {
               "code": "A",
               "text": "我能感受到别人不太会留意到的细微情绪。",
-              "text_en": "我能感受到别人不太会留意到的细微情绪。",
+              "text_en": "I can sense subtle emotions that others may not notice.",
               "text_zh": "我能感受到别人不太会留意到的细微情绪。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我能长时间专注在自己感兴趣的问题上。",
-              "text_en": "我能长时间专注在自己感兴趣的问题上。",
+              "text_en": "I can focus for a long time on problems that interest me.",
               "text_zh": "我能长时间专注在自己感兴趣的问题上。",
               "type_code": "T5"
             }
@@ -7333,14 +7333,14 @@
             {
               "code": "A",
               "text": "我不太愿意把自己长期困在无聊和受限里。",
-              "text_en": "我不太愿意把自己长期困在无聊和受限里。",
+              "text_en": "I am not willing to keep myself trapped in boredom and restriction for long.",
               "text_zh": "我不太愿意把自己长期困在无聊和受限里。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "面对分歧时，我会先想办法缓一缓。",
-              "text_en": "面对分歧时，我会先想办法缓一缓。",
+              "text_en": "When facing disagreement, I first try to slow things down.",
               "text_zh": "面对分歧时，我会先想办法缓一缓。",
               "type_code": "T9"
             }
@@ -7358,14 +7358,14 @@
             {
               "code": "A",
               "text": "我很自然地会去照顾身边的人。",
-              "text_en": "我很自然地会去照顾身边的人。",
+              "text_en": "I naturally take care of the people around me.",
               "text_zh": "我很自然地会去照顾身边的人。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我很在意把事情做对。",
-              "text_en": "我很在意把事情做对。",
+              "text_en": "I care a lot about doing things correctly.",
               "text_zh": "我很在意把事情做对。",
               "type_code": "T1"
             }
@@ -7383,14 +7383,14 @@
             {
               "code": "A",
               "text": "我有时会顺着别人走，却没那么清楚自己想要什么。",
-              "text_en": "我有时会顺着别人走，却没那么清楚自己想要什么。",
+              "text_en": "Sometimes I go along with others without being very clear about what I want.",
               "text_zh": "我有时会顺着别人走，却没那么清楚自己想要什么。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "如果没有想明白，我不太愿意仓促表态。",
-              "text_en": "如果没有想明白，我不太愿意仓促表态。",
+              "text_en": "If I have not thought it through, I do not like taking a position in a hurry.",
               "text_zh": "如果没有想明白，我不太愿意仓促表态。",
               "type_code": "T5"
             }
@@ -7408,14 +7408,14 @@
             {
               "code": "A",
               "text": "我遇到冲突时，通常不会退得太快。",
-              "text_en": "我遇到冲突时，通常不会退得太快。",
+              "text_en": "When I encounter conflict, I usually do not back down too quickly.",
               "text_zh": "我遇到冲突时，通常不会退得太快。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我常会把他人的需要放进自己的安排里。",
-              "text_en": "我常会把他人的需要放进自己的安排里。",
+              "text_en": "I often include other people's needs in my own plans.",
               "text_zh": "我常会把他人的需要放进自己的安排里。",
               "type_code": "T2"
             }
@@ -7433,14 +7433,14 @@
             {
               "code": "A",
               "text": "我喜欢看到自己不断向上移动。",
-              "text_en": "我喜欢看到自己不断向上移动。",
+              "text_en": "I like seeing myself keep moving upward.",
               "text_zh": "我喜欢看到自己不断向上移动。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我宁可往前试一试，也不太想被困在原地。",
-              "text_en": "我宁可往前试一试，也不太想被困在原地。",
+              "text_en": "I would rather try moving forward than stay stuck in place.",
               "text_zh": "我宁可往前试一试，也不太想被困在原地。",
               "type_code": "T7"
             }
@@ -7458,14 +7458,14 @@
             {
               "code": "A",
               "text": "我会对失去的人或事停留很久。",
-              "text_en": "我会对失去的人或事停留很久。",
+              "text_en": "I may linger for a long time on people or things I have lost.",
               "text_zh": "我会对失去的人或事停留很久。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我不太喜欢别人突然闯进我的节奏里。",
-              "text_en": "我不太喜欢别人突然闯进我的节奏里。",
+              "text_en": "I do not like others suddenly intruding into my rhythm.",
               "text_zh": "我不太喜欢别人突然闯进我的节奏里。",
               "type_code": "T5"
             }
@@ -7483,14 +7483,14 @@
             {
               "code": "A",
               "text": "我通常会先看怎么避免冲突升级。",
-              "text_en": "我通常会先看怎么避免冲突升级。",
+              "text_en": "I usually first look for how to prevent conflict from escalating.",
               "text_zh": "我通常会先看怎么避免冲突升级。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我会把保护已有的东西看得很重要。",
-              "text_en": "我会把保护已有的东西看得很重要。",
+              "text_en": "I place a lot of importance on protecting what already exists.",
               "text_zh": "我会把保护已有的东西看得很重要。",
               "type_code": "T6"
             }
@@ -7508,14 +7508,14 @@
             {
               "code": "A",
               "text": "我喜欢让别人感到被关心、被照顾。",
-              "text_en": "我喜欢让别人感到被关心、被照顾。",
+              "text_en": "I like helping others feel cared for and looked after.",
               "text_zh": "我喜欢让别人感到被关心、被照顾。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我会认真对待自己内心真实的感受。",
-              "text_en": "我会认真对待自己内心真实的感受。",
+              "text_en": "I take my genuine inner feelings seriously.",
               "text_zh": "我会认真对待自己内心真实的感受。",
               "type_code": "T4"
             }
@@ -7533,14 +7533,14 @@
             {
               "code": "A",
               "text": "我有时会更愿意旁观，而不是立刻卷进去。",
-              "text_en": "我有时会更愿意旁观，而不是立刻卷进去。",
+              "text_en": "Sometimes I would rather observe than get involved immediately.",
               "text_zh": "我有时会更愿意旁观，而不是立刻卷进去。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我不太容易对风险掉以轻心。",
-              "text_en": "我不太容易对风险掉以轻心。",
+              "text_en": "I do not easily take risks lightly.",
               "text_zh": "我不太容易对风险掉以轻心。",
               "type_code": "T6"
             }
@@ -7558,14 +7558,14 @@
             {
               "code": "A",
               "text": "我更习惯掌握局面，而不是被局面推着走。",
-              "text_en": "我更习惯掌握局面，而不是被局面推着走。",
+              "text_en": "I am more used to taking charge of a situation than being pushed by it.",
               "text_zh": "我更习惯掌握局面，而不是被局面推着走。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我很容易被可能性和新点子点燃。",
-              "text_en": "我很容易被可能性和新点子点燃。",
+              "text_en": "I am easily energized by possibilities and new ideas.",
               "text_zh": "我很容易被可能性和新点子点燃。",
               "type_code": "T7"
             }
@@ -7583,14 +7583,14 @@
             {
               "code": "A",
               "text": "当进展不明显时，我会有点焦躁。",
-              "text_en": "当进展不明显时，我会有点焦躁。",
+              "text_en": "When progress is not visible, I get a bit restless.",
               "text_zh": "当进展不明显时，我会有点焦躁。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "当外界太吵或要求太多时，我会想退回自己的空间。",
-              "text_en": "当外界太吵或要求太多时，我会想退回自己的空间。",
+              "text_en": "When the outside world is too noisy or demanding, I want to retreat to my own space.",
               "text_zh": "当外界太吵或要求太多时，我会想退回自己的空间。",
               "type_code": "T5"
             }
@@ -7608,14 +7608,14 @@
             {
               "code": "A",
               "text": "我会自然地去维护自己认定的人或事。",
-              "text_en": "我会自然地去维护自己认定的人或事。",
+              "text_en": "I naturally protect the people or things I believe in.",
               "text_zh": "我会自然地去维护自己认定的人或事。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我会花时间体会自己的情绪变化。",
-              "text_en": "我会花时间体会自己的情绪变化。",
+              "text_en": "I spend time experiencing changes in my emotions.",
               "text_zh": "我会花时间体会自己的情绪变化。",
               "type_code": "T4"
             }
@@ -7633,14 +7633,14 @@
             {
               "code": "A",
               "text": "我很容易被有趣的新体验吸引。",
-              "text_en": "我很容易被有趣的新体验吸引。",
+              "text_en": "I am easily attracted to interesting new experiences.",
               "text_zh": "我很容易被有趣的新体验吸引。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我对细节和质量比较敏感。",
-              "text_en": "我对细节和质量比较敏感。",
+              "text_en": "I am sensitive to details and quality.",
               "text_zh": "我对细节和质量比较敏感。",
               "type_code": "T1"
             }
@@ -7658,14 +7658,14 @@
             {
               "code": "A",
               "text": "我更容易把“安全”和“责任”放在前面。",
-              "text_en": "我更容易把“安全”和“责任”放在前面。",
+              "text_en": "I am more likely to put safety and responsibility first.",
               "text_zh": "我更容易把“安全”和“责任”放在前面。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "在团体里，我愿意承担照应别人的角色。",
-              "text_en": "在团体里，我愿意承担照应别人的角色。",
+              "text_en": "In a group, I am willing to take on the role of looking after others.",
               "text_zh": "在团体里，我愿意承担照应别人的角色。",
               "type_code": "T2"
             }
@@ -7683,14 +7683,14 @@
             {
               "code": "A",
               "text": "我常能把气氛带得更轻松一些。",
-              "text_en": "我常能把气氛带得更轻松一些。",
+              "text_en": "I can often make the atmosphere feel lighter.",
               "text_zh": "我常能把气氛带得更轻松一些。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我喜欢让自己处在有进展的状态里。",
-              "text_en": "我喜欢让自己处在有进展的状态里。",
+              "text_en": "I like keeping myself in a state of progress.",
               "text_zh": "我喜欢让自己处在有进展的状态里。",
               "type_code": "T3"
             }
@@ -7708,14 +7708,14 @@
             {
               "code": "A",
               "text": "我不喜欢自己被限制、被压着走。",
-              "text_en": "我不喜欢自己被限制、被压着走。",
+              "text_en": "I do not like being restricted or pushed down.",
               "text_zh": "我不喜欢自己被限制、被压着走。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我偶尔会显得有点冷淡或抽离。",
-              "text_en": "我偶尔会显得有点冷淡或抽离。",
+              "text_en": "Sometimes I may seem a little cold or detached.",
               "text_zh": "我偶尔会显得有点冷淡或抽离。",
               "type_code": "T5"
             }
@@ -7733,14 +7733,14 @@
             {
               "code": "A",
               "text": "我做事时很看重结果和成效。",
-              "text_en": "我做事时很看重结果和成效。",
+              "text_en": "When doing things, I value results and effectiveness.",
               "text_zh": "我做事时很看重结果和成效。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我很重视可靠、稳妥和可预期。",
-              "text_en": "我很重视可靠、稳妥和可预期。",
+              "text_en": "I value reliability, steadiness, and predictability.",
               "text_zh": "我很重视可靠、稳妥和可预期。",
               "type_code": "T6"
             }
@@ -7758,14 +7758,14 @@
             {
               "code": "A",
               "text": "比起顾虑太多，我更想先把事推动起来。",
-              "text_en": "比起顾虑太多，我更想先把事推动起来。",
+              "text_en": "Rather than worrying too much, I want to get things moving first.",
               "text_zh": "比起顾虑太多，我更想先把事推动起来。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "遇到分歧时，我会坚持自己认为对的做法。",
-              "text_en": "遇到分歧时，我会坚持自己认为对的做法。",
+              "text_en": "When there is disagreement, I stick to what I believe is right.",
               "text_zh": "遇到分歧时，我会坚持自己认为对的做法。",
               "type_code": "T1"
             }
@@ -7783,14 +7783,14 @@
             {
               "code": "A",
               "text": "我对安全边界和底线比较敏感。",
-              "text_en": "我对安全边界和底线比较敏感。",
+              "text_en": "I am sensitive to safety boundaries and bottom lines.",
               "text_zh": "我对安全边界和底线比较敏感。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我通常带着好奇心去接近新事物。",
-              "text_en": "我通常带着好奇心去接近新事物。",
+              "text_en": "I usually approach new things with curiosity.",
               "text_zh": "我通常带着好奇心去接近新事物。",
               "type_code": "T7"
             }
@@ -7808,14 +7808,14 @@
             {
               "code": "A",
               "text": "我更倾向于从本质层面理解问题。",
-              "text_en": "我更倾向于从本质层面理解问题。",
+              "text_en": "I tend to understand problems at the level of their essence.",
               "text_zh": "我更倾向于从本质层面理解问题。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我常会思考自己真正想要的是什么。",
-              "text_en": "我常会思考自己真正想要的是什么。",
+              "text_en": "I often think about what I truly want.",
               "text_zh": "我常会思考自己真正想要的是什么。",
               "type_code": "T4"
             }
@@ -7833,14 +7833,14 @@
             {
               "code": "A",
               "text": "我会留心别人是否认可我、接纳我。",
-              "text_en": "我会留心别人是否认可我、接纳我。",
+              "text_en": "I pay attention to whether others recognize and accept me.",
               "text_zh": "我会留心别人是否认可我、接纳我。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "当生活太重复时，我会有点坐不住。",
-              "text_en": "当生活太重复时，我会有点坐不住。",
+              "text_en": "When life becomes too repetitive, I get a bit restless.",
               "text_zh": "当生活太重复时，我会有点坐不住。",
               "type_code": "T7"
             }
@@ -7858,14 +7858,14 @@
             {
               "code": "A",
               "text": "我能和不同类型的人相处得比较自然。",
-              "text_en": "我能和不同类型的人相处得比较自然。",
+              "text_en": "I can get along fairly naturally with different kinds of people.",
               "text_zh": "我能和不同类型的人相处得比较自然。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我会努力让自己和身边的人更有保障。",
-              "text_en": "我会努力让自己和身边的人更有保障。",
+              "text_en": "I work to make myself and the people around me feel more secure.",
               "text_zh": "我会努力让自己和身边的人更有保障。",
               "type_code": "T6"
             }
@@ -7883,14 +7883,14 @@
             {
               "code": "A",
               "text": "我更愿意做正确的事，而不只是轻松的事。",
-              "text_en": "我更愿意做正确的事，而不只是轻松的事。",
+              "text_en": "I would rather do the right thing than just the easy thing.",
               "text_zh": "我更愿意做正确的事，而不只是轻松的事。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "比起立刻行动，我更希望先建立清楚的理解。",
-              "text_en": "比起立刻行动，我更希望先建立清楚的理解。",
+              "text_en": "Rather than act immediately, I want to build clear understanding first.",
               "text_zh": "比起立刻行动，我更希望先建立清楚的理解。",
               "type_code": "T5"
             }
@@ -7908,14 +7908,14 @@
             {
               "code": "A",
               "text": "我偶尔会因为顾虑太多而变得谨慎过头。",
-              "text_en": "我偶尔会因为顾虑太多而变得谨慎过头。",
+              "text_en": "Sometimes I become overly cautious because I consider too many concerns.",
               "text_zh": "我偶尔会因为顾虑太多而变得谨慎过头。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我不太想让关系因为立场不同变得紧张。",
-              "text_en": "我不太想让关系因为立场不同变得紧张。",
+              "text_en": "I do not want relationships to become tense because of different positions.",
               "text_zh": "我不太想让关系因为立场不同变得紧张。",
               "type_code": "T9"
             }
@@ -7933,14 +7933,14 @@
             {
               "code": "A",
               "text": "我更愿意用结果来证明自己。",
-              "text_en": "我更愿意用结果来证明自己。",
+              "text_en": "I prefer to prove myself through results.",
               "text_zh": "我更愿意用结果来证明自己。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我喜欢给未来留出弹性和空间。",
-              "text_en": "我喜欢给未来留出弹性和空间。",
+              "text_en": "I like leaving flexibility and space for the future.",
               "text_zh": "我喜欢给未来留出弹性和空间。",
               "type_code": "T7"
             }
@@ -7958,14 +7958,14 @@
             {
               "code": "A",
               "text": "我通常会被知识、原理和系统吸引。",
-              "text_en": "我通常会被知识、原理和系统吸引。",
+              "text_en": "I am usually drawn to knowledge, principles, and systems.",
               "text_zh": "我通常会被知识、原理和系统吸引。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我会留意别人有没有被忽略。",
-              "text_en": "我会留意别人有没有被忽略。",
+              "text_en": "I notice whether someone is being overlooked.",
               "text_zh": "我会留意别人有没有被忽略。",
               "type_code": "T2"
             }
@@ -7983,14 +7983,14 @@
             {
               "code": "A",
               "text": "我通常先看一件事是否合理，再看它是否方便。",
-              "text_en": "我通常先看一件事是否合理，再看它是否方便。",
+              "text_en": "I usually first ask whether something is reasonable, then whether it is convenient.",
               "text_zh": "我通常先看一件事是否合理，再看它是否方便。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "比起看起来合群，我更在意自己是不是真实。",
-              "text_en": "比起看起来合群，我更在意自己是不是真实。",
+              "text_en": "I care more about being real than about appearing to fit in.",
               "text_zh": "比起看起来合群，我更在意自己是不是真实。",
               "type_code": "T4"
             }
@@ -8008,14 +8008,14 @@
             {
               "code": "A",
               "text": "让别人因为我而轻松一点，会让我很满足。",
-              "text_en": "让别人因为我而轻松一点，会让我很满足。",
+              "text_en": "It satisfies me when others feel a little more at ease because of me.",
               "text_zh": "让别人因为我而轻松一点，会让我很满足。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "我通常会主动给生活找点新鲜感。",
-              "text_en": "我通常会主动给生活找点新鲜感。",
+              "text_en": "I usually take initiative to bring freshness into life.",
               "text_zh": "我通常会主动给生活找点新鲜感。",
               "type_code": "T7"
             }
@@ -8033,14 +8033,14 @@
             {
               "code": "A",
               "text": "我更愿意把精力投向真正值得研究的事情。",
-              "text_en": "我更愿意把精力投向真正值得研究的事情。",
+              "text_en": "I prefer to put my energy into things that are truly worth studying.",
               "text_zh": "我更愿意把精力投向真正值得研究的事情。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我更在意事情能否平稳推进。",
-              "text_en": "我更在意事情能否平稳推进。",
+              "text_en": "I care more about whether things can move forward smoothly.",
               "text_zh": "我更在意事情能否平稳推进。",
               "type_code": "T9"
             }
@@ -8058,14 +8058,14 @@
             {
               "code": "A",
               "text": "我有时会因为想得太周全而迟迟定不下来。",
-              "text_en": "我有时会因为想得太周全而迟迟定不下来。",
+              "text_en": "Sometimes I cannot decide for a long time because I am trying to think too thoroughly.",
               "text_zh": "我有时会因为想得太周全而迟迟定不下来。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我会反复检查，怕自己哪里没做好。",
-              "text_en": "我会反复检查，怕自己哪里没做好。",
+              "text_en": "I check repeatedly because I worry I may not have done something well enough.",
               "text_zh": "我会反复检查，怕自己哪里没做好。",
               "type_code": "T1"
             }
@@ -8083,14 +8083,14 @@
             {
               "code": "A",
               "text": "我习惯把注意力放在下一步怎么赢。",
-              "text_en": "我习惯把注意力放在下一步怎么赢。",
+              "text_en": "I tend to focus on how to win the next step.",
               "text_zh": "我习惯把注意力放在下一步怎么赢。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我常会先顺着整体的安排走。",
-              "text_en": "我常会先顺着整体的安排走。",
+              "text_en": "I often first go along with the overall arrangement.",
               "text_zh": "我常会先顺着整体的安排走。",
               "type_code": "T9"
             }
@@ -8108,14 +8108,14 @@
             {
               "code": "A",
               "text": "我做决定时往往比较果断。",
-              "text_en": "我做决定时往往比较果断。",
+              "text_en": "I tend to be decisive when making decisions.",
               "text_zh": "我做决定时往往比较果断。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我对美感和独特性比较有感觉。",
-              "text_en": "我对美感和独特性比较有感觉。",
+              "text_en": "I have a strong feel for aesthetics and uniqueness.",
               "text_zh": "我对美感和独特性比较有感觉。",
               "type_code": "T4"
             }
@@ -8133,14 +8133,14 @@
             {
               "code": "A",
               "text": "我做决定时常会考虑什么最有效。",
-              "text_en": "我做决定时常会考虑什么最有效。",
+              "text_en": "When making decisions, I often consider what will be most effective.",
               "text_zh": "我做决定时常会考虑什么最有效。",
               "type_code": "T3"
             },
             {
               "code": "B",
               "text": "我做决定时会考虑是否合乎原则。",
-              "text_en": "我做决定时会考虑是否合乎原则。",
+              "text_en": "When making decisions, I consider whether they align with principles.",
               "text_zh": "我做决定时会考虑是否合乎原则。",
               "type_code": "T1"
             }
@@ -8158,14 +8158,14 @@
             {
               "code": "A",
               "text": "我通常愿意给别人留余地。",
-              "text_en": "我通常愿意给别人留余地。",
+              "text_en": "I am usually willing to leave room for others.",
               "text_zh": "我通常愿意给别人留余地。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我喜欢那些有个人气质、有灵魂的东西。",
-              "text_en": "我喜欢那些有个人气质、有灵魂的东西。",
+              "text_en": "I like things that have personal character and soul.",
               "text_zh": "我喜欢那些有个人气质、有灵魂的东西。",
               "type_code": "T4"
             }
@@ -8183,14 +8183,14 @@
             {
               "code": "A",
               "text": "对我来说，立场清楚比讨所有人喜欢更重要。",
-              "text_en": "对我来说，立场清楚比讨所有人喜欢更重要。",
+              "text_en": "For me, having a clear position matters more than pleasing everyone.",
               "text_zh": "对我来说，立场清楚比讨所有人喜欢更重要。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "对我来说，快乐常常来自探索和展开。",
-              "text_en": "对我来说，快乐常常来自探索和展开。",
+              "text_en": "For me, joy often comes from exploration and expansion.",
               "text_zh": "对我来说，快乐常常来自探索和展开。",
               "type_code": "T7"
             }
@@ -8208,14 +8208,14 @@
             {
               "code": "A",
               "text": "我更喜欢按照熟悉、舒服的节奏来。",
-              "text_en": "我更喜欢按照熟悉、舒服的节奏来。",
+              "text_en": "I prefer to follow a familiar, comfortable rhythm.",
               "text_zh": "我更喜欢按照熟悉、舒服的节奏来。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我常把“应该怎么做”放在心上。",
-              "text_en": "我常把“应该怎么做”放在心上。",
+              "text_en": "I often keep in mind what should be done.",
               "text_zh": "我常把“应该怎么做”放在心上。",
               "type_code": "T1"
             }
@@ -8233,14 +8233,14 @@
             {
               "code": "A",
               "text": "我通常先追求洞见，而不是声量。",
-              "text_en": "我通常先追求洞见，而不是声量。",
+              "text_en": "I usually pursue insight before visibility.",
               "text_zh": "我通常先追求洞见，而不是声量。",
               "type_code": "T5"
             },
             {
               "code": "B",
               "text": "我希望自己是别人会佩服、会关注的人。",
-              "text_en": "我希望自己是别人会佩服、会关注的人。",
+              "text_en": "I want to be someone others admire and pay attention to.",
               "text_zh": "我希望自己是别人会佩服、会关注的人。",
               "type_code": "T3"
             }
@@ -8258,14 +8258,14 @@
             {
               "code": "A",
               "text": "我有时会因为太想推进而显得强势。",
-              "text_en": "我有时会因为太想推进而显得强势。",
+              "text_en": "Sometimes I seem forceful because I want to move things forward so much.",
               "text_zh": "我有时会因为太想推进而显得强势。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "如果缺乏清晰支持，我会不太踏实。",
-              "text_en": "如果缺乏清晰支持，我会不太踏实。",
+              "text_en": "If clear support is lacking, I feel uneasy.",
               "text_zh": "如果缺乏清晰支持，我会不太踏实。",
               "type_code": "T6"
             }
@@ -8283,14 +8283,14 @@
             {
               "code": "A",
               "text": "我更倾向于在现有基础上慢慢调整。",
-              "text_en": "我更倾向于在现有基础上慢慢调整。",
+              "text_en": "I tend to adjust gradually based on what already exists.",
               "text_zh": "我更倾向于在现有基础上慢慢调整。",
               "type_code": "T9"
             },
             {
               "code": "B",
               "text": "我更偏好深度而不是热闹。",
-              "text_en": "我更偏好深度而不是热闹。",
+              "text_en": "I prefer depth over buzz.",
               "text_zh": "我更偏好深度而不是热闹。",
               "type_code": "T5"
             }
@@ -8308,14 +8308,14 @@
             {
               "code": "A",
               "text": "我常会主动把事情整理得更规范。",
-              "text_en": "我常会主动把事情整理得更规范。",
+              "text_en": "I often proactively make things more orderly and standardized.",
               "text_zh": "我常会主动把事情整理得更规范。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我通常会提前想到可能出问题的地方。",
-              "text_en": "我通常会提前想到可能出问题的地方。",
+              "text_en": "I usually think ahead about where problems may arise.",
               "text_zh": "我通常会提前想到可能出问题的地方。",
               "type_code": "T6"
             }
@@ -8333,14 +8333,14 @@
             {
               "code": "A",
               "text": "我偶尔会宁愿强一点，也不想显得软弱。",
-              "text_en": "我偶尔会宁愿强一点，也不想显得软弱。",
+              "text_en": "Sometimes I would rather be stronger than appear weak.",
               "text_zh": "我偶尔会宁愿强一点，也不想显得软弱。",
               "type_code": "T8"
             },
             {
               "code": "B",
               "text": "我偶尔会把“别起冲突”放得太前面。",
-              "text_en": "我偶尔会把“别起冲突”放得太前面。",
+              "text_en": "Sometimes I put avoiding conflict too far ahead of other concerns.",
               "text_zh": "我偶尔会把“别起冲突”放得太前面。",
               "type_code": "T9"
             }
@@ -8358,14 +8358,14 @@
             {
               "code": "A",
               "text": "比起冒险一把，我更看重稳稳地走下去。",
-              "text_en": "比起冒险一把，我更看重稳稳地走下去。",
+              "text_en": "Rather than taking a big risk, I value moving forward steadily.",
               "text_zh": "比起冒险一把，我更看重稳稳地走下去。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我会把自我完善当成长期课题。",
-              "text_en": "我会把自我完善当成长期课题。",
+              "text_en": "I treat self-improvement as a long-term project.",
               "text_zh": "我会把自我完善当成长期课题。",
               "type_code": "T1"
             }
@@ -8383,14 +8383,14 @@
             {
               "code": "A",
               "text": "我喜欢让生活保持流动和变化。",
-              "text_en": "我喜欢让生活保持流动和变化。",
+              "text_en": "I like keeping life fluid and changing.",
               "text_zh": "我喜欢让生活保持流动和变化。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我通常愿意独立思考，不急着跟风。",
-              "text_en": "我通常愿意独立思考，不急着跟风。",
+              "text_en": "I am usually willing to think independently instead of rushing to follow the crowd.",
               "text_zh": "我通常愿意独立思考，不急着跟风。",
               "type_code": "T5"
             }
@@ -8408,14 +8408,14 @@
             {
               "code": "A",
               "text": "比起讨好别人，我更在意问心无愧。",
-              "text_en": "比起讨好别人，我更在意问心无愧。",
+              "text_en": "Rather than pleasing others, I care more about having a clear conscience.",
               "text_zh": "比起讨好别人，我更在意问心无愧。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "比起把事情做得漂亮，我更在意人是不是被照顾到。",
-              "text_en": "比起把事情做得漂亮，我更在意人是不是被照顾到。",
+              "text_en": "Rather than making things look impressive, I care more about whether people are cared for.",
               "text_zh": "比起把事情做得漂亮，我更在意人是不是被照顾到。",
               "type_code": "T2"
             }
@@ -8433,14 +8433,14 @@
             {
               "code": "A",
               "text": "我偶尔会因为太在意感受而变得敏感。",
-              "text_en": "我偶尔会因为太在意感受而变得敏感。",
+              "text_en": "Sometimes I become sensitive because I care too much about feelings.",
               "text_zh": "我偶尔会因为太在意感受而变得敏感。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我偶尔会一下子铺开太多计划。",
-              "text_en": "我偶尔会一下子铺开太多计划。",
+              "text_en": "Sometimes I spread out too many plans at once.",
               "text_zh": "我偶尔会一下子铺开太多计划。",
               "type_code": "T7"
             }
@@ -8458,14 +8458,14 @@
             {
               "code": "A",
               "text": "我通常先问“会不会有问题”，再问“能不能更快”。",
-              "text_en": "我通常先问“会不会有问题”，再问“能不能更快”。",
+              "text_en": "I usually ask whether there will be a problem before asking whether it can be faster.",
               "text_zh": "我通常先问“会不会有问题”，再问“能不能更快”。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我宁可直一点，也不太想把真实意思藏着。",
-              "text_en": "我宁可直一点，也不太想把真实意思藏着。",
+              "text_en": "I would rather be direct than hide what I really mean.",
               "text_zh": "我宁可直一点，也不太想把真实意思藏着。",
               "type_code": "T8"
             }
@@ -8483,14 +8483,14 @@
             {
               "code": "A",
               "text": "我愿意为更高标准多花一点力气。",
-              "text_en": "我愿意为更高标准多花一点力气。",
+              "text_en": "I am willing to put in extra effort for a higher standard.",
               "text_zh": "我愿意为更高标准多花一点力气。",
               "type_code": "T1"
             },
             {
               "code": "B",
               "text": "我喜欢把事情做出看得见的成果。",
-              "text_en": "我喜欢把事情做出看得见的成果。",
+              "text_en": "I like producing visible results.",
               "text_zh": "我喜欢把事情做出看得见的成果。",
               "type_code": "T3"
             }
@@ -8508,14 +8508,14 @@
             {
               "code": "A",
               "text": "我习惯准备备用方案。",
-              "text_en": "我习惯准备备用方案。",
+              "text_en": "I am used to preparing backup plans.",
               "text_zh": "我习惯准备备用方案。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我不太喜欢被过度打扰或被迫社交。",
-              "text_en": "我不太喜欢被过度打扰或被迫社交。",
+              "text_en": "I do not like being overly interrupted or forced to socialize.",
               "text_zh": "我不太喜欢被过度打扰或被迫社交。",
               "type_code": "T5"
             }
@@ -8533,14 +8533,14 @@
             {
               "code": "A",
               "text": "我有时很难拒绝别人提出的请求。",
-              "text_en": "我有时很难拒绝别人提出的请求。",
+              "text_en": "Sometimes it is hard for me to refuse other people's requests.",
               "text_zh": "我有时很难拒绝别人提出的请求。",
               "type_code": "T2"
             },
             {
               "code": "B",
               "text": "当别人含糊不清时，我会有点不耐烦。",
-              "text_en": "当别人含糊不清时，我会有点不耐烦。",
+              "text_en": "When others are vague, I get a bit impatient.",
               "text_zh": "当别人含糊不清时，我会有点不耐烦。",
               "type_code": "T8"
             }
@@ -8558,14 +8558,14 @@
             {
               "code": "A",
               "text": "我更倾向于先确认基础稳不稳，再往前冲。",
-              "text_en": "我更倾向于先确认基础稳不稳，再往前冲。",
+              "text_en": "I tend to confirm that the foundation is stable before rushing forward.",
               "text_zh": "我更倾向于先确认基础稳不稳，再往前冲。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我很看重自己思想上的独立性。",
-              "text_en": "我很看重自己思想上的独立性。",
+              "text_en": "I place a lot of importance on intellectual independence.",
               "text_zh": "我很看重自己思想上的独立性。",
               "type_code": "T5"
             }
@@ -8583,14 +8583,14 @@
             {
               "code": "A",
               "text": "我有时会为了不难受而赶紧转移注意力。",
-              "text_en": "我有时会为了不难受而赶紧转移注意力。",
+              "text_en": "Sometimes I quickly shift my attention so I do not feel bad.",
               "text_zh": "我有时会为了不难受而赶紧转移注意力。",
               "type_code": "T7"
             },
             {
               "code": "B",
               "text": "我不容易对明显的错误视而不见。",
-              "text_en": "我不容易对明显的错误视而不见。",
+              "text_en": "I do not easily ignore obvious mistakes.",
               "text_zh": "我不容易对明显的错误视而不见。",
               "type_code": "T1"
             }
@@ -8608,14 +8608,14 @@
             {
               "code": "A",
               "text": "对我来说，安心感往往来自可预见和有准备。",
-              "text_en": "对我来说，安心感往往来自可预见和有准备。",
+              "text_en": "For me, peace of mind often comes from predictability and preparation.",
               "text_zh": "对我来说，安心感往往来自可预见和有准备。",
               "type_code": "T6"
             },
             {
               "code": "B",
               "text": "我希望生活能有熟悉感和可延续性。",
-              "text_en": "我希望生活能有熟悉感和可延续性。",
+              "text_en": "I want life to have familiarity and continuity.",
               "text_zh": "我希望生活能有熟悉感和可延续性。",
               "type_code": "T9"
             }
@@ -8633,14 +8633,14 @@
             {
               "code": "A",
               "text": "我有时会觉得别人并不真正懂我。",
-              "text_en": "我有时会觉得别人并不真正懂我。",
+              "text_en": "Sometimes I feel that others do not truly understand me.",
               "text_zh": "我有时会觉得别人并不真正懂我。",
               "type_code": "T4"
             },
             {
               "code": "B",
               "text": "我有时会因为太想做好而绷得很紧。",
-              "text_en": "我有时会因为太想做好而绷得很紧。",
+              "text_en": "Sometimes I become tense because I want to do things too well.",
               "text_zh": "我有时会因为太想做好而绷得很紧。",
               "type_code": "T1"
             }

--- a/backend/tests/Feature/V0_3/EnneagramQuestionLocaleTranslationTest.php
+++ b/backend/tests/Feature/V0_3/EnneagramQuestionLocaleTranslationTest.php
@@ -1,0 +1,103 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class EnneagramQuestionLocaleTranslationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->artisan('migrate', ['--force' => true]);
+        $this->artisan('fap:scales:seed-default');
+        $this->artisan('fap:scales:sync-slugs');
+    }
+
+    public function test_forced_choice_144_english_options_are_translated_without_changing_count_or_scoring(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?locale=en&form_code=enneagram_forced_choice_144');
+
+        $response->assertOk();
+        $response->assertJsonPath('locale', 'en');
+        $response->assertJsonPath('form_code', 'enneagram_forced_choice_144');
+        $response->assertJsonPath('dir_version', 'v1-forced-choice-144');
+
+        $items = (array) data_get($response->json(), 'questions.items', []);
+        $this->assertCount(144, $items);
+        $this->assertSame('', data_get($items, '0.text'));
+        $this->assertSame('A', data_get($items, '0.options.0.code'));
+        $this->assertSame('T1', data_get($items, '0.options.0.type_code'));
+        $this->assertSame('I notice where things could still be improved.', data_get($items, '0.options.0.text'));
+        $this->assertSame('我会留意哪里还能再改进。', data_get($items, '0.options.0.text_zh'));
+        $this->assertSame('When I make decisions, I also consider what could go wrong.', data_get($items, '0.options.1.text'));
+        $this->assertSame('T6', data_get($items, '0.options.1.type_code'));
+
+        $this->assertDisplayedOptionFieldsDoNotContainChinese($items);
+    }
+
+    public function test_forced_choice_144_zh_locale_keeps_chinese_display_fields_with_english_sidecar(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?locale=zh-CN&form_code=enneagram_forced_choice_144');
+
+        $response->assertOk();
+        $response->assertJsonPath('locale', 'zh-CN');
+        $response->assertJsonPath('form_code', 'enneagram_forced_choice_144');
+
+        $items = (array) data_get($response->json(), 'questions.items', []);
+        $this->assertCount(144, $items);
+        $this->assertSame('我会留意哪里还能再改进。', data_get($items, '0.options.0.text'));
+        $this->assertSame('I notice where things could still be improved.', data_get($items, '0.options.0.text_en'));
+        $this->assertSame('我做决定时会把“万一呢”也考虑进去。', data_get($items, '0.options.1.text'));
+        $this->assertSame('When I make decisions, I also consider what could go wrong.', data_get($items, '0.options.1.text_en'));
+    }
+
+    public function test_likert_105_english_locale_remains_translated(): void
+    {
+        $response = $this->getJson('/api/v0.3/scales/ENNEAGRAM/questions?locale=en&form_code=enneagram_likert_105');
+
+        $response->assertOk();
+        $response->assertJsonPath('locale', 'en');
+        $response->assertJsonPath('form_code', 'enneagram_likert_105');
+        $response->assertJsonPath('dir_version', 'v1-likert-105');
+
+        $items = (array) data_get($response->json(), 'questions.items', []);
+        $this->assertCount(105, $items);
+        $this->assertSame('I usually strive to do things as perfectly as possible.', data_get($items, '0.text'));
+        $this->assertDisplayedFieldsDoNotContainChinese($items);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    private function assertDisplayedFieldsDoNotContainChinese(array $items): void
+    {
+        foreach ($items as $item) {
+            $this->assertDoesNotMatchRegularExpression('/\p{Han}/u', (string) ($item['text'] ?? ''));
+        }
+
+        $this->assertDisplayedOptionFieldsDoNotContainChinese($items);
+    }
+
+    /**
+     * @param  array<int, array<string, mixed>>  $items
+     */
+    private function assertDisplayedOptionFieldsDoNotContainChinese(array $items): void
+    {
+        foreach ($items as $item) {
+            foreach ((array) ($item['options'] ?? []) as $option) {
+                if (! is_array($option)) {
+                    continue;
+                }
+
+                $this->assertDoesNotMatchRegularExpression('/\p{Han}/u', (string) ($option['text'] ?? ''));
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1636,6 +1636,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_enneagram_forced_choice_question_pack_translation_changes(): void
+    {
+        $changed = [
+            'backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json',
+            'backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_career_display_import_service_changes(): void
     {
         $changed = [
@@ -2583,6 +2593,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEnneagramForcedChoiceQuestionPackTranslationFile($file)) {
+                continue;
+            }
+
             if ($this->isIqReportFoundationFile($file)) {
                 continue;
             }
@@ -3312,6 +3326,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isRiasecQuestionPackTranslationFile(string $file): bool
     {
         return preg_match('#^backend/content_packs/RIASEC/v1-(?:standard-60|enhanced-140)/compiled/(?:questions\\.compiled|manifest)\\.json$#', $file) === 1;
+    }
+
+    private function isEnneagramForcedChoiceQuestionPackTranslationFile(string $file): bool
+    {
+        return preg_match('#^backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/(?:questions\\.compiled|manifest)\\.json$#', $file) === 1;
     }
 
     private function isIqReportFoundationFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -30047,12 +30047,12 @@
     "repo": "fap-api",
     "branch": "codex/enneagram-fc144-en-questions-pack-03",
     "base": "main",
-    "status": "pr_opened",
+    "status": "github_checks_passed",
     "depends_on": [
       "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02"
     ],
     "title": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 Enneagram forced-choice English question pack",
-    "commit_sha": "953174e38e683e889081366034618a9b04f26e31",
+    "commit_sha": "0b23d1c7b112542c7686facabab8faa6f37a182f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1736",
     "failure_reason": null,
     "merged_at": null,
@@ -30119,8 +30119,13 @@
         "evidence": "Focused Enneagram locale test, Enneagram flow regression, Big Five freeze classifier, route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
       },
       "github_required_checks": {
-        "status": "pending",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/1736"
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1736",
+        "evidence": "GitHub required checks passed after rebase onto origin/main; mergeStateStatus is CLEAN."
+      },
+      "rebase": {
+        "status": "pass",
+        "evidence": "Rebased onto origin/main after PR #1735 landed; resolved manifest/state ordering conflict by preserving MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01 and the current Enneagram entry."
       }
     },
     "scope": {
@@ -30167,6 +30172,11 @@
         "at": "2026-05-28T00:45:00+08:00",
         "status": "pr_opened",
         "summary": "Opened PR #1736 for Enneagram forced-choice 144 English question pack; GitHub checks pending."
+      },
+      {
+        "at": "2026-05-28T00:58:00+08:00",
+        "status": "github_checks_passed",
+        "summary": "After rebase onto latest origin/main, GitHub required checks passed and mergeStateStatus is CLEAN for PR #1736."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -30052,7 +30052,7 @@
       "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02"
     ],
     "title": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 Enneagram forced-choice English question pack",
-    "commit_sha": "2e57614d36f83133c61bb71ef1c8b87abcaa4381",
+    "commit_sha": "8f7b756db56e8ee6051cd91ffd552d4d91161109",
     "pr_url": null,
     "failure_reason": null,
     "merged_at": null,
@@ -30153,6 +30153,11 @@
         "at": "2026-05-28T00:41:00+08:00",
         "status": "committed",
         "summary": "Committed local Enneagram forced-choice English question pack fix as 2e57614d36f83133c61bb71ef1c8b87abcaa4381."
+      },
+      {
+        "at": "2026-05-28T00:43:00+08:00",
+        "status": "state_commit_recorded",
+        "summary": "Recorded implementation commit 8f7b756db56e8ee6051cd91ffd552d4d91161109 before PR push; later PR/merge reconciliation will replace this with PR or merge evidence."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -30047,13 +30047,13 @@
     "repo": "fap-api",
     "branch": "codex/enneagram-fc144-en-questions-pack-03",
     "base": "main",
-    "status": "local_validation_passed",
+    "status": "pr_opened",
     "depends_on": [
       "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02"
     ],
     "title": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 Enneagram forced-choice English question pack",
-    "commit_sha": "8f7b756db56e8ee6051cd91ffd552d4d91161109",
-    "pr_url": null,
+    "commit_sha": "953174e38e683e889081366034618a9b04f26e31",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1736",
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -30117,6 +30117,10 @@
           "git -C /Users/rainie/Desktop/GitHub/fap-web status --short"
         ],
         "evidence": "Focused Enneagram locale test, Enneagram flow regression, Big Five freeze classifier, route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
+      },
+      "github_required_checks": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1736"
       }
     },
     "scope": {
@@ -30158,6 +30162,11 @@
         "at": "2026-05-28T00:43:00+08:00",
         "status": "state_commit_recorded",
         "summary": "Recorded implementation commit 8f7b756db56e8ee6051cd91ffd552d4d91161109 before PR push; later PR/merge reconciliation will replace this with PR or merge evidence."
+      },
+      {
+        "at": "2026-05-28T00:45:00+08:00",
+        "status": "pr_opened",
+        "summary": "Opened PR #1736 for Enneagram forced-choice 144 English question pack; GitHub checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -29901,17 +29901,17 @@
     "repo": "fap-api",
     "branch": "codex/riasec-en-questions-pack-translation-02",
     "base": "main",
-    "status": "local_validation_passed",
+    "status": "merged",
     "depends_on": [
       "MBTI-EN-QUESTIONS-PACK-PROJECTION-01"
     ],
     "title": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 RIASEC English question pack translation",
-    "commit_sha": "17bbb89e6ac290115c0811ceacf724c64caf9376",
+    "commit_sha": "eb3876451408231a542c3e96bd20d0d9a7f7728e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1734",
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-27T16:22:48Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -29974,17 +29974,18 @@
         "evidence": "After CI fix, Big Five freeze classifier test passed, RIASEC focused and flow tests passed, and route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
       },
       "github_required_checks": {
-        "status": "pending_rerun",
+        "status": "pass",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1734",
-        "previous_failed_checks": [
-          "verify-mbti-legacy",
-          "verify-mbti-v2"
-        ],
-        "fix_evidence": "Local BigFiveResultPageV2CoreBodyPreviewTest now passes with the RIASEC question-pack-only allowance."
+        "evidence": "GitHub required checks passed after CI scope fix; PR #1734 was squash-merged as eb3876451408231a542c3e96bd20d0d9a7f7728e."
       },
       "ci_fix_scope": {
         "status": "pass",
         "evidence": "Added a focused test-only freeze classifier allowance for backend/content_packs/RIASEC v1-standard-60 and v1-enhanced-140 compiled questions/manifests; no runtime code changed."
+      },
+      "post_merge_focused_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=RiasecQuestionLocaleTranslation --no-ansi",
+        "evidence": "3 tests passed, 1226 assertions after syncing main."
       }
     },
     "scope": {
@@ -30033,6 +30034,125 @@
         "at": "2026-05-28T01:03:00+08:00",
         "status": "local_validation_passed_after_ci_fix",
         "summary": "Added focused Big Five freeze classifier allowance for RIASEC question-pack translation files and reran Big Five freeze, RIASEC focused/flow, route list, Pint, composer validate/audit, JSON/YAML parse, and diff checks successfully."
+      },
+      {
+        "at": "2026-05-28T00:22:48+08:00",
+        "status": "merged_reconciled",
+        "summary": "Reconciled PR #1734 as merged with squash commit eb3876451408231a542c3e96bd20d0d9a7f7728e; origin/main contains the merge commit, branch cleanup is complete, and post-merge focused test passed."
+      }
+    ]
+  },
+  "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03": {
+    "id": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03",
+    "repo": "fap-api",
+    "branch": "codex/enneagram-fc144-en-questions-pack-03",
+    "base": "main",
+    "status": "local_validation_passed",
+    "depends_on": [
+      "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02"
+    ],
+    "title": "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 Enneagram forced-choice English question pack",
+    "commit_sha": "2e57614d36f83133c61bb71ef1c8b87abcaa4381",
+    "pr_url": null,
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "TAKE-EN-QUESTION-LOCALE-SCAN-00 recommended ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 and the user instructed the three backend content-pack fixes to proceed sequentially."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02 merged as PR #1734 with merge commit eb3876451408231a542c3e96bd20d0d9a7f7728e."
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_files": [
+          "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json",
+          "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json",
+          "backend/tests/Feature/V0_3/EnneagramQuestionLocaleTranslationTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "outside_scope": [],
+        "changed_files": [
+          "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json",
+          "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json",
+          "backend/tests/Feature/V0_3/EnneagramQuestionLocaleTranslationTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ],
+        "evidence": "Changed files are confined to Enneagram forced-choice compiled question pack/manifest, focused Enneagram locale test, Big Five freeze classifier test-only allowance for the Enneagram pack files, and authorized PR-train metadata."
+      },
+      "focused_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramQuestionLocaleTranslation --no-ansi",
+        "evidence": "3 tests passed, 944 assertions."
+      },
+      "enneagram_flow_regression": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=EnneagramAssessmentFlow --no-ansi",
+        "evidence": "3 tests passed, 66 assertions."
+      },
+      "local_validation": {
+        "status": "pass",
+        "commands": [
+          "cd backend && php artisan test --filter=EnneagramQuestionLocaleTranslation --no-ansi",
+          "cd backend && php artisan test --filter=EnneagramAssessmentFlow --no-ansi",
+          "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi",
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && vendor/bin/pint --test",
+          "cd backend && composer validate --strict",
+          "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "python3 -m json.tool backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json >/dev/null",
+          "python3 -m json.tool backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('yaml ok')\nPY",
+          "git diff --check",
+          "git diff --cached --check",
+          "git -C /Users/rainie/Desktop/GitHub/fap-web status --short"
+        ],
+        "evidence": "Focused Enneagram locale test, Enneagram flow regression, Big Five freeze classifier, route list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference status passed locally."
+      }
+    },
+    "scope": {
+      "allowed_files": [
+        "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json",
+        "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json",
+        "backend/tests/Feature/V0_3/EnneagramQuestionLocaleTranslationTest.php",
+        "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+        "docs/codex/pr-train.yaml",
+        "docs/codex/pr-train-state.json"
+      ],
+      "api_runtime_change": false,
+      "content_pack_mutation": true,
+      "cms_mutation": false,
+      "publish": false,
+      "deploy": false,
+      "search_channel_action": false,
+      "url_submission": false,
+      "fap_web_modified": false,
+      "frontend_fallback_authority": false
+    },
+    "history": [
+      {
+        "at": "2026-05-28T00:29:47+08:00",
+        "status": "implementation_in_progress",
+        "summary": "Started Enneagram forced-choice 144 English question pack translation after RIASEC PR merge; scope is Enneagram forced-choice compiled question pack, manifest hash, focused test, freeze classifier allowance, and train metadata only."
+      },
+      {
+        "at": "2026-05-28T00:38:00+08:00",
+        "status": "local_validation_passed",
+        "summary": "Translated Enneagram forced-choice 144 English option text in backend content pack, updated manifest hash, added focused locale test and Big Five freeze classifier allowance, and passed local validation."
+      },
+      {
+        "at": "2026-05-28T00:41:00+08:00",
+        "status": "committed",
+        "summary": "Committed local Enneagram forced-choice English question pack fix as 2e57614d36f83133c61bb71ef1c8b87abcaa4381."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15106,6 +15106,53 @@ prs:
     frontend_fallback_authority: false
     next_task: ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03
 
+  - id: ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03
+    repo: fap-api
+    depends_on:
+      - RIASEC-EN-QUESTIONS-PACK-TRANSLATION-02
+    branch: codex/enneagram-fc144-en-questions-pack-03
+    base: main
+    title: "ENNEAGRAM-FC144-EN-QUESTIONS-PACK-03 Enneagram forced-choice English question pack"
+    train_scope: take_question_locale_parity
+    risk_level: p1_content_pack_translation
+    allowed_paths:
+      - backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json
+      - backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json
+      - backend/tests/Feature/V0_3/EnneagramQuestionLocaleTranslationTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Translate Enneagram enneagram_forced_choice_144 English displayed forced-choice options in backend content pack authority.
+      - Preserve zh-CN displayed option text, option codes, type codes, pair routing, question count, scoring semantics, and Enneagram likert 105 behavior.
+      - Do not change MBTI, RIASEC, Big Five, IQ, EQ, Clinical Combo, SDS, fap-web runtime, CMS, publish state, deploy state, Search Channel, sitemap, llms, footer, or nav.
+    validation:
+      - cd backend && php artisan test --filter=EnneagramQuestionLocaleTranslation --no-ansi
+      - cd backend && php artisan test --filter=EnneagramAssessmentFlow --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json >/dev/null
+      - python3 -m json.tool backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    content_pack_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: null
+
   - id: MBTI-DESKTOP-CLONE-MEDIA-ASSETS-01
     repo: fap-api
     branch: codex/mbti-desktop-clone-media-assets-01


### PR DESCRIPTION
## What changed
- Translated `enneagram_forced_choice_144` English forced-choice option display text in the backend Enneagram content pack authority.
- Preserved zh-CN displayed option text, option codes, type codes, pair routing, question count, and scoring semantics.
- Updated the Enneagram forced-choice content pack manifest hashes.
- Added focused V0.3 locale regression coverage and a Big Five freeze classifier test-only allowance for this Enneagram content-pack-only change.
- Added/reconciled the current PR train manifest/state entry.

## Why
`TAKE-EN-QUESTION-LOCALE-SCAN-00` found that the English Enneagram forced-choice 144 take flow displayed Chinese option text because the backend `en` content pack document still contained zh-CN option strings. This PR fixes the backend authority layer without adding frontend fallback content.

## Validation
- `cd backend && php artisan test --filter=EnneagramQuestionLocaleTranslation --no-ansi`
- `cd backend && php artisan test --filter=EnneagramAssessmentFlow --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json >/dev/null`
- `python3 -m json.tool backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`
- `git -C /Users/rainie/Desktop/GitHub/fap-web status --short`

## Intentionally deferred
- No frontend changes.
- No CMS mutation.
- No publish, deploy, Search Channel action, URL submission, sitemap, llms, footer, or nav changes.
- No MBTI, RIASEC, Big Five, IQ, EQ, Clinical Combo, or SDS changes.
