### PR TITLE
DETAIL_READY_1048_ROLLOUT_DRY_RUN-01 detail-ready 1048 rollout dry-run manifest blockers

### DIFF
--- a/backend/docs/seo/detail-ready-1048-rollout-dry-run-01.md
+++ b/backend/docs/seo/detail-ready-1048-rollout-dry-run-01.md
@@ -1,0 +1,51 @@
+# DETAIL_READY_1048_ROLLOUT_DRY_RUN-01
+
+## Summary
+
+This read-only dry-run PR prepares the `detail_ready_1048` rollout gate without
+promoting any Career runtime rows.
+
+The intended rollout shape is:
+
+- current public detail cohort: 30 slugs
+- ready-not-public delta: 1018 slugs
+- target public detail total: 1048 slugs
+- expected locale rows for `en,zh`: 2036
+
+## Dry-Run Result
+
+The repo already contains the read-only scanner, candidate-prep planner, rollout
+manifest planner, and rollout gate planner for this path. The local authority
+scan command was attempted, but the developer database was unavailable, so a
+slug-level 1018 manifest was not generated in this PR.
+
+The dry-run therefore stops at a blocker state:
+
+- no explicit 1018 slug list was written
+- no runtime candidate rows were prepared
+- no rollout manifest was applied
+- no database/runtime promotion occurred
+
+## Required Blockers Before Apply
+
+Before `DETAIL_READY_1048_ROLLOUT_APPLY-01`, a later approved task must provide
+or regenerate the authority artifact proving:
+
+- exactly 30 current public baseline slugs
+- exactly 1018 ready-not-public delta slugs
+- no overlap between baseline and delta
+- no manual-hold slugs such as `software-developers`
+- no CN proxy rows
+- no review-needed, family-handoff, or blocked slugs
+- rollback group equals the 1018 delta slug list
+- `apply_allowed=false` remains true in the dry-run manifest
+
+## Boundaries
+
+This PR does not deploy, mutate CMS, run production migrations, enqueue Search
+Channel, submit URLs, call external search APIs, or publish Career pages.
+
+## Next Task
+
+`DETAIL_READY_1048_ROLLOUT_APPLY-01` must not start until the user explicitly
+approves DB/runtime promotion after reviewing a clean dry-run manifest.

--- a/backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json
+++ b/backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json
@@ -1,0 +1,108 @@
+{
+  "schema_version": "detail_ready_1048_rollout_dry_run.v1",
+  "task": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01",
+  "generated_at": "2026-05-28T10:58:00+08:00",
+  "final_decision": "detail_ready_1048_rollout_dry_run_blocked_pending_authority_scan",
+  "source_context": {
+    "previous_diagnosis_pr": "https://github.com/fermatmind/fap-api/pull/1737",
+    "previous_authority_alignment_pr": "https://github.com/fermatmind/fap-api/pull/1738",
+    "current_public_detail_count": 30,
+    "ready_not_public_delta_count": 1018,
+    "target_public_detail_total": 1048,
+    "locales": [
+      "en",
+      "zh"
+    ],
+    "expected_delta_locale_rows": 2036
+  },
+  "dry_run_scope": {
+    "scan_1018_delta": true,
+    "prepare_manifest_contract": true,
+    "record_blockers": true,
+    "runtime_promotion": false,
+    "db_apply": false,
+    "cms_mutation": false,
+    "deploy": false,
+    "search_channel_action": false,
+    "url_submission": false
+  },
+  "local_command_attempts": [
+    {
+      "command": "cd backend && php artisan career:audit-detail-ready-1048-candidates --json --output=/tmp/detail-ready-1048-dry-run/detail-ready-1048-scan.json",
+      "status": "blocked_local_environment",
+      "writes_database": false,
+      "failure_summary": "Local MySQL connection was unavailable, so the read-only authority scan could not enumerate the 1018 delta slugs."
+    }
+  ],
+  "manifest_contract": {
+    "schema_version": "career_delta_rollout_manifest.v1",
+    "target": "detail_ready_1048",
+    "target_key": "detail_ready_1048",
+    "target_public_total": 1048,
+    "published_baseline_count_required": 30,
+    "delta_slug_count_required": 1018,
+    "expected_delta_locale_rows": 2036,
+    "batch_id": "career_detail_ready_1048_canonical_001",
+    "rollback_group_rule": "rollback_group_must_equal_explicit_1018_delta_slug_list",
+    "dry_run_allowed_requires_clean_authority_scan": true,
+    "apply_allowed": false,
+    "rollout_apply_allowed": false,
+    "writes_database": false
+  },
+  "blockers": [
+    {
+      "reason": "authority_scan_unavailable_in_local_environment",
+      "severity": "blocking",
+      "evidence": "The read-only scanner could not connect to the local development MySQL database.",
+      "required_resolution": "Run the read-only scan in an environment with safe read access to the Career authority tables or provide a repo-backed scan artifact."
+    },
+    {
+      "reason": "explicit_1018_delta_slug_list_missing",
+      "severity": "blocking",
+      "evidence": "The current repo artifacts summarize the 1018 delta but do not include the slug-level list needed for rollback-group equality and blocker checks.",
+      "required_resolution": "Produce a JSON artifact with exactly 1018 ready-not-public slugs and exactly 30 baseline slugs."
+    },
+    {
+      "reason": "rollout_manifest_not_generated",
+      "severity": "blocking",
+      "evidence": "No slug-level manifest was generated because the authority scan was unavailable.",
+      "required_resolution": "Generate career_detail_ready_1048_rollout_manifest.json from a clean authority scan and candidate-prep plan."
+    },
+    {
+      "reason": "apply_requires_future_explicit_approval",
+      "severity": "blocking",
+      "evidence": "The user explicitly limited this PR to dry-run/manifest/blockers and did not authorize DB/runtime promotion.",
+      "required_resolution": "Start DETAIL_READY_1048_ROLLOUT_APPLY-01 only after explicit approval."
+    }
+  ],
+  "gates_required_before_apply": {
+    "current_public_baseline_count": 30,
+    "delta_slug_count": 1018,
+    "target_public_total": 1048,
+    "baseline_delta_overlap_count": 0,
+    "manual_hold_slugs_present": false,
+    "cn_proxy_rows_present": false,
+    "review_needed_rows_present": false,
+    "family_handoff_rows_present": false,
+    "blocked_rows_present": false,
+    "rollback_group_matches_delta": true,
+    "apply_allowed_must_remain_false_in_dry_run": true
+  },
+  "future_commands": {
+    "read_only_scan": "php artisan career:audit-detail-ready-1048-candidates --json --output=/tmp/career_detail_ready_1048_publication_scan.json",
+    "candidate_prep_plan": "php artisan career:plan-canonical-runtime-candidate-prep --target-delta=/tmp/career_detail_ready_1048_publication_scan.json --target-total=1048 --cohort=detail_ready_1048 --chunk-size=250 --json --output=/tmp/career_detail_ready_1048_runtime_candidate_prep_plan.json",
+    "manifest_plan": "php artisan career:generate-canonical-delta-rollout-manifest --target-delta=/tmp/career_detail_ready_1048_publication_scan.json --candidate-prep-plan=/tmp/career_detail_ready_1048_runtime_candidate_prep_plan.json --target=detail_ready_1048 --target-public-total=1048 --expect-delta-count=1018 --batch-id=career_detail_ready_1048_canonical_001 --json --output=/tmp/career_detail_ready_1048_rollout_manifest.json",
+    "gate_plan": "php artisan career:plan-canonical-delta-rollout-gate --manifest=/tmp/career_detail_ready_1048_rollout_manifest.json --target=detail_ready_1048 --target-public-total=1048 --expect-delta-count=1018 --json --output=/tmp/career_detail_ready_1048_rollout_gate.json"
+  },
+  "future_apply_requires_explicit_user_approval": true,
+  "apply_task_added_to_manifest": false,
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_pseo_generation": true,
+  "runtime_promotion_performed": false,
+  "database_write_performed": false,
+  "next_task": "DETAIL_READY_1048_ROLLOUT_APPLY-01"
+}

--- a/backend/tests/Feature/SeoIntel/DetailReady1048RolloutDryRun01Test.php
+++ b/backend/tests/Feature/SeoIntel/DetailReady1048RolloutDryRun01Test.php
@@ -1,0 +1,46 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class DetailReady1048RolloutDryRun01Test extends TestCase
+{
+    public function test_generated_dry_run_artifact_records_blockers_and_no_apply(): void
+    {
+        $path = base_path('docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json');
+
+        $this->assertFileExists($path);
+        $payload = json_decode((string) file_get_contents($path), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('DETAIL_READY_1048_ROLLOUT_DRY_RUN-01', $payload['task']);
+        $this->assertSame('detail_ready_1048_rollout_dry_run_blocked_pending_authority_scan', $payload['final_decision']);
+        $this->assertSame(30, $payload['source_context']['current_public_detail_count']);
+        $this->assertSame(1018, $payload['source_context']['ready_not_public_delta_count']);
+        $this->assertSame(1048, $payload['source_context']['target_public_detail_total']);
+        $this->assertSame(2036, $payload['source_context']['expected_delta_locale_rows']);
+        $this->assertSame('detail_ready_1048', $payload['manifest_contract']['target']);
+        $this->assertFalse($payload['manifest_contract']['apply_allowed']);
+        $this->assertFalse($payload['manifest_contract']['rollout_apply_allowed']);
+        $this->assertFalse($payload['manifest_contract']['writes_database']);
+        $this->assertFalse($payload['apply_task_added_to_manifest']);
+        $this->assertTrue($payload['future_apply_requires_explicit_user_approval']);
+        $this->assertTrue($payload['no_cms_mutation']);
+        $this->assertTrue($payload['no_deploy']);
+        $this->assertTrue($payload['no_search_channel_action']);
+        $this->assertTrue($payload['no_url_submission']);
+        $this->assertTrue($payload['no_external_search_api_call']);
+        $this->assertTrue($payload['no_pseo_generation']);
+        $this->assertFalse($payload['runtime_promotion_performed']);
+        $this->assertFalse($payload['database_write_performed']);
+        $this->assertSame('DETAIL_READY_1048_ROLLOUT_APPLY-01', $payload['next_task']);
+
+        $blockerReasons = array_column($payload['blockers'], 'reason');
+        $this->assertContains('authority_scan_unavailable_in_local_environment', $blockerReasons);
+        $this->assertContains('explicit_1018_delta_slug_list_missing', $blockerReasons);
+        $this->assertContains('rollout_manifest_not_generated', $blockerReasons);
+        $this->assertContains('apply_requires_future_explicit_approval', $blockerReasons);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-28T10:39:28+08:00",
+  "updated_at": "2026-05-28T11:02:29+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -21072,10 +21072,10 @@
       "repo": "fap-api",
       "branch": "codex/global-career-runtime-cohort-publish-authority-alignment-01",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "merged",
       "title": "GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01 career publish authority alignment",
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "e59b2e1eec484896994cc1eda02adb256b2b4d2a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1738",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -21129,6 +21129,10 @@
           "status": "pass",
           "command": "git diff --check && git diff --cached --check",
           "evidence": "No whitespace errors."
+        },
+        "ledger_reconciliation": {
+          "status": "pass",
+          "evidence": "GitHub reports PR #1738 as MERGED with merge commit e59b2e1eec484896994cc1eda02adb256b2b4d2a; origin/main contains the merge commit and remote-tracking branch was pruned."
         }
       },
       "scope": {
@@ -21151,9 +21155,9 @@
         "frontend_fallback_authority": false
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-28T02:48:30Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "next_task": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01",
       "events": [
         {
@@ -21170,6 +21174,122 @@
           "at": "2026-05-28T10:39:28+08:00",
           "status": "local_validation_passed",
           "summary": "Scoped tests, adjacent career detail/SEO tests, route list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks passed."
+        },
+        {
+          "at": "2026-05-28T10:57:01+08:00",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled PR #1738 merged state while starting DETAIL_READY_1048_ROLLOUT_DRY_RUN-01."
+        }
+      ]
+    },
+    "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01": {
+      "id": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01",
+      "repo": "fap-api",
+      "branch": "codex/detail-ready-1048-rollout-dry-run-01",
+      "base": "main",
+      "status": "pr_open",
+      "title": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01 detail-ready 1048 rollout dry-run manifest blockers",
+      "commit_sha": "9415093776fe84170df90a392f63fd0c201fe643",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1739",
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized DETAIL_READY_1048_ROLLOUT_DRY_RUN-01 manifest/state updates for the current PR only and instructed not to add DETAIL_READY_1048_ROLLOUT_APPLY-01 yet."
+        },
+        "local_authority_scan_attempt": {
+          "status": "blocked_external_local_env",
+          "command": "cd backend && php artisan career:audit-detail-ready-1048-candidates --json --output=/tmp/detail-ready-1048-dry-run/detail-ready-1048-scan.json",
+          "evidence": "Local MySQL connection was unavailable; no database write was attempted and no runtime promotion occurred."
+        },
+        "dry_run_artifact": {
+          "status": "pass",
+          "evidence": "Generated blocker-state dry-run artifact documenting the required 1018 delta manifest contract and apply approval gate."
+        },
+        "focused_test": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=DetailReady1048RolloutDryRun01 --no-ansi",
+          "evidence": "PASS: 1 test, 26 assertions."
+        },
+        "career_planner_regression_tests": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerRuntimeCandidatePrepPlanner --no-ansi && php artisan test --filter=CareerDeltaRolloutManifestPlanner --no-ansi && php artisan test --filter=CareerDeltaRolloutGatePlanner --no-ansi",
+          "evidence": "PASS: 10 tests / 58 assertions; 9 tests / 44 assertions; 10 tests / 49 assertions."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && yaml.safe_load(docs/codex/pr-train.yaml)",
+          "evidence": "Generated JSON, train state JSON, and train YAML parse successfully."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "PASS: route list generated successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "PASS: 3610 files."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "PASS: ./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "PASS: No security vulnerability advisories found."
+        },
+        "diff_checks": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "No whitespace errors."
+        }
+      },
+      "scope": {
+        "allowed_files": [
+          "backend/docs/seo/detail-ready-1048-rollout-dry-run-01.md",
+          "backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json",
+          "backend/tests/Feature/SeoIntel/DetailReady1048RolloutDryRun01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "cms_mutation": false,
+        "api_runtime_change": false,
+        "publish": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "url_submission": false,
+        "broad_pseo_generation": false,
+        "fap_web_modified": false,
+        "frontend_fallback_authority": false,
+        "apply_task_added_to_manifest": false
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "DETAIL_READY_1048_ROLLOUT_APPLY-01",
+      "events": [
+        {
+          "at": "2026-05-28T10:57:01+08:00",
+          "status": "manifest_registered",
+          "summary": "Registered current dry-run task after explicit user authorization. Did not add DETAIL_READY_1048_ROLLOUT_APPLY-01."
+        },
+        {
+          "at": "2026-05-28T10:57:01+08:00",
+          "status": "implementation_in_progress",
+          "summary": "Added read-only blocker-state dry-run report and focused test. No DB/runtime promotion, CMS mutation, deploy, Search Channel action, URL submission, or fap-web changes."
+        },
+        {
+          "at": "2026-05-28T10:59:39+08:00",
+          "status": "local_validation_passed",
+          "summary": "Focused dry-run test, adjacent career planner regression tests, route list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks passed. Real slug-level authority scan remains blocked by unavailable local MySQL and is recorded in the dry-run artifact."
+        },
+        {
+          "at": "2026-05-28T11:02:29+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1739 for the scoped dry-run artifact and blocker report."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15289,3 +15289,51 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DETAIL_READY_1048_ROLLOUT_DRY_RUN-01
+
+
+  - id: DETAIL_READY_1048_ROLLOUT_DRY_RUN-01
+    repo: fap-api
+    branch: codex/detail-ready-1048-rollout-dry-run-01
+    base: main
+    title: "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01 detail-ready 1048 rollout dry-run manifest blockers"
+    train_scope: career_detail_ready_1048_rollout_dry_run
+    risk_level: p1_career_runtime_publication_gate
+    depends_on:
+      - GLOBAL-CAREER-RUNTIME-COHORT-PUBLISH-AUTHORITY-ALIGNMENT-01
+    allowed_paths:
+      - backend/docs/seo/detail-ready-1048-rollout-dry-run-01.md
+      - backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json
+      - backend/tests/Feature/SeoIntel/DetailReady1048RolloutDryRun01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Record the read-only detail_ready_1048 rollout dry-run contract for the 1018 ready-not-public delta.
+      - Record blockers when a slug-level authority scan or explicit 1018 delta manifest is unavailable.
+      - Do not add DETAIL_READY_1048_ROLLOUT_APPLY-01 to manifest/state in this PR.
+      - Do not promote runtime rows, mutate CMS, deploy, enqueue Search Channel, submit URLs, run migrations, or use frontend fallback authority.
+    validation:
+      - cd backend && php artisan test --filter=DetailReady1048RolloutDryRun01 --no-ansi
+      - cd backend && php artisan test --filter=CareerRuntimeCandidatePrepPlanner --no-ansi
+      - cd backend && php artisan test --filter=CareerDeltaRolloutManifestPlanner --no-ansi
+      - cd backend && php artisan test --filter=CareerDeltaRolloutGatePlanner --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DETAIL_READY_1048_ROLLOUT_APPLY-01


### PR DESCRIPTION
## What changed
- Added a read-only DETAIL_READY_1048_ROLLOUT_DRY_RUN-01 report and generated JSON artifact for the 1018 ready-not-public career detail rollout path.
- Added a focused SeoIntel test asserting blocker-state dry-run semantics and no apply/write behavior.
- Registered only the current PR in pr-train manifest/state, reconciled merged PR #1738, and did not add DETAIL_READY_1048_ROLLOUT_APPLY-01.

## Why
The 1048 career detail rollout needs a slug-level dry-run manifest and blocker record before any future DB/runtime promotion. Local authority scan could not produce the real 1018 delta because the local MySQL development connection is unavailable, so this PR records the blocker state instead of pretending the rollout is ready.

## Validation
- cd backend && php artisan test --filter=DetailReady1048RolloutDryRun01 --no-ansi
- cd backend && php artisan test --filter=CareerRuntimeCandidatePrepPlanner --no-ansi
- cd backend && php artisan test --filter=CareerDeltaRolloutManifestPlanner --no-ansi
- cd backend && php artisan test --filter=CareerDeltaRolloutGatePlanner --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-rollout-dry-run-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- YAML parse for docs/codex/pr-train.yaml
- git diff --check && git diff --cached --check

## Intentionally deferred
- No DB/runtime promotion.
- No CMS mutation, deploy, Search Channel action, URL submission, or external search API call.
- No DETAIL_READY_1048_ROLLOUT_APPLY-01 manifest/state entry.
- Real 1018 slug-level delta manifest remains blocked until a safe authority scan is available and future explicit approval is given.