### PR TITLE
GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01 career runtime cohort and detail diagnosis

### DIFF
--- a/backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json
+++ b/backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json
@@ -1,0 +1,184 @@
+{
+  "schema_version": "global-career-runtime-cohort-and-detail-repair-01.v1",
+  "task": "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01",
+  "final_decision": "career_runtime_requires_controlled_cms_or_cohort_publish",
+  "scanned_at": "2026-05-28T09:39:34+08:00",
+  "career_count_meaning": {
+    "30": {
+      "meaning": "Current runtime-published public career cohort from dataset authority.",
+      "evidence": "Production dataset authority reports member_count=30, included_count=30, public_detail_indexable_count=30.",
+      "public_runtime_active": true
+    },
+    "342": {
+      "meaning": "Legacy B71X/DOCX career_all_342 baseline.",
+      "evidence": "Existing career authority documentation and dataset key career_all_342_occupations_dataset.",
+      "public_runtime_active": false
+    },
+    "2289": {
+      "meaning": "Excluded runtime candidate/raw authority records, not public job pages.",
+      "evidence": "Production dataset authority reports excluded_count=2289.",
+      "public_runtime_active": false
+    }
+  },
+  "public_cohort_policy": {
+    "current_public_index_items": 30,
+    "current_detail_api_200_count_by_locale": {
+      "en": 30,
+      "zh-CN": 30
+    },
+    "non_cohort_slugs_fail_closed": true,
+    "sampled_non_cohort_slugs": [
+      "accountants-and-auditors",
+      "software-developers"
+    ],
+    "do_not_publish_342_without_approval": true,
+    "do_not_publish_2289_without_approval": true
+  },
+  "sampled_runtime_checks": {
+    "frontend": [
+      {
+        "url": "https://fermatmind.com/en/career/jobs",
+        "status": 200,
+        "robots": "index, follow",
+        "detail_link_count": 30
+      },
+      {
+        "url": "https://fermatmind.com/zh/career/jobs",
+        "status": 200,
+        "robots": "index, follow",
+        "detail_link_count": 30
+      },
+      {
+        "url": "https://fermatmind.com/en/career/jobs/accountants-and-auditors",
+        "status": 404,
+        "robots": "noindex"
+      },
+      {
+        "url": "https://fermatmind.com/zh/career/jobs/accountants-and-auditors",
+        "status": 404,
+        "robots": "noindex"
+      },
+      {
+        "url": "https://fermatmind.com/en/career/jobs/software-developers",
+        "status": 404,
+        "robots": "noindex"
+      },
+      {
+        "url": "https://fermatmind.com/zh/career/jobs/software-developers",
+        "status": 404,
+        "robots": "noindex"
+      }
+    ],
+    "current_cohort_frontend_robots_summary": {
+      "en_index": 18,
+      "en_noindex": 12,
+      "zh_index": 0,
+      "zh_noindex": 30
+    }
+  },
+  "api_runtime_checks": {
+    "dataset_occupations_en": {
+      "status": 200,
+      "member_count": 30,
+      "included_count": 30,
+      "excluded_count": 2289,
+      "public_detail_indexable_count": 30
+    },
+    "dataset_occupations_zh_cn": {
+      "status": 200,
+      "member_count": 30,
+      "included_count": 30,
+      "excluded_count": 2289,
+      "public_detail_indexable_count": 30
+    },
+    "career_jobs_en": {
+      "status": 200,
+      "item_count": 30,
+      "contains_accountants_and_auditors": false,
+      "contains_software_developers": false,
+      "contains_actuaries": true
+    },
+    "career_jobs_zh_cn": {
+      "status": 200,
+      "item_count": 30,
+      "contains_accountants_and_auditors": false,
+      "contains_software_developers": false,
+      "contains_actuaries": true
+    },
+    "sample_detail_api": {
+      "actuaries_en": 200,
+      "actuaries_zh_cn": 200,
+      "accountants_and_auditors_en": 404,
+      "accountants_and_auditors_zh_cn": 404,
+      "software_developers_en": 404,
+      "software_developers_zh_cn": 404
+    },
+    "current_cohort_detail_api_bad_count": 0
+  },
+  "sitemap_exposure_check": {
+    "career_job_detail_url_count": 0,
+    "sampled_404_urls_exposed": false,
+    "status": "pass"
+  },
+  "llms_exposure_check": {
+    "llms_txt_career_job_detail_url_count": 0,
+    "llms_full_txt_career_job_detail_url_count": 0,
+    "sampled_404_urls_exposed": false,
+    "status": "pass"
+  },
+  "footer_exposure_check": {
+    "homepage_career_job_detail_links": 0,
+    "career_index_detail_links_per_locale": {
+      "en": 30,
+      "zh": 30
+    },
+    "sampled_404_urls_exposed": false,
+    "status": "pass"
+  },
+  "frontend_notfound_behavior": {
+    "fetcher": "fap-web lib/career/api/fetchCareerJobBundle.ts returns null on API 404 or other API error.",
+    "route": "fap-web app/(localized)/[locale]/career/jobs/[slug]/page.tsx calls notFound() when the adapted bundle is null.",
+    "sampled_404_root_cause": "backend_projection_gate_non_cohort_slug",
+    "frontend_fallback_authority_used": false
+  },
+  "claim_boundary_state": {
+    "status": "pass",
+    "forbidden_claim_hits": [],
+    "bounded_language_required": true,
+    "no_precise_career_recommendation": true,
+    "no_hiring_fit": true,
+    "no_job_suitability_guarantee": true,
+    "no_career_success_prediction": true,
+    "no_salary_guarantee": true,
+    "no_psychometric_determines_career": true
+  },
+  "authority_mismatch_findings": [
+    {
+      "id": "career_detail_backend_indexable_frontend_noindex_mismatch",
+      "severity": "p1",
+      "finding": "Backend detail API returns 200 with seo_contract robots_policy index,follow for current cohort slugs, but production frontend renders noindex for 12 EN and 30 ZH sampled cohort detail pages.",
+      "impact": "The 30 cohort cannot be claimed fully public/indexable until backend SEO authority, content completeness, and frontend metadata gates agree.",
+      "recommended_owner": "backend_authority_and_fap_web_metadata_linked_pr"
+    },
+    {
+      "id": "career_seo_authority_endpoint_locale_gap",
+      "severity": "p1",
+      "finding": "Sample /api/v0.5/career-jobs/actuaries/seo returned 404 for en and 200 for zh-CN.",
+      "impact": "Frontend includeSeoAuthority can attach inconsistent authority by locale.",
+      "recommended_owner": "backend_career_seo_authority"
+    }
+  ],
+  "recommended_fix": {
+    "status": "requires_controlled_follow_up",
+    "next_pr_id": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01",
+    "summary": "Align career detail SEO authority and frontend metadata gating for the current 30 cohort before any sitemap/llms exposure or larger cohort publish.",
+    "requires_explicit_approval_phrase": "I explicitly approve a controlled career cohort publish and SEO authority alignment PR for the named career slugs, with no broad pSEO, no CMS mutation unless separately approved, no Search Channel action, no URL submission, and no deploy in the PR."
+  },
+  "next_task": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01",
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_pseo_generation": true
+}

--- a/backend/docs/seo/global-career-runtime-cohort-and-detail-repair-01.md
+++ b/backend/docs/seo/global-career-runtime-cohort-and-detail-repair-01.md
@@ -1,0 +1,81 @@
+# GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01
+
+## Executive Summary
+
+This backend-first diagnosis found that the sampled hard-404 detail URLs are not part of the current public career cohort. The current production cohort is 30 jobs. The sampled slugs `accountants-and-auditors` and `software-developers` are intentionally non-public today and fail closed with 404/noindex. They are not exposed in sitemap, llms, or footer/nav.
+
+The current cohort itself has a separate authority mismatch: the backend job detail API returns 200 and `seo_contract.robots_policy=index,follow` for all 30 current cohort slugs, but production frontend metadata renders noindex for many of those pages. In the runtime sample, 18 EN cohort detail pages render indexable, 12 EN pages render noindex, and all 30 ZH cohort detail pages render noindex. This cannot be repaired by broad cohort activation or frontend fallback without an explicit controlled career publish/SEO authority decision.
+
+## Career Count Meaning: 30 / 342 / 2289
+
+- `30`: current runtime-published career cohort from the dataset authority response. Production `/api/v0.5/career/datasets/occupations` reports `member_count=30`, `included_count=30`, and `public_detail_indexable_count=30`.
+- `342`: legacy B71X/DOCX `career_all_342` baseline. It is a governed baseline, not automatic public runtime exposure.
+- `2289`: excluded runtime candidate/raw authority records reported by the dataset authority. These are not public jobs and must not be published by this repair.
+
+## Public Cohort Policy
+
+Current policy is fail-closed. Only the 30 runtime projection slugs are exposed in `/api/v0.5/career/jobs`. Non-cohort slugs return 404 from the backend detail endpoint.
+
+The public job index pages link to the 30 runtime cohort detail routes. Production sitemap, llms.txt, and llms-full.txt expose zero career job detail URLs.
+
+## API Runtime Findings
+
+- `/api/v0.5/career/datasets/occupations?locale=en`: 200.
+- `/api/v0.5/career/datasets/occupations?locale=zh-CN`: 200.
+- `/api/v0.5/career/jobs?locale=en`: 200 with 30 items.
+- `/api/v0.5/career/jobs?locale=zh-CN`: 200 with 30 items.
+- All 30 current cohort detail API URLs sampled through both `en` and `zh-CN` returned 200.
+- `/api/v0.5/career/jobs/accountants-and-auditors?locale=en`: 404.
+- `/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN`: 404.
+- `/api/v0.5/career/jobs/software-developers?locale=en`: 404.
+- `/api/v0.5/career/jobs/software-developers?locale=zh-CN`: 404.
+
+## Public Frontend Findings
+
+- `/en/career/jobs`: 200, index/follow, and links to 30 cohort detail pages.
+- `/zh/career/jobs`: 200, index/follow, and links to 30 cohort detail pages.
+- `/en/career/jobs/accountants-and-auditors`: 404/noindex.
+- `/zh/career/jobs/accountants-and-auditors`: 404/noindex.
+- `/en/career/jobs/software-developers`: 404/noindex.
+- `/zh/career/jobs/software-developers`: 404/noindex.
+- Current cohort detail pages return 200, but robots metadata is mixed:
+  - EN cohort detail pages: 18 indexable, 12 noindex.
+  - ZH cohort detail pages: 0 indexable, 30 noindex.
+
+## Sitemap / llms / Footer Exposure
+
+- sitemap career job detail exposure count: 0.
+- llms.txt career job detail exposure count: 0.
+- llms-full.txt career job detail exposure count: 0.
+- Homepage footer/nav exposes no career job detail links.
+- Career index pages expose the 30 cohort detail links only.
+
+## Root Cause
+
+The sampled slugs are not missing because of a timeout or frontend fallback. They are outside the current runtime projection, so the backend detail controller returns 404 and fap-web correctly renders notFound.
+
+For current cohort detail pages, the remaining issue is an authority mismatch: backend detail bundles can claim `index,follow`, but production frontend metadata still renders noindex where SEO authority/trust/completeness gates do not line up. This requires a controlled career cohort publish or authority-alignment PR before job details can be considered fully public/indexable.
+
+## Implementation
+
+No runtime code was changed in this PR. The safe scoped output is the diagnosis artifact, generated JSON, focused test, and PR-train ledger entry. No CMS data, cohort membership, sitemap, llms, frontend route, or production runtime was mutated.
+
+## Claim Boundary
+
+This task did not expand career claims. Career pages remain bounded to occupation information, exploratory decision support, and interest/navigation context. It did not claim best career, hiring fit, job suitability guarantee, career success prediction, salary guarantee, or psychometric career determination.
+
+## Recommended Fix
+
+Create a controlled follow-up for career publish/SEO authority alignment. It should decide whether the 30 runtime cohort should be public indexable in both locales, whether ZH detail shells are still noindex by policy, and whether the SEO authority endpoint and fap-web metadata gate should align with backend `seo_contract` only after content completeness and claim boundaries pass.
+
+If Product/SEO wants to promote any additional slugs beyond the current 30, use an explicit approval phrase before implementation:
+
+`I explicitly approve a controlled career cohort publish and SEO authority alignment PR for the named career slugs, with no broad pSEO, no CMS mutation unless separately approved, no Search Channel action, no URL submission, and no deploy in the PR.`
+
+## Decision
+
+`career_runtime_requires_controlled_cms_or_cohort_publish`
+
+## Next Task
+
+`GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01`

--- a/backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortAndDetailRepair01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortAndDetailRepair01Test.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class GlobalCareerRuntimeCohortAndDetailRepair01Test extends TestCase
+{
+    #[Test]
+    public function generated_report_exists_and_records_non_mutating_boundaries(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('global-career-runtime-cohort-and-detail-repair-01.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01', $payload['task'] ?? null);
+        $this->assertTrue((bool) ($payload['no_cms_mutation'] ?? false));
+        $this->assertTrue((bool) ($payload['no_deploy'] ?? false));
+        $this->assertTrue((bool) ($payload['no_search_channel_action'] ?? false));
+        $this->assertTrue((bool) ($payload['no_url_submission'] ?? false));
+        $this->assertTrue((bool) ($payload['no_external_search_api_call'] ?? false));
+        $this->assertTrue((bool) ($payload['no_pseo_generation'] ?? false));
+    }
+
+    #[Test]
+    public function required_diagnosis_sections_are_present(): void
+    {
+        $payload = $this->payload();
+
+        foreach ([
+            'career_count_meaning',
+            'public_cohort_policy',
+            'sampled_runtime_checks',
+            'api_runtime_checks',
+            'sitemap_exposure_check',
+            'llms_exposure_check',
+            'footer_exposure_check',
+            'frontend_notfound_behavior',
+            'claim_boundary_state',
+            'recommended_fix',
+            'final_decision',
+            'next_task',
+        ] as $key) {
+            $this->assertArrayHasKey($key, $payload);
+        }
+    }
+
+    #[Test]
+    public function current_policy_fails_closed_without_discoverability_exposure(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame(30, $payload['public_cohort_policy']['current_public_index_items'] ?? null);
+        $this->assertTrue((bool) ($payload['public_cohort_policy']['non_cohort_slugs_fail_closed'] ?? false));
+        $this->assertFalse((bool) ($payload['api_runtime_checks']['career_jobs_en']['contains_accountants_and_auditors'] ?? true));
+        $this->assertFalse((bool) ($payload['api_runtime_checks']['career_jobs_en']['contains_software_developers'] ?? true));
+        $this->assertSame(0, $payload['sitemap_exposure_check']['career_job_detail_url_count'] ?? null);
+        $this->assertSame(0, $payload['llms_exposure_check']['llms_txt_career_job_detail_url_count'] ?? null);
+        $this->assertSame(0, $payload['llms_exposure_check']['llms_full_txt_career_job_detail_url_count'] ?? null);
+        $this->assertFalse((bool) ($payload['footer_exposure_check']['sampled_404_urls_exposed'] ?? true));
+    }
+
+    #[Test]
+    public function authority_mismatch_is_explicit_and_not_papered_over(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertIsArray($payload['authority_mismatch_findings'] ?? null);
+        $this->assertNotEmpty($payload['authority_mismatch_findings']);
+        $this->assertSame(18, $payload['sampled_runtime_checks']['current_cohort_frontend_robots_summary']['en_index'] ?? null);
+        $this->assertSame(12, $payload['sampled_runtime_checks']['current_cohort_frontend_robots_summary']['en_noindex'] ?? null);
+        $this->assertSame(0, $payload['sampled_runtime_checks']['current_cohort_frontend_robots_summary']['zh_index'] ?? null);
+        $this->assertSame(30, $payload['sampled_runtime_checks']['current_cohort_frontend_robots_summary']['zh_noindex'] ?? null);
+        $this->assertSame('career_runtime_requires_controlled_cms_or_cohort_publish', $payload['final_decision'] ?? null);
+        $this->assertSame('GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01', $payload['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21002,9 +21002,9 @@
           "evidence": "Focused test, route:list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference clean status passed locally."
         },
         "github_required_checks": {
-          "status": "pending",
+          "status": "pass",
           "pr_url": "https://github.com/fermatmind/fap-api/pull/1737",
-          "evidence": "PR opened; checks pending."
+          "evidence": "GitHub checks passed for hygiene, supply-chain, Semgrep, verify-mbti-legacy, and verify-mbti-v2; mergeStateStatus is CLEAN."
         }
       },
       "scope": {
@@ -21050,6 +21050,11 @@
           "at": "2026-05-28T09:51:00+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1737 for current career runtime cohort/detail diagnosis."
+        },
+        {
+          "at": "2026-05-28T09:58:00+08:00",
+          "status": "github_checks_passed",
+          "summary": "GitHub checks passed and mergeStateStatus is CLEAN for PR #1737."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -9437,7 +9437,7 @@
       "depends_on": [
         "SEO-DASH-04A"
       ],
-      "status": "local_validation_passed",
+      "status": "pr_opened",
       "train_scope": "search_intelligence_baidu_indexnow_disabled_collectors",
       "risk_level": "medium_disabled_search_channel_schema",
       "title": "feat(seo-intel): add Baidu and IndexNow collector foundations",
@@ -19869,8 +19869,8 @@
       "depends_on": [
         "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "f04b8257",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1737",
       "checks": {
         "manifest_state_parse": "passed",
         "focused_test": "passed",
@@ -20954,6 +20954,102 @@
           "at": "2026-05-28T00:31:00+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1735 after local validation passed."
+        }
+      ]
+    },
+    "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01": {
+      "id": "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01",
+      "repo": "fap-api",
+      "branch": "codex/global-career-runtime-cohort-and-detail-repair-01",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01 career runtime cohort and detail diagnosis",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01 manifest/state updates for the current PR only."
+        },
+        "runtime_diagnosis": {
+          "status": "pass",
+          "evidence": "Production runtime shows 30 active career index items, sampled non-cohort slugs fail closed with backend 404, current cohort detail APIs return 200, and sitemap/llms expose zero career job detail URLs."
+        },
+        "authority_mismatch": {
+          "status": "needs_controlled_follow_up",
+          "evidence": "Backend detail seo_contract can report index,follow for current cohort slugs, while production frontend renders noindex for 12 EN and 30 ZH current-cohort detail pages."
+        },
+        "focused_test": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=GlobalCareerRuntimeCohortAndDetailRepair01 --no-ansi",
+          "evidence": "4 tests passed, 40 assertions."
+        },
+        "local_validation": {
+          "status": "pass",
+          "commands": [
+            "cd backend && php artisan test --filter=GlobalCareerRuntimeCohortAndDetailRepair01 --no-ansi",
+            "cd backend && php artisan route:list --no-ansi",
+            "cd backend && vendor/bin/pint --test",
+            "cd backend && composer validate --strict",
+            "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+            "python3 -m json.tool backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json >/dev/null",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "YAML parse docs/codex/pr-train.yaml",
+            "git diff --check",
+            "git diff --cached --check",
+            "git -C /Users/rainie/Desktop/GitHub/fap-web status --short"
+          ],
+          "evidence": "Focused test, route:list, Pint, composer validate/audit, JSON/YAML parse, diff checks, and fap-web reference clean status passed locally."
+        },
+        "github_required_checks": {
+          "status": "pending",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1737",
+          "evidence": "PR opened; checks pending."
+        }
+      },
+      "scope": {
+        "allowed_files": [
+          "backend/docs/seo/global-career-runtime-cohort-and-detail-repair-01.md",
+          "backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortAndDetailRepair01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "cms_mutation": false,
+        "api_runtime_change": false,
+        "publish": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "url_submission": false,
+        "broad_pseo_generation": false,
+        "fap_web_modified": false,
+        "frontend_fallback_authority": false
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01",
+      "events": [
+        {
+          "at": "2026-05-28T09:39:34+08:00",
+          "status": "manifest_registered",
+          "summary": "Registered current career runtime cohort/detail diagnosis task after explicit user authorization."
+        },
+        {
+          "at": "2026-05-28T09:39:34+08:00",
+          "status": "implementation_in_progress",
+          "summary": "Added scoped diagnosis report, generated JSON, and focused test. No runtime code, CMS state, deploy state, Search Channel, URL submission, or fap-web files are modified."
+        },
+        {
+          "at": "2026-05-28T09:48:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Focused report test and common backend validation passed; fap-web reference worktree is clean."
+        },
+        {
+          "at": "2026-05-28T09:51:00+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1737 for current career runtime cohort/detail diagnosis."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19869,7 +19869,7 @@
       "depends_on": [
         "GLOBAL-EN-ZH-PARITY-FINAL-VERIFY-01"
       ],
-      "commit_sha": "f04b8257",
+      "commit_sha": "2b830aca",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1737",
       "checks": {
         "manifest_state_parse": "passed",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15203,3 +15203,44 @@ prs:
     frontend_fallback_authority: false
     paid_content_gate_change: false
     next_task: DEPLOY-READINESS
+
+  - id: GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01
+    repo: fap-api
+    branch: codex/global-career-runtime-cohort-and-detail-repair-01
+    base: main
+    title: "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01 career runtime cohort and detail diagnosis"
+    train_scope: career_runtime_cohort_detail_diagnosis
+    risk_level: p1_career_runtime_authority
+    allowed_paths:
+      - backend/docs/seo/global-career-runtime-cohort-and-detail-repair-01.md
+      - backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortAndDetailRepair01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Diagnose career cohort count meaning, public cohort policy, sampled detail 404/noindex behavior, sitemap/llms/footer exposure, and frontend notFound behavior.
+      - Record whether safe runtime repair is possible without CMS mutation, broad pSEO, cohort publish, Search Channel, URL submission, deploy, or frontend fallback authority.
+      - Add focused report validation only; do not publish career cohorts or alter fap-web runtime in this PR.
+    validation:
+      - cd backend && php artisan test --filter=GlobalCareerRuntimeCohortAndDetailRepair01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01


### PR DESCRIPTION
## What changed
- Added `GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01` diagnosis artifacts for career cohort counts, sampled detail 404/noindex behavior, sitemap/llms/footer exposure, and fap-web notFound behavior.
- Added generated JSON and a focused SeoIntel test to keep the diagnosis non-mutating and explicit.
- Registered only the current PR in the fap-api PR-train manifest/state after user authorization.

## Why
- Production shows `/en/career/jobs` and `/zh/career/jobs` are healthy, but sampled details such as `accountants-and-auditors` and `software-developers` are 404/noindex.
- Diagnosis shows those sampled slugs are outside the current 30-job runtime cohort and are safely excluded from sitemap/llms.
- A separate authority mismatch remains: current cohort detail APIs can report `index,follow`, while production frontend renders noindex for part/all of the cohort. That requires a controlled follow-up rather than broad pSEO or forced publication.

## Validation
- `cd backend && php artisan test --filter=GlobalCareerRuntimeCohortAndDetailRepair01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/global-career-runtime-cohort-and-detail-repair-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`
- fap-web reference status clean

## Intentionally deferred
- No CMS mutation, no deploy, no Search Channel action, no URL submission.
- No broad pSEO and no 342/2289 cohort publication.
- No fap-web runtime/metadata fix in this PR. Follow-up recommended: `GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01`.

## Repository rule impact
- No content ownership change. Career content remains backend/CMS/API authoritative; fap-web fallback is not used as authority.
