### PR TITLE
RESULT-EMAIL-GATE-POLICY-02 relax result email gate policy

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+++ b/backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
@@ -2201,6 +2201,10 @@ class AttemptReadController extends Controller
             return false;
         }
 
+        if (! (bool) config('fap.result_email_gate.require_binding_for_read', false)) {
+            return false;
+        }
+
         $normalized = strtoupper(trim($scaleCode));
         if ($normalized === '' || in_array($normalized, self::SENSITIVE_RESULT_READ_SCALES, true)) {
             return false;

--- a/backend/config/fap.php
+++ b/backend/config/fap.php
@@ -31,6 +31,7 @@ return [
     ],
 
     'result_email_gate' => [
+        'require_binding_for_read' => (bool) env('FAP_RESULT_EMAIL_REQUIRE_BINDING_FOR_READ', false),
         'enabled_scale_codes' => ['MBTI', 'BIG5_OCEAN', 'IQ_RAVEN', 'EQ_60', 'ENNEAGRAM', 'RIASEC'],
     ],
 

--- a/backend/tests/Feature/ResultEmailGatedReadTest.php
+++ b/backend/tests/Feature/ResultEmailGatedReadTest.php
@@ -35,7 +35,7 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('attempt_id', $attemptId);
     }
 
-    public function test_unbound_public_result_read_requires_email_when_gate_is_enabled(): void
+    public function test_unbound_public_result_read_stays_open_when_email_recovery_is_enabled(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
@@ -47,13 +47,13 @@ final class ResultEmailGatedReadTest extends TestCase
         ])
             ->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
-        $response->assertStatus(428);
-        $response->assertJsonPath('error_code', 'EMAIL_BIND_REQUIRED');
-        $response->assertJsonPath('details.attempt_id', $attemptId);
-        $response->assertJsonPath('details.bind_endpoint', "/api/v0.3/attempts/{$attemptId}/email-bind");
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonMissingPath('error_code');
     }
 
-    public function test_unbound_public_report_read_requires_email_when_gate_is_enabled(): void
+    public function test_unbound_public_report_read_stays_open_when_email_recovery_is_enabled(): void
     {
         config()->set('fap.features.email_first_result_access', true);
         config()->set('fap.features.report_snapshot_strict_v2', false);
@@ -65,9 +65,45 @@ final class ResultEmailGatedReadTest extends TestCase
             'Authorization' => "Bearer {$token}",
         ])->getJson("/api/v0.3/attempts/{$attemptId}/report");
 
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonMissingPath('error_code');
+    }
+
+    public function test_unbound_public_report_access_stays_open_when_email_recovery_is_enabled(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_report_access_open', 'MBTI');
+        $token = $this->seedFmToken('anon_email_gate_report_access_open');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->getJson("/api/v0.3/attempts/{$attemptId}/report-access");
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonMissingPath('error_code');
+    }
+
+    public function test_unbound_public_result_read_can_be_blocked_only_by_explicit_rollback_gate(): void
+    {
+        config()->set('fap.features.email_first_result_access', true);
+        config()->set('fap.result_email_gate.require_binding_for_read', true);
+
+        $attemptId = $this->seedAttemptWithResult('anon_email_gate_rollback_required', 'MBTI');
+        $token = $this->seedFmToken('anon_email_gate_rollback_required');
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])
+            ->getJson("/api/v0.3/attempts/{$attemptId}/result");
+
         $response->assertStatus(428);
         $response->assertJsonPath('error_code', 'EMAIL_BIND_REQUIRED');
         $response->assertJsonPath('details.attempt_id', $attemptId);
+        $response->assertJsonPath('details.bind_endpoint', "/api/v0.3/attempts/{$attemptId}/email-bind");
     }
 
     public function test_active_email_binding_allows_owner_result_read_when_gate_is_enabled(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-28T23:01:01+08:00",
+  "updated_at": "2026-05-29T01:25:43+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -27924,10 +27924,10 @@
       "repo": "fap-api",
       "branch": "codex/email-directmail-smtp-readiness-01",
       "base": "main",
-      "status": "in_progress",
+      "status": "merged",
       "title": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 DirectMail SMTP readiness docs env and outbox test",
       "commit_sha": "bc79c7c5776a51cc67a862fbc1a460eec3aa8b68",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1750",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -27972,13 +27972,17 @@
         "github_required_checks": {
           "status": "pass",
           "evidence": "PR #1750 checks passed: hygiene, supply-chain, Semgrep blocking secrets, semgrep sarif non-blocking upload, Semgrep OSS, verify-mbti-legacy, verify-mbti-v2. mergeStateStatus CLEAN."
+        },
+        "merged_reconciled_before_result_email_gate_policy_02": {
+          "status": "pass",
+          "evidence": "PR #1750 is MERGED; origin/main and local main contain merge commit 1f8b4ac77215020b17da5da1e1a0d531ed074ba1; remote task branch is absent; local task branch cleanup completed by gh merge/main checkout."
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "merge_commit": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-28T17:09:43Z",
+      "merge_commit": "1f8b4ac77215020b17da5da1e1a0d531ed074ba1",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "next_task": "RESULT-EMAIL-GATE-POLICY-02",
       "sidecars": [],
       "transitions": [
@@ -28001,6 +28005,99 @@
           "at": "2026-05-29T01:01:00+08:00",
           "status": "github_checks_passed_ready_to_merge",
           "summary": "GitHub checks passed and mergeStateStatus was CLEAN for PR #1750."
+        },
+        {
+          "at": "2026-05-29T01:18:23+08:00",
+          "status": "merged_reconciled_before_result_email_gate_policy_02",
+          "summary": "Reconciled EMAIL-DIRECTMAIL-SMTP-READINESS-01 as merged before starting RESULT-EMAIL-GATE-POLICY-02."
+        }
+      ]
+    },
+    "RESULT-EMAIL-GATE-POLICY-02": {
+      "id": "RESULT-EMAIL-GATE-POLICY-02",
+      "repo": "fap-api",
+      "branch": "codex/result-email-gate-policy-02",
+      "base": "main",
+      "status": "local_validation_passed",
+      "title": "RESULT-EMAIL-GATE-POLICY-02 relax result email gate policy",
+      "depends_on": [
+        "EMAIL-DIRECTMAIL-SMTP-READINESS-01"
+      ],
+      "commit_sha": "71bfa940427af841ee950778d45a711659d9315e",
+      "pr_url": null,
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User requested RESULT-EMAIL-GATE-POLICY-02 product logic PR to relax the result email gate and keep email binding optional for recovery/send-link."
+        },
+        "dependency_email_directmail_smtp_readiness_01": {
+          "status": "pass",
+          "evidence": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 merged as PR #1750 with merge commit 1f8b4ac77215020b17da5da1e1a0d531ed074ba1."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "Backend result-access policy only; no production env write, real email send, deploy, CMS/content mutation, URL submission, Search Channel action, or fap-web change in this PR."
+        },
+        "php_artisan_test_filter_ResultEmailGatedRead": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test --filter=ResultEmailGatedRead --no-ansi"
+        },
+        "php_artisan_route_list": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan route:list --no-ansi"
+        },
+        "pint_test": {
+          "status": "pass",
+          "evidence": "cd backend && vendor/bin/pint --test"
+        },
+        "composer_validate_strict": {
+          "status": "pass",
+          "evidence": "cd backend && composer validate --strict"
+        },
+        "composer_audit_locked": {
+          "status": "pass",
+          "evidence": "cd backend && composer audit --locked --no-interaction --ignore-unreachable"
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "evidence": "pr-train-state.json parsed with python3 -m json.tool; pr-train.yaml parsed with yaml.safe_load."
+        },
+        "diff_hygiene": {
+          "status": "pass",
+          "evidence": "git diff --check && git diff --cached --check"
+        },
+        "ci_verify_mbti": {
+          "status": "pass",
+          "evidence": "cd backend && bash scripts/ci_verify_mbti.sh"
+        },
+        "scope_cleanup": {
+          "status": "pass",
+          "evidence": "Reverted generated BIG5_OCEAN compiled artifact diffs produced by ci_verify_mbti.sh; remaining diff is confined to current PR scope."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "merge_commit": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "RESULT-EMAIL-ACCESS-LINK-03",
+      "sidecars": [
+        {
+          "id": "fap-web-result-email-gate-copy-followup",
+          "status": "deferred_external_scope",
+          "summary": "fap-web still contains legacy EMAIL_BIND_REQUIRED UI copy/contract handling for backward compatibility. Current PR does not modify fap-web because that worktree has an unrelated active branch and dirty changes."
+        }
+      ],
+      "transitions": [
+        {
+          "at": "2026-05-29T01:18:23+08:00",
+          "status": "in_progress",
+          "summary": "Started backend product policy PR to stop requiring email binding before accurate result/report/report-access reads while preserving optional recovery token flows."
+        },
+        {
+          "at": "2026-05-29T01:25:43+08:00",
+          "status": "local_validation_passed",
+          "summary": "ResultEmailGatedRead focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, and ci_verify_mbti passed locally."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-29T01:31:37+08:00",
+  "updated_at": "2026-05-29T01:39:31+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28018,12 +28018,12 @@
       "repo": "fap-api",
       "branch": "codex/result-email-gate-policy-02",
       "base": "main",
-      "status": "pr_opened",
+      "status": "github_checks_passed_ready_to_merge",
       "title": "RESULT-EMAIL-GATE-POLICY-02 relax result email gate policy",
       "depends_on": [
         "EMAIL-DIRECTMAIL-SMTP-READINESS-01"
       ],
-      "commit_sha": "f3625219f256214b4e4d50712a1742a1ae3bb7c5",
+      "commit_sha": "acebf6f522ddb7be3e06820216a993a60a61df15",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1751",
       "checks": {
         "manifest_registration": {
@@ -28073,6 +28073,10 @@
         "scope_cleanup": {
           "status": "pass",
           "evidence": "Reverted generated BIG5_OCEAN compiled artifact diffs produced by ci_verify_mbti.sh; remaining diff is confined to current PR scope."
+        },
+        "github_required_checks": {
+          "status": "pass",
+          "evidence": "PR #1751 checks passed: hygiene, supply-chain, Semgrep blocking secrets, semgrep sarif non-blocking upload, Semgrep OSS, verify-mbti-legacy, verify-mbti-v2. mergeStateStatus CLEAN."
         }
       },
       "failure_reason": null,
@@ -28103,6 +28107,11 @@
           "at": "2026-05-29T01:31:37+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1751 after local validation; waiting for GitHub required checks."
+        },
+        {
+          "at": "2026-05-29T01:39:31+08:00",
+          "status": "github_checks_passed_ready_to_merge",
+          "summary": "GitHub checks passed and mergeStateStatus was CLEAN for PR #1751."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-29T01:25:43+08:00",
+  "updated_at": "2026-05-29T01:31:37+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -28018,13 +28018,13 @@
       "repo": "fap-api",
       "branch": "codex/result-email-gate-policy-02",
       "base": "main",
-      "status": "local_validation_passed",
+      "status": "pr_opened",
       "title": "RESULT-EMAIL-GATE-POLICY-02 relax result email gate policy",
       "depends_on": [
         "EMAIL-DIRECTMAIL-SMTP-READINESS-01"
       ],
-      "commit_sha": "71bfa940427af841ee950778d45a711659d9315e",
-      "pr_url": null,
+      "commit_sha": "f3625219f256214b4e4d50712a1742a1ae3bb7c5",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1751",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -28098,6 +28098,11 @@
           "at": "2026-05-29T01:25:43+08:00",
           "status": "local_validation_passed",
           "summary": "ResultEmailGatedRead focused test, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, and ci_verify_mbti passed locally."
+        },
+        {
+          "at": "2026-05-29T01:31:37+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1751 after local validation; waiting for GitHub required checks."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15826,3 +15826,47 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: RESULT-EMAIL-GATE-POLICY-02 explicit approval required before implementation
+
+  - id: RESULT-EMAIL-GATE-POLICY-02
+    repo: fap-api
+    branch: codex/result-email-gate-policy-02
+    base: main
+    title: "RESULT-EMAIL-GATE-POLICY-02 relax result email gate policy"
+    train_scope: result_email_gate_policy
+    risk_level: p1_result_access_product_policy
+    depends_on:
+      - EMAIL-DIRECTMAIL-SMTP-READINESS-01
+    allowed_paths:
+      - backend/config/fap.php
+      - backend/app/Http/Controllers/API/V0_3/AttemptReadController.php
+      - backend/tests/Feature/ResultEmailGatedReadTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Stop requiring email binding before public result, report, and report-access reads.
+      - Keep email binding/result access token paths as optional result recovery and send-link infrastructure.
+      - Keep legacy blocking behavior available only behind an explicit rollback gate.
+      - Do not send email, mutate production env, deploy, mutate CMS/content, submit URLs, enqueue Search Channel actions, or modify fap-web in this PR.
+    validation:
+      - cd backend && php artisan test --filter=ResultEmailGatedRead --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: RESULT-EMAIL-ACCESS-LINK-03 explicit approval required before implementation


### PR DESCRIPTION
## What changed
- Changed backend result email gate policy so unbound public result/report/report-access reads stay open by default, even when email recovery infrastructure is enabled.
- Added an explicit rollback-only gate, FAP_RESULT_EMAIL_REQUIRE_BINDING_FOR_READ, defaulting to false.
- Updated ResultEmailGatedRead coverage for result, report, and report-access reads, while preserving optional result access token and email binding behavior.
- Reconciled EMAIL-DIRECTMAIL-SMTP-READINESS-01 ledger status as merged before starting this PR.

## Why
Users should be able to view accurate result pages without entering an email. Email binding remains useful as optional result recovery / send-link infrastructure, not as a required access gate.

## Validation
- cd backend && php artisan test --filter=ResultEmailGatedRead --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- YAML parse for docs/codex/pr-train.yaml
- git diff --check && git diff --cached --check
- cd backend && bash scripts/ci_verify_mbti.sh

## Intentionally deferred
- No DirectMail send-link email implementation; that remains RESULT-EMAIL-ACCESS-LINK-03.
- No fap-web copy cleanup in this PR because fap-web has an unrelated active dirty worktree; backend no longer emits EMAIL_BIND_REQUIRED by default.
- No production env write, real email send, deploy, CMS/content mutation, Search Channel action, or URL submission.

Repository rule impact: result access policy changes in backend authority only; email binding is now optional recovery infrastructure by default, with explicit rollback gate for legacy blocking behavior.