### PR TITLE
DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01 replacement authority import package

### DIFF
--- a/backend/docs/seo/detail-ready-1048-replacement-authority-import-01.md
+++ b/backend/docs/seo/detail-ready-1048-replacement-authority-import-01.md
@@ -1,0 +1,52 @@
+# DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01
+
+## Summary
+
+This PR prepares one repo-backed replacement authority import package for the
+`detail_ready_1048` career rollout path.
+
+The previous dry-run proved that the 1018 ready-not-public delta contains the
+manual-hold slug `software-developers`. Excluding that slug leaves only 1017
+delta members, so the rollout needs one additional qualified replacement before
+the clean 1018 manifest can be regenerated.
+
+## Replacement Candidate
+
+- slug: `computer-occupations-all-other`
+- observed occupation id: `019da904-3dbb-723b-ace7-532fb069b486`
+- observed authority: O*NET-SOC 2019 `15-1299.00`
+- current blocker: missing `us_soc` crosswalk and `career_job_public_display`
+  display asset
+
+The package proposes:
+
+- one `occupation_crosswalks` `us_soc` row derived from the observed O*NET-SOC
+  code
+- one `career_job_display_assets` `display.surface.v1` / `v4.2` import payload
+  with the required 24 component order and both `en` and `zh` page payloads
+
+## Boundaries
+
+This PR does not write production data, mutate CMS, publish career pages, deploy,
+enqueue Search Channel, submit URLs, or expose the replacement in sitemap/llms.
+
+The replacement remains import-package-only until a future explicitly approved
+controlled import task writes it into the backend authority tables. After that
+import, the 1048 authority scan must be rerun and the clean manifest must still
+exclude `software-developers`.
+
+## Expected Post-Import Shape
+
+- current public detail cohort: 30
+- existing detail-ready union: 1048
+- replacement added after import: 1
+- manual-hold slugs excluded: 1
+- clean target union excluding manual hold: 1048
+- clean ready-not-public delta: 1018
+- expected locale rows for the clean delta: 2036
+
+## Next Task
+
+`DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01` should rerun the slug-level
+authority scan only after the replacement import is explicitly reviewed and
+applied in a separate approved task.

--- a/backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json
+++ b/backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json
@@ -1,0 +1,116 @@
+{
+  "schema_version": "detail_ready_1048_replacement_authority_import.v1",
+  "task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01",
+  "generated_at": "2026-05-28T17:22:41+08:00",
+  "final_decision": "replacement_authority_import_package_ready_for_human_review",
+  "source_context": {
+    "previous_dry_run_pr": "https://github.com/fermatmind/fap-api/pull/1739",
+    "previous_dry_run_merge_commit": "683299199947e1495723e803b0694ba1751ceef4",
+    "current_public_detail_count": 30,
+    "existing_union_detail_ready_count": 1048,
+    "existing_ready_not_public_delta_count": 1018,
+    "manual_hold_slugs": [
+      "software-developers"
+    ],
+    "manual_hold_in_existing_delta": true,
+    "target_public_detail_total": 1048,
+    "locales": [
+      "en",
+      "zh"
+    ]
+  },
+  "replacement_candidate": {
+    "canonical_slug": "computer-occupations-all-other",
+    "occupation_id_observed": "019da904-3dbb-723b-ace7-532fb069b486",
+    "title_en": "Computer Occupations, All Other",
+    "title_zh": "计算机",
+    "authority_basis": "Existing production occupation row with O*NET-SOC 2019 crosswalk observed by read-only scan.",
+    "existing_crosswalks_observed": [
+      {
+        "source_system": "onet_soc_2019",
+        "source_code": "15-1299.00",
+        "source_title": "Computer Occupations, All Other",
+        "mapping_type": "directory_candidate",
+        "confidence_score": 0.5
+      }
+    ],
+    "missing_authority_before_import": [
+      "us_soc crosswalk row",
+      "career_job_public_display asset with display.surface.v1/v4.2 and 24 component order",
+      "human review of bilingual display copy before import"
+    ],
+    "why_selected": [
+      "Not currently in the detail_ready_1048 union.",
+      "Not a manual-hold slug.",
+      "Not a CN proxy slug.",
+      "Has a stable O*NET-SOC 2019 code that can be paired with a matching US SOC source code for review.",
+      "Keeps software-developers on manual hold while allowing a future clean 1018 delta after controlled import."
+    ]
+  },
+  "replacement_asset_plan": {
+    "package_path": "backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json",
+    "package_type": "career_detail_ready_replacement_authority_import",
+    "runtime_authority_after_import": [
+      "occupation_crosswalks.us_soc",
+      "career_job_display_assets.career_job_public_display"
+    ],
+    "display_surface_contract": {
+      "surface_version": "display.surface.v1",
+      "asset_version": "v4.2",
+      "template_version": "v4.2",
+      "asset_type": "career_job_public_display",
+      "asset_role": "formal_pilot_master",
+      "status_after_human_review": "ready_for_pilot",
+      "component_order_count": 24,
+      "requires_page_payload_zh": true,
+      "requires_page_payload_en": true
+    },
+    "claim_boundary": {
+      "no_precise_career_recommendation": true,
+      "no_best_career_claim": true,
+      "no_hiring_fit_claim": true,
+      "no_job_suitability_guarantee": true,
+      "no_salary_guarantee": true,
+      "no_career_success_prediction": true,
+      "occupation_information_only": true,
+      "decision_support_only": true
+    }
+  },
+  "post_import_expected_counts": {
+    "current_public_detail_count": 30,
+    "existing_union_detail_ready_count": 1048,
+    "replacement_added_to_union_after_import": 1,
+    "manual_hold_excluded_from_clean_manifest": 1,
+    "clean_union_excluding_manual_hold": 1048,
+    "clean_ready_not_public_delta_count": 1018,
+    "expected_locale_rows_for_clean_delta": 2036
+  },
+  "gates_before_next_manifest": {
+    "human_review_required": true,
+    "controlled_import_required": true,
+    "production_db_write_requires_future_explicit_approval": true,
+    "rerun_authority_scan_after_import": true,
+    "regenerate_candidate_prep_after_import": true,
+    "software_developers_must_remain_manual_hold": true,
+    "clean_manifest_must_exclude_manual_hold_slugs": true
+  },
+  "exposure_policy": {
+    "sitemap_eligible_in_this_pr": false,
+    "llms_eligible_in_this_pr": false,
+    "footer_eligible_in_this_pr": false,
+    "search_channel_eligible_in_this_pr": false,
+    "runtime_public_in_this_pr": false,
+    "draft_or_import_package_exposed": false
+  },
+  "no_cms_mutation": true,
+  "no_database_write": true,
+  "no_runtime_promotion": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_frontend_fallback_authority": true,
+  "no_pseo_generation": true,
+  "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01"
+}

--- a/backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json
+++ b/backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json
@@ -1,0 +1,169 @@
+{
+  "schema_version": "detail_ready_1048_replacement_authority_import_package.v1",
+  "task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01",
+  "package_type": "career_detail_ready_replacement_authority_import",
+  "generated_at": "2026-05-28T17:22:41+08:00",
+  "status": "human_review_required_before_import",
+  "write_policy": {
+    "dry_run_only_in_this_pr": true,
+    "no_cms_mutation_in_this_pr": true,
+    "no_database_write_in_this_pr": true,
+    "future_force_import_requires_explicit_user_approval": true,
+    "future_runtime_promotion_requires_separate_explicit_user_approval": true
+  },
+  "replacement_member": {
+    "canonical_slug": "computer-occupations-all-other",
+    "occupation_id_observed": "019da904-3dbb-723b-ace7-532fb069b486",
+    "title_en": "Computer Occupations, All Other",
+    "title_zh": "计算机",
+    "manual_hold": false,
+    "cn_proxy": false,
+    "existing_union_member": false,
+    "source_authority_observed": {
+      "source_system": "onet_soc_2019",
+      "source_code": "15-1299.00",
+      "source_title": "Computer Occupations, All Other",
+      "mapping_type": "directory_candidate",
+      "confidence_score": 0.5
+    },
+    "proposed_crosswalk_imports": [
+      {
+        "table": "occupation_crosswalks",
+        "source_system": "us_soc",
+        "source_code": "15-1299",
+        "source_title": "Computer Occupations, All Other",
+        "mapping_type": "same_soc_family_from_onet_soc_2019",
+        "confidence_score": 0.5,
+        "notes": "Derived from the observed O*NET-SOC 2019 code 15-1299.00; requires human review before controlled import."
+      }
+    ],
+    "proposed_display_asset_import": {
+      "table": "career_job_display_assets",
+      "canonical_slug": "computer-occupations-all-other",
+      "surface_version": "display.surface.v1",
+      "asset_version": "v4.2",
+      "template_version": "v4.2",
+      "asset_type": "career_job_public_display",
+      "asset_role": "formal_pilot_master",
+      "status": "ready_for_pilot",
+      "component_order_json": [
+        "breadcrumb",
+        "hero",
+        "fermat_decision_card",
+        "primary_cta",
+        "career_snapshot_primary_locale",
+        "career_snapshot_secondary_locale",
+        "fit_decision_checklist",
+        "riasec_fit_block",
+        "personality_fit_block",
+        "definition_block",
+        "responsibilities_block",
+        "work_context_block",
+        "market_signal_card",
+        "adjacent_career_comparison_table",
+        "ai_impact_table",
+        "career_risk_cards",
+        "contract_project_risk_block",
+        "next_steps_block",
+        "faq_block",
+        "related_next_pages",
+        "source_card",
+        "review_validity_card",
+        "boundary_notice",
+        "final_cta"
+      ],
+      "page_payload_json": {
+        "page": {
+          "en": {
+            "hero": {
+              "title": "Computer Occupations, All Other",
+              "subtitle": "Occupation information for roles grouped under O*NET-SOC 15-1299.00.",
+              "boundary": "Use this page as an occupational reference and decision-support signal, not as a hiring, salary, or career-success prediction."
+            },
+            "source_card": {
+              "source_system": "O*NET-SOC 2019",
+              "source_code": "15-1299.00",
+              "review_state": "human_review_required"
+            },
+            "boundary_notice": {
+              "copy": "This content describes occupation information only. It does not determine the best career for any person."
+            }
+          },
+          "zh": {
+            "hero": {
+              "title": "计算机相关职业（其他）",
+              "subtitle": "基于 O*NET-SOC 15-1299.00 的职业信息参考。",
+              "boundary": "本页仅作为职业信息与决策参考，不用于招聘适配、薪资预测或职业成功承诺。"
+            },
+            "source_card": {
+              "source_system": "O*NET-SOC 2019",
+              "source_code": "15-1299.00",
+              "review_state": "human_review_required"
+            },
+            "boundary_notice": {
+              "copy": "该内容只描述职业信息，不判断任何人的最佳职业。"
+            }
+          }
+        }
+      },
+      "seo_payload_json": {
+        "canonical_path_en": "/en/career/jobs/computer-occupations-all-other",
+        "canonical_path_zh": "/zh/career/jobs/computer-occupations-all-other",
+        "indexable_after_controlled_import_and_runtime_gate": true
+      },
+      "sources_json": {
+        "observed_source": "production read-only occupation row",
+        "source_system": "onet_soc_2019",
+        "source_code": "15-1299.00",
+        "human_review_required": true
+      },
+      "structured_data_json": {
+        "type": "OccupationInformation",
+        "authority_scope": "occupation_reference_only",
+        "emit_schema_after_runtime_gate": true
+      },
+      "implementation_contract_json": {
+        "must_have_component_order_count": 24,
+        "must_have_page_en": true,
+        "must_have_page_zh": true,
+        "must_not_include_release_gates_in_public_payload": true
+      },
+      "metadata_json": {
+        "replacement_for_manual_hold_slug": "software-developers",
+        "manual_hold_slug_remains_excluded": true,
+        "target": "detail_ready_1048",
+        "import_package": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01"
+      }
+    }
+  },
+  "claim_boundary": {
+    "forbidden_claims": [
+      "precise career recommendation",
+      "best career for you",
+      "hiring fit",
+      "job suitability guarantee",
+      "career success prediction",
+      "salary guarantee",
+      "MBTI determines career",
+      "RIASEC ranks best career",
+      "Big Five predicts job performance"
+    ],
+    "allowed_framing": [
+      "occupation information",
+      "career direction reference",
+      "workstyle tendency",
+      "interest signal",
+      "exploratory guidance",
+      "decision support",
+      "for reference only"
+    ]
+  },
+  "exposure_policy": {
+    "sitemap_eligible": false,
+    "llms_eligible": false,
+    "footer_eligible": false,
+    "search_channel_eligible": false,
+    "runtime_public": false
+  },
+  "next_required_action": "Run a controlled human-review import/dry-run for this replacement asset, then rerun the 1048 delta authority scan before any apply approval."
+}

--- a/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityImport01Test.php
+++ b/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityImport01Test.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class DetailReady1048ReplacementAuthorityImport01Test extends TestCase
+{
+    public function test_replacement_authority_import_package_is_review_only_and_not_exposed(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json');
+        $packagePath = base_path('docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json');
+
+        $this->assertFileExists($generatedPath);
+        $this->assertFileExists($packagePath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+        $package = json_decode((string) file_get_contents($packagePath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01', $generated['task'] ?? null);
+        $this->assertSame('replacement_authority_import_package_ready_for_human_review', $generated['final_decision'] ?? null);
+        $this->assertSame('career_detail_ready_replacement_authority_import', $package['package_type'] ?? null);
+
+        $this->assertSame(['software-developers'], $generated['source_context']['manual_hold_slugs'] ?? null);
+        $this->assertTrue($generated['source_context']['manual_hold_in_existing_delta'] ?? false);
+
+        $candidate = $generated['replacement_candidate'] ?? [];
+        $this->assertSame('computer-occupations-all-other', $candidate['canonical_slug'] ?? null);
+        $this->assertNotSame('software-developers', $candidate['canonical_slug'] ?? null);
+        $this->assertContains('Not a manual-hold slug.', $candidate['why_selected'] ?? []);
+        $this->assertContains('Not a CN proxy slug.', $candidate['why_selected'] ?? []);
+
+        $counts = $generated['post_import_expected_counts'] ?? [];
+        $this->assertSame(30, $counts['current_public_detail_count'] ?? null);
+        $this->assertSame(1048, $counts['existing_union_detail_ready_count'] ?? null);
+        $this->assertSame(1, $counts['replacement_added_to_union_after_import'] ?? null);
+        $this->assertSame(1, $counts['manual_hold_excluded_from_clean_manifest'] ?? null);
+        $this->assertSame(1048, $counts['clean_union_excluding_manual_hold'] ?? null);
+        $this->assertSame(1018, $counts['clean_ready_not_public_delta_count'] ?? null);
+        $this->assertSame(2036, $counts['expected_locale_rows_for_clean_delta'] ?? null);
+
+        $this->assertTrue($generated['gates_before_next_manifest']['human_review_required'] ?? false);
+        $this->assertTrue($generated['gates_before_next_manifest']['controlled_import_required'] ?? false);
+        $this->assertTrue($generated['gates_before_next_manifest']['production_db_write_requires_future_explicit_approval'] ?? false);
+        $this->assertTrue($generated['gates_before_next_manifest']['software_developers_must_remain_manual_hold'] ?? false);
+
+        foreach (['sitemap_eligible_in_this_pr', 'llms_eligible_in_this_pr', 'footer_eligible_in_this_pr', 'search_channel_eligible_in_this_pr', 'runtime_public_in_this_pr'] as $field) {
+            $this->assertFalse($generated['exposure_policy'][$field] ?? true, $field);
+        }
+
+        foreach (['no_cms_mutation', 'no_database_write', 'no_runtime_promotion', 'no_publish', 'no_deploy', 'no_search_channel_action', 'no_url_submission', 'no_external_search_api_call', 'no_frontend_fallback_authority', 'no_pseo_generation'] as $field) {
+            $this->assertTrue($generated[$field] ?? false, $field);
+        }
+
+        $member = $package['replacement_member'] ?? [];
+        $this->assertSame('computer-occupations-all-other', $member['canonical_slug'] ?? null);
+        $this->assertFalse($member['manual_hold'] ?? true);
+        $this->assertFalse($member['cn_proxy'] ?? true);
+        $this->assertFalse($member['existing_union_member'] ?? true);
+
+        $crosswalks = $member['proposed_crosswalk_imports'] ?? [];
+        $this->assertCount(1, $crosswalks);
+        $this->assertSame('us_soc', $crosswalks[0]['source_system'] ?? null);
+        $this->assertSame('15-1299', $crosswalks[0]['source_code'] ?? null);
+
+        $asset = $member['proposed_display_asset_import'] ?? [];
+        $this->assertSame('career_job_public_display', $asset['asset_type'] ?? null);
+        $this->assertSame('ready_for_pilot', $asset['status'] ?? null);
+        $this->assertCount(24, $asset['component_order_json'] ?? []);
+        $this->assertIsArray(data_get($asset, 'page_payload_json.page.en'));
+        $this->assertIsArray(data_get($asset, 'page_payload_json.page.zh'));
+
+        foreach (['sitemap_eligible', 'llms_eligible', 'footer_eligible', 'search_channel_eligible', 'runtime_public'] as $field) {
+            $this->assertFalse($package['exposure_policy'][$field] ?? true, $field);
+        }
+
+        $this->assertSame('DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01', $generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21187,9 +21187,9 @@
       "repo": "fap-api",
       "branch": "codex/detail-ready-1048-rollout-dry-run-01",
       "base": "main",
-      "status": "pr_open",
+      "status": "merged",
       "title": "DETAIL_READY_1048_ROLLOUT_DRY_RUN-01 detail-ready 1048 rollout dry-run manifest blockers",
-      "commit_sha": "9415093776fe84170df90a392f63fd0c201fe643",
+      "commit_sha": "683299199947e1495723e803b0694ba1751ceef4",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1739",
       "checks": {
         "manifest_registration": {
@@ -21266,9 +21266,9 @@
         "apply_task_added_to_manifest": false
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-28T03:10:25Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "next_task": "DETAIL_READY_1048_ROLLOUT_APPLY-01",
       "events": [
         {
@@ -21290,6 +21290,118 @@
           "at": "2026-05-28T11:02:29+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1739 for the scoped dry-run artifact and blocker report."
+        },
+        {
+          "at": "2026-05-28T17:22:41+08:00",
+          "status": "ledger_reconciled_merged",
+          "summary": "Reconciled PR #1739 merged state while starting DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01; GitHub reports merge commit 683299199947e1495723e803b0694ba1751ceef4 and the remote branch is absent."
+        }
+      ]
+    },
+    "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01": {
+      "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01",
+      "repo": "fap-api",
+      "branch": "codex/detail-ready-1048-replacement-authority-import-01",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01 replacement authority import package",
+      "commit_sha": "b0fdf1ae96e4484ee337f6d772d821931cf0e8ca",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1740",
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01 manifest/state updates for the current PR only."
+        },
+        "replacement_candidate_scan": {
+          "status": "pass",
+          "evidence": "Read-only scan found software-developers is the only manual-hold slug in the existing 1018 delta; computer-occupations-all-other is outside the current union, not manual-hold, not CN proxy, and has observed O*NET-SOC 2019 authority."
+        },
+        "import_package": {
+          "status": "pass",
+          "evidence": "Repo-backed replacement import package prepared for human review; no DB write, runtime promotion, CMS mutation, deploy, Search Channel action, URL submission, or fap-web change."
+        },
+        "focused_test": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityImport01 --no-ansi",
+          "evidence": "PASS: 1 test, 55 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "PASS: route list generated successfully with 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "PASS: 3611 files."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "PASS: ./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "PASS: No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json >/dev/null && python3 -m json.tool backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && yaml.safe_load(docs/codex/pr-train.yaml)",
+          "evidence": "Generated JSON, import package JSON, train state JSON, and train YAML parse successfully."
+        },
+        "diff_checks": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "No whitespace errors before staging."
+        }
+      },
+      "scope": {
+        "allowed_files": [
+          "backend/docs/seo/detail-ready-1048-replacement-authority-import-01.md",
+          "backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json",
+          "backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json",
+          "backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityImport01Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "cms_mutation": false,
+        "api_runtime_change": false,
+        "publish": false,
+        "deploy": false,
+        "search_channel_action": false,
+        "url_submission": false,
+        "broad_pseo_generation": false,
+        "fap_web_modified": false,
+        "frontend_fallback_authority": false,
+        "runtime_promotion": false,
+        "database_write": false
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
+      "events": [
+        {
+          "at": "2026-05-28T17:22:41+08:00",
+          "status": "manifest_registered",
+          "summary": "Registered current replacement authority import task after explicit user authorization."
+        },
+        {
+          "at": "2026-05-28T17:22:41+08:00",
+          "status": "implementation_in_progress",
+          "summary": "Preparing a non-runtime replacement authority import package for computer-occupations-all-other while preserving software-developers manual hold."
+        },
+        {
+          "at": "2026-05-28T17:22:41+08:00",
+          "status": "local_validation_passed",
+          "summary": "Focused replacement authority import test, route list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks passed. No production write, runtime promotion, CMS mutation, deploy, Search Channel action, URL submission, or fap-web change."
+        },
+        {
+          "at": "2026-05-28T17:22:41+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #1740 for the scoped replacement authority import package."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15337,3 +15337,50 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DETAIL_READY_1048_ROLLOUT_APPLY-01
+
+  - id: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01
+    repo: fap-api
+    branch: codex/detail-ready-1048-replacement-authority-import-01
+    base: main
+    title: "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01 replacement authority import package"
+    train_scope: career_detail_ready_1048_replacement_authority_import
+    risk_level: p1_career_runtime_publication_gate
+    depends_on:
+      - DETAIL_READY_1048_ROLLOUT_DRY_RUN-01
+    allowed_paths:
+      - backend/docs/seo/detail-ready-1048-replacement-authority-import-01.md
+      - backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json
+      - backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json
+      - backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityImport01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Prepare one repo-backed replacement authority import package for the detail_ready_1048 rollout path.
+      - Preserve software-developers as a manual-hold slug and do not release it in this PR.
+      - Use a real observed occupation authority candidate outside the current union and not a CN proxy/manual-hold slug.
+      - Record the missing us_soc crosswalk and career_job_public_display asset payload needed before a future clean 1018 manifest can be generated.
+      - Do not write production DB rows, mutate CMS, promote runtime rows, deploy, enqueue Search Channel, submit URLs, or use frontend fallback authority.
+    validation:
+      - cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityImport01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01


### PR DESCRIPTION
## What changed
- Added a repo-backed replacement authority import package for `computer-occupations-all-other`.
- Recorded the exact post-import count contract needed to keep `software-developers` on manual hold while restoring a clean 1018 delta path.
- Added a focused SeoIntel test for the generated report/import package and current PR-train ledger entry.
- Reconciled #1739 merged state in the ledger while adding only this current PR entry.

## Why
The real detail-ready scan showed the existing 1018 delta contains the manual-hold slug `software-developers`. Excluding it leaves only 1017 delta members. This PR prepares one non-runtime replacement authority package so a future explicitly approved import can add one replacement before regenerating a clean 1018 manifest.

## Validation
- `cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityImport01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-import-01.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml, pathlib
yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())
print('yaml ok')
PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production DB write or CMS mutation.
- No runtime promotion, sitemap/llms exposure, deploy, Search Channel action, or URL submission.
- The replacement still needs explicit human-review import approval before a clean 1018 delta manifest can be regenerated.

## Repository rule impact
This is a backend-authoritative, non-runtime import package for a career job display asset/crosswalk. It does not introduce frontend content authority or runtime exposure.