### PR TITLE
DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01 controlled replacement authority source import path

### DIFF
--- a/backend/app/Console/Commands/CareerImportDetailReadyReplacementAuthoritySource.php
+++ b/backend/app/Console/Commands/CareerImportDetailReadyReplacementAuthoritySource.php
@@ -1,0 +1,515 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use Throwable;
+
+final class CareerImportDetailReadyReplacementAuthoritySource extends Command
+{
+    private const COMMAND_NAME = 'career:import-detail-ready-replacement-authority-source';
+
+    private const VALIDATOR_VERSION = 'detail_ready_1048_replacement_authority_source_import_v0.1';
+
+    private const DEFAULT_PACKAGE = 'docs/seo/import-packages/detail-ready-1048-replacement-authority-source-repair-01.import.v1.json';
+
+    private const EXPECTED_TASK = 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01';
+
+    private const EXPECTED_PACKAGE_TYPE = 'career_detail_ready_replacement_authority_source_repair';
+
+    private const TARGET_SLUG = 'digital-forensics-analysts';
+
+    private const TARGET_FAMILY_SLUG = 'computer-and-information-technology';
+
+    private const MANUAL_HOLD_SLUG = 'software-developers';
+
+    private const EXPECTED_ONET_CODE = '15-1299.06';
+
+    private const EXPECTED_US_SOC_CODE = '15-1299';
+
+    private const CONFIRM_PHRASE = 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT_APPROVED';
+
+    /** @var list<string> */
+    private const FORBIDDEN_PUBLIC_KEYS = [
+        'release_gate',
+        'release_gates',
+        'qa_risk',
+        'admin_review_state',
+        'tracking_json',
+        'raw_ai_exposure_score',
+    ];
+
+    protected $signature = 'career:import-detail-ready-replacement-authority-source
+        {--package= : Source repair package path; defaults to the repo-backed source repair package}
+        {--apply : Write the reviewed replacement authority source rows}
+        {--confirm= : Required confirmation phrase when --apply is used}
+        {--json : Emit machine-readable report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Validate and optionally import the reviewed detail-ready 1048 replacement authority source package.';
+
+    public function handle(): int
+    {
+        $report = $this->baseReport();
+
+        try {
+            $apply = (bool) $this->option('apply');
+            $report['mode'] = $apply ? 'apply' : 'dry_run';
+
+            if ($apply && trim((string) $this->option('confirm')) !== self::CONFIRM_PHRASE) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => ['--confirm must equal '.self::CONFIRM_PHRASE.' when --apply is used.'],
+                ]), false);
+            }
+
+            $packagePath = $this->packagePath();
+            $package = $this->readJson($packagePath);
+            $plan = $this->validatePackage($package);
+            $report = array_merge($report, $plan['report'], [
+                'package_path' => $packagePath,
+                'package_sha256' => hash_file('sha256', $packagePath) ?: null,
+            ]);
+
+            if ($plan['errors'] !== []) {
+                return $this->finish(array_merge($report, [
+                    'decision' => 'fail',
+                    'errors' => $plan['errors'],
+                ]), false);
+            }
+
+            $report['would_write'] = true;
+            $report['decision'] = 'pass';
+
+            if (! $apply) {
+                return $this->finish($report, true);
+            }
+
+            $writeSummary = DB::transaction(function () use ($plan, $package, $packagePath): array {
+                $familyPayload = $plan['family_payload'];
+                $occupationPayload = $plan['occupation_payload'];
+                $crosswalkPayloads = $plan['crosswalk_payloads'];
+                $assetPayload = $plan['asset_payload'];
+
+                $importRun = CareerImportRun::query()->create([
+                    'dataset_name' => 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01',
+                    'dataset_version' => (string) ($package['schema_version'] ?? 'unknown'),
+                    'dataset_checksum' => hash_file('sha256', $packagePath) ?: hash('sha256', json_encode($package, JSON_THROW_ON_ERROR)),
+                    'source_path' => $packagePath,
+                    'scope_mode' => 'detail_ready_replacement_authority_source',
+                    'dry_run' => false,
+                    'status' => 'completed',
+                    'started_at' => now(),
+                    'finished_at' => now(),
+                    'rows_seen' => 1,
+                    'rows_accepted' => 1,
+                    'rows_skipped' => 0,
+                    'rows_failed' => 0,
+                    'output_counts' => [
+                        'occupation_families' => 1,
+                        'occupations' => 1,
+                        'occupation_crosswalks' => count($crosswalkPayloads),
+                        'career_job_display_assets' => 1,
+                        'index_states' => 0,
+                        'runtime_promotions' => 0,
+                    ],
+                    'error_summary' => [],
+                    'meta' => [
+                        'command' => self::COMMAND_NAME,
+                        'validator_version' => self::VALIDATOR_VERSION,
+                        'target_slug' => self::TARGET_SLUG,
+                        'manual_hold_slug_kept_excluded' => self::MANUAL_HOLD_SLUG,
+                        'runtime_promotion_performed' => false,
+                        'sitemap_llms_footer_exposure_performed' => false,
+                    ],
+                ]);
+
+                $family = OccupationFamily::query()->updateOrCreate(
+                    ['canonical_slug' => self::TARGET_FAMILY_SLUG],
+                    [
+                        'title_en' => (string) $familyPayload['title_en'],
+                        'title_zh' => (string) $familyPayload['title_zh'],
+                    ]
+                );
+
+                $occupation = Occupation::query()->updateOrCreate(
+                    ['canonical_slug' => self::TARGET_SLUG],
+                    [
+                        'family_id' => $family->id,
+                        'entity_level' => (string) $occupationPayload['entity_level'],
+                        'truth_market' => (string) $occupationPayload['truth_market'],
+                        'display_market' => (string) $occupationPayload['display_market'],
+                        'crosswalk_mode' => (string) $occupationPayload['crosswalk_mode'],
+                        'canonical_title_en' => (string) $occupationPayload['canonical_title_en'],
+                        'canonical_title_zh' => (string) $occupationPayload['canonical_title_zh'],
+                        'search_h1_zh' => (string) $occupationPayload['search_h1_zh'],
+                    ]
+                );
+
+                $crosswalkIds = [];
+                foreach ($crosswalkPayloads as $crosswalkPayload) {
+                    $crosswalk = OccupationCrosswalk::query()->updateOrCreate(
+                        [
+                            'occupation_id' => $occupation->id,
+                            'source_system' => (string) $crosswalkPayload['source_system'],
+                            'source_code' => (string) $crosswalkPayload['source_code'],
+                        ],
+                        [
+                            'source_title' => (string) $crosswalkPayload['source_title'],
+                            'mapping_type' => (string) $crosswalkPayload['mapping_type'],
+                            'confidence_score' => (float) $crosswalkPayload['confidence_score'],
+                            'notes' => (string) ($crosswalkPayload['notes'] ?? ''),
+                            'import_run_id' => $importRun->id,
+                            'row_fingerprint' => hash('sha256', implode('|', [
+                                'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01',
+                                self::TARGET_SLUG,
+                                (string) $crosswalkPayload['source_system'],
+                                (string) $crosswalkPayload['source_code'],
+                            ])),
+                        ]
+                    );
+                    $crosswalkIds[] = $crosswalk->id;
+                }
+
+                $asset = CareerJobDisplayAsset::query()->updateOrCreate(
+                    [
+                        'canonical_slug' => self::TARGET_SLUG,
+                        'asset_version' => (string) $assetPayload['asset_version'],
+                    ],
+                    [
+                        'occupation_id' => $occupation->id,
+                        'surface_version' => (string) $assetPayload['surface_version'],
+                        'template_version' => (string) $assetPayload['template_version'],
+                        'asset_type' => (string) $assetPayload['asset_type'],
+                        'asset_role' => (string) $assetPayload['asset_role'],
+                        'status' => (string) $assetPayload['status'],
+                        'component_order_json' => $assetPayload['component_order_json'],
+                        'page_payload_json' => $assetPayload['page_payload_json'],
+                        'seo_payload_json' => $assetPayload['seo_payload_json'] ?? null,
+                        'sources_json' => $assetPayload['sources_json'] ?? null,
+                        'structured_data_json' => $assetPayload['structured_data_json'] ?? null,
+                        'implementation_contract_json' => $assetPayload['implementation_contract_json'] ?? null,
+                        'metadata_json' => array_merge((array) ($assetPayload['metadata_json'] ?? []), [
+                            'controlled_import_task' => 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01',
+                            'runtime_promotion_performed' => false,
+                        ]),
+                        'import_run_id' => $importRun->id,
+                    ]
+                );
+
+                return [
+                    'import_run_id' => $importRun->id,
+                    'family_id' => $family->id,
+                    'occupation_id' => $occupation->id,
+                    'crosswalk_ids' => $crosswalkIds,
+                    'display_asset_id' => $asset->id,
+                ];
+            });
+
+            return $this->finish(array_merge($report, $writeSummary, [
+                'did_write' => true,
+                'runtime_promotion_performed' => false,
+                'index_state_rows_written' => 0,
+            ]), true);
+        } catch (Throwable $throwable) {
+            return $this->finish(array_merge($report, [
+                'decision' => 'fail',
+                'errors' => [$this->safeErrorMessage($throwable)],
+            ]), false);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function baseReport(): array
+    {
+        return [
+            'command' => self::COMMAND_NAME,
+            'validator_version' => self::VALIDATOR_VERSION,
+            'mode' => 'dry_run',
+            'target_slug' => self::TARGET_SLUG,
+            'manual_hold_slug_kept_excluded' => self::MANUAL_HOLD_SLUG,
+            'family_valid' => false,
+            'occupation_valid' => false,
+            'onet_crosswalk_valid' => false,
+            'us_soc_crosswalk_valid' => false,
+            'display_asset_valid' => false,
+            'public_payload_forbidden_keys_found' => [],
+            'existing_occupation_found' => false,
+            'existing_index_state_rows' => 0,
+            'existing_indexable_state_rows' => 0,
+            'would_write' => false,
+            'did_write' => false,
+            'runtime_promotion_performed' => false,
+            'sitemap_llms_footer_exposure_performed' => false,
+            'decision' => 'fail',
+            'errors' => [],
+        ];
+    }
+
+    private function packagePath(): string
+    {
+        $path = trim((string) $this->option('package'));
+        if ($path === '') {
+            $path = base_path(self::DEFAULT_PACKAGE);
+        } elseif (! str_starts_with($path, '/')) {
+            $path = base_path($path);
+        }
+
+        if (! is_file($path)) {
+            throw new \RuntimeException('--package does not exist: '.$path);
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Invalid JSON package: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string, mixed>  $package
+     * @return array{report: array<string, mixed>, errors: list<string>, family_payload?: array<string, mixed>, occupation_payload?: array<string, mixed>, crosswalk_payloads?: list<array<string, mixed>>, asset_payload?: array<string, mixed>}
+     */
+    private function validatePackage(array $package): array
+    {
+        $errors = [];
+        $source = $this->arrayValue($package, 'replacement_source');
+        $family = $this->arrayValue($source, 'proposed_family_import');
+        $occupation = $this->arrayValue($source, 'proposed_occupation_import');
+        $asset = $this->arrayValue($source, 'proposed_display_asset_import');
+        $crosswalks = $source['proposed_crosswalk_imports'] ?? [];
+        $crosswalks = is_array($crosswalks) ? array_values(array_filter($crosswalks, 'is_array')) : [];
+        $exposure = $this->arrayValue($package, 'exposure_policy');
+
+        $this->expect(($package['task'] ?? null) === self::EXPECTED_TASK, 'package.task must match '.self::EXPECTED_TASK.'.', $errors);
+        $this->expect(($package['package_type'] ?? null) === self::EXPECTED_PACKAGE_TYPE, 'package_type must be '.self::EXPECTED_PACKAGE_TYPE.'.', $errors);
+
+        $this->expect($this->stringValue($source, 'canonical_slug') === self::TARGET_SLUG, 'replacement_source.canonical_slug must be '.self::TARGET_SLUG.'.', $errors);
+        $this->expect((bool) ($source['manual_hold'] ?? true) === false, 'replacement_source.manual_hold must be false.', $errors);
+        $this->expect((bool) ($source['cn_proxy'] ?? true) === false, 'replacement_source.cn_proxy must be false.', $errors);
+        $this->expect((bool) ($source['known_blocked_slug'] ?? true) === false, 'replacement_source.known_blocked_slug must be false.', $errors);
+        $this->expect((bool) ($source['existing_union_member_must_be_false_in_target_authority'] ?? false) === true, 'replacement_source.existing_union_member_must_be_false_in_target_authority must be true.', $errors);
+
+        foreach (['sitemap_eligible', 'llms_eligible', 'footer_eligible', 'search_channel_eligible', 'runtime_public'] as $flag) {
+            $this->expect(($exposure[$flag] ?? null) === false, 'exposure_policy.'.$flag.' must be false.', $errors);
+        }
+
+        $familyValid = $this->stringValue($family, 'canonical_slug') === self::TARGET_FAMILY_SLUG
+            && $this->stringValue($family, 'title_en') !== ''
+            && $this->stringValue($family, 'title_zh') !== '';
+
+        $occupationValid = $this->stringValue($occupation, 'canonical_slug') === self::TARGET_SLUG
+            && $this->stringValue($occupation, 'entity_level') !== ''
+            && $this->stringValue($occupation, 'truth_market') === 'US'
+            && $this->stringValue($occupation, 'canonical_title_en') !== ''
+            && $this->stringValue($occupation, 'canonical_title_zh') !== ''
+            && $this->stringValue($occupation, 'search_h1_zh') !== '';
+
+        $onet = $this->firstCrosswalk($crosswalks, 'onet_soc_2019');
+        $usSoc = $this->firstCrosswalk($crosswalks, 'us_soc');
+
+        $onetValid = $this->stringValue($onet, 'source_code') === self::EXPECTED_ONET_CODE
+            && $this->stringValue($onet, 'source_title') !== ''
+            && $this->stringValue($onet, 'mapping_type') === 'direct_onet_soc_2019';
+
+        $usSocValid = $this->stringValue($usSoc, 'source_code') === self::EXPECTED_US_SOC_CODE
+            && $this->stringValue($usSoc, 'source_title') !== ''
+            && $this->stringValue($usSoc, 'mapping_type') === 'same_soc_family_from_onet_soc_2019';
+
+        $displayAssetValid = $this->stringValue($asset, 'canonical_slug') === self::TARGET_SLUG
+            && $this->stringValue($asset, 'surface_version') === 'display.surface.v1'
+            && $this->stringValue($asset, 'asset_version') === 'v4.2'
+            && $this->stringValue($asset, 'template_version') === 'v4.2'
+            && $this->stringValue($asset, 'asset_type') === 'career_job_public_display'
+            && $this->stringValue($asset, 'asset_role') === 'formal_pilot_master'
+            && $this->stringValue($asset, 'status') === 'ready_for_pilot';
+
+        $componentOrder = $asset['component_order_json'] ?? null;
+        $pagePayload = $asset['page_payload_json'] ?? null;
+
+        $this->expect($familyValid, 'Replacement family payload is invalid.', $errors);
+        $this->expect($occupationValid, 'Replacement occupation payload is invalid.', $errors);
+        $this->expect($onetValid, 'Replacement O*NET-SOC 2019 crosswalk payload is invalid.', $errors);
+        $this->expect($usSocValid, 'Replacement us_soc crosswalk payload is invalid.', $errors);
+        $this->expect($displayAssetValid, 'Replacement display asset payload is invalid.', $errors);
+        $this->expect(is_array($componentOrder) && count($componentOrder) === 24, 'component_order_json must contain 24 components.', $errors);
+        $this->expect(is_array($pagePayload) && is_array($pagePayload['page']['en'] ?? null), 'page_payload_json.page.en must exist.', $errors);
+        $this->expect(is_array($pagePayload) && is_array($pagePayload['page']['zh'] ?? null), 'page_payload_json.page.zh must exist.', $errors);
+
+        $forbiddenKeys = $this->forbiddenPublicKeys([
+            'component_order_json' => $componentOrder,
+            'page_payload_json' => $pagePayload,
+            'seo_payload_json' => $asset['seo_payload_json'] ?? [],
+            'sources_json' => $asset['sources_json'] ?? [],
+            'structured_data_json' => $asset['structured_data_json'] ?? [],
+            'implementation_contract_json' => $asset['implementation_contract_json'] ?? [],
+        ]);
+        if ($forbiddenKeys !== []) {
+            $errors[] = 'Forbidden public payload keys found: '.implode(', ', $forbiddenKeys).'.';
+        }
+
+        $existingOccupation = Occupation::query()->where('canonical_slug', self::TARGET_SLUG)->first();
+        $existingOccupationFound = $existingOccupation instanceof Occupation;
+        $existingIndexStateRows = $existingOccupationFound ? IndexState::query()->where('occupation_id', $existingOccupation->id)->count() : 0;
+        $existingIndexableStateRows = $existingOccupationFound ? IndexState::query()
+            ->where('occupation_id', $existingOccupation->id)
+            ->where('index_eligible', true)
+            ->count() : 0;
+        $this->expect($existingIndexableStateRows === 0, 'Controlled source import must not target an already indexable occupation.', $errors);
+
+        $report = [
+            'target_slug' => self::TARGET_SLUG,
+            'family_valid' => $familyValid,
+            'occupation_valid' => $occupationValid,
+            'onet_crosswalk_valid' => $onetValid,
+            'us_soc_crosswalk_valid' => $usSocValid,
+            'display_asset_valid' => $displayAssetValid,
+            'public_payload_forbidden_keys_found' => $forbiddenKeys,
+            'existing_occupation_found' => $existingOccupationFound,
+            'existing_index_state_rows' => $existingIndexStateRows,
+            'existing_indexable_state_rows' => $existingIndexableStateRows,
+            'planned_writes' => [
+                'occupation_families' => 1,
+                'occupations' => 1,
+                'occupation_crosswalks' => 2,
+                'career_job_display_assets' => 1,
+                'career_import_runs' => 1,
+                'index_states' => 0,
+                'runtime_promotions' => 0,
+            ],
+        ];
+
+        $plan = [
+            'report' => $report,
+            'errors' => $errors,
+        ];
+
+        if ($familyValid) {
+            $plan['family_payload'] = $family;
+        }
+        if ($occupationValid) {
+            $plan['occupation_payload'] = $occupation;
+        }
+        if ($onetValid && $usSocValid) {
+            $plan['crosswalk_payloads'] = [$onet, $usSoc];
+        }
+        if ($displayAssetValid) {
+            $plan['asset_payload'] = $asset;
+        }
+
+        return $plan;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $crosswalks
+     * @return array<string, mixed>
+     */
+    private function firstCrosswalk(array $crosswalks, string $sourceSystem): array
+    {
+        foreach ($crosswalks as $crosswalk) {
+            if ($this->stringValue($crosswalk, 'source_system') === $sourceSystem) {
+                return $crosswalk;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<mixed>  $payload
+     * @return list<string>
+     */
+    private function forbiddenPublicKeys(array $payload, string $prefix = ''): array
+    {
+        $found = [];
+        foreach ($payload as $key => $value) {
+            $path = $prefix === '' ? (string) $key : $prefix.'.'.(string) $key;
+            if (is_string($key) && in_array($key, self::FORBIDDEN_PUBLIC_KEYS, true)) {
+                $found[] = $path;
+            }
+            if (is_array($value)) {
+                array_push($found, ...$this->forbiddenPublicKeys($value, $path));
+            }
+        }
+
+        return array_values(array_unique($found));
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array<string, mixed>
+     */
+    private function arrayValue(array $payload, string $key): array
+    {
+        return is_array($payload[$key] ?? null) ? $payload[$key] : [];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function stringValue(array $payload, string $key): string
+    {
+        return is_string($payload[$key] ?? null) ? trim((string) $payload[$key]) : '';
+    }
+
+    /**
+     * @param  list<string>  $errors
+     */
+    private function expect(bool $condition, string $message, array &$errors): void
+    {
+        if (! $condition) {
+            $errors[] = $message;
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report, bool $success): int
+    {
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            $json = '{}';
+        }
+
+        $output = trim((string) $this->option('output'));
+        if ($output !== '') {
+            file_put_contents($output, $json.PHP_EOL);
+        }
+
+        if ((bool) $this->option('json')) {
+            $this->line($json);
+        } elseif ($success) {
+            $this->info((string) ($report['mode'] ?? 'dry_run').' complete: '.$report['decision']);
+        } else {
+            $this->error('source import failed: '.implode('; ', (array) ($report['errors'] ?? [])));
+        }
+
+        return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function safeErrorMessage(Throwable $throwable): string
+    {
+        return preg_replace('/\s+/', ' ', trim($throwable->getMessage())) ?: $throwable::class;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -45,6 +45,7 @@ use App\Console\Commands\CareerGenerateCanonicalProgressiveRolloutManifest;
 use App\Console\Commands\CareerImportActorsDisplayAsset;
 use App\Console\Commands\CareerImportAuthorityWave;
 use App\Console\Commands\CareerImportDetailReadyReplacementAuthority;
+use App\Console\Commands\CareerImportDetailReadyReplacementAuthoritySource;
 use App\Console\Commands\CareerImportOccupationDirectoryDrafts;
 use App\Console\Commands\CareerImportOccupationDirectoryDryRun;
 use App\Console\Commands\CareerImportSelectedDisplayAssets;
@@ -223,6 +224,7 @@ class Kernel extends ConsoleKernel
         CareerImportActorsDisplayAsset::class,
         CareerImportAuthorityWave::class,
         CareerImportDetailReadyReplacementAuthority::class,
+        CareerImportDetailReadyReplacementAuthoritySource::class,
         CareerImportOccupationDirectoryDrafts::class,
         CareerImportOccupationDirectoryDryRun::class,
         CareerImportSelectedDisplayAssets::class,

--- a/backend/docs/seo/detail-ready-1048-replacement-authority-source-controlled-import-01.md
+++ b/backend/docs/seo/detail-ready-1048-replacement-authority-source-controlled-import-01.md
@@ -1,0 +1,73 @@
+# DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01
+
+## Executive Summary
+
+This task adds a controlled import path for the source-repair package created by `DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01`.
+
+Final decision: `source_controlled_import_path_completed_ready_for_deploy_and_explicit_apply`.
+
+The command validates and can import `digital-forensics-analysts` into the career authority source layer after explicit approval. It does not publish the occupation, does not promote the 1048 cohort, and does not expose sitemap, llms, footer, or Search Channel surfaces.
+
+## Command
+
+```bash
+php artisan career:import-detail-ready-replacement-authority-source --json
+```
+
+The dry-run command validates the package without writes.
+
+Future apply requires the exact confirmation phrase:
+
+```bash
+php artisan career:import-detail-ready-replacement-authority-source --apply --confirm=DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT_APPROVED --json
+```
+
+## Controlled Writes
+
+When explicitly confirmed, the command may write only:
+
+- one `career_import_runs` ledger row
+- one `occupation_families` row, if missing
+- one `occupations` row, if missing
+- two `occupation_crosswalks` rows
+- one `career_job_display_assets` row
+
+It must write zero:
+
+- `index_states`
+- runtime projection rows
+- sitemap rows
+- llms rows
+- footer/nav entries
+- Search Channel rows
+
+## Safety Gates
+
+The command fails closed if:
+
+- confirmation phrase is missing during apply
+- package task/type does not match the source-repair package
+- target slug is not `digital-forensics-analysts`
+- candidate is manual hold, blocked, or CN proxy
+- target authority already has indexable `index_states` for the candidate
+- display asset is not v4.2 / `display.surface.v1` / `ready_for_pilot`
+- public payload contains forbidden runtime or release-gate keys
+
+`software-developers` remains manual hold.
+
+## What Was Not Done
+
+- No controlled import was executed in production.
+- No production deploy was performed.
+- No runtime promotion was performed.
+- No publish was performed.
+- No Search Channel action or URL submission was performed.
+- No fap-web change was made.
+
+## Next Task
+
+Deploy readiness is required before the command can exist in the target authority environment. After deployment, a separate exact apply confirmation is required before running the controlled import.
+
+Recommended next task:
+
+`DEPLOY-READINESS | Deploy replacement authority source controlled import path`

--- a/backend/docs/seo/generated/detail-ready-1048-replacement-authority-source-controlled-import-01.v1.json
+++ b/backend/docs/seo/generated/detail-ready-1048-replacement-authority-source-controlled-import-01.v1.json
@@ -1,0 +1,50 @@
+{
+  "schema_version": "detail_ready_1048_replacement_authority_source_controlled_import.v1",
+  "task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01",
+  "generated_at": "2026-05-28T20:45:00+08:00",
+  "final_decision": "source_controlled_import_path_completed_ready_for_deploy_and_explicit_apply",
+  "command": "career:import-detail-ready-replacement-authority-source",
+  "source_package": "backend/docs/seo/import-packages/detail-ready-1048-replacement-authority-source-repair-01.import.v1.json",
+  "target_slug": "digital-forensics-analysts",
+  "manual_hold_slug_kept_excluded": "software-developers",
+  "apply_confirmation_phrase": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT_APPROVED",
+  "controlled_writes_after_future_apply_approval": {
+    "career_import_runs": 1,
+    "occupation_families": "upsert_if_missing",
+    "occupations": "upsert_if_missing_and_non_indexable",
+    "occupation_crosswalks": 2,
+    "career_job_display_assets": 1,
+    "index_states": 0,
+    "runtime_promotions": 0,
+    "sitemap_llms_footer_exposure": 0
+  },
+  "safety_gates": {
+    "apply_requires_exact_confirmation": true,
+    "target_slug_fixed": "digital-forensics-analysts",
+    "package_task_must_match_source_repair": true,
+    "must_not_be_manual_hold": true,
+    "must_not_be_blocked": true,
+    "must_not_be_cn_proxy": true,
+    "must_have_onet_soc_2019_crosswalk": true,
+    "must_have_us_soc_crosswalk": true,
+    "must_have_display_asset_v4_2": true,
+    "must_have_zero_existing_indexable_index_states": true,
+    "forbidden_public_payload_keys_rejected": true
+  },
+  "local_validation": {
+    "focused_command_test": "cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthoritySourceCommandTest --no-ansi",
+    "focused_report_test": "cd backend && php artisan test --filter=DetailReady1048ReplacementAuthoritySourceControlledImport01 --no-ansi"
+  },
+  "no_cms_mutation": true,
+  "no_database_write": true,
+  "no_runtime_promotion": true,
+  "no_sitemap_llms_footer_exposure": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_frontend_fallback_authority": true,
+  "no_pseo_generation": true,
+  "next_task": "DEPLOY-READINESS | Deploy replacement authority source controlled import path"
+}

--- a/backend/tests/Feature/Console/CareerImportDetailReadyReplacementAuthoritySourceCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportDetailReadyReplacementAuthoritySourceCommandTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\CareerImportRun;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\IndexState;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerImportDetailReadyReplacementAuthoritySourceCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const COMMAND = 'career:import-detail-ready-replacement-authority-source';
+
+    private const CONFIRM = 'DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT_APPROVED';
+
+    #[Test]
+    public function dry_run_validates_source_package_without_writing_authority_rows(): void
+    {
+        [$exitCode, $report] = $this->runImport();
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('dry_run', $report['mode']);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('digital-forensics-analysts', $report['target_slug']);
+        $this->assertTrue($report['would_write']);
+        $this->assertFalse($report['did_write']);
+        $this->assertTrue($report['family_valid']);
+        $this->assertTrue($report['occupation_valid']);
+        $this->assertTrue($report['onet_crosswalk_valid']);
+        $this->assertTrue($report['us_soc_crosswalk_valid']);
+        $this->assertTrue($report['display_asset_valid']);
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(0, OccupationFamily::query()->count());
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, OccupationCrosswalk::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    #[Test]
+    public function apply_requires_exact_confirmation_phrase(): void
+    {
+        [$exitCode, $report] = $this->runImport(['--apply' => true]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertStringContainsString('--confirm must equal', implode(' ', $report['errors']));
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(0, Occupation::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    #[Test]
+    public function confirmed_apply_writes_only_source_authority_rows_without_runtime_promotion(): void
+    {
+        [$exitCode, $report] = $this->runImport([
+            '--apply' => true,
+            '--confirm' => self::CONFIRM,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('apply', $report['mode']);
+        $this->assertSame('pass', $report['decision']);
+        $this->assertTrue($report['did_write']);
+        $this->assertFalse($report['runtime_promotion_performed']);
+        $this->assertSame(0, $report['index_state_rows_written']);
+
+        $this->assertSame(1, CareerImportRun::query()->count());
+        $this->assertSame(1, OccupationFamily::query()->count());
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+
+        $occupation = Occupation::query()->where('canonical_slug', 'digital-forensics-analysts')->firstOrFail();
+        $this->assertDatabaseHas('occupation_families', [
+            'canonical_slug' => 'computer-and-information-technology',
+        ]);
+        $this->assertDatabaseHas('occupation_crosswalks', [
+            'occupation_id' => $occupation->id,
+            'source_system' => 'onet_soc_2019',
+            'source_code' => '15-1299.06',
+            'mapping_type' => 'direct_onet_soc_2019',
+        ]);
+        $this->assertDatabaseHas('occupation_crosswalks', [
+            'occupation_id' => $occupation->id,
+            'source_system' => 'us_soc',
+            'source_code' => '15-1299',
+            'mapping_type' => 'same_soc_family_from_onet_soc_2019',
+        ]);
+        $this->assertDatabaseHas('career_job_display_assets', [
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => 'digital-forensics-analysts',
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+        ]);
+
+        $asset = CareerJobDisplayAsset::query()->firstOrFail();
+        $this->assertSame(24, count($asset->component_order_json));
+        $this->assertIsArray($asset->page_payload_json['page']['en'] ?? null);
+        $this->assertIsArray($asset->page_payload_json['page']['zh'] ?? null);
+        $this->assertFalse((bool) ($asset->metadata_json['runtime_promotion_performed'] ?? true));
+    }
+
+    #[Test]
+    public function repeated_apply_updates_same_source_authority_rows_without_duplicates(): void
+    {
+        $this->runImport(['--apply' => true, '--confirm' => self::CONFIRM]);
+        [$exitCode, $report] = $this->runImport(['--apply' => true, '--confirm' => self::CONFIRM]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(2, CareerImportRun::query()->count());
+        $this->assertSame(1, OccupationFamily::query()->count());
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+        $this->assertSame(0, IndexState::query()->count());
+    }
+
+    #[Test]
+    public function indexed_existing_occupation_blocks_source_import(): void
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'computer-and-information-technology',
+            'title_en' => 'Computer and Information Technology',
+            'title_zh' => '计算机与信息技术',
+        ]);
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => 'digital-forensics-analysts',
+            'entity_level' => 'market_child',
+            'truth_market' => 'US',
+            'display_market' => 'CN',
+            'crosswalk_mode' => 'onet_soc_2019_direct',
+            'canonical_title_en' => 'Digital Forensics Analysts',
+            'canonical_title_zh' => '数字取证分析师',
+            'search_h1_zh' => '数字取证分析师',
+        ]);
+        IndexState::query()->create([
+            'occupation_id' => $occupation->id,
+            'index_state' => 'indexable',
+            'index_eligible' => true,
+            'canonical_path' => '/en/career/jobs/digital-forensics-analysts',
+            'reason_codes' => [],
+            'changed_at' => now(),
+        ]);
+
+        [$exitCode, $report] = $this->runImport(['--apply' => true, '--confirm' => self::CONFIRM]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertSame(1, $report['existing_indexable_state_rows']);
+        $this->assertStringContainsString('already indexable occupation', implode(' ', $report['errors']));
+        $this->assertSame(0, CareerImportRun::query()->count());
+        $this->assertSame(0, CareerJobDisplayAsset::query()->count());
+    }
+
+    /**
+     * @return array{0:int, 1:array<string,mixed>}
+     */
+    private function runImport(array $options = []): array
+    {
+        $exitCode = Artisan::call(self::COMMAND, array_merge([
+            '--json' => true,
+        ], $options));
+
+        $report = json_decode(Artisan::output(), true);
+        $this->assertIsArray($report, Artisan::output());
+
+        return [$exitCode, $report];
+    }
+}

--- a/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthoritySourceControlledImport01Test.php
+++ b/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthoritySourceControlledImport01Test.php
@@ -1,0 +1,56 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class DetailReady1048ReplacementAuthoritySourceControlledImport01Test extends TestCase
+{
+    public function test_controlled_import_report_records_apply_boundaries(): void
+    {
+        $path = base_path('docs/seo/generated/detail-ready-1048-replacement-authority-source-controlled-import-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('detail_ready_1048_replacement_authority_source_controlled_import.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01', $payload['task'] ?? null);
+        $this->assertSame('source_controlled_import_path_completed_ready_for_deploy_and_explicit_apply', $payload['final_decision'] ?? null);
+        $this->assertSame('career:import-detail-ready-replacement-authority-source', $payload['command'] ?? null);
+        $this->assertSame('digital-forensics-analysts', $payload['target_slug'] ?? null);
+        $this->assertSame('software-developers', $payload['manual_hold_slug_kept_excluded'] ?? null);
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT_APPROVED', $payload['apply_confirmation_phrase'] ?? null);
+
+        $writes = $payload['controlled_writes_after_future_apply_approval'] ?? [];
+        $this->assertSame(2, $writes['occupation_crosswalks'] ?? null);
+        $this->assertSame(1, $writes['career_job_display_assets'] ?? null);
+        $this->assertSame(0, $writes['index_states'] ?? null);
+        $this->assertSame(0, $writes['runtime_promotions'] ?? null);
+        $this->assertSame(0, $writes['sitemap_llms_footer_exposure'] ?? null);
+
+        $gates = $payload['safety_gates'] ?? [];
+        foreach ([
+            'apply_requires_exact_confirmation',
+            'package_task_must_match_source_repair',
+            'must_not_be_manual_hold',
+            'must_not_be_blocked',
+            'must_not_be_cn_proxy',
+            'must_have_onet_soc_2019_crosswalk',
+            'must_have_us_soc_crosswalk',
+            'must_have_display_asset_v4_2',
+            'must_have_zero_existing_indexable_index_states',
+            'forbidden_public_payload_keys_rejected',
+        ] as $field) {
+            $this->assertTrue($gates[$field] ?? false, $field);
+        }
+
+        foreach (['no_cms_mutation', 'no_database_write', 'no_runtime_promotion', 'no_sitemap_llms_footer_exposure', 'no_publish', 'no_deploy', 'no_search_channel_action', 'no_url_submission', 'no_external_search_api_call', 'no_frontend_fallback_authority', 'no_pseo_generation'] as $field) {
+            $this->assertTrue($payload[$field] ?? false, $field);
+        }
+
+        $this->assertSame('DEPLOY-READINESS | Deploy replacement authority source controlled import path', $payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -30825,7 +30825,7 @@
     "branch": "codex/detail-ready-1048-replacement-authority-source-repair-01",
     "base": "main",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01 replacement authority source repair",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_RESELECT-01"
     ],
@@ -30864,7 +30864,7 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
+    "merged_at": "2026-05-28T11:09:41Z",
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "transitions": [
@@ -30892,6 +30892,11 @@
         "status": "pr_open",
         "at": "2026-05-28T20:30:00+08:00",
         "summary": "Opened PR #1743 for scoped replacement authority source repair package."
+      },
+      {
+        "status": "merged_reconciled",
+        "at": "2026-05-28T19:29:20+08:00",
+        "summary": "Reconciled PR #1743 merged state before starting DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01; GitHub reports merge commit 54b47ccc27aa556e5d0596cee72245a66bbb3df3 and remote branch still exists."
       }
     ],
     "scope_validation": {
@@ -30900,6 +30905,111 @@
       "git_diff_cached_check": "passed"
     },
     "sidecars": [],
-    "next_task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01"
+    "next_task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01",
+    "merge_commit": "54b47ccc27aa556e5d0596cee72245a66bbb3df3"
+  },
+  "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01": {
+    "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01",
+    "repo": "fap-api",
+    "branch": "codex/detail-ready-1048-replacement-authority-source-controlled-import-01",
+    "base": "main",
+    "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01 controlled replacement authority source import path",
+    "status": "pr_open",
+    "depends_on": [
+      "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01"
+    ],
+    "commit_sha": "39cf71156636a265e16f0a570fe2eafaf74535da",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1744",
+    "checks": [
+      {
+        "command": "cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthoritySourceCommandTest --no-ansi",
+        "status": "passed",
+        "summary": "5 tests / 62 assertions passed"
+      },
+      {
+        "command": "cd backend && php artisan test --filter=DetailReady1048ReplacementAuthoritySourceControlledImport01 --no-ansi",
+        "status": "passed",
+        "summary": "1 test / 35 assertions passed"
+      },
+      {
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "203 routes listed"
+      },
+      {
+        "command": "cd backend && vendor/bin/pint --test",
+        "status": "passed",
+        "summary": "3619 files passed"
+      },
+      {
+        "command": "cd backend && composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid"
+      },
+      {
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found"
+      },
+      {
+        "command": "JSON/YAML parse and git diff checks",
+        "status": "passed",
+        "summary": "Generated report JSON, train state JSON, train YAML, git diff --check, and git diff --cached --check passed before staging"
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-28T19:29:20+08:00",
+        "summary": "User explicitly authorized DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01 manifest/state updates for the current PR only."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-28T19:29:20+08:00",
+        "summary": "Adding a controlled backend import path for the reviewed replacement authority source package without running production import, runtime promotion, deploy, sitemap/llms/footer exposure, Search Channel action, URL submission, or fap-web changes."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-28T19:45:00+08:00",
+        "summary": "Focused command/report tests, route list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks passed. No production import, runtime promotion, deploy, Search Channel action, URL submission, sitemap/llms/footer exposure, or fap-web change."
+      },
+      {
+        "status": "committed",
+        "at": "2026-05-28T19:49:00+08:00",
+        "summary": "Committed scoped controlled import path for the replacement authority source package."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-28T19:53:00+08:00",
+        "summary": "Opened PR #1744 for the scoped controlled replacement authority source import path."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [
+      {
+        "source_pr": null,
+        "repo": "fap-api",
+        "branch": "codex/detail-ready-1048-replacement-authority-source-controlled-import-01",
+        "command_or_check": "cd backend && php artisan career:import-detail-ready-replacement-authority-source --json",
+        "evidence": "SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' while the default local mysql connection tried to read fap_api. This direct command was exploratory, not a manifest validation command.",
+        "failure_summary": "Local default DB is unavailable for direct command dry-run outside the Laravel test harness.",
+        "why_external_to_current_pr": "Focused feature tests exercised dry-run and confirmed apply behavior with RefreshDatabase; manifest-required local checks passed. The failure is local database configuration, not command logic.",
+        "impact_on_current_pr": "No merge blocker; target command remains guarded and will require deploy readiness plus explicit apply confirmation before use in the target authority environment.",
+        "owner": "ops/local-env",
+        "follow_up_recommendation": "Run the command in the target authority environment only after deploy readiness and explicit apply confirmation, or set local DB env before manual dry-run.",
+        "required_checks_status": "local manifest checks passed",
+        "scope_validation_status": "passed",
+        "continue_train_decision": "continue_current_pr"
+      }
+    ],
+    "next_task": "DEPLOY-READINESS | Deploy replacement authority source controlled import path"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15521,3 +15521,51 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01
+  - id: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01
+    repo: fap-api
+    branch: codex/detail-ready-1048-replacement-authority-source-controlled-import-01
+    base: main
+    title: "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01 controlled replacement authority source import path"
+    train_scope: career_detail_ready_1048_replacement_authority_source_controlled_import
+    risk_level: p1_career_runtime_publication_gate
+    depends_on:
+      - DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01
+    allowed_paths:
+      - backend/app/Console/Commands/CareerImportDetailReadyReplacementAuthoritySource.php
+      - backend/app/Console/Kernel.php
+      - backend/docs/seo/detail-ready-1048-replacement-authority-source-controlled-import-01.md
+      - backend/docs/seo/generated/detail-ready-1048-replacement-authority-source-controlled-import-01.v1.json
+      - backend/tests/Feature/Console/CareerImportDetailReadyReplacementAuthoritySourceCommandTest.php
+      - backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthoritySourceControlledImport01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a controlled backend import command for the source-repair package created by DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01.
+      - Require exact apply confirmation before writing target replacement authority source rows.
+      - Write only family, occupation, crosswalk, display asset, and import-run rows after future explicit approval.
+      - Preserve software-developers manual hold and do not publish runtime pages or expose sitemap/llms/footer/Search Channel surfaces.
+      - Do not deploy, run production import, promote the 1048 cohort, submit URLs, or use frontend fallback authority.
+    validation:
+      - cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthoritySourceCommandTest --no-ansi
+      - cd backend && php artisan test --filter=DetailReady1048ReplacementAuthoritySourceControlledImport01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-source-controlled-import-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DEPLOY-READINESS | Deploy replacement authority source controlled import path


### PR DESCRIPTION
## What changed
- Added `career:import-detail-ready-replacement-authority-source` as a guarded backend command for the reviewed `digital-forensics-analysts` replacement source package.
- Registered the command and added feature coverage for dry-run, exact apply confirmation, idempotent apply, indexable-target blocking, and report boundaries.
- Added the scoped SEO/report artifact and PR-train manifest/state entry, including reconciliation that PR #1743 is already merged.

## Why
The replacement authority source package exists, but the target authority environment needs a controlled import path before a future explicit apply can write the authority rows. This PR adds that path without running the import, publishing runtime pages, promoting the 1048 cohort, or exposing sitemap/llms/footer/Search Channel surfaces.

## Validation
- `cd backend && php artisan test --filter=CareerImportDetailReadyReplacementAuthoritySourceCommandTest --no-ansi` - passed, 5 tests / 62 assertions
- `cd backend && php artisan test --filter=DetailReady1048ReplacementAuthoritySourceControlledImport01 --no-ansi` - passed, 1 test / 35 assertions
- `cd backend && php artisan route:list --no-ansi` - passed, 203 routes listed
- `cd backend && vendor/bin/pint --test` - passed, 3619 files
- `cd backend && composer validate --strict` - passed
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` - passed, no advisories
- JSON/YAML parse - passed
- `git diff --check` / `git diff --cached --check` - passed

## Intentionally deferred
- No production import was executed.
- No production deploy was performed.
- No runtime promotion, sitemap/llms/footer exposure, Search Channel action, URL submission, or fap-web change was made.
- `software-developers` remains on manual hold.

## Repository rule impact
This adds an authority-layer controlled import command only. It does not move content authority into frontend code, does not add runtime fallback content, and does not change public discoverability until a separately approved deploy/apply flow runs.

## Sidecar
A direct local manual dry-run outside the test harness hit local MySQL access denial for the default `root` connection. Manifest-required tests passed with Laravel `RefreshDatabase`; this is a local DB configuration issue, not a current-scope logic failure.
