### PR TITLE
DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01 replacement authority candidate reselect

### DIFF
--- a/backend/docs/seo/detail-ready-1048-replacement-authority-reselect-01.md
+++ b/backend/docs/seo/detail-ready-1048-replacement-authority-reselect-01.md
@@ -1,0 +1,94 @@
+# DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01
+
+## Executive Summary
+
+This task re-ran the replacement candidate selection after the previously selected replacement, `computer-occupations-all-other`, was found to be already indexable in production authority.
+
+Final decision: `blocked_no_eligible_replacement_candidate`.
+
+No new controlled import package was generated because no candidate satisfied the required replacement gates.
+
+## Selection Gates
+
+The replacement candidate must be:
+
+- outside the current 1048 detail-ready union
+- non-indexable
+- not `software-developers`
+- not manual-hold
+- not blocked
+- not a CN proxy / CN directory row
+- backed by O*NET/SOC authority, or safely importable through the controlled O*NET/SOC authority path
+- compatible with controlled v4.2 public display asset import
+- not exposed in sitemap, llms, footer, or runtime in this PR
+
+## Read-Only Production Authority Evidence
+
+Command used:
+
+```bash
+php artisan career:audit-detail-ready-1048-candidates --json --output=/tmp/detail-ready-1048-reselect-scan.json
+```
+
+Observed counts:
+
+- current public detail: 30
+- union detail ready: 1048
+- ready not currently public: 1018
+- manual-hold ready: 1
+- raw occupation assets: 2786
+- outside-union non-indexable rows: 1543
+- outside-union non-indexable rows with O*NET-SOC 2019 crosswalk: 0
+- outside-union non-indexable rows with display asset: 0
+- legacy career_jobs rows outside union: 36
+
+## Previous Candidate Disqualification
+
+`computer-occupations-all-other` is not usable as the replacement now:
+
+- occupation row exists
+- observed O*NET-SOC 2019 crosswalk exists
+- existing index state rows: 2
+- existing indexable state rows: 2
+- disqualification: already indexable
+
+The controlled import command correctly failed dry-run rather than writing authority rows.
+
+## Rejected Candidate Classes
+
+### CN directory/proxy rows
+
+The 1543 outside-union non-indexable rows are not acceptable replacement authority because they are CN directory/proxy-style rows. They must not be counted toward the product-visible 1048 claim.
+
+### Legacy career_jobs rows
+
+The 36 legacy `career_jobs` rows outside the union are not acceptable replacement authority because the 1048 cohort is based on occupation foundation authority plus runtime projection gates, not legacy job content rows.
+
+### Already indexable occupation rows
+
+Rows such as `computer-occupations-all-other` fail the replacement gate because the replacement must be non-indexable before controlled import.
+
+## Boundaries Preserved
+
+- No CMS mutation
+- No production DB write
+- No runtime promotion
+- No publish
+- No deploy
+- No Search Channel action
+- No URL submission
+- No frontend fallback authority
+- No sitemap / llms / footer exposure
+- `software-developers` remains on manual hold
+
+## Next Task
+
+Recommended next task:
+
+`DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01`
+
+Purpose: create or identify a real non-CN, O*NET/SOC-backed, non-indexable occupation authority row with controlled v4.2 display asset readiness before generating a new replacement import package.
+
+Only after that import succeeds should the train return to:
+
+`DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01`

--- a/backend/docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json
+++ b/backend/docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json
@@ -1,0 +1,125 @@
+{
+  "schema_version": "detail_ready_1048_replacement_authority_reselect.v1",
+  "task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01",
+  "generated_at": "2026-05-28T18:48:00+08:00",
+  "final_decision": "blocked_no_eligible_replacement_candidate",
+  "source_context": {
+    "previous_controlled_import_pr": "https://github.com/fermatmind/fap-api/pull/1741",
+    "previous_replacement_slug": "computer-occupations-all-other",
+    "previous_replacement_status": "already_indexable_in_production_authority",
+    "manual_hold_slugs": [
+      "software-developers"
+    ],
+    "read_only_scan_command": "php artisan career:audit-detail-ready-1048-candidates --json --output=/tmp/detail-ready-1048-reselect-scan.json",
+    "read_only_scan_environment": "production authority environment",
+    "scan_writes_database": false
+  },
+  "candidate_requirements": {
+    "must_be_outside_current_1048_union": true,
+    "must_be_non_indexable": true,
+    "must_not_be_manual_hold": true,
+    "must_not_be_blocked": true,
+    "must_not_be_cn_proxy": true,
+    "must_have_observed_onet_soc_2019_crosswalk": true,
+    "must_have_or_accept_controlled_us_soc_crosswalk": true,
+    "must_have_or_accept_controlled_display_asset_v4_2": true,
+    "must_not_expose_sitemap_llms_footer_in_this_pr": true
+  },
+  "production_authority_scan_summary": {
+    "current_public_detail": 30,
+    "union_detail_ready": 1048,
+    "ready_not_currently_public": 1018,
+    "manual_hold_ready": 1,
+    "raw_occupation_assets": 2786,
+    "outside_union_nonindexable_rows": 1543,
+    "outside_union_nonindexable_with_any_crosswalk": 1543,
+    "outside_union_nonindexable_with_onet_soc_2019_crosswalk": 0,
+    "outside_union_nonindexable_with_display_asset": 0,
+    "legacy_career_jobs_outside_union": 36,
+    "legacy_career_jobs_are_not_detail_ready_replacement_authority": true
+  },
+  "previous_replacement_disqualification": {
+    "canonical_slug": "computer-occupations-all-other",
+    "occupation_found": true,
+    "observed_onet_crosswalk_valid": true,
+    "display_asset_rows": 0,
+    "existing_index_state_rows": 2,
+    "existing_indexable_state_rows": 2,
+    "disqualification_reason": "already_indexable",
+    "manual_hold_slug_kept_excluded": "software-developers"
+  },
+  "candidate_selection_result": {
+    "selected": false,
+    "selected_slug": null,
+    "new_import_package_generated": false,
+    "reason": "No production authority row outside the current 1048 union satisfied all replacement gates. Rows outside the union are either CN directory/proxy-style rows without O*NET/SOC detail authority, lack display-ready v4.2 assets, or belong to legacy career_jobs content rather than the occupation authority source required for the 1048 cohort.",
+    "blocked_on": [
+      "outside_union_nonindexable_with_onet_soc_2019_crosswalk_zero",
+      "outside_union_nonindexable_with_display_asset_zero",
+      "legacy_career_jobs_not_valid_replacement_authority",
+      "computer_occupations_all_other_already_indexable"
+    ]
+  },
+  "rejected_candidate_classes": [
+    {
+      "class": "cn_directory_proxy_rows",
+      "count": 1543,
+      "accepted": false,
+      "reason": "CN directory/proxy rows are explicitly outside the detail-ready public replacement authority gate and must not be counted toward the product-visible 1048 claim."
+    },
+    {
+      "class": "legacy_career_jobs_rows",
+      "count": 36,
+      "accepted": false,
+      "reason": "Legacy career_jobs rows are not occupation foundation authority and include legacy content/claim surfaces that require a separate review path."
+    },
+    {
+      "class": "already_indexable_occupation_rows",
+      "example_slug": "computer-occupations-all-other",
+      "accepted": false,
+      "reason": "Replacement must be non-indexable before controlled import; this slug already has indexable index_states."
+    }
+  ],
+  "exposure_policy": {
+    "sitemap_eligible_in_this_pr": false,
+    "llms_eligible_in_this_pr": false,
+    "footer_eligible_in_this_pr": false,
+    "search_channel_eligible_in_this_pr": false,
+    "runtime_public_in_this_pr": false
+  },
+  "claim_boundary": {
+    "career_claim_expansion_performed": false,
+    "forbidden_claims_checked": [
+      "precise career recommendation",
+      "best career for you",
+      "hiring fit",
+      "job suitability guarantee",
+      "career success prediction",
+      "salary guarantee",
+      "MBTI determines career",
+      "RIASEC ranks best career",
+      "Big Five predicts job performance"
+    ]
+  },
+  "recommended_next_tasks": [
+    {
+      "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01",
+      "reason": "Create or identify a real non-CN, O*NET/SOC-backed, non-indexable occupation authority row with controlled v4.2 display asset readiness before generating a new replacement import package."
+    },
+    {
+      "id": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
+      "reason": "Run only after a valid replacement has been imported into the authority source; then regenerate the clean 1018 manifest while keeping software-developers on manual hold."
+    }
+  ],
+  "no_cms_mutation": true,
+  "no_database_write": true,
+  "no_runtime_promotion": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_frontend_fallback_authority": true,
+  "no_pseo_generation": true,
+  "next_task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01"
+}

--- a/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityReselect01Test.php
+++ b/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityReselect01Test.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class DetailReady1048ReplacementAuthorityReselect01Test extends TestCase
+{
+    public function test_reselect_report_blocks_package_when_no_eligible_replacement_exists(): void
+    {
+        $path = base_path('docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('detail_ready_1048_replacement_authority_reselect.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01', $payload['task'] ?? null);
+        $this->assertSame('blocked_no_eligible_replacement_candidate', $payload['final_decision'] ?? null);
+
+        $requirements = $payload['candidate_requirements'] ?? [];
+        $this->assertTrue($requirements['must_be_outside_current_1048_union'] ?? false);
+        $this->assertTrue($requirements['must_be_non_indexable'] ?? false);
+        $this->assertTrue($requirements['must_not_be_manual_hold'] ?? false);
+        $this->assertTrue($requirements['must_not_be_blocked'] ?? false);
+        $this->assertTrue($requirements['must_not_be_cn_proxy'] ?? false);
+
+        $summary = $payload['production_authority_scan_summary'] ?? [];
+        $this->assertSame(1048, $summary['union_detail_ready'] ?? null);
+        $this->assertSame(1018, $summary['ready_not_currently_public'] ?? null);
+        $this->assertSame(0, $summary['outside_union_nonindexable_with_onet_soc_2019_crosswalk'] ?? null);
+        $this->assertSame(0, $summary['outside_union_nonindexable_with_display_asset'] ?? null);
+
+        $previous = $payload['previous_replacement_disqualification'] ?? [];
+        $this->assertSame('computer-occupations-all-other', $previous['canonical_slug'] ?? null);
+        $this->assertSame(2, $previous['existing_indexable_state_rows'] ?? null);
+        $this->assertSame('already_indexable', $previous['disqualification_reason'] ?? null);
+
+        $selection = $payload['candidate_selection_result'] ?? [];
+        $this->assertFalse($selection['selected'] ?? true);
+        $this->assertNull($selection['selected_slug'] ?? null);
+        $this->assertFalse($selection['new_import_package_generated'] ?? true);
+        $this->assertContains('legacy_career_jobs_not_valid_replacement_authority', $selection['blocked_on'] ?? []);
+
+        foreach (['sitemap_eligible_in_this_pr', 'llms_eligible_in_this_pr', 'footer_eligible_in_this_pr', 'search_channel_eligible_in_this_pr', 'runtime_public_in_this_pr'] as $field) {
+            $this->assertFalse($payload['exposure_policy'][$field] ?? true, $field);
+        }
+
+        foreach (['no_cms_mutation', 'no_database_write', 'no_runtime_promotion', 'no_publish', 'no_deploy', 'no_search_channel_action', 'no_url_submission', 'no_external_search_api_call', 'no_frontend_fallback_authority', 'no_pseo_generation'] as $field) {
+            $this->assertTrue($payload[$field] ?? false, $field);
+        }
+
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01', $payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -27831,6 +27831,93 @@
           "summary": "Opened PR #1708 after local validation; waiting for GitHub required checks."
         }
       ]
+    },
+    "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01": {
+      "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01",
+      "repo": "fap-api",
+      "branch": "codex/detail-ready-1048-replacement-authority-reselect-01",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01 replacement authority candidate reselect",
+      "commit_sha": "7e37665337189060202c4a36a67cfad0a0bb44a5",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1742",
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01 manifest/state updates for the current PR only."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "No deploy, publish, runtime promotion, production write, sitemap/llms/footer exposure, Search Channel action, URL submission, fap-web change, or frontend fallback authority allowed."
+        },
+        "focused_report_test": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityReselect01 --no-ansi",
+          "evidence": "PASS: 1 test, 36 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "PASS: route list generated successfully with 203 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "PASS: 3615 files."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "PASS: ./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "PASS: No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && yaml.safe_load(docs/codex/pr-train.yaml)",
+          "evidence": "Generated JSON, state JSON, and train YAML parse successfully."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "PASS: no whitespace errors."
+        },
+        "candidate_selection": {
+          "status": "blocked_no_eligible_replacement_candidate",
+          "evidence": "Read-only production authority scan found outside_union_nonindexable_with_onet_soc_2019_crosswalk=0 and outside_union_nonindexable_with_display_asset=0; previous candidate computer-occupations-all-other has existing_indexable_state_rows=2."
+        },
+        "pr_opened": {
+          "status": "pass",
+          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1742."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "merge_commit": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01",
+      "sidecars": [],
+      "transitions": [
+        {
+          "at": "2026-05-28T18:48:00+08:00",
+          "status": "in_progress",
+          "summary": "Registered current replacement authority reselect task after explicit user authorization. Did not add future task entries."
+        },
+        {
+          "at": "2026-05-28T18:58:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Generated reselect report/test. No eligible replacement candidate exists under the non-indexable, non-CN, non-manual-hold, authority-sufficient gate; no import package generated."
+        },
+        {
+          "at": "2026-05-28T19:02:00+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1742 after local validation; waiting for GitHub required checks."
+        }
+      ]
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15433,3 +15433,46 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01
+  - id: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01
+    repo: fap-api
+    branch: codex/detail-ready-1048-replacement-authority-reselect-01
+    base: main
+    title: "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01 replacement authority candidate reselect"
+    train_scope: career_detail_ready_1048_replacement_authority_reselect
+    risk_level: p1_career_runtime_publication_gate
+    depends_on:
+      - DETAIL_READY_1048_REPLACEMENT_AUTHORITY_CONTROLLED_IMPORT-01
+    allowed_paths:
+      - backend/docs/seo/detail-ready-1048-replacement-authority-reselect-01.md
+      - backend/docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json
+      - backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityReselect01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Reselect a replacement authority candidate after computer-occupations-all-other was found already indexable in production authority.
+      - Use read-only authority evidence to require the replacement candidate to be non-indexable, non-manual-hold, non-blocked, non-CN-proxy, outside the current 1048 union, and authority-sufficient.
+      - Generate a scoped reselect report and block package generation if no candidate satisfies the authority gate.
+      - Do not deploy, publish runtime pages, promote the 1048 cohort, write production DB rows, expose sitemap/llms/footer, enqueue Search Channel, submit URLs, or use frontend fallback authority.
+    validation:
+      - cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityReselect01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01


### PR DESCRIPTION
## What changed
- Added a scoped DETAIL_READY_1048 replacement reselect report and generated JSON artifact.
- Added a focused SeoIntel test proving no eligible replacement package is generated when the authority gate has no qualifying candidate.
- Added the current PR entry to the PR train manifest/state only.

## Why
The previously selected replacement, computer-occupations-all-other, is already indexable in production authority. A read-only production authority scan found no outside-union, non-indexable, non-CN, O*NET/SOC-backed display-ready candidate. Creating a new import package would fake authority, so this PR records the blocker and routes to source repair.

## Validation
- cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityReselect01 --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-reselect-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- JSON/YAML parse
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No import package generated because no candidate satisfies the authority gate.
- No production write, CMS mutation, deploy, runtime promotion, sitemap/llms/footer exposure, Search Channel action, URL submission, pSEO generation, or fap-web change.
- Next task should create or identify a real replacement authority source before returning to DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01.

## Repository rule impact
No content ownership or runtime authority rule changes. This PR preserves backend authority boundaries and records that frontend fallback or legacy career_jobs rows cannot be used as replacement authority.