### PR TITLE
DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01 controlled replacement authority import path

### DIFF
--- a/backend/app/Console/Commands/CareerImportDetailReadyReplacementAuthority.php
+++ b/backend/app/Console/Commands/CareerImportDetailReadyReplacementAuthority.php
@@ -1,0 +1,446 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final class CareerImportDetailReadyReplacementAuthority extends Command
+{
+    private const COMMAND_NAME = 'career:import-detail-ready-replacement-authority';
+
+    private const VALIDATOR_VERSION = 'detail_ready_1048_replacement_authority_import_v0.1';
+
+    private const DEFAULT_PACKAGE = 'docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json';
+
+    private const EXPECTED_TASK = 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01';
+
+    private const TARGET_SLUG = 'computer-occupations-all-other';
+
+    private const MANUAL_HOLD_SLUG = 'software-developers';
+
+    private const EXPECTED_ONET_CODE = '15-1299.00';
+
+    private const EXPECTED_US_SOC_CODE = '15-1299';
+
+    private const CONFIRM_PHRASE = 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT_APPROVED';
+
+    /** @var list<string> */
+    private const FORBIDDEN_PUBLIC_KEYS = [
+        'release_gate',
+        'release_gates',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    protected $signature = 'career:import-detail-ready-replacement-authority
+        {--package= : Import package path; defaults to the repo-backed DETAIL_READY_1048 package}
+        {--apply : Write the reviewed replacement authority rows}
+        {--confirm= : Required confirmation phrase when --apply is used}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Validate and optionally import the reviewed detail-ready 1048 replacement authority package.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $apply = (bool) $this->option('apply');
+            $report['mode'] = $apply ? 'apply' : 'dry_run';
+
+            if ($apply && trim((string) $this->option('confirm')) !== self::CONFIRM_PHRASE) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => ['--confirm must equal '.self::CONFIRM_PHRASE.' when --apply is used.'],
+                ]), false);
+            }
+
+            $packagePath = $this->packagePath();
+            $package = $this->readJson($packagePath);
+            $plan = $this->validatePackage($package);
+            $report = array_merge($report, $plan['report'], [
+                'package_path' => $packagePath,
+                'package_sha256' => hash_file('sha256', $packagePath) ?: null,
+            ]);
+
+            if ($plan['errors'] !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $plan['errors'],
+                ]), false);
+            }
+
+            $report['would_write'] = true;
+            $report['decision'] = 'pass';
+
+            if (! $apply) {
+                return $this->finish($report, true);
+            }
+
+            $writeSummary = DB::transaction(function () use ($plan, $package, $packagePath): array {
+                /** @var Occupation $occupation */
+                $occupation = $plan['occupation'];
+                $crosswalkPayload = $plan['crosswalk_payload'];
+                $assetPayload = $plan['asset_payload'];
+
+                $importRun = CareerImportRun::query()->create([
+                    'dataset_name' => self::EXPECTED_TASK,
+                    'dataset_version' => (string) ($package['schema_version'] ?? 'unknown'),
+                    'dataset_checksum' => hash_file('sha256', $packagePath) ?: hash('sha256', json_encode($package, JSON_THROW_ON_ERROR)),
+                    'source_path' => $packagePath,
+                    'scope_mode' => 'detail_ready_replacement_authority',
+                    'dry_run' => false,
+                    'status' => 'completed',
+                    'started_at' => now(),
+                    'finished_at' => now(),
+                    'rows_seen' => 1,
+                    'rows_accepted' => 1,
+                    'rows_skipped' => 0,
+                    'rows_failed' => 0,
+                    'output_counts' => [
+                        'occupation_crosswalks' => 1,
+                        'career_job_display_assets' => 1,
+                        'index_states' => 0,
+                        'runtime_promotions' => 0,
+                    ],
+                    'error_summary' => [],
+                    'meta' => [
+                        'command' => self::COMMAND_NAME,
+                        'validator_version' => self::VALIDATOR_VERSION,
+                        'target_slug' => self::TARGET_SLUG,
+                        'manual_hold_slug_kept_excluded' => self::MANUAL_HOLD_SLUG,
+                        'runtime_promotion_performed' => false,
+                        'sitemap_llms_footer_exposure_performed' => false,
+                    ],
+                ]);
+
+                $crosswalk = OccupationCrosswalk::query()->updateOrCreate(
+                    [
+                        'occupation_id' => $occupation->id,
+                        'source_system' => (string) $crosswalkPayload['source_system'],
+                        'source_code' => (string) $crosswalkPayload['source_code'],
+                    ],
+                    [
+                        'source_title' => (string) $crosswalkPayload['source_title'],
+                        'mapping_type' => (string) $crosswalkPayload['mapping_type'],
+                        'confidence_score' => (float) $crosswalkPayload['confidence_score'],
+                        'notes' => (string) ($crosswalkPayload['notes'] ?? ''),
+                        'import_run_id' => $importRun->id,
+                        'row_fingerprint' => hash('sha256', implode('|', [
+                            self::EXPECTED_TASK,
+                            self::TARGET_SLUG,
+                            (string) $crosswalkPayload['source_system'],
+                            (string) $crosswalkPayload['source_code'],
+                        ])),
+                    ]
+                );
+
+                $asset = CareerJobDisplayAsset::query()->updateOrCreate(
+                    [
+                        'canonical_slug' => self::TARGET_SLUG,
+                        'asset_version' => (string) $assetPayload['asset_version'],
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'surface_version' => (string) $assetPayload['surface_version'],
+                        'template_version' => (string) $assetPayload['template_version'],
+                        'asset_type' => (string) $assetPayload['asset_type'],
+                        'asset_role' => (string) $assetPayload['asset_role'],
+                        'status' => (string) $assetPayload['status'],
+                        'component_order_json' => $assetPayload['component_order_json'],
+                        'page_payload_json' => $assetPayload['page_payload_json'],
+                        'seo_payload_json' => $assetPayload['seo_payload_json'] ?? null,
+                        'sources_json' => $assetPayload['sources_json'] ?? null,
+                        'structured_data_json' => $assetPayload['structured_data_json'] ?? null,
+                        'implementation_contract_json' => $assetPayload['implementation_contract_json'] ?? null,
+                        'metadata_json' => array_merge((array) ($assetPayload['metadata_json'] ?? []), [
+                            'controlled_import_task' => 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01',
+                            'runtime_promotion_performed' => false,
+                        ]),
+                        'import_run_id' => $importRun->id,
+                    ]
+                );
+
+                return [
+                    'import_run_id' => $importRun->id,
+                    'crosswalk_id' => $crosswalk->id,
+                    'display_asset_id' => $asset->id,
+                ];
+            });
+
+            return $this->finish(array_merge($report, $writeSummary, [
+                'did_write' => true,
+                'runtime_promotion_performed' => false,
+                'index_state_rows_written' => 0,
+            ]), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'mode' => 'dry_run',
+            'target_slug' => self::TARGET_SLUG,
+            'manual_hold_slug_kept_excluded' => self::MANUAL_HOLD_SLUG,
+            'occupation_found' => false,
+            'observed_onet_crosswalk_valid' => false,
+            'replacement_us_soc_valid' => false,
+            'display_asset_valid' => false,
+            'public_payload_forbidden_keys_found' => [],
+            'would_write' => false,
+            'did_write' => false,
+            'runtime_promotion_performed' => false,
+            'sitemap_llms_footer_exposure_performed' => false,
+            'decision' => 'fail',
+            'errors' => [],
+        ];
+    }
+
+    private function packagePath(): string
+    {
+        $path = trim((string) $this->option('package'));
+        if ($path === '') {
+            $path = base_path(self::DEFAULT_PACKAGE);
+        } elseif (! str_starts_with($path, '/')) {
+            $path = base_path($path);
+        }
+
+        if (! is_file($path)) {
+            throw new \RuntimeException('--package does not exist: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Invalid JSON package: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array{report: array<string, mixed>, errors: list<string>, occupation?: Occupation, crosswalk_payload?: array<string, mixed>, asset_payload?: array<string, mixed>}
+     */
+    private function validatePackage(array $package): array
+    {
+        $errors = [];
+        $member = $this->arrayValue($package, 'replacement_member');
+        $asset = $this->arrayValue($member, 'proposed_display_asset_import');
+        $crosswalks = $member['proposed_crosswalk_imports'] ?? [];
+        $crosswalk = is_array($crosswalks) && is_array($crosswalks[0] ?? null) ? $crosswalks[0] : [];
+        $exposure = $this->arrayValue($package, 'exposure_policy');
+
+        $slug = $this->stringValue($member, 'canonical_slug');
+        $this->expect(($package['task'] ?? null) === self::EXPECTED_TASK, 'package.task must match '.self::EXPECTED_TASK.'.', $errors);
+        $this->expect(($package['package_type'] ?? null) === 'career_detail_ready_replacement_authority_import', 'package_type must be career_detail_ready_replacement_authority_import.', $errors);
+        $this->expect($slug === self::TARGET_SLUG, 'replacement_member.canonical_slug must be '.self::TARGET_SLUG.'.', $errors);
+        $this->expect((bool) ($member['manual_hold'] ?? true) === false, 'replacement_member.manual_hold must be false.', $errors);
+        $this->expect((bool) ($member['cn_proxy'] ?? true) === false, 'replacement_member.cn_proxy must be false.', $errors);
+        $this->expect((bool) ($member['existing_union_member'] ?? true) === false, 'replacement_member.existing_union_member must be false.', $errors);
+
+        foreach (['sitemap_eligible', 'llms_eligible', 'footer_eligible', 'search_channel_eligible', 'runtime_public'] as $flag) {
+            $this->expect(($exposure[$flag] ?? null) === false, 'exposure_policy.'.$flag.' must be false.', $errors);
+        }
+
+        $occupation = Occupation::query()
+            ->where('canonical_slug', self::TARGET_SLUG)
+            ->when($this->stringValue($member, 'occupation_id_observed') !== '', fn ($query) => $query->whereKey($this->stringValue($member, 'occupation_id_observed')))
+            ->first();
+        $occupationFound = $occupation instanceof Occupation;
+        $observedOnetValid = $occupationFound && $this->hasCrosswalk($occupation, 'onet_soc_2019', self::EXPECTED_ONET_CODE);
+
+        $replacementUsSocValid = $this->stringValue($crosswalk, 'source_system') === 'us_soc'
+            && $this->stringValue($crosswalk, 'source_code') === self::EXPECTED_US_SOC_CODE
+            && $this->stringValue($crosswalk, 'source_title') !== ''
+            && $this->stringValue($crosswalk, 'mapping_type') === 'same_soc_family_from_onet_soc_2019';
+
+        $displayAssetValid = $this->stringValue($asset, 'canonical_slug') === self::TARGET_SLUG
+            && $this->stringValue($asset, 'surface_version') === 'display.surface.v1'
+            && $this->stringValue($asset, 'asset_version') === 'v4.2'
+            && $this->stringValue($asset, 'template_version') === 'v4.2'
+            && $this->stringValue($asset, 'asset_type') === 'career_job_public_display'
+            && $this->stringValue($asset, 'asset_role') === 'formal_pilot_master'
+            && $this->stringValue($asset, 'status') === 'ready_for_pilot';
+
+        $componentOrder = $asset['component_order_json'] ?? null;
+        $pagePayload = $asset['page_payload_json'] ?? null;
+        $this->expect($occupationFound, 'Target occupation row must exist before controlled import.', $errors);
+        $this->expect($observedOnetValid, 'Target occupation must have observed O*NET-SOC 2019 crosswalk '.self::EXPECTED_ONET_CODE.'.', $errors);
+        $this->expect($replacementUsSocValid, 'Replacement us_soc crosswalk payload is invalid.', $errors);
+        $this->expect($displayAssetValid, 'Replacement display asset payload is invalid.', $errors);
+        $this->expect(is_array($componentOrder) && count($componentOrder) === 24, 'component_order_json must contain 24 components.', $errors);
+        $this->expect(is_array($pagePayload) && is_array($pagePayload['page']['en'] ?? null), 'page_payload_json.page.en must exist.', $errors);
+        $this->expect(is_array($pagePayload) && is_array($pagePayload['page']['zh'] ?? null), 'page_payload_json.page.zh must exist.', $errors);
+
+        $forbiddenKeys = $this->forbiddenPublicKeys([
+            'component_order_json' => $componentOrder,
+            'page_payload_json' => $pagePayload,
+            'seo_payload_json' => $asset['seo_payload_json'] ?? [],
+            'sources_json' => $asset['sources_json'] ?? [],
+            'structured_data_json' => $asset['structured_data_json'] ?? [],
+            'implementation_contract_json' => $asset['implementation_contract_json'] ?? [],
+        ]);
+        if ($forbiddenKeys !== []) {
+            $errors[] = 'Forbidden public payload keys found: '.implode(', ', $forbiddenKeys).'.';
+        }
+
+        $existingIndexStateRows = $occupationFound ? IndexState::query()->where('occupation_id', $occupation->id)->count() : 0;
+        $existingIndexableStateRows = $occupationFound ? IndexState::query()
+            ->where('occupation_id', $occupation->id)
+            ->where('index_eligible', true)
+            ->count() : 0;
+        $this->expect($existingIndexableStateRows === 0, 'Controlled replacement import must not target an already indexable occupation.', $errors);
+
+        $report = [
+            'target_slug' => $slug,
+            'occupation_found' => $occupationFound,
+            'observed_onet_crosswalk_valid' => $observedOnetValid,
+            'replacement_us_soc_valid' => $replacementUsSocValid,
+            'display_asset_valid' => $displayAssetValid,
+            'public_payload_forbidden_keys_found' => $forbiddenKeys,
+            'existing_index_state_rows' => $existingIndexStateRows,
+            'existing_indexable_state_rows' => $existingIndexableStateRows,
+            'planned_writes' => [
+                'occupation_crosswalks' => 1,
+                'career_job_display_assets' => 1,
+                'career_import_runs' => 1,
+                'index_states' => 0,
+                'runtime_promotions' => 0,
+            ],
+        ];
+
+        $plan = [
+            'report' => $report,
+            'errors' => $errors,
+        ];
+
+        if ($occupationFound) {
+            $plan['occupation'] = $occupation;
+        }
+        if (is_array($crosswalk)) {
+            $plan['crosswalk_payload'] = $crosswalk;
+        }
+        if (is_array($asset)) {
+            $plan['asset_payload'] = $asset;
+        }
+
+        return $plan;
+    }
+
+    private function hasCrosswalk(Occupation $occupation, string $sourceSystem, string $sourceCode): bool
+    {
+        return OccupationCrosswalk::query()
+            ->where('occupation_id', $occupation->id)
+            ->where('source_system', $sourceSystem)
+            ->where('source_code', $sourceCode)
+            ->exists();
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     * @return list<string>
+     */
+    private function forbiddenPublicKeys(array $payload, string $prefix = ''): array
+    {
+        $found = [];
+        foreach ($payload as $key => $value) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.(string) $key;
+            if (is_string($key) && in_array($key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                $found[] = $path;
+            }
+            if (is_array($value)) {
+                array_push($found, ...$this->forbiddenPublicKeys($value, $path));
+            }
+        }
+
+        return array_values(array_unique($found));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function arrayValue(array $payload, string $key): array
+    {
+        return is_array($payload[$key] ?? null) ? $payload[$key] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function stringValue(array $payload, string $key): string
+    {
+        return is_string($payload[$key] ?? null) ? trim((string) $payload[$key]) : '';
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            $json = '{}';
+        }
+
+        $output = trim((string) $this->option('output'));
+        if ($output !== '') {
+            file_put_contents($output, $json.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($json);
+        } elseif ($success) {
+            $this->info((string) ($report['mode'] ?? 'dry_run').' complete: '.$report['decision']);
+        } else {
+            $this->error('import failed: '.implode('; ', (array) ($report['errors'] ?? [])));
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        return preg_replace('/\\s+/', ' ', trim($throwable->getMessage())) ?: $throwable::class;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -44,6 +44,7 @@ use App\Console\Commands\CareerGenerateCanonicalExpansionManifestTrain;
 use App\Console\Commands\CareerGenerateCanonicalProgressiveRolloutManifest;
 use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
+use App\Console\Commands\CareerImportDetailReadyReplacementAuthority;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
@@ -221,6 +222,7 @@ class Kernel extends ConsoleKernel
         CareerAlignSelectedOnetCrosswalks::class,
         CareerImportActorsDisplayAsset::class,
         CareerImportAuthorityWave::class,
+        CareerImportDetailReadyReplacementAuthority::class,
         CareerImportOccupationDirectoryDrafts::class,
         CareerImportOccupationDirectoryDryRun::class,
         CareerImportSelectedDisplayAssets::class,

--- a/backend/docs/seo/detail-ready-1048-replacement-authority-controlled-import-01.md
+++ b/backend/docs/seo/detail-ready-1048-replacement-authority-controlled-import-01.md
@@ -1,0 +1,58 @@
+# DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01
+
+## Summary
+
+This PR adds a controlled backend import path for the reviewed
+`DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01` package.
+
+It does not run the import against production, promote the 1048 runtime cohort,
+publish career pages, expose sitemap/llms/footer URLs, deploy, or enqueue Search
+Channel.
+
+## Controlled Import Path
+
+New command:
+
+```bash
+php artisan career:import-detail-ready-replacement-authority --json
+```
+
+Default mode is dry-run and writes no rows.
+
+The write path requires:
+
+```bash
+php artisan career:import-detail-ready-replacement-authority \
+  --apply \
+  --confirm=DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT_APPROVED \
+  --json
+```
+
+When explicitly confirmed, the command writes only:
+
+- one `career_import_runs` ledger row
+- one `occupation_crosswalks` `us_soc` row for `computer-occupations-all-other`
+- one `career_job_display_assets` `display.surface.v1` / `v4.2` row
+
+It intentionally writes zero `index_states` rows and performs zero runtime
+promotion actions.
+
+## Guardrails
+
+- target slug is fixed to `computer-occupations-all-other`
+- `software-developers` remains manual hold
+- target occupation must already exist
+- target occupation must already have observed O*NET-SOC 2019 authority
+  `15-1299.00`
+- replacement `us_soc` source code must be `15-1299`
+- display asset must have `display.surface.v1`, `v4.2`, 24 components, and both
+  EN/ZH page payloads
+- sitemap, llms, footer, Search Channel, and runtime public exposure are not
+  changed
+
+## Next Task
+
+After an explicitly approved controlled import is actually executed in the
+target authority environment, run `DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01`
+to regenerate the clean 1018 manifest while keeping `software-developers`
+excluded.

--- a/backend/docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json
+++ b/backend/docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json
@@ -1,0 +1,51 @@
+{
+  "schema_version": "detail_ready_1048_replacement_authority_controlled_import.v1",
+  "task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01",
+  "final_decision": "controlled_import_path_ready_requires_explicit_apply_execution",
+  "source_import_package": "backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-import-01.import.v1.json",
+  "target_slug": "computer-occupations-all-other",
+  "manual_hold_slugs_preserved": [
+    "software-developers"
+  ],
+  "controlled_import_command": "php artisan career:import-detail-ready-replacement-authority --json",
+  "controlled_apply_command": "php artisan career:import-detail-ready-replacement-authority --apply --confirm=DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT_APPROVED --json",
+  "default_mode": "dry_run",
+  "apply_requires_confirmation": true,
+  "confirmation_phrase": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT_APPROVED",
+  "write_scope_when_confirmed": {
+    "career_import_runs": 1,
+    "occupation_crosswalks": 1,
+    "career_job_display_assets": 1,
+    "index_states": 0,
+    "runtime_promotions": 0,
+    "sitemap_exposure": 0,
+    "llms_exposure": 0,
+    "footer_exposure": 0,
+    "search_channel_actions": 0
+  },
+  "validation_guards": {
+    "target_slug_fixed": true,
+    "target_occupation_must_exist": true,
+    "observed_onet_crosswalk_required": "15-1299.00",
+    "replacement_us_soc_required": "15-1299",
+    "display_surface_version_required": "display.surface.v1",
+    "asset_version_required": "v4.2",
+    "component_order_count_required": 24,
+    "page_payload_en_required": true,
+    "page_payload_zh_required": true,
+    "existing_indexable_state_blocks_import": true,
+    "forbidden_public_payload_keys_block_import": true
+  },
+  "no_deploy": true,
+  "no_publish": true,
+  "no_runtime_promotion": true,
+  "no_sitemap_llms_footer_exposure": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_frontend_fallback_authority": true,
+  "production_import_executed_in_this_pr": false,
+  "future_explicit_apply_execution_required": true,
+  "next_task_after_import_execution": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
+  "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01"
+}

--- a/backend/tests/Feature/Console/CareerImportDetailReadyReplacementAuthorityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportDetailReadyReplacementAuthorityCommandTest.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerImportDetailReadyReplacementAuthorityCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COMMAND = 'career:import-detail-ready-replacement-authority';
+
+    private const CONFIRM = 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT_APPROVED';
+
+    #[Test]
+    public function dry_run_validates_package_without_writing_authority_rows(): void
+    {
+        $this->createReplacementOccupation();
+
+        [$exitCode, $report] = $this->runImport();
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['would_write']);
+        $this->assertFalse($report['did_write']);
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(1, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    #[Test]
+    public function apply_requires_exact_confirmation_phrase(): void
+    {
+        $this->createReplacementOccupation();
+
+        [$exitCode, $report] = $this->runImport(['--apply' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('--confirm must equal', implode(' ', $report['errors']));
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(1, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    #[Test]
+    public function confirmed_apply_writes_only_crosswalk_display_asset_and_import_run(): void
+    {
+        $occupation = $this->createReplacementOccupation();
+
+        [$exitCode, $report] = $this->runImport([
+            '--apply' => true,
+            '--confirm' => self::CONFIRM,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('apply', $report['mode']);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['did_write']);
+        $this->assertFalse($report['runtime_promotion_performed']);
+        $this->assertSame(0, $report['index_state_rows_written']);
+        $this->assertSame(1, CareerImportRun::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+
+        $this->assertDatabaseHas('occupation_crosswalks', [
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => '15-1299',
+            'source_title' => 'Computer Occupations, All Other',
+            'mapping_type' => 'same_soc_family_from_onet_soc_2019',
+        ]);
+        $this->assertDatabaseHas('career_job_display_assets', [
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => 'computer-occupations-all-other',
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+        ]);
+
+        $asset = CareerJobDisplayAsset::query()->firstOrFail();
+        $this->assertIsArray($asset->page_payload_json['page']['en'] ?? null);
+        $this->assertIsArray($asset->page_payload_json['page']['zh'] ?? null);
+        $this->assertSame(24, count($asset->component_order_json));
+        $this->assertFalse((bool) ($asset->metadata_json['runtime_promotion_performed'] ?? true));
+    }
+
+    #[Test]
+    public function repeated_apply_updates_same_authority_rows_without_duplicates(): void
+    {
+        $this->createReplacementOccupation();
+
+        $this->runImport(['--apply' => true, '--confirm' => self::CONFIRM]);
+        [$exitCode, $report] = $this->runImport(['--apply' => true, '--confirm' => self::CONFIRM]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(2, CareerImportRun::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    #[Test]
+    public function missing_observed_onet_authority_blocks_import(): void
+    {
+        $this->createReplacementOccupation(withOnetCrosswalk: false);
+
+        [$exitCode, $report] = $this->runImport([
+            '--apply' => true,
+            '--confirm' => self::CONFIRM,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($report['observed_onet_crosswalk_valid']);
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    #[Test]
+    public function indexed_occupation_blocks_replacement_import(): void
+    {
+        $occupation = $this->createReplacementOccupation();
+        IndexState::query()->create([
+            'occupation_id' => $occupation->id,
+            'index_state' => 'indexable',
+            'index_eligible' => true,
+            'canonical_path' => '/en/career/jobs/computer-occupations-all-other',
+            'reason_codes' => [],
+            'changed_at' => now(),
+        ]);
+
+        [$exitCode, $report] = $this->runImport([
+            '--apply' => true,
+            '--confirm' => self::CONFIRM,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame(1, $report['existing_index_state_rows']);
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    /**
+     * @return array{0:int, 1:array<string,mixed>}
+     */
+    private function runImport(array $options = []): array
+    {
+        $exitCode = Artisan::call(self::COMMAND, array_merge([
+            '--json' => true,
+        ], $options));
+
+        $report = json_decode(Artisan::output(), true);
+        $this->assertIsArray($report, Artisan::output());
+
+        return [$exitCode, $report];
+    }
+
+    private function createReplacementOccupation(bool $withOnetCrosswalk = true): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'computer-occupations',
+            'title_en' => 'Computer Occupations',
+            'title_zh' => '计算机职业',
+        ]);
+
+        $occupation = Occupation::query()->create([
+            'id' => '019da904-3dbb-723b-ace7-532fb069b486',
+            'family_id' => $family->id,
+            'canonical_slug' => 'computer-occupations-all-other',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'directory_candidate',
+            'canonical_title_en' => 'Computer Occupations, All Other',
+            'canonical_title_zh' => '计算机',
+            'search_h1_zh' => '计算机相关职业（其他）',
+        ]);
+
+        if ($withOnetCrosswalk) {
+            OccupationCrosswalk::query()->create([
+                'occupation_id' => $occupation->id,
+                'source_system' => 'onet_soc_2019',
+                'source_code' => '15-1299.00',
+                'source_title' => 'Computer Occupations, All Other',
+                'mapping_type' => 'directory_candidate',
+                'confidence_score' => 0.5,
+            ]);
+        }
+
+        return $occupation;
+    }
+}

--- a/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityControlledImport01Test.php
+++ b/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityControlledImport01Test.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class DetailReady1048ReplacementAuthorityControlledImport01Test extends TestCase
+{
+    public function test_controlled_import_report_exists_and_preserves_non_public_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+        $this->assertSame('detail_ready_1048_replacement_authority_controlled_import.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01', $payload['task'] ?? null);
+        $this->assertSame('computer-occupations-all-other', $payload['target_slug'] ?? null);
+        $this->assertContains('software-developers', $payload['manual_hold_slugs_preserved'] ?? []);
+        $this->assertSame('dry_run', $payload['default_mode'] ?? null);
+        $this->assertTrue($payload['apply_requires_confirmation'] ?? false);
+        $this->assertTrue($payload['no_deploy'] ?? false);
+        $this->assertTrue($payload['no_publish'] ?? false);
+        $this->assertTrue($payload['no_runtime_promotion'] ?? false);
+        $this->assertTrue($payload['no_sitemap_llms_footer_exposure'] ?? false);
+        $this->assertTrue($payload['no_search_channel_action'] ?? false);
+        $this->assertTrue($payload['no_url_submission'] ?? false);
+        $this->assertFalse($payload['production_import_executed_in_this_pr'] ?? true);
+        $this->assertSame(0, $payload['write_scope_when_confirmed']['index_states'] ?? null);
+        $this->assertSame(0, $payload['write_scope_when_confirmed']['runtime_promotions'] ?? null);
+        $this->assertSame('DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01', $payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-28T11:02:29+08:00",
+  "updated_at": "2026-05-28T09:57:28Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -21303,9 +21303,9 @@
       "repo": "fap-api",
       "branch": "codex/detail-ready-1048-replacement-authority-import-01",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "merged",
       "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01 replacement authority import package",
-      "commit_sha": "b0fdf1ae96e4484ee337f6d772d821931cf0e8ca",
+      "commit_sha": "0a5a5fcf80481bfd491a2f7f8d171ec2f6c70a2d",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1740",
       "checks": {
         "manifest_registration": {
@@ -21354,6 +21354,14 @@
           "status": "pass",
           "command": "git diff --check && git diff --cached --check",
           "evidence": "No whitespace errors before staging."
+        },
+        "github_checks": {
+          "status": "pass",
+          "evidence": "PR #1740 merged with required checks green; merge commit 0777aaf359387ee49b33df5b75c130f6244695d0."
+        },
+        "local_cleanup": {
+          "status": "partial",
+          "evidence": "Remote branch was deleted by GitHub merge. Local cleanup script scripts/post_merge_cleanup.sh was absent in this clone; no local task branch remained after merge checkout."
         }
       },
       "scope": {
@@ -21378,8 +21386,8 @@
         "database_write": false
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
+      "merged_at": "2026-05-28T09:38:08Z",
+      "remote_branch_deleted": true,
       "local_cleanup_executed": false,
       "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
       "events": [
@@ -21402,6 +21410,102 @@
           "at": "2026-05-28T17:22:41+08:00",
           "status": "pr_open",
           "summary": "Opened PR #1740 for the scoped replacement authority import package."
+        }
+      ],
+      "merge_commit": "0777aaf359387ee49b33df5b75c130f6244695d0",
+      "transitions": [
+        {
+          "at": "2026-05-28T09:51:44Z",
+          "status": "merged_reconciled",
+          "summary": "Reconciled PR #1740 merged state while starting DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01."
+        }
+      ]
+    },
+    "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01": {
+      "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01",
+      "repo": "fap-api",
+      "branch": "codex/detail-ready-1048-replacement-authority-controlled-import-01",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01 controlled replacement authority import path",
+      "commit_sha": "9ffff45d90e4f386164be2bcbf202b236fe71302",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1741",
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01 manifest/state updates for the current PR only and a controlled import path using the repo-backed import package."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "Current PR must not deploy, publish runtime pages, promote the 1048 cohort, expose sitemap/llms/footer, mutate production CMS outside the controlled import path, or release software-developers from manual hold."
+        },
+        "focused_command_test": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthorityCommandTest --no-ansi",
+          "evidence": "PASS: 6 tests, 52 assertions."
+        },
+        "focused_report_test": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityControlledImport01 --no-ansi",
+          "evidence": "PASS: 1 test, 18 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "PASS: route list generated successfully with 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "PASS: 3614 files."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "PASS: ./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "PASS: No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && yaml.safe_load(docs/codex/pr-train.yaml)",
+          "evidence": "PASS: generated JSON, state JSON, and manifest YAML parse."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "PASS: no whitespace errors."
+        },
+        "pr_opened": {
+          "status": "pass",
+          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1741."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "merge_commit": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
+      "sidecars": [],
+      "transitions": [
+        {
+          "at": "2026-05-28T09:51:44Z",
+          "status": "in_progress",
+          "summary": "Registered current controlled import path task after explicit user authorization. Did not add future task entries."
+        },
+        {
+          "at": "2026-05-28T09:53:42Z",
+          "status": "local_validation_passed",
+          "summary": "Implemented controlled replacement authority import command, report, focused tests, and current manifest/state entry. No production import, deploy, publish, runtime promotion, or discoverability exposure performed."
+        },
+        {
+          "at": "2026-05-28T09:57:28Z",
+          "status": "pr_opened",
+          "summary": "Opened PR #1741 for controlled replacement authority import path."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15384,3 +15384,52 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01
+
+  - id: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01
+    repo: fap-api
+    branch: codex/detail-ready-1048-replacement-authority-controlled-import-01
+    base: main
+    title: "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01 controlled replacement authority import path"
+    train_scope: career_detail_ready_1048_replacement_authority_controlled_import
+    risk_level: p1_career_runtime_publication_gate
+    depends_on:
+      - DETAIL_READY_1048_REPLACEMENT_AUTHORITY_IMPORT-01
+    allowed_paths:
+      - backend/app/Console/Commands/CareerImportDetailReadyReplacementAuthority.php
+      - backend/app/Console/Kernel.php
+      - backend/docs/seo/detail-ready-1048-replacement-authority-controlled-import-01.md
+      - backend/docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json
+      - backend/tests/Feature/Console/CareerImportDetailReadyReplacementAuthorityCommandTest.php
+      - backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityControlledImport01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a controlled backend import path for the reviewed DETAIL_READY_1048 replacement import package.
+      - Default to dry-run and require an exact confirmation phrase before local/test authority writes.
+      - When explicitly confirmed, write only a career_import_runs ledger row, one us_soc occupation_crosswalk, and one career_job_display_assets row for computer-occupations-all-other.
+      - Preserve software-developers as manual hold and do not release it in this PR.
+      - Do not promote runtime rows, write index_states, publish career pages, deploy, expose sitemap/llms/footer, enqueue Search Channel, submit URLs, or use frontend fallback authority.
+    validation:
+      - cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthorityCommandTest --no-ansi
+      - cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityControlledImport01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01


### PR DESCRIPTION
## What changed
- Added a controlled backend import command for the reviewed DETAIL_READY_1048 replacement package.
- Registered the command in the console kernel and added focused command/report tests.
- Added a scoped report and current PR train ledger entry; reconciled PR #1740 merged state.

## Why
- The clean 1018 detail-ready manifest needs one replacement authority asset while keeping software-developers on manual hold.
- This creates a guarded path to import only the replacement authority rows before rerunning the delta authority repair scan.

## Validation
- cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthorityCommandTest --no-ansi
- cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityControlledImport01 --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-controlled-import-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 YAML parse for docs/codex/pr-train.yaml
- git diff --check && git diff --cached --check

## Intentionally deferred
- No production import was executed.
- No deploy, runtime promotion, index_states writes, sitemap/llms/footer exposure, Search Channel action, or URL submission.
- DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01 remains next after the controlled import is explicitly executed in the target authority environment.

## Repository rule impact
- Backend remains the authority for career job content and public eligibility. This PR adds a guarded backend import path only; it does not move any content authority into fap-web or fallback content.