### PR TITLE
DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 replacement index-state runtime projection conflict report

### DIFF
--- a/backend/docs/seo/detail-ready-1048-replacement-authority-index-state-conflict-01.md
+++ b/backend/docs/seo/detail-ready-1048-replacement-authority-index-state-conflict-01.md
@@ -1,0 +1,76 @@
+# DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01
+
+## Executive Summary
+
+`digital-forensics-analysts` is not a safe replacement slug for the DETAIL_READY_1048 rollout.
+
+Read-only production inspection showed that the slug already has backend authority rows, crosswalks, a display asset, and index-state rows marked `index_eligible=true`, but it is absent from the runtime publish projection and still returns 404/noindex at the public detail surface. This is an index-state/runtime-projection conflict, not a missing source-authority gap.
+
+No production write, CMS mutation, runtime promotion, deploy, sitemap exposure, llms exposure, footer exposure, Search Channel action, URL submission, or fap-web change was performed.
+
+## Target Slug
+
+- `digital-forensics-analysts`
+- English title: Digital Forensics Analysts
+- Chinese title: 数字取证分析师
+- O*NET-SOC 2019: `15-1299.06`
+- US SOC: `15-1299`
+
+## Observed Production State
+
+| Check | Result |
+|---|---|
+| Occupation row | Exists |
+| Crosswalk | Exists: `onet_soc_2019=15-1299.06`, `us_soc=15-1299` |
+| Display asset | Exists: `career_job_public_display`, `v4.2`, `ready_for_pilot` |
+| Recommendation snapshots | 0 |
+| Published CareerJob row | 0 |
+| Index states | 2 rows, both `index_eligible=true` |
+| Runtime publish projection item | Absent |
+| Public dataset cache | 30 public items; target slug absent |
+| Public detail API | 404 |
+| Public frontend detail page | 404/noindex |
+
+## Conflict Class
+
+`index_state_runtime_projection_conflict`
+
+The controlled import path correctly blocked the target because the import safety gate requires the replacement to be non-indexable before import. The target already has index-state rows that mark it index-eligible, while the runtime projection does not publish or expose it.
+
+## Replacement Decision
+
+`replacement_safe=false`
+
+This slug must not be used as the 1048 replacement without separate reconciliation. Reusing it as a clean replacement would mix three different states:
+
+- source authority exists;
+- index-state history says promotion/indexed;
+- runtime projection and public API say non-public.
+
+## Recommended Path
+
+Use a conservative path:
+
+1. Do not apply the controlled import for `digital-forensics-analysts`.
+2. Keep `software-developers` on manual hold.
+3. Treat the current rollout target as 1047 unless a separate human-approved decision releases `software-developers` or a clean replacement is created.
+4. If 1048 remains mandatory, run a separate reconciliation task for the conflicted slug or create a new replacement authority source that is confirmed non-indexable in the target authority environment before import.
+
+## What Was Not Done
+
+- No production write.
+- No CMS mutation.
+- No runtime promotion.
+- No deploy.
+- No sitemap, llms, or footer exposure.
+- No Search Channel action.
+- No URL submission.
+- No external search API call.
+- No fap-web change.
+- No change to `software-developers` manual hold.
+- No production state modification for `digital-forensics-analysts`.
+
+## Final Decision
+
+`replacement_slug_not_safe_recommend_1047_target`
+

--- a/backend/docs/seo/generated/detail-ready-1048-replacement-authority-index-state-conflict-01.v1.json
+++ b/backend/docs/seo/generated/detail-ready-1048-replacement-authority-index-state-conflict-01.v1.json
@@ -1,0 +1,89 @@
+{
+  "schema_version": "detail_ready_1048_replacement_authority_index_state_conflict.v1",
+  "task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01",
+  "generated_at": "2026-05-28T20:44:16+08:00",
+  "final_decision": "replacement_slug_not_safe_recommend_1047_target",
+  "target_slug": "digital-forensics-analysts",
+  "conflict_class": "index_state_runtime_projection_conflict",
+  "replacement_safe": false,
+  "production_observation": {
+    "occupation_row_exists": true,
+    "crosswalk_exists": true,
+    "crosswalks": [
+      {
+        "source_system": "onet_soc_2019",
+        "source_code": "15-1299.06",
+        "mapping_type": "directory_candidate"
+      },
+      {
+        "source_system": "us_soc",
+        "source_code": "15-1299",
+        "mapping_type": "direct_match"
+      }
+    ],
+    "display_asset_exists": true,
+    "display_asset": {
+      "asset_type": "career_job_public_display",
+      "surface_version": "display.surface.v1",
+      "asset_version": "v4.2",
+      "template_version": "v4.2",
+      "status": "ready_for_pilot"
+    },
+    "recommendation_snapshots_count": 0,
+    "published_career_job_rows_count": 0,
+    "index_state_rows_count": 2,
+    "index_eligible_rows_count": 2,
+    "runtime_publish_projection_item_present": false,
+    "runtime_detail_route_enabled": false,
+    "runtime_dataset_visible": false,
+    "runtime_robots_indexable": false,
+    "runtime_release_gate_pass": false,
+    "public_dataset_cache_member_count": 30,
+    "public_dataset_cache_includes_target_slug": false,
+    "detail_api_status": 404,
+    "frontend_detail_page_status": 404,
+    "frontend_detail_page_robots": "noindex"
+  },
+  "import_gate_result": {
+    "controlled_import_command": "career:import-detail-ready-replacement-authority-source --json",
+    "decision": "fail",
+    "did_write": false,
+    "error": "Controlled source import must not target an already indexable occupation."
+  },
+  "root_cause_summary": "The target slug has source authority and index-state history, but no runtime publish projection item. It is not a clean non-indexable replacement candidate.",
+  "software_developers_manual_hold_unchanged": true,
+  "digital_forensics_production_state_modified": false,
+  "recommended_path": [
+    {
+      "path": "1047_target",
+      "decision": "recommended",
+      "reason": "Keep software-developers on manual hold and avoid using a conflicted replacement slug."
+    },
+    {
+      "path": "software_developers_hold_decision",
+      "decision": "human_approval_required",
+      "reason": "Only a separate explicit decision can release software-developers from manual hold."
+    },
+    {
+      "path": "replacement_reconciliation",
+      "decision": "separate_task_required",
+      "reason": "digital-forensics-analysts requires index-state/runtime-projection reconciliation before any use as replacement."
+    }
+  ],
+  "guardrails": {
+    "production_write_performed": false,
+    "cms_mutation_performed": false,
+    "runtime_promotion_performed": false,
+    "deploy_performed": false,
+    "sitemap_exposure_performed": false,
+    "llms_exposure_performed": false,
+    "footer_exposure_performed": false,
+    "search_channel_action_performed": false,
+    "url_submission_performed": false,
+    "external_search_api_call_performed": false,
+    "fap_web_change_performed": false,
+    "software_developers_manual_hold_unchanged": true
+  },
+  "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01 or 1047 target decision"
+}
+

--- a/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityIndexStateConflict01Test.php
+++ b/backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityIndexStateConflict01Test.php
@@ -1,0 +1,76 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class DetailReady1048ReplacementAuthorityIndexStateConflict01Test extends TestCase
+{
+    public function test_conflict_report_marks_digital_forensics_replacement_unsafe(): void
+    {
+        $reportPath = base_path('docs/seo/generated/detail-ready-1048-replacement-authority-index-state-conflict-01.v1.json');
+
+        $this->assertFileExists($reportPath);
+
+        $report = json_decode((string) file_get_contents($reportPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('detail_ready_1048_replacement_authority_index_state_conflict.v1', $report['schema_version'] ?? null);
+        $this->assertSame('DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01', $report['task'] ?? null);
+        $this->assertSame('replacement_slug_not_safe_recommend_1047_target', $report['final_decision'] ?? null);
+        $this->assertSame('digital-forensics-analysts', $report['target_slug'] ?? null);
+        $this->assertSame('index_state_runtime_projection_conflict', $report['conflict_class'] ?? null);
+        $this->assertFalse($report['replacement_safe'] ?? true);
+
+        $observation = $report['production_observation'] ?? [];
+        $this->assertTrue($observation['occupation_row_exists'] ?? false);
+        $this->assertTrue($observation['crosswalk_exists'] ?? false);
+        $this->assertTrue($observation['display_asset_exists'] ?? false);
+        $this->assertSame(0, $observation['recommendation_snapshots_count'] ?? null);
+        $this->assertSame(0, $observation['published_career_job_rows_count'] ?? null);
+        $this->assertSame(2, $observation['index_state_rows_count'] ?? null);
+        $this->assertSame(2, $observation['index_eligible_rows_count'] ?? null);
+        $this->assertFalse($observation['runtime_publish_projection_item_present'] ?? true);
+        $this->assertFalse($observation['runtime_detail_route_enabled'] ?? true);
+        $this->assertFalse($observation['runtime_dataset_visible'] ?? true);
+        $this->assertFalse($observation['runtime_release_gate_pass'] ?? true);
+        $this->assertFalse($observation['public_dataset_cache_includes_target_slug'] ?? true);
+        $this->assertSame(404, $observation['detail_api_status'] ?? null);
+        $this->assertSame(404, $observation['frontend_detail_page_status'] ?? null);
+
+        $importGate = $report['import_gate_result'] ?? [];
+        $this->assertSame('fail', $importGate['decision'] ?? null);
+        $this->assertFalse($importGate['did_write'] ?? true);
+
+        $guardrails = $report['guardrails'] ?? [];
+        foreach ([
+            'production_write_performed',
+            'cms_mutation_performed',
+            'runtime_promotion_performed',
+            'deploy_performed',
+            'sitemap_exposure_performed',
+            'llms_exposure_performed',
+            'footer_exposure_performed',
+            'search_channel_action_performed',
+            'url_submission_performed',
+            'external_search_api_call_performed',
+            'fap_web_change_performed',
+        ] as $field) {
+            $this->assertFalse($guardrails[$field] ?? true, $field);
+        }
+
+        $this->assertTrue($report['software_developers_manual_hold_unchanged'] ?? false);
+        $this->assertTrue($guardrails['software_developers_manual_hold_unchanged'] ?? false);
+        $this->assertFalse($report['digital_forensics_production_state_modified'] ?? true);
+
+        $recommendedPaths = array_map(
+            static fn (array $item): string => (string) ($item['path'] ?? ''),
+            array_filter($report['recommended_path'] ?? [], static fn (mixed $item): bool => is_array($item)),
+        );
+
+        $this->assertContains('1047_target', $recommendedPaths);
+        $this->assertContains('software_developers_hold_decision', $recommendedPaths);
+        $this->assertNotEmpty($report['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -23201,7 +23201,7 @@
   "SEARCH-CHANNEL-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/search-channel-live-00-readiness-split-scan",
-    "status": "in_progress",
+    "status": "local_checks_passed",
     "depends_on": [
       "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00"
     ],
@@ -23391,7 +23391,7 @@
     "depends_on": [
       "GSC-LIVE-00"
     ],
-    "commit_sha": null,
+    "commit_sha": "9a58701f1d7a4f01c2ce8426779c493cd3854f0e",
     "pr_url": null,
     "checks": {
       "dependency": {
@@ -31011,5 +31011,81 @@
       }
     ],
     "next_task": "DEPLOY-READINESS | Deploy replacement authority source controlled import path"
+  },
+  "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01": {
+    "id": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01",
+    "repo": "fap-api",
+    "branch": "codex/detail-ready-1048-replacement-authority-index-state-conflict-01",
+    "base": "main",
+    "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 replacement index-state runtime projection conflict report",
+    "status": "in_progress",
+    "depends_on": [],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityIndexStateConflict01 --no-ansi",
+        "status": "passed",
+        "summary": "1 test / 40 assertions passed"
+      },
+      {
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "203 routes listed"
+      },
+      {
+        "command": "cd backend && vendor/bin/pint --test",
+        "status": "passed",
+        "summary": "3620 files passed after formatting the scoped new test file"
+      },
+      {
+        "command": "cd backend && composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid"
+      },
+      {
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found"
+      },
+      {
+        "command": "JSON/YAML parse and git diff checks",
+        "status": "passed",
+        "summary": "Generated conflict JSON, train state JSON, train YAML, git diff --check, and git diff --cached --check passed"
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-28T20:44:16+08:00",
+        "summary": "User explicitly authorized DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 manifest/state updates for the current PR only."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-28T20:44:16+08:00",
+        "summary": "Recording the digital-forensics-analysts index-state/runtime-projection conflict as report-only evidence. No production write, CMS mutation, runtime promotion, deploy, sitemap/llms/footer exposure, Search Channel action, URL submission, external search API call, fap-web change, software-developers hold release, or digital-forensics production state change."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-28T20:44:16+08:00",
+        "summary": "Focused conflict test, route list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks passed. This PR remains report-only."
+      },
+      {
+        "status": "committed",
+        "at": "2026-05-28T20:44:16+08:00",
+        "summary": "Committed scoped replacement index-state/runtime-projection conflict report."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [],
+    "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01 or 1047 target decision"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -23201,7 +23201,7 @@
   "SEARCH-CHANNEL-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/search-channel-live-00-readiness-split-scan",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "SEO-INTEL-TWO-STAGE-URL-TRUTH-HANDOFF-PR-00"
     ],
@@ -23392,7 +23392,7 @@
       "GSC-LIVE-00"
     ],
     "commit_sha": "a6b4b1578d7d0fbbb4212cc13e330bef5d84cb5c",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1745",
     "checks": {
       "dependency": {
         "status": "pass",
@@ -31078,6 +31078,11 @@
         "status": "committed",
         "at": "2026-05-28T20:44:16+08:00",
         "summary": "Committed scoped replacement index-state/runtime-projection conflict report."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-28T20:44:16+08:00",
+        "summary": "Opened PR #1745 for the scoped report-only replacement index-state/runtime-projection conflict record."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -23391,7 +23391,7 @@
     "depends_on": [
       "GSC-LIVE-00"
     ],
-    "commit_sha": "9a58701f1d7a4f01c2ce8426779c493cd3854f0e",
+    "commit_sha": "a6b4b1578d7d0fbbb4212cc13e330bef5d84cb5c",
     "pr_url": null,
     "checks": {
       "dependency": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15569,3 +15569,44 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DEPLOY-READINESS | Deploy replacement authority source controlled import path
+  - id: DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01
+    repo: fap-api
+    branch: codex/detail-ready-1048-replacement-authority-index-state-conflict-01
+    base: main
+    title: "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 replacement index-state runtime projection conflict report"
+    train_scope: career_detail_ready_1048_replacement_authority_index_state_conflict
+    risk_level: p1_career_runtime_publication_gate
+    allowed_paths:
+      - backend/docs/seo/detail-ready-1048-replacement-authority-index-state-conflict-01.md
+      - backend/docs/seo/generated/detail-ready-1048-replacement-authority-index-state-conflict-01.v1.json
+      - backend/tests/Feature/SeoIntel/DetailReady1048ReplacementAuthorityIndexStateConflict01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Record that digital-forensics-analysts has an index-state/runtime-projection conflict and is not a clean 1048 replacement.
+      - Preserve software-developers manual hold and recommend 1047 target or a separate hold/replacement reconciliation decision.
+      - Produce report-only markdown, generated JSON, focused SeoIntel test, and current task train ledger entry.
+      - Do not write production, mutate CMS, promote runtime, deploy, expose sitemap/llms/footer, enqueue Search Channel, submit URLs, call external search APIs, change fap-web, release software-developers, or modify digital-forensics-analysts production state.
+    validation:
+      - cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityIndexStateConflict01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-index-state-conflict-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01 or 1047 target decision


### PR DESCRIPTION
## What changed
- Added a report-only markdown summary for the digital-forensics-analysts replacement conflict.
- Added a generated JSON artifact classifying the slug as index_state_runtime_projection_conflict with replacement_safe=false.
- Added a focused SeoIntel test asserting the conflict class, guardrails, software-developers hold preservation, and recommended 1047/hold-decision path.
- Added the current PR entry to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json only.

## Why
The controlled import dry-run showed digital-forensics-analysts is not a clean non-indexable replacement: production has source authority and index_eligible index-state rows, but runtime projection/public detail remain absent/404. This PR records the conflict and prevents using the slug as a 1048 replacement without separate reconciliation.

## Validation
- cd backend && php artisan test --filter=DetailReady1048ReplacementAuthorityIndexStateConflict01 --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/detail-ready-1048-replacement-authority-index-state-conflict-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 YAML parse for docs/codex/pr-train.yaml
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No production write, CMS mutation, runtime promotion, deploy, sitemap/llms/footer exposure, Search Channel action, URL submission, external search API call, or fap-web change.
- No release of software-developers manual hold.
- No production state modification for digital-forensics-analysts.
- Follow-up decision remains: target 1047, separately decide software-developers hold, or reconcile/create a clean replacement.