### PR TITLE
GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01 career publish authority alignment

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
@@ -4,10 +4,13 @@ declare(strict_types=1);
 
 namespace App\Http\Controllers\API\V0_5\Cms;
 
+use App\DTO\Career\CareerJobDetailBundle;
 use App\Http\Controllers\Concerns\RespondsWithNotFound;
 use App\Http\Controllers\Controller;
 use App\Models\CareerJob;
 use App\Models\CareerJobSection;
+use App\Services\Career\Bundles\CareerJobDetailBundleBuilder;
+use App\Services\Career\StructuredData\CareerStructuredDataBuilder;
 use App\Services\Cms\CareerJobSeoService;
 use App\Services\Cms\CareerJobService;
 use App\Services\PublicSurface\AnswerSurfaceContractService;
@@ -25,6 +28,8 @@ final class CareerJobController extends Controller
     public function __construct(
         private readonly CareerJobService $careerJobService,
         private readonly CareerJobSeoService $careerJobSeoService,
+        private readonly CareerJobDetailBundleBuilder $careerJobDetailBundleBuilder,
+        private readonly CareerStructuredDataBuilder $careerStructuredDataBuilder,
         private readonly AnswerSurfaceContractService $answerSurfaceContractService,
         private readonly LandingSurfaceContractService $landingSurfaceContractService,
         private readonly SeoSurfaceContractService $seoSurfaceContractService,
@@ -120,28 +125,121 @@ final class CareerJobController extends Controller
             return $validated;
         }
 
-        $job = $this->careerJobService->getPublicJobBySlug(
-            $slug,
-            $validated['org_id'],
-            $validated['locale'],
-        );
-
-        if (! $job instanceof CareerJob) {
-            return response()->json(['error' => 'not found'], 404);
+        $bundle = $this->careerJobDetailBundleBuilder->buildBySlug($slug, $validated['locale']);
+        if ($bundle instanceof CareerJobDetailBundle) {
+            return response()->json($this->bundleSeoAuthorityPayload($bundle, $validated['locale']));
         }
 
-        $frontendDetailAvailable = $this->careerJobSeoService->isFrontendDetailAvailable($job, $validated['locale']);
-        $meta = PublicMediaUrlGuard::sanitizeSeoMeta(
-            $this->careerJobSeoService->buildMeta($job, $validated['locale'], $frontendDetailAvailable)
-        );
-        $jsonLd = $this->careerJobSeoService->buildJsonLd($job, $validated['locale'], $frontendDetailAvailable);
-        $publicIndexable = $this->careerJobSeoService->isPublicIndexable($job, $validated['locale'], $frontendDetailAvailable);
+        // The career detail page is the public runtime authority. If the route cannot
+        // render from the same runtime gate, the SEO endpoint must fail closed too.
+        return response()->json(['error' => 'not found'], 404);
+    }
 
-        return response()->json([
+    /**
+     * @return array<string,mixed>
+     */
+    private function bundleSeoAuthorityPayload(CareerJobDetailBundle $bundle, string $locale): array
+    {
+        $seoContract = $bundle->seoContract;
+        $canonical = $this->canonicalFromSeoContract($seoContract, $bundle, $locale);
+        $title = $this->bundleTitle($bundle, $locale);
+        $description = $this->bundleDescription($bundle, $title);
+        $robots = $this->seoContractRobots($seoContract);
+        $publicIndexable = ! $this->containsNoindex($robots)
+            && (bool) ($seoContract['index_eligible'] ?? false);
+        $jsonLd = $this->careerStructuredDataBuilder->build('career_job_detail', $bundle);
+
+        $meta = PublicMediaUrlGuard::sanitizeSeoMeta([
+            'title' => $title,
+            'description' => $description,
+            'canonical' => $canonical,
+            'alternates' => [
+                'en' => '/en/career/jobs/'.rawurlencode((string) ($bundle->identity['canonical_slug'] ?? '')),
+                'zh-CN' => '/zh/career/jobs/'.rawurlencode((string) ($bundle->identity['canonical_slug'] ?? '')),
+            ],
+            'og' => [
+                'title' => $title,
+                'description' => $description,
+                'image' => null,
+                'type' => 'article',
+                'url' => $canonical,
+            ],
+            'twitter' => [
+                'card' => 'summary_large_image',
+                'title' => $title,
+                'description' => $description,
+                'image' => null,
+            ],
+            'robots' => $robots,
+        ]);
+
+        return [
             'meta' => $meta,
             'jsonld' => $jsonLd,
             'seo_surface_v1' => $this->buildSeoSurface($meta, $jsonLd, 'career_job_public_detail', $publicIndexable),
-        ]);
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $seoContract
+     */
+    private function canonicalFromSeoContract(array $seoContract, CareerJobDetailBundle $bundle, string $locale): string
+    {
+        $canonical = trim((string) ($seoContract['canonical_target'] ?? $seoContract['canonical_path'] ?? ''));
+        if ($canonical !== '') {
+            return $canonical;
+        }
+
+        $segment = $locale === 'zh-CN' ? 'zh' : 'en';
+        $slug = rawurlencode((string) ($bundle->identity['canonical_slug'] ?? ''));
+
+        return '/'.$segment.'/career/jobs/'.$slug;
+    }
+
+    private function bundleTitle(CareerJobDetailBundle $bundle, string $locale): string
+    {
+        $title = $locale === 'zh-CN'
+            ? ($bundle->titles['search_h1_zh'] ?? $bundle->titles['canonical_zh'] ?? null)
+            : ($bundle->titles['canonical_en'] ?? null);
+
+        return trim((string) ($title ?: ($bundle->identity['canonical_slug'] ?? 'Career job')));
+    }
+
+    private function bundleDescription(CareerJobDetailBundle $bundle, string $title): string
+    {
+        $summary = $bundle->truthLayer['summary'] ?? null;
+        if (is_string($summary) && trim($summary) !== '') {
+            return trim($summary);
+        }
+
+        if (is_string($bundle->contentBodyMd) && trim($bundle->contentBodyMd) !== '') {
+            return str(trim($bundle->contentBodyMd))->squish()->limit(160, '')->toString();
+        }
+
+        return 'Career overview and next steps for '.$title.'.';
+    }
+
+    /**
+     * @param  array<string,mixed>  $seoContract
+     */
+    private function seoContractRobots(array $seoContract): string
+    {
+        $robots = trim((string) ($seoContract['robots_policy'] ?? ''));
+        if ($robots !== '') {
+            return $robots;
+        }
+
+        return (bool) ($seoContract['index_eligible'] ?? false) ? 'index,follow' : 'noindex,follow';
+    }
+
+    private function containsNoindex(string $robots): bool
+    {
+        $tokens = array_map(
+            static fn (string $token): string => strtolower(trim($token)),
+            explode(',', $robots)
+        );
+
+        return in_array('noindex', $tokens, true);
     }
 
     /**
@@ -150,7 +248,7 @@ final class CareerJobController extends Controller
      */
     private function buildSeoSurface(array $meta, array $jsonLd, string $surfaceType, bool $publicIndexable): array
     {
-        return $this->seoSurfaceContractService->build([
+        $surface = $this->seoSurfaceContractService->build([
             'metadata_scope' => $publicIndexable ? 'public_indexable_detail' : 'public_noindex_detail',
             'surface_type' => $surfaceType,
             'canonical_url' => $meta['canonical'] ?? null,
@@ -165,6 +263,11 @@ final class CareerJobController extends Controller
             'sitemap_state' => $publicIndexable ? 'included' : 'excluded',
             'llms_exposure_state' => $publicIndexable ? 'allow' : 'withhold',
         ]);
+
+        $surface['index_eligible'] = $publicIndexable;
+        $surface['index_state'] = $publicIndexable ? 'indexable' : 'noindex';
+
+        return $surface;
     }
 
     /**

--- a/backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json
+++ b/backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "global_career_runtime_cohort_publish_authority_alignment.v1",
+  "task": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01",
+  "final_decision": "career_publish_authority_alignment_completed_ready_for_1048_dry_run",
+  "summary": {
+    "problem": "Career job detail runtime authority and career job SEO authority could disagree. Detail runtime uses the career protocol bundle release gate, while /career-jobs/{slug}/seo previously used CMS career job rows directly.",
+    "fix": "The career job SEO endpoint now fails closed unless the same runtime detail bundle can be built for the requested slug and locale. It emits index_eligible/index_state in seo_surface_v1 for frontend metadata consumption.",
+    "scope": "Current 30 cohort authority alignment only. No 1018 candidate promotion, no CMS mutation, no deploy, no Search Channel action, and no URL submission."
+  },
+  "runtime_authority_alignment": {
+    "detail_api_authority": "/api/v0.5/career/jobs/{slug}",
+    "seo_authority_api": "/api/v0.5/career-jobs/{slug}/seo",
+    "shared_gate": "CareerJobDetailBundleBuilder::buildBySlug",
+    "blocked_slug_behavior": "SEO endpoint returns 404 when the runtime detail bundle is unavailable.",
+    "indexable_slug_behavior": "SEO endpoint returns seo_surface_v1.index_eligible=true and index_state=indexable only when the runtime bundle seo_contract is indexable."
+  },
+  "known_production_context_before_fix": {
+    "current_public_detail_cohort": 30,
+    "ready_not_public_delta": 1018,
+    "target_public_detail_total": 1048,
+    "manual_hold_examples": [
+      "software-developers"
+    ],
+    "observed_risk": "Some non-runtime-published career slugs could still receive a zh-CN SEO authority response from the CMS endpoint, while their detail runtime returned 404."
+  },
+  "sitemap_llms_safety": {
+    "career_detail_sitemap_exposure_changed": false,
+    "career_detail_llms_exposure_changed": false,
+    "career_detail_urls_added": 0,
+    "draft_or_candidate_urls_exposed": false,
+    "frontend_fallback_authority_used": false
+  },
+  "claim_boundary_state": {
+    "precise_career_recommendation_claim_added": false,
+    "hiring_fit_claim_added": false,
+    "salary_guarantee_claim_added": false,
+    "success_prediction_claim_added": false,
+    "career_copy_changed": false
+  },
+  "rollout_state": {
+    "cohort_publish_performed": false,
+    "detail_ready_1048_dry_run_performed": false,
+    "detail_ready_1048_apply_performed": false,
+    "future_dry_run_required": true,
+    "future_apply_requires_explicit_user_approval": true
+  },
+  "guards": {
+    "no_cms_mutation": true,
+    "no_deploy": true,
+    "no_search_channel_action": true,
+    "no_url_submission": true,
+    "no_external_search_api_call": true,
+    "no_pseo_generation": true
+  },
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_pseo_generation": true,
+  "cohort_publish_performed": false,
+  "next_task": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01"
+}

--- a/backend/docs/seo/global-career-runtime-cohort-publish-authority-alignment-01.md
+++ b/backend/docs/seo/global-career-runtime-cohort-publish-authority-alignment-01.md
@@ -1,0 +1,26 @@
+# GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01
+
+## Summary
+
+This PR aligns career job SEO authority with the career job detail runtime gate.
+
+Before this fix, `/api/v0.5/career/jobs/{slug}` used `CareerJobDetailBundleBuilder` and runtime publish projection, while `/api/v0.5/career-jobs/{slug}/seo` could answer from CMS `CareerJob` rows directly. That allowed a drift state where a slug could be 404 in the runtime detail API but still appear indexable through the SEO authority endpoint.
+
+## Implementation
+
+- `/api/v0.5/career-jobs/{slug}/seo` now uses `CareerJobDetailBundleBuilder::buildBySlug()` as the authority gate.
+- If the runtime detail bundle cannot be built, the SEO authority endpoint returns 404.
+- If the runtime detail bundle is available and indexable, the SEO payload includes:
+  - `meta.robots=index,follow`
+  - `seo_surface_v1.index_eligible=true`
+  - `seo_surface_v1.index_state=indexable`
+  - `seo_surface_v1.sitemap_state=included`
+  - `seo_surface_v1.llms_exposure_state=allow`
+
+## Boundaries
+
+No career cohort publish was performed. This PR does not promote the 1018 ready-not-public candidates, does not mutate CMS data, does not deploy, does not enqueue Search Channel, and does not submit URLs.
+
+## Next Task
+
+`DETAIL_READY_1048_ROLLOUT_DRY_RUN-01`

--- a/backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortPublishAuthorityAlignment01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortPublishAuthorityAlignment01Test.php
@@ -1,0 +1,202 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJob;
+use App\Models\CareerJobSeoMeta;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
+use Tests\TestCase;
+
+final class GlobalCareerRuntimeCohortPublishAuthorityAlignment01Test extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_runtime_detail_and_seo_authority_are_aligned_for_public_en_and_zh_routes(): void
+    {
+        $this->configureRuntimeProjection(['runtime-aligned-job' => true]);
+        $this->createRuntimeOccupation('runtime-aligned-job');
+
+        $this->getJson('/api/v0.5/career/jobs/runtime-aligned-job?locale=en')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'runtime-aligned-job')
+            ->assertJsonPath('seo_contract.canonical_path', '/en/career/jobs/runtime-aligned-job')
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow');
+
+        $this->getJson('/api/v0.5/career/jobs/runtime-aligned-job?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('identity.canonical_slug', 'runtime-aligned-job')
+            ->assertJsonPath('seo_contract.canonical_path', '/zh/career/jobs/runtime-aligned-job')
+            ->assertJsonPath('seo_contract.index_eligible', true)
+            ->assertJsonPath('seo_contract.robots_policy', 'index,follow');
+
+        foreach ([
+            'en' => '/en/career/jobs/runtime-aligned-job',
+            'zh-CN' => '/zh/career/jobs/runtime-aligned-job',
+        ] as $locale => $canonicalPath) {
+            $response = $this->getJson('/api/v0.5/career-jobs/runtime-aligned-job/seo?locale='.$locale.'&org_id=0')
+                ->assertOk()
+                ->assertJsonPath('meta.robots', 'index,follow')
+                ->assertJsonPath('meta.canonical', $canonicalPath)
+                ->assertJsonPath('seo_surface_v1.index_eligible', true)
+                ->assertJsonPath('seo_surface_v1.index_state', 'indexable')
+                ->assertJsonPath('seo_surface_v1.indexability_state', 'indexable')
+                ->assertJsonPath('seo_surface_v1.sitemap_state', 'included')
+                ->assertJsonPath('seo_surface_v1.llms_exposure_state', 'allow');
+
+            $this->assertContains('Occupation', $response->json('seo_surface_v1.structured_data_keys'));
+        }
+    }
+
+    public function test_seo_authority_fails_closed_when_runtime_detail_route_is_blocked_even_if_cms_row_exists(): void
+    {
+        $this->configureRuntimeProjection(['software-developers' => false]);
+        $this->createPublishedDocxCareerJob('software-developers');
+
+        $this->getJson('/api/v0.5/career/jobs/software-developers?locale=zh-CN')
+            ->assertStatus(404)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+
+        $this->getJson('/api/v0.5/career-jobs/software-developers/seo?locale=zh-CN&org_id=0')
+            ->assertStatus(404)
+            ->assertJsonPath('error', 'not found');
+    }
+
+    public function test_alignment_report_artifact_records_no_publish_or_search_mutation(): void
+    {
+        $path = base_path('docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json');
+
+        $this->assertFileExists($path);
+        $payload = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01', $payload['task']);
+        $this->assertSame('career_publish_authority_alignment_completed_ready_for_1048_dry_run', $payload['final_decision']);
+        $this->assertTrue($payload['no_cms_mutation']);
+        $this->assertTrue($payload['no_deploy']);
+        $this->assertTrue($payload['no_search_channel_action']);
+        $this->assertTrue($payload['no_url_submission']);
+        $this->assertFalse($payload['cohort_publish_performed']);
+        $this->assertSame('DETAIL_READY_1048_ROLLOUT_DRY_RUN-01', $payload['next_task']);
+    }
+
+    /**
+     * @param  array<string,bool>  $visibilityBySlug
+     */
+    private function configureRuntimeProjection(array $visibilityBySlug): void
+    {
+        $detailRouteEnabled = [];
+        $robotsIndexable = [];
+        $releaseGatePass = [];
+        $items = [];
+
+        foreach ($visibilityBySlug as $slug => $enabled) {
+            $normalizedSlug = strtolower(trim($slug));
+            $detailRouteEnabled[$normalizedSlug] = $enabled;
+            $robotsIndexable[$normalizedSlug] = $enabled;
+            $releaseGatePass[$normalizedSlug] = $enabled;
+
+            foreach (['en', 'zh'] as $locale) {
+                $items[$normalizedSlug.'|'.$locale] = [
+                    'slug' => $normalizedSlug,
+                    'locale' => $locale,
+                    'dataset_visible' => $enabled,
+                    'search_visible' => $enabled,
+                    'detail_route_enabled' => $enabled,
+                    'robots_indexable' => $enabled,
+                    'release_gate_pass' => $enabled,
+                    'runtime_publish_state' => $enabled ? 'published' : 'blocked',
+                ];
+            }
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                detailRouteEnabled: $detailRouteEnabled,
+                robotsIndexable: $robotsIndexable,
+                releaseGatePass: $releaseGatePass,
+                items: $items,
+            ),
+        );
+    }
+
+    private function createRuntimeOccupation(string $slug): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => $slug.'-family',
+            'title_en' => 'Runtime Family',
+            'title_zh' => '运行时职业族',
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'exact',
+            'canonical_title_en' => 'Runtime Aligned Job',
+            'canonical_title_zh' => '运行时对齐职业',
+            'search_h1_zh' => '运行时对齐职业',
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+        ]);
+    }
+
+    private function createPublishedDocxCareerJob(string $slug): CareerJob
+    {
+        $job = CareerJob::query()->create([
+            'org_id' => 0,
+            'job_code' => $slug,
+            'slug' => $slug,
+            'locale' => 'zh-CN',
+            'title' => '软件开发、质量保证分析与测试人员',
+            'subtitle' => 'Software Developers',
+            'excerpt' => 'Published DOCX fallback fixture.',
+            'body_md' => '# Published DOCX fallback fixture',
+            'status' => CareerJob::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subMinute(),
+            'salary_json' => ['annual_median_usd' => 132270],
+            'outlook_json' => ['jobs_2024' => 2000000],
+            'growth_path_json' => ['raw' => ['Fixture growth path.']],
+            'market_demand_json' => [
+                'ai_exposure_score_10' => 6,
+                'source_refs' => [
+                    [
+                        'label' => 'BLS Occupational Outlook Handbook',
+                        'url' => 'https://www.bls.gov/ooh/computer-and-information-technology/software-developers.htm',
+                    ],
+                ],
+            ],
+        ]);
+
+        CareerJobSeoMeta::query()->create([
+            'job_id' => (int) $job->id,
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => [
+                'source_docx' => $slug.'.docx',
+            ],
+        ]);
+
+        return $job;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-28T00:31:00+08:00",
+  "updated_at": "2026-05-28T10:39:28+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -20962,10 +20962,10 @@
       "repo": "fap-api",
       "branch": "codex/global-career-runtime-cohort-and-detail-repair-01",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "merged",
       "title": "GLOBAL-CAREER-RUNTIME-COHORT-AND-DETAIL-REPAIR-01 career runtime cohort and detail diagnosis",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "a543dfc6057765ab46788acc9d3b6944a418cf66",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1737",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -21005,6 +21005,10 @@
           "status": "pass",
           "pr_url": "https://github.com/fermatmind/fap-api/pull/1737",
           "evidence": "GitHub checks passed for hygiene, supply-chain, Semgrep, verify-mbti-legacy, and verify-mbti-v2; mergeStateStatus is CLEAN."
+        },
+        "ledger_reconciliation": {
+          "status": "pass",
+          "evidence": "GitHub reports PR #1737 as MERGED with merge commit a543dfc6057765ab46788acc9d3b6944a418cf66; origin/main contains the merge commit. Reconciled before current authority alignment PR."
         }
       },
       "scope": {
@@ -21026,9 +21030,9 @@
         "frontend_fallback_authority": false
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-28T02:06:56Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "next_task": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01",
       "events": [
         {
@@ -21055,6 +21059,117 @@
           "at": "2026-05-28T09:58:00+08:00",
           "status": "github_checks_passed",
           "summary": "GitHub checks passed and mergeStateStatus is CLEAN for PR #1737."
+        },
+        {
+          "at": "2026-05-28T10:33:29+08:00",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled PR #1737 merged state while starting GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01."
+        }
+      ]
+    },
+    "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01": {
+      "id": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01",
+      "repo": "fap-api",
+      "branch": "codex/global-career-runtime-cohort-publish-authority-alignment-01",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01 career publish authority alignment",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01 manifest/state updates for the current PR only."
+        },
+        "authority_alignment": {
+          "status": "pass",
+          "evidence": "Career job SEO endpoint now uses the runtime detail bundle gate; blocked runtime details fail closed even if CMS rows exist; seo_surface_v1 exposes index_eligible/index_state for frontend trust checks."
+        },
+        "php_artisan_test_global_career_runtime_cohort_publish_authority_alignment_01": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=GlobalCareerRuntimeCohortPublishAuthorityAlignment01 --no-ansi",
+          "evidence": "3 tests passed, 42 assertions."
+        },
+        "php_artisan_test_career_job_detail_api": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerJobDetailApi --no-ansi",
+          "evidence": "10 tests passed, 122 assertions."
+        },
+        "php_artisan_test_career_job_seo_service": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerJobSeoService --no-ansi",
+          "evidence": "4 tests passed, 13 assertions."
+        },
+        "php_artisan_route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list completed; 203 routes shown."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Pint passed across 3609 files after formatting CareerJobController.php."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 - <<'PY' ... yaml.safe_load(...)",
+          "evidence": "Generated report JSON, train state JSON, and train manifest YAML parse successfully."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "No whitespace errors."
+        }
+      },
+      "scope": {
+        "allowed_files": [
+          "backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php",
+          "backend/docs/seo/global-career-runtime-cohort-publish-authority-alignment-01.md",
+          "backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json",
+          "backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortPublishAuthorityAlignment01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "cms_mutation": false,
+        "api_runtime_change": true,
+        "publish": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "url_submission": false,
+        "broad_pseo_generation": false,
+        "fap_web_modified": false,
+        "frontend_fallback_authority": false
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01",
+      "events": [
+        {
+          "at": "2026-05-28T10:33:29+08:00",
+          "status": "manifest_registered",
+          "summary": "Registered current career publish authority alignment task after explicit user authorization."
+        },
+        {
+          "at": "2026-05-28T10:33:29+08:00",
+          "status": "implementation_in_progress",
+          "summary": "Aligning career job SEO authority with runtime detail bundle authority. No cohort publish, CMS mutation, deploy, Search Channel action, URL submission, or fap-web changes."
+        },
+        {
+          "at": "2026-05-28T10:39:28+08:00",
+          "status": "local_validation_passed",
+          "summary": "Scoped tests, adjacent career detail/SEO tests, route list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks passed."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15244,3 +15244,48 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01
+
+  - id: GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01
+    repo: fap-api
+    branch: codex/global-career-runtime-cohort-publish-authority-alignment-01
+    base: main
+    title: "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01 career publish authority alignment"
+    train_scope: career_runtime_cohort_publish_authority_alignment
+    risk_level: p1_career_runtime_authority
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_5/Cms/CareerJobController.php
+      - backend/docs/seo/global-career-runtime-cohort-publish-authority-alignment-01.md
+      - backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json
+      - backend/tests/Feature/SeoIntel/GlobalCareerRuntimeCohortPublishAuthorityAlignment01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Align career job SEO authority with the same runtime detail bundle gate used by /api/v0.5/career/jobs/{slug}.
+      - Ensure SEO authority fails closed for runtime-blocked slugs even when a CMS career job row exists.
+      - Include explicit seo_surface_v1 index_eligible and index_state for frontend metadata consumption.
+      - Do not promote the 1018 detail-ready candidates, mutate CMS, deploy, submit URLs, enqueue Search Channel, or use frontend fallback authority.
+    validation:
+      - cd backend && php artisan test --filter=GlobalCareerRuntimeCohortPublishAuthorityAlignment01 --no-ansi
+      - cd backend && php artisan test --filter=CareerJobDetailApi --no-ansi
+      - cd backend && php artisan test --filter=CareerJobSeoService --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DETAIL_READY_1048_ROLLOUT_DRY_RUN-01


### PR DESCRIPTION
## What changed

- Aligned `/api/v0.5/career-jobs/{slug}/seo` with the same runtime detail bundle authority gate used by `/api/v0.5/career/jobs/{slug}`.
- Made the SEO endpoint fail closed with 404 when a career detail bundle is not runtime-published/indexable, even if a CMS `CareerJob` row exists.
- Added explicit `seo_surface_v1.index_eligible` and `seo_surface_v1.index_state` fields so frontend metadata trust checks can distinguish runtime-indexable career details.
- Added a scoped scan/report artifact and focused regression test for the authority alignment.
- Reconciled the already-merged prior career runtime diagnosis PR #1737 in the train ledger.

## Why

The prior scan showed career runtime detail authority and legacy CMS SEO authority could drift: hidden/non-runtime slugs could be 404 in the actual detail API while still looking SEO-indexable through `/api/v0.5/career-jobs/{slug}/seo`. This PR makes the detail runtime gate the single authority for career job SEO exposure.

## Validation

- `cd backend && php artisan test --filter=GlobalCareerRuntimeCohortPublishAuthorityAlignment01 --no-ansi` — passed, 3 tests / 42 assertions
- `cd backend && php artisan test --filter=CareerJobDetailApi --no-ansi` — passed, 10 tests / 122 assertions
- `cd backend && php artisan test --filter=CareerJobSeoService --no-ansi` — passed, 4 tests / 13 assertions
- `cd backend && php artisan route:list --no-ansi` — passed, 203 routes
- `cd backend && vendor/bin/pint --test` — passed, 3609 files
- `cd backend && composer validate --strict` — passed
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` — passed, no advisories
- `python3 -m json.tool backend/docs/seo/generated/global-career-runtime-cohort-publish-authority-alignment-01.v1.json >/dev/null` — passed
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` — passed
- YAML manifest parse — passed
- `git diff --check && git diff --cached --check` — passed

## Intentionally deferred

- No 1018 detail-ready cohort rollout or promotion.
- No DB/runtime publication mutation.
- No CMS mutation.
- No deploy.
- No Search Channel enqueue or URL submission.
- No fap-web fallback/content changes.

## Repository rule impact

Career job SEO exposure remains backend-authoritative and now follows the same runtime detail bundle gate as the public detail API. No frontend content authority or fallback behavior is introduced.
