### PR TITLE
EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -85,6 +85,24 @@ MAIL_USERNAME=null
 MAIL_PASSWORD=null
 MAIL_FROM_ADDRESS="hello@example.com"
 MAIL_FROM_NAME="${APP_NAME}"
+MAIL_EHLO_DOMAIN=
+EMAIL_OUTBOX_SEND=false
+
+# Production DirectMail SMTP readiness template.
+# Keep local/CI defaults above on log transport. Ops must set these only in
+# production secret/env storage after the DirectMail sender domain and address
+# are verified. Do not commit real SMTP passwords.
+# MAIL_MAILER=smtp
+# MAIL_SCHEME=smtps
+# MAIL_HOST=smtpdm.aliyun.com
+# MAIL_PORT=465
+# MAIL_USERNAME=noreply@mail.fermatmind.com
+# MAIL_PASSWORD=<DirectMail SMTP password>
+# MAIL_FROM_ADDRESS=noreply@mail.fermatmind.com
+# MAIL_FROM_NAME=FermatMind
+# MAIL_EHLO_DOMAIN=mail.fermatmind.com
+# EMAIL_OUTBOX_SEND=true
+# OPS_GATE_SPF_DKIM_DMARC_OK=true
 
 AWS_ACCESS_KEY_ID=
 AWS_SECRET_ACCESS_KEY=

--- a/backend/tests/Feature/Email/DirectMailSmtpReadinessTest.php
+++ b/backend/tests/Feature/Email/DirectMailSmtpReadinessTest.php
@@ -1,0 +1,80 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use Tests\TestCase;
+
+final class DirectMailSmtpReadinessTest extends TestCase
+{
+    public function test_env_example_documents_directmail_without_enabling_external_mail_by_default(): void
+    {
+        $env = $this->repoFile('backend/.env.example');
+
+        $this->assertStringContainsString('MAIL_MAILER=log', $env);
+        $this->assertStringContainsString('MAIL_HOST=127.0.0.1', $env);
+        $this->assertStringContainsString('MAIL_PORT=2525', $env);
+        $this->assertStringContainsString('MAIL_PASSWORD=null', $env);
+        $this->assertStringContainsString('EMAIL_OUTBOX_SEND=false', $env);
+        $this->assertStringContainsString('OPS_GATE_SPF_DKIM_DMARC_OK=false', $env);
+
+        $this->assertStringContainsString('# Production DirectMail SMTP readiness template.', $env);
+        $this->assertStringContainsString('# MAIL_MAILER=smtp', $env);
+        $this->assertStringContainsString('# MAIL_SCHEME=smtps', $env);
+        $this->assertStringContainsString('# MAIL_HOST=smtpdm.aliyun.com', $env);
+        $this->assertStringContainsString('# MAIL_PORT=465', $env);
+        $this->assertStringContainsString('# MAIL_USERNAME=noreply@mail.fermatmind.com', $env);
+        $this->assertStringContainsString('# MAIL_PASSWORD=<DirectMail SMTP password>', $env);
+        $this->assertStringContainsString('# MAIL_FROM_ADDRESS=noreply@mail.fermatmind.com', $env);
+        $this->assertStringContainsString('# MAIL_FROM_NAME=FermatMind', $env);
+        $this->assertStringContainsString('# MAIL_EHLO_DOMAIN=mail.fermatmind.com', $env);
+        $this->assertStringContainsString('# EMAIL_OUTBOX_SEND=true', $env);
+        $this->assertStringContainsString('# OPS_GATE_SPF_DKIM_DMARC_OK=true', $env);
+
+        $this->assertDoesNotMatchRegularExpression('/^MAIL_PASSWORD=(?!null$).+/m', $env);
+    }
+
+    public function test_runbook_records_directmail_dns_smtp_and_smoke_readiness(): void
+    {
+        $runbook = $this->repoFile('docs/RUNBOOK_SMTP_DNS.md');
+
+        foreach ([
+            'mail.fermatmind.com',
+            'noreply@mail.fermatmind.com',
+            'smtpdm.aliyun.com',
+            'MAIL_SCHEME=smtps',
+            'MAIL_PORT=465',
+            'MAIL_EHLO_DOMAIN=mail.fermatmind.com',
+            'EMAIL_OUTBOX_SEND=true',
+            'OPS_GATE_SPF_DKIM_DMARC_OK=true',
+            'v=spf1 include:spf1.dm.aliyun.com -all',
+            'aliyun-cn-hangzhou._domainkey.mail',
+            'v=DMARC1;p=none;rua=mailto:dmarc_report@service.aliyun.com',
+            'mx01.dm.aliyun.com',
+            'php artisan email:outbox-send --limit=1',
+            'Mailer smtp: sent 1, blocked 0, failed 0.',
+            '250 Send Mail OK',
+            'delivered to Outlook inbox',
+        ] as $needle) {
+            $this->assertStringContainsString($needle, $runbook);
+        }
+
+        foreach ([
+            'Do not commit `MAIL_PASSWORD`',
+            'without raw credentials or private user data',
+            'did not mutate code, publish content, deploy, submit URLs, enqueue',
+        ] as $safetyBoundary) {
+            $this->assertStringContainsString($safetyBoundary, $runbook);
+        }
+    }
+
+    private function repoFile(string $relativePath): string
+    {
+        $path = dirname(base_path()).'/'.$relativePath;
+
+        $this->assertFileExists($path);
+
+        return (string) file_get_contents($path);
+    }
+}

--- a/docs/RUNBOOK_SMTP_DNS.md
+++ b/docs/RUNBOOK_SMTP_DNS.md
@@ -5,31 +5,61 @@ Ensure transactional emails (delivery/refund/support) from `fap-api` are accepte
 
 ## 1. Required DNS records
 
+### FermatMind DirectMail baseline
+
+- Sender domain: `mail.fermatmind.com`
+- Sender address: `noreply@mail.fermatmind.com`
+- SMTP host: `smtpdm.aliyun.com`
+- SMTP port: `465`
+- SMTP scheme: `smtps`
+- EHLO/local domain: `mail.fermatmind.com`
+- Outbox sender: `php artisan email:outbox-send`
+- Runtime send gate: `EMAIL_OUTBOX_SEND=true`
+- DNS gate: `OPS_GATE_SPF_DKIM_DMARC_OK=true`
+
+Production secrets must stay in production env/secret storage only.
+Do not commit `MAIL_PASSWORD` or browser-exported credentials, cookies,
+session tokens, or provider API keys.
+
 ### SPF (TXT on root)
-- Host: `@`
+- Host: `mail`
 - Type: `TXT`
-- Value example: `v=spf1 include:_spf.your-mail-provider.com ~all`
+- Value: `v=spf1 include:spf1.dm.aliyun.com -all`
 - Rule: only one SPF TXT record for the same domain.
 
 ### DKIM (TXT on selector)
-- Host: `<selector>._domainkey`
+- Host: `aliyun-cn-hangzhou._domainkey.mail`
 - Type: `TXT`
 - Value: provider public key (`v=DKIM1; k=rsa; p=...`)
 - Rule: selector must match SMTP provider configuration.
 
 ### DMARC (TXT on `_dmarc`)
-- Host: `_dmarc`
+- Host: `_dmarc.mail`
 - Type: `TXT`
 - Value baseline:
-  - `v=DMARC1; p=none; rua=mailto:dmarc@your-domain.com; adkim=s; aspf=s`
+  - `v=DMARC1;p=none;rua=mailto:dmarc_report@service.aliyun.com`
 - Production hardening suggestion:
   - move from `p=none` -> `p=quarantine` -> `p=reject` after monitoring.
+
+### MX
+- Host: `mail`
+- Type: `MX`
+- Value: `mx01.dm.aliyun.com`
+- Priority: `10`
 
 ## 2. Backend configuration checklist
 
 - `MAIL_MAILER=smtp`
-- `MAIL_HOST`, `MAIL_PORT`, `MAIL_USERNAME`, `MAIL_PASSWORD` configured
-- `MAIL_FROM_ADDRESS` uses verified sender domain
+- `MAIL_SCHEME=smtps`
+- `MAIL_HOST=smtpdm.aliyun.com`
+- `MAIL_PORT=465`
+- `MAIL_USERNAME=noreply@mail.fermatmind.com`
+- `MAIL_PASSWORD` configured in production secret/env storage
+- `MAIL_FROM_ADDRESS=noreply@mail.fermatmind.com`
+- `MAIL_FROM_NAME=FermatMind`
+- `MAIL_EHLO_DOMAIN=mail.fermatmind.com`
+- `EMAIL_OUTBOX_SEND=true`
+- `OPS_GATE_SPF_DKIM_DMARC_OK=true`
 - `FAP_SUPPORT_EMAIL` set (or fallback `support@fermatmind.com`)
 - `FAP_GLOBAL_TERMS_URL`, `FAP_GLOBAL_PRIVACY_URL`, `FAP_GLOBAL_REFUND_URL`
 - `FAP_CN_TERMS_URL`, `FAP_CN_PRIVACY_URL`, `FAP_CN_REFUND_URL`
@@ -41,10 +71,11 @@ Ensure transactional emails (delivery/refund/support) from `fap-api` are accepte
 nslookup -type=txt your-domain.com
 nslookup -type=txt <selector>._domainkey.your-domain.com
 nslookup -type=txt _dmarc.your-domain.com
+nslookup -type=mx mail.your-domain.com
 
 # Laravel config check
 cd backend && php artisan config:clear
-cd backend && php artisan tinker --execute="dump(config('mail.default')); dump(config('mail.from'));"
+cd backend && php artisan tinker --execute="dump(config('mail.default')); dump(config('mail.mailers.smtp.host')); dump(config('mail.from'));"
 ```
 
 ## 4. Delivery verification
@@ -78,3 +109,21 @@ Store screenshots/log snippets for:
 - provider accepted events
 - Gmail inbox + Outlook inbox samples
 - Ops HealthChecks mailer summary page
+
+## 7. Controlled smoke result
+
+2026-05-29 controlled production smoke result:
+
+- Scope: one internal Outlook recipient only.
+- fap-api command: `php artisan email:outbox-send --limit=1`
+- Outbox result: `Mailer smtp: sent 1, blocked 0, failed 0.`
+- Outbox status: `sent`
+- Mailer: `smtp`
+- DirectMail result: `250 Send Mail OK`
+- Subject: `FermatMind DirectMail smoke test`
+- From: `noreply@mail.fermatmind.com`
+- Recipient confirmation: delivered to Outlook inbox.
+
+This smoke did not mutate code, publish content, deploy, submit URLs, enqueue
+Search Channel actions, or send to real users. Future production smoke tests
+must remain opt-in, scoped to internal recipients, and recorded without raw credentials or private user data.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19606,7 +19606,7 @@
       "depends_on": [
         "RESULT-EN-PARITY-03"
       ],
-      "commit_sha": "8d28d187de12a25f809a808d78738fb7883f8110",
+      "commit_sha": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
       "checks": {
         "dependency_result_en_parity_00": {
@@ -27926,7 +27926,7 @@
       "base": "main",
       "status": "in_progress",
       "title": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test",
-      "commit_sha": null,
+      "commit_sha": "bc79c7c5776a51cc67a862fbc1a460eec3aa8b68",
       "pr_url": null,
       "checks": {
         "manifest_registration": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -25541,7 +25541,7 @@
     "CONTENT-OPS-CLAIM-LINK-OPS-READINESS": {
       "repo": "fap-api",
       "branch": "codex/content-ops-claim-link-ops-readiness",
-      "status": "in_progress",
+      "status": "pr_opened",
       "depends_on": [
         "CONTENT-OPS-02B",
         "INTERNAL-LINK-01B",
@@ -26064,7 +26064,7 @@
       "status": "in_progress",
       "depends_on": [],
       "commit_sha": null,
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1750",
       "checks": {
         "local": {
           "ops_theme_build": "passed: cd backend && npm run build:ops-theme",
@@ -27987,6 +27987,11 @@
           "at": "2026-05-29T00:44:54+08:00",
           "status": "local_validation_passed",
           "summary": "Validated env example, DirectMail DNS/SMTP runbook, controlled smoke evidence, and focused readiness test; no production mutation or email send performed by this PR."
+        },
+        {
+          "at": "2026-05-29T00:51:00+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1750 and pushed branch codex/email-directmail-smtp-readiness-01; waiting for GitHub required checks."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -9437,7 +9437,7 @@
       "depends_on": [
         "SEO-DASH-04A"
       ],
-      "status": "pr_opened",
+      "status": "github_checks_passed_ready_to_merge",
       "train_scope": "search_intelligence_baidu_indexnow_disabled_collectors",
       "risk_level": "medium_disabled_search_channel_schema",
       "title": "feat(seo-intel): add Baidu and IndexNow collector foundations",
@@ -27968,6 +27968,10 @@
         "fap_web_reference_check": {
           "status": "pass",
           "evidence": "Reference-only fap-web status clean; no fap-web changes committed."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1750 checks passed: hygiene, supply-chain, Semgrep blocking secrets, semgrep sarif non-blocking upload, Semgrep OSS, verify-mbti-legacy, verify-mbti-v2. mergeStateStatus CLEAN."
         }
       },
       "failure_reason": null,
@@ -27992,6 +27996,11 @@
           "at": "2026-05-29T00:51:00+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1750 and pushed branch codex/email-directmail-smtp-readiness-01; waiting for GitHub required checks."
+        },
+        {
+          "at": "2026-05-29T01:01:00+08:00",
+          "status": "github_checks_passed_ready_to_merge",
+          "summary": "GitHub checks passed and mergeStateStatus was CLEAN for PR #1750."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19606,7 +19606,7 @@
       "depends_on": [
         "RESULT-EN-PARITY-03"
       ],
-      "commit_sha": null,
+      "commit_sha": "8d28d187de12a25f809a808d78738fb7883f8110",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
       "checks": {
         "dependency_result_en_parity_00": {
@@ -27916,6 +27916,77 @@
           "at": "2026-05-28T19:02:00+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1742 after local validation; waiting for GitHub required checks."
+        }
+      ]
+    },
+    "EMAIL-DIRECTMAIL-SMTP-READINESS-01": {
+      "id": "EMAIL-DIRECTMAIL-SMTP-READINESS-01",
+      "repo": "fap-api",
+      "branch": "codex/email-directmail-smtp-readiness-01",
+      "base": "main",
+      "status": "in_progress",
+      "title": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding EMAIL-DIRECTMAIL-SMTP-READINESS-01 to fap-api pr-train manifest/state."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "Docs/env-example/focused-test readiness only; no production env write, real email send, deploy, CMS/content mutation, URL submission, Search Channel action, or fap-web change in this PR."
+        },
+        "php_artisan_test_filter_DirectMailSmtpReadiness": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test --filter=DirectMailSmtpReadiness --no-ansi"
+        },
+        "php_artisan_route_list": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan route:list --no-ansi"
+        },
+        "pint_test": {
+          "status": "pass",
+          "evidence": "cd backend && vendor/bin/pint --test"
+        },
+        "composer_validate_strict": {
+          "status": "pass",
+          "evidence": "cd backend && composer validate --strict"
+        },
+        "composer_audit_locked": {
+          "status": "pass",
+          "evidence": "cd backend && composer audit --locked --no-interaction --ignore-unreachable"
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "evidence": "pr-train-state.json parsed with python3 -m json.tool; pr-train.yaml parsed with yaml.safe_load."
+        },
+        "diff_hygiene": {
+          "status": "pass",
+          "evidence": "git diff --check && git diff --cached --check"
+        },
+        "fap_web_reference_check": {
+          "status": "pass",
+          "evidence": "Reference-only fap-web status clean; no fap-web changes committed."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "merge_commit": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "RESULT-EMAIL-GATE-POLICY-02",
+      "sidecars": [],
+      "transitions": [
+        {
+          "at": "2026-05-29T00:36:09+08:00",
+          "status": "in_progress",
+          "summary": "Registered DirectMail SMTP readiness PR after successful controlled production smoke and explicit manifest/state authorization."
+        },
+        {
+          "at": "2026-05-29T00:44:54+08:00",
+          "status": "local_validation_passed",
+          "summary": "Validated env example, DirectMail DNS/SMTP runbook, controlled smoke evidence, and focused readiness test; no production mutation or email send performed by this PR."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15783,3 +15783,46 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 rerun production no-write preflight after deploy
+
+  - id: EMAIL-DIRECTMAIL-SMTP-READINESS-01
+    repo: fap-api
+    branch: codex/email-directmail-smtp-readiness-01
+    base: main
+    title: "EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test"
+    train_scope: directmail_smtp_readiness
+    risk_level: p2_transactional_email_readiness
+    allowed_paths:
+      - backend/.env.example
+      - docs/RUNBOOK_SMTP_DNS.md
+      - backend/tests/Feature/Email/DirectMailSmtpReadinessTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Document Aliyun DirectMail SMTP production readiness without committing secrets.
+      - Keep local and CI mail defaults on log transport with EMAIL_OUTBOX_SEND disabled.
+      - Record DNS, sender address, SMTP host/port/scheme, outbox gate, and controlled smoke evidence.
+      - Add a focused test that validates DirectMail readiness docs and env examples do not enable external mail by default.
+      - Do not modify production env, send real email, deploy, mutate CMS/content, submit URLs, or enqueue Search Channel actions in this PR.
+    validation:
+      - cd backend && php artisan test --filter=DirectMailSmtpReadiness --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: RESULT-EMAIL-GATE-POLICY-02 explicit approval required before implementation


### PR DESCRIPTION
## What changed
- Documented Aliyun DirectMail SMTP readiness in backend/.env.example without enabling external mail by default.
- Updated docs/RUNBOOK_SMTP_DNS.md with verified sender domain/address, SMTP host/port/scheme, DNS records, and controlled smoke evidence.
- Added DirectMailSmtpReadinessTest to lock env/runbook readiness and safety boundaries.
- Registered EMAIL-DIRECTMAIL-SMTP-READINESS-01 in the PR train manifest/state.

## Why
DirectMail is now configured and smoke-tested in production, but the repository needed a readiness baseline that documents required env/DNS gates without committing secrets or changing runtime behavior.

## Validation
- cd backend && php artisan test --filter=DirectMailSmtpReadiness --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- YAML parse for docs/codex/pr-train.yaml
- git diff --check && git diff --cached --check
- Reference-only fap-web status clean

## Intentionally deferred
- No production env change in this PR.
- No real email send in this PR.
- No result-page email gate change.
- No access-link delivery flow.
- No deploy, CMS mutation, Search Channel action, or URL submission.

Repository rule impact: no content ownership or runtime authority change; this PR documents transactional email readiness only.