### PR TITLE
RESULT-EMAIL-ACCESS-LINK-03 send result access links by email

### DIFF
--- a/backend/app/Services/Attempts/AttemptEmailBindingService.php
+++ b/backend/app/Services/Attempts/AttemptEmailBindingService.php
@@ -9,6 +9,8 @@ use App\Models\Attempt;
 use App\Models\AttemptEmailBinding;
 use App\Models\Result;
 use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailOutboxService;
+use App\Services\Results\ResultAccessTokenService;
 use App\Services\Scale\ScaleCodeResponseProjector;
 use App\Support\PiiCipher;
 use Illuminate\Support\Facades\DB;
@@ -33,6 +35,8 @@ final class AttemptEmailBindingService
         private readonly PiiCipher $piiCipher,
         private readonly ScaleCodeResponseProjector $scaleCodeProjector,
         private readonly EmailCaptureService $emailCaptureService,
+        private readonly ResultAccessTokenService $resultAccessTokens,
+        private readonly EmailOutboxService $emailOutbox,
     ) {}
 
     /**
@@ -109,6 +113,7 @@ final class AttemptEmailBindingService
         });
 
         $this->captureEmailLifecycle($normalizedEmail, $attemptId, $context);
+        $accessLink = $this->queueResultAccessLink($binding, $normalizedEmail, $context);
 
         return [
             'ok' => true,
@@ -117,7 +122,51 @@ final class AttemptEmailBindingService
             'binding_id' => (string) $binding->getKey(),
             'result_ready' => $result instanceof Result,
             'result_url' => $this->localizedResultUrl($attemptId, $context['locale'] ?? null),
+            'result_access_link_email_queued' => (bool) ($accessLink['queued'] ?? false),
+            'result_access_token_expires_at' => $accessLink['expires_at'] ?? null,
         ];
+    }
+
+    /**
+     * @param  array{locale?:string|null,surface?:string|null}  $context
+     * @return array{queued:bool,expires_at?:string|null,error?:string|null}
+     */
+    private function queueResultAccessLink(AttemptEmailBinding $binding, string $email, array $context): array
+    {
+        try {
+            $token = $this->resultAccessTokens->issueForBinding($binding);
+            $rawToken = (string) ($token['token'] ?? '');
+            if ($rawToken === '') {
+                return ['queued' => false, 'error' => 'TOKEN_MISSING'];
+            }
+
+            $attemptId = (string) ($binding->attempt_id ?? '');
+            $resultUrl = $this->appendAccessTokenToUrl(
+                $this->localizedResultUrl($attemptId, $context['locale'] ?? null),
+                $rawToken,
+            );
+
+            $queued = $this->emailOutbox->queueResultAccessLink(
+                $binding,
+                $email,
+                $token,
+                $resultUrl,
+                $this->normalizeNullableString($context['locale'] ?? null, 16),
+                [
+                    'surface' => $this->normalizeSource($context['surface'] ?? null),
+                ],
+            );
+
+            return [
+                'queued' => (bool) ($queued['queued'] ?? false),
+                'expires_at' => (string) ($token['expires_at'] ?? ''),
+                'error' => $queued['error'] ?? null,
+            ];
+        } catch (\Throwable $exception) {
+            report($exception);
+
+            return ['queued' => false, 'error' => 'QUEUE_FAILED'];
+        }
     }
 
     private function resolveScaleCode(Attempt $attempt, ?Result $result): string
@@ -157,6 +206,21 @@ final class AttemptEmailBindingService
         $prefix = str_starts_with($normalized, 'zh') ? '/zh' : '/en';
 
         return "{$prefix}/result/{$attemptId}";
+    }
+
+    private function appendAccessTokenToUrl(string $url, string $token): string
+    {
+        $fragment = '';
+        $base = $url;
+        $fragmentPosition = strpos($url, '#');
+        if ($fragmentPosition !== false) {
+            $base = substr($url, 0, $fragmentPosition);
+            $fragment = substr($url, $fragmentPosition);
+        }
+
+        $separator = str_contains($base, '?') ? '&' : '?';
+
+        return $base.$separator.'access_token='.rawurlencode($token).$fragment;
     }
 
     private function normalizeSource(mixed $source): string

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -2,6 +2,7 @@
 
 namespace App\Services\Email;
 
+use App\Models\AttemptEmailBinding;
 use App\Models\EmailPreference;
 use App\Models\EmailSubscriber;
 use App\Support\PiiCipher;
@@ -14,6 +15,8 @@ use Illuminate\Support\Str;
 
 class EmailOutboxService
 {
+    private const RESULT_ACCESS_LINK_TEMPLATE = 'result_access_link';
+
     public function __construct(
         private readonly PiiCipher $piiCipher,
         private readonly PiiReadFallbackMonitor $fallbackMonitor,
@@ -396,6 +399,153 @@ class EmailOutboxService
         DB::table('email_outbox')->insert($row);
 
         return ['ok' => true];
+    }
+
+    /**
+     * Queue an optional result recovery access link email. The token is stored only in the encrypted payload.
+     *
+     * @param  array{token:string,expires_at:string}  $token
+     * @param  array<string,mixed>  $context
+     * @return array{ok:bool,queued:bool,error?:string,reason?:string}
+     */
+    public function queueResultAccessLink(
+        AttemptEmailBinding $binding,
+        string $email,
+        array $token,
+        string $resultUrl,
+        ?string $preferredLocale = null,
+        array $context = []
+    ): array {
+        if (! \App\Support\SchemaBaseline::hasTable('email_outbox')) {
+            return ['ok' => false, 'queued' => false, 'error' => 'TABLE_MISSING'];
+        }
+
+        $email = $this->normalizeEmailAddress($email);
+        $attemptId = $this->trimOrNull((string) ($binding->attempt_id ?? ''));
+        $resultAccessToken = $this->trimOrNull((string) ($token['token'] ?? ''));
+        $resultAccessUrl = $this->trimOrNull($resultUrl);
+        if ($email === null || $attemptId === null || $resultAccessToken === null || $resultAccessUrl === null) {
+            return ['ok' => false, 'queued' => false, 'error' => 'INVALID_INPUT'];
+        }
+
+        $emailHash = $this->piiCipher->emailHash($email);
+        $emailEnc = $this->piiCipher->encrypt($email);
+        $locale = $this->resolveRequestedLocale($attemptId, $preferredLocale);
+        $subject = $this->defaultSubjectForTemplate(self::RESULT_ACCESS_LINK_TEMPLATE, $locale);
+        $outboxUserId = $this->resultAccessLinkOutboxUserId($binding);
+        $lifecycleContext = $this->buildLifecyclePayloadContext($email, null, [
+            'surface' => $context['surface'] ?? 'result_access_link',
+            'locale' => $locale,
+        ]);
+        $normalizedAttribution = is_array($lifecycleContext['attribution'] ?? null)
+            ? $lifecycleContext['attribution']
+            : [];
+
+        $payload = [
+            'attempt_id' => $attemptId,
+            'order_no' => null,
+            'result_access_url' => $resultAccessUrl,
+            'result_access_token' => $resultAccessToken,
+            'result_access_token_expires_at' => (string) ($token['expires_at'] ?? ''),
+            'locale' => $locale,
+            'template_key' => self::RESULT_ACCESS_LINK_TEMPLATE,
+            'to_email' => $email,
+            'subject' => $subject,
+            'subscriber_status' => (string) ($lifecycleContext['subscriber_status'] ?? 'active'),
+            'marketing_consent' => false,
+            'transactional_recovery_enabled' => (bool) ($lifecycleContext['transactional_recovery_enabled'] ?? true),
+            'surface' => 'result_access_link',
+            'attribution' => $this->payloadAttribution($normalizedAttribution),
+        ];
+        $payloadJson = $this->encodePayloadJson($this->sanitizePayloadForJson($payload));
+        $payloadEnc = $this->encodePayloadEncrypted($payload);
+
+        $pending = DB::table('email_outbox')
+            ->where('user_id', $outboxUserId)
+            ->where('status', 'pending')
+            ->where(function ($builder): void {
+                if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+                    $builder->where('template_key', self::RESULT_ACCESS_LINK_TEMPLATE);
+
+                    return;
+                }
+
+                $builder->where('template', self::RESULT_ACCESS_LINK_TEMPLATE);
+            });
+
+        if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+            $pending->where('attempt_id', $attemptId);
+        }
+
+        $pendingRow = $pending->orderByDesc('updated_at')->first();
+        if ($pendingRow) {
+            $update = [
+                'payload_json' => $payloadJson,
+                'claim_token_hash' => hash('sha256', self::RESULT_ACCESS_LINK_TEMPLATE.'|'.$outboxUserId.'|'.Str::uuid()->toString()),
+                'claim_expires_at' => null,
+                'updated_at' => now(),
+            ];
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email')) {
+                $update['email'] = $this->maskedLegacyEmail($emailHash);
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'attempt_id')) {
+                $update['attempt_id'] = $attemptId;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_hash')) {
+                $update['email_hash'] = $emailHash;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'email_enc')) {
+                $update['email_enc'] = $emailEnc;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_hash')) {
+                $update['to_email_hash'] = $emailHash;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email_enc')) {
+                $update['to_email_enc'] = $emailEnc;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
+                $update['payload_enc'] = $payloadEnc;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_schema_version')) {
+                $update['payload_schema_version'] = 'v1';
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'key_version')) {
+                $update['key_version'] = $this->piiCipher->currentKeyVersion();
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'locale')) {
+                $update['locale'] = $locale;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'template_key')) {
+                $update['template_key'] = self::RESULT_ACCESS_LINK_TEMPLATE;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'to_email')) {
+                $update['to_email'] = $this->maskedLegacyEmail($emailHash);
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'subject')) {
+                $update['subject'] = $subject;
+            }
+            if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
+                $update['body_html'] = null;
+            }
+
+            DB::table('email_outbox')->where('id', $pendingRow->id)->update($update);
+
+            return ['ok' => true, 'queued' => true];
+        }
+
+        DB::table('email_outbox')->insert($this->buildLifecycleOutboxRow(
+            $outboxUserId,
+            self::RESULT_ACCESS_LINK_TEMPLATE,
+            $emailHash,
+            $emailEnc,
+            $attemptId,
+            $locale,
+            $subject,
+            $payloadJson,
+            $payloadEnc
+        ));
+
+        return ['ok' => true, 'queued' => true];
     }
 
     /**
@@ -893,6 +1043,7 @@ class EmailOutboxService
             'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
             'updated_at' => $sentAt,
         ];
+        $persistBodyHtml = $this->shouldPersistBodyHtml($templateKey);
 
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
             $update['payload_enc'] = $this->encodePayloadEncrypted($payload);
@@ -910,7 +1061,7 @@ class EmailOutboxService
             $update['subject'] = $subject;
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
-            $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
+            $update['body_html'] = $persistBodyHtml && $bodyHtml !== '' ? $bodyHtml : null;
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'sent_at')) {
             $update['sent_at'] = $sentAt;
@@ -952,6 +1103,7 @@ class EmailOutboxService
             'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
             'updated_at' => now(),
         ];
+        $persistBodyHtml = $this->shouldPersistBodyHtml($templateKey);
 
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
             $update['payload_enc'] = $this->encodePayloadEncrypted($payload);
@@ -966,7 +1118,7 @@ class EmailOutboxService
             $update['subject'] = $subject;
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
-            $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
+            $update['body_html'] = $persistBodyHtml && $bodyHtml !== '' ? $bodyHtml : null;
         }
 
         DB::table('email_outbox')
@@ -1003,6 +1155,7 @@ class EmailOutboxService
             'payload_json' => $this->encodePayloadJson($this->sanitizePayloadForJson($payload)),
             'updated_at' => now(),
         ];
+        $persistBodyHtml = $this->shouldPersistBodyHtml($templateKey);
 
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'payload_enc')) {
             $update['payload_enc'] = $this->encodePayloadEncrypted($payload);
@@ -1017,7 +1170,7 @@ class EmailOutboxService
             $update['subject'] = $subject;
         }
         if (\App\Support\SchemaBaseline::hasColumn('email_outbox', 'body_html')) {
-            $update['body_html'] = $bodyHtml !== '' ? $bodyHtml : null;
+            $update['body_html'] = $persistBodyHtml && $bodyHtml !== '' ? $bodyHtml : null;
         }
 
         DB::table('email_outbox')
@@ -1443,6 +1596,11 @@ class EmailOutboxService
         }
 
         $data = $this->buildTemplateData((object) [], $payload, $locale, $templateKey, $recipientEmail, []);
+        $resultAccessUrl = trim((string) ($data['result_access_url'] ?? ''));
+        if ($resultAccessUrl !== '') {
+            return $resultAccessUrl;
+        }
+
         $reportUrl = trim((string) ($data['report_url'] ?? ''));
         if ($reportUrl !== '') {
             return $reportUrl;
@@ -1482,6 +1640,7 @@ class EmailOutboxService
             'report_reactivation',
             'welcome',
             'onboarding',
+            self::RESULT_ACCESS_LINK_TEMPLATE,
         ];
         if (! in_array($templateKey, $supported, true)) {
             return '';
@@ -1565,6 +1724,7 @@ class EmailOutboxService
         $attemptId = trim((string) ($payload['attempt_id'] ?? ''));
         $reportUrl = $this->absoluteUrl((string) ($payload['report_url'] ?? ''), $backendBaseUrl);
         $reportPdfUrl = $this->absoluteUrl((string) ($payload['report_pdf_url'] ?? ''), $backendBaseUrl);
+        $resultAccessUrl = $this->absoluteUrl((string) ($payload['result_access_url'] ?? ''), $frontendBaseUrl);
 
         $tokenContext = [
             'locale' => $locale,
@@ -1604,6 +1764,10 @@ class EmailOutboxService
             'report_url' => $reportUrl,
             'reportPdfUrl' => $reportPdfUrl,
             'report_pdf_url' => $reportPdfUrl,
+            'resultAccessUrl' => $resultAccessUrl,
+            'result_access_url' => $resultAccessUrl,
+            'resultAccessTokenExpiresAt' => trim((string) ($payload['result_access_token_expires_at'] ?? '')),
+            'result_access_token_expires_at' => trim((string) ($payload['result_access_token_expires_at'] ?? '')),
             'orderLookupUrl' => $orderLookupUrl,
             'order_lookup_url' => $orderLookupUrl,
             'emailPreferencesUrl' => $emailPreferencesUrl,
@@ -1809,10 +1973,17 @@ class EmailOutboxService
             $payload['email'],
             $payload['to_email'],
             $payload['claim_token'],
-            $payload['claim_url']
+            $payload['claim_url'],
+            $payload['result_access_token'],
+            $payload['result_access_url']
         );
 
         return $payload;
+    }
+
+    private function shouldPersistBodyHtml(string $templateKey): bool
+    {
+        return $templateKey !== self::RESULT_ACCESS_LINK_TEMPLATE;
     }
 
     /**
@@ -2046,6 +2217,18 @@ class EmailOutboxService
         return $this->piiCipher->legacyEmailPlaceholder($emailHash);
     }
 
+    private function resultAccessLinkOutboxUserId(AttemptEmailBinding $binding): string
+    {
+        $bindingId = $this->trimOrNull((string) $binding->getKey());
+        if ($bindingId !== null) {
+            return mb_substr('result_binding_'.$bindingId, 0, 64, 'UTF-8');
+        }
+
+        $attemptId = $this->trimOrNull((string) ($binding->attempt_id ?? '')) ?? (string) Str::uuid();
+
+        return mb_substr('result_attempt_'.$attemptId, 0, 64, 'UTF-8');
+    }
+
     /**
      * @param  array<string,mixed>  $payload
      */
@@ -2117,6 +2300,9 @@ class EmailOutboxService
         $lang = strtolower((string) explode('-', str_replace('_', '-', $locale))[0]);
         if ($templateKey === 'report_claim') {
             return $lang === 'zh' ? '你的报告链接已准备好' : 'Your report link is ready';
+        }
+        if ($templateKey === self::RESULT_ACCESS_LINK_TEMPLATE) {
+            return $lang === 'zh' ? '你的结果访问链接' : 'Your result access link';
         }
         if ($templateKey === 'payment_success') {
             return $lang === 'zh' ? '支付成功与报告交付通知' : 'Payment successful and report delivered';

--- a/backend/app/Services/Results/ResultEmailReadAccessService.php
+++ b/backend/app/Services/Results/ResultEmailReadAccessService.php
@@ -70,10 +70,6 @@ final class ResultEmailReadAccessService
             return null;
         }
 
-        if (! $this->bindingMatchesRequestActor($request, $binding)) {
-            return null;
-        }
-
         $request->attributes->set($cacheKey, $binding);
 
         return $binding;

--- a/backend/resources/views/emails/en/result_access_link.blade.php
+++ b/backend/resources/views/emails/en/result_access_link.blade.php
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="en">
+<head>
+    <meta charset="utf-8">
+    <title>Result Access Link</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.6;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">Your result access link</h1>
+    <p style="margin:0 0 16px;">Use this link to return to your FermatMind result. The link is time-limited and should not be shared.</p>
+
+    @if(!empty($result_access_url))
+        <p style="margin:0 0 12px;"><a href="{{ $result_access_url }}">View result</a></p>
+    @endif
+    @if(!empty($result_access_token_expires_at))
+        <p style="margin:0 0 24px;font-size:13px;color:#52606d;">Expires at: {{ $result_access_token_expires_at }}</p>
+    @endif
+
+    <p style="margin:0 0 8px;">Need help? Contact <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>.</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">Manage email preferences</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">Unsubscribe from emails</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">Privacy</a> |
+        <a href="{{ $terms_url }}">Terms</a> |
+        <a href="{{ $refund_url }}">Refund</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/resources/views/emails/zh/result_access_link.blade.php
+++ b/backend/resources/views/emails/zh/result_access_link.blade.php
@@ -1,0 +1,30 @@
+<!doctype html>
+<html lang="zh-CN">
+<head>
+    <meta charset="utf-8">
+    <title>结果访问链接</title>
+</head>
+<body style="margin:0;padding:24px;background:#f6f4ef;font-family:Arial,sans-serif;color:#1f2933;line-height:1.7;">
+<div style="max-width:640px;margin:0 auto;background:#ffffff;border:1px solid #e5e7eb;padding:32px;">
+    <h1 style="margin:0 0 16px;font-size:28px;line-height:1.2;">你的结果访问链接</h1>
+    <p style="margin:0 0 16px;">点击下方链接即可回到你的 FermatMind 结果页。链接有时效限制，请勿转发给他人。</p>
+
+    @if(!empty($result_access_url))
+        <p style="margin:0 0 12px;"><a href="{{ $result_access_url }}">查看结果</a></p>
+    @endif
+    @if(!empty($result_access_token_expires_at))
+        <p style="margin:0 0 24px;font-size:13px;color:#52606d;">过期时间：{{ $result_access_token_expires_at }}</p>
+    @endif
+
+    <p style="margin:0 0 8px;">如需帮助，请联系 <a href="mailto:{{ $support_email }}">{{ $support_email }}</a>。</p>
+    <p style="margin:0 0 8px;"><a href="{{ $email_preferences_url }}">管理邮件偏好</a></p>
+    <p style="margin:0 0 24px;"><a href="{{ $email_unsubscribe_url }}">退订邮件</a></p>
+
+    <p style="margin:0;font-size:12px;color:#52606d;">
+        <a href="{{ $privacy_url }}">隐私政策</a> |
+        <a href="{{ $terms_url }}">服务条款</a> |
+        <a href="{{ $refund_url }}">退款政策</a>
+    </p>
+</div>
+</body>
+</html>

--- a/backend/tests/Feature/AttemptEmailBindingTest.php
+++ b/backend/tests/Feature/AttemptEmailBindingTest.php
@@ -36,6 +36,8 @@ final class AttemptEmailBindingTest extends TestCase
         $response->assertJsonPath('attempt_id', $attemptId);
         $response->assertJsonPath('status', 'active');
         $response->assertJsonPath('result_url', "/zh/result/{$attemptId}");
+        $response->assertJsonPath('result_access_link_email_queued', true);
+        $this->assertIsString($response->json('result_access_token_expires_at'));
 
         $emailHash = app(PiiCipher::class)->emailHash('owner@example.test');
         $this->assertDatabaseHas('attempt_email_bindings', [
@@ -49,6 +51,27 @@ final class AttemptEmailBindingTest extends TestCase
         $this->assertDatabaseMissing('attempt_email_bindings', [
             'email_enc' => 'owner@example.test',
         ]);
+
+        $outbox = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'result_access_link')
+            ->first();
+        $this->assertNotNull($outbox);
+        $this->assertSame($emailHash, (string) ($outbox->email_hash ?? ''));
+        $this->assertSame($emailHash, (string) ($outbox->to_email_hash ?? ''));
+
+        $payloadJson = json_decode((string) ($outbox->payload_json ?? '{}'), true);
+        $this->assertIsArray($payloadJson);
+        $this->assertSame($attemptId, (string) ($payloadJson['attempt_id'] ?? ''));
+        $this->assertSame('result_access_link', (string) ($payloadJson['template_key'] ?? ''));
+        $this->assertArrayNotHasKey('result_access_token', $payloadJson);
+        $this->assertArrayNotHasKey('result_access_url', $payloadJson);
+
+        $payloadEnc = json_decode((string) app(PiiCipher::class)->decrypt((string) ($outbox->payload_enc ?? '')), true);
+        $this->assertIsArray($payloadEnc);
+        $this->assertSame('owner@example.test', (string) ($payloadEnc['to_email'] ?? ''));
+        $this->assertStringStartsWith("/zh/result/{$attemptId}?access_token=", (string) ($payloadEnc['result_access_url'] ?? ''));
+        $this->assertNotEmpty((string) ($payloadEnc['result_access_token'] ?? ''));
     }
 
     public function test_wrong_anon_cannot_bind_someone_else_attempt(): void

--- a/backend/tests/Feature/Email/ResultAccessLinkTemplateDeliveryTest.php
+++ b/backend/tests/Feature/Email/ResultAccessLinkTemplateDeliveryTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use App\Models\AttemptEmailBinding;
+use App\Services\Email\EmailOutboxService;
+use App\Services\Results\ResultAccessTokenService;
+use App\Support\PiiCipher;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Mail;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+final class ResultAccessLinkTemplateDeliveryTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[DataProvider('localeProvider')]
+    public function test_result_access_link_renders_signed_frontend_link_without_persisting_plaintext_token(
+        string $locale,
+        string $expectedTitle,
+        string $expectedPathPrefix
+    ): void {
+        config([
+            'fap.runtime.EMAIL_OUTBOX_SEND' => true,
+            'fap.runtime.FAP_BASE_URL' => 'https://app.example.test',
+            'app.url' => 'https://api.example.test',
+            'mail.default' => 'array',
+        ]);
+
+        $this->flushArrayTransport();
+        $attemptId = $this->createAttempt($locale);
+        $binding = $this->createBinding($attemptId, 'recover@example.test');
+        $token = app(ResultAccessTokenService::class)->issueForBinding($binding);
+        $resultUrl = $expectedPathPrefix.$attemptId.'?access_token='.rawurlencode((string) $token['token']);
+
+        $queued = app(EmailOutboxService::class)->queueResultAccessLink(
+            $binding,
+            'recover@example.test',
+            $token,
+            $resultUrl,
+            $locale,
+            ['surface' => 'result_email_recovery']
+        );
+
+        $this->assertTrue((bool) ($queued['ok'] ?? false));
+        $this->assertTrue((bool) ($queued['queued'] ?? false));
+
+        $this->artisan('email:outbox-send --limit=10')
+            ->expectsOutput('Mailer array: sent 1, blocked 0, failed 0.')
+            ->assertExitCode(0);
+
+        $html = (string) Mail::mailer('array')->getSymfonyTransport()->messages()->first()->getOriginalMessage()->getHtmlBody();
+        $absoluteResultUrl = 'https://app.example.test'.$resultUrl;
+        $this->assertStringContainsString($expectedTitle, $html);
+        $this->assertStringContainsString($absoluteResultUrl, $html);
+
+        $row = DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'result_access_link')
+            ->first();
+        $this->assertNotNull($row);
+        $this->assertSame('sent', (string) ($row->status ?? ''));
+        $this->assertSame('', (string) ($row->body_html ?? ''));
+        $this->assertStringNotContainsString((string) $token['token'], (string) ($row->payload_json ?? ''));
+
+        $payload = json_decode((string) app(PiiCipher::class)->decrypt((string) ($row->payload_enc ?? '')), true);
+        $this->assertIsArray($payload);
+        $this->assertSame($absoluteResultUrl, (string) $this->absolutePayloadUrl($payload['result_access_url'] ?? ''));
+        $this->assertSame((string) $token['token'], (string) ($payload['result_access_token'] ?? ''));
+    }
+
+    /**
+     * @return array<string,array{0:string,1:string,2:string}>
+     */
+    public static function localeProvider(): array
+    {
+        return [
+            'en' => ['en', 'Your result access link', '/en/result/'],
+            'zh-CN' => ['zh-CN', '你的结果访问链接', '/zh/result/'],
+        ];
+    }
+
+    private function createAttempt(string $locale): string
+    {
+        $attemptId = (string) Str::uuid();
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'ticket_code' => 'FMT-'.strtoupper(substr(str_replace('-', '', $attemptId), 0, 8)),
+            'org_id' => 0,
+            'anon_id' => 'anon_result_access_link',
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => $locale,
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'client_version' => '1.0.0',
+            'channel' => 'test',
+            'started_at' => now()->subMinute(),
+            'submitted_at' => now(),
+            'pack_id' => (string) config('content_packs.default_pack_id'),
+            'dir_version' => (string) config('content_packs.default_dir_version'),
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $attemptId;
+    }
+
+    private function createBinding(string $attemptId, string $email): AttemptEmailBinding
+    {
+        $cipher = app(PiiCipher::class);
+        $normalizedEmail = $cipher->normalizeEmail($email);
+
+        return AttemptEmailBinding::create([
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'pii_email_key_version' => (string) $cipher->currentKeyVersion(),
+            'email_hash' => $cipher->emailHash($normalizedEmail),
+            'email_enc' => $cipher->encrypt($normalizedEmail),
+            'bound_anon_id' => 'anon_result_access_link',
+            'bound_user_id' => null,
+            'status' => AttemptEmailBinding::STATUS_ACTIVE,
+            'source' => 'result_gate',
+            'first_bound_at' => now(),
+            'last_accessed_at' => now(),
+        ]);
+    }
+
+    private function flushArrayTransport(): void
+    {
+        Mail::mailer('array')->getSymfonyTransport()->flush();
+    }
+
+    private function absolutePayloadUrl(mixed $value): string
+    {
+        $url = trim((string) $value);
+        if (str_starts_with($url, 'http')) {
+            return $url;
+        }
+
+        return 'https://app.example.test/'.ltrim($url, '/');
+    }
+}

--- a/backend/tests/Feature/ResultEmailGatedReadTest.php
+++ b/backend/tests/Feature/ResultEmailGatedReadTest.php
@@ -124,7 +124,7 @@ final class ResultEmailGatedReadTest extends TestCase
         $response->assertJsonPath('attempt_id', $attemptId);
     }
 
-    public function test_result_access_token_does_not_grant_result_access_without_matching_actor(): void
+    public function test_result_access_token_grants_read_only_result_access_without_matching_actor(): void
     {
         config()->set('fap.features.email_first_result_access', true);
 
@@ -136,8 +136,10 @@ final class ResultEmailGatedReadTest extends TestCase
             'X-Result-Access-Token' => $token,
         ])->getJson("/api/v0.3/attempts/{$attemptId}/result");
 
-        $response->assertStatus(404);
-        $response->assertJsonPath('error_code', 'RESOURCE_NOT_FOUND');
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('attempt_id', $attemptId);
+        $response->assertJsonPath('type_code', 'INTJ-A');
     }
 
     public function test_result_access_token_grants_read_only_result_access_for_matching_actor(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1387,6 +1387,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_result_email_access_link_delivery_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Email/EmailOutboxService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_funnel_attribution_ingest_contract_changes(): void
     {
         $changed = [
@@ -2517,6 +2526,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isResultEmailGatedReadFile($file)) {
+                continue;
+            }
+
+            if ($this->isResultEmailAccessLinkDeliveryFile($file)) {
                 continue;
             }
 
@@ -3930,6 +3943,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Controllers/API/V0_3/AttemptReadController.php',
             'backend/app/Services/Results/ResultEmailReadAccessService.php',
         ], true);
+    }
+
+    private function isResultEmailAccessLinkDeliveryFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Email/EmailOutboxService.php';
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-29T02:27:14+08:00",
+  "updated_at": "2026-05-29T02:49:26+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -20653,7 +20653,7 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-media-alt-visual-review-batch-07",
       "base": "main",
-      "status": "pr_opened",
+      "status": "ci_fix_local_validation_passed",
       "depends_on": [
         "GLOBAL-EN-ZH-RESULT-REPORT-ASSET-BATCH-06"
       ],
@@ -28195,8 +28195,16 @@
           "evidence": "Reverted generated BIG5_OCEAN compiled artifact diffs produced by ci_verify_mbti.sh; remaining diff is confined to current PR scope."
         },
         "github_pr": {
-          "status": "pending",
-          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1752 from codex/result-email-access-link-03."
+          "status": "failed_then_fixed_locally",
+          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1752 from codex/result-email-access-link-03; initial GitHub verify-mbti-legacy failed because BigFiveResultPageV2CoreBodyPreviewTest incorrectly classified EmailOutboxService.php as Big Five runtime-impacting."
+        },
+        "github_verify_mbti_initial_failure": {
+          "status": "fixed_in_current_pr_scope",
+          "evidence": "verify-mbti-legacy failed on BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff for backend/app/Services/Email/EmailOutboxService.php; added a focused classifier ignore for result access link delivery."
+        },
+        "php_artisan_test_filter_BigFiveResultPageV2CoreBodyPreview": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi"
         }
       },
       "failure_reason": null,
@@ -28227,6 +28235,11 @@
           "at": "2026-05-29T02:27:14+08:00",
           "status": "pr_opened",
           "summary": "Opened PR #1752 for RESULT-EMAIL-ACCESS-LINK-03 and queued GitHub checks."
+        },
+        {
+          "at": "2026-05-29T02:49:26+08:00",
+          "status": "ci_fix_local_validation_passed",
+          "summary": "Fixed GitHub verify-mbti-legacy classifier failure for EmailOutboxService result access link delivery; reran focused email tests, BigFiveResultPageV2CoreBodyPreview, route list, Pint, composer validate/audit, JSON/YAML parse, diff check, and ci_verify_mbti locally."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-29T01:39:31+08:00",
+  "updated_at": "2026-05-29T02:27:14+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -9437,7 +9437,7 @@
       "depends_on": [
         "SEO-DASH-04A"
       ],
-      "status": "github_checks_passed_ready_to_merge",
+      "status": "merged",
       "train_scope": "search_intelligence_baidu_indexnow_disabled_collectors",
       "risk_level": "medium_disabled_search_channel_schema",
       "title": "feat(seo-intel): add Baidu and IndexNow collector foundations",
@@ -21485,10 +21485,10 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "merge_commit": null,
+      "merged_at": "2026-05-28T17:47:03Z",
+      "merge_commit": "24cd5c83c8e55bb714725965211571dac59438e0",
       "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "local_cleanup_executed": true,
       "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
       "sidecars": [],
       "transitions": [
@@ -26061,7 +26061,7 @@
     "OPS-ADMIN-UI-01": {
       "repo": "fap-api",
       "branch": "codex/ops-admin-ui-01-table-toolbar",
-      "status": "in_progress",
+      "status": "pr_opened",
       "depends_on": [],
       "commit_sha": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1750",
@@ -26117,8 +26117,8 @@
       "depends_on": [
         "OPS-ADMIN-UI-01"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "81a320a567962bddca2920134b1a9a83c0ac6563",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1752",
       "checks": {
         "local": {
           "ops_shell_and_i18n": "passed: cd backend && php artisan test tests/Feature/Ops/OpsShellPolishTest.php tests/Feature/Ops/OpsCustomPagesI18nContractTest.php --no-ansi (21 tests, 246 assertions)",
@@ -28112,6 +28112,121 @@
           "at": "2026-05-29T01:39:31+08:00",
           "status": "github_checks_passed_ready_to_merge",
           "summary": "GitHub checks passed and mergeStateStatus was CLEAN for PR #1751."
+        },
+        {
+          "at": "2026-05-29T01:55:00+08:00",
+          "status": "merged_reconciled_before_result_email_access_link_03",
+          "summary": "Reconciled PR #1751 as merged with origin/main containing squash merge 24cd5c83c8e55bb714725965211571dac59438e0 before starting RESULT-EMAIL-ACCESS-LINK-03; remote branch still present."
+        }
+      ]
+    },
+    "RESULT-EMAIL-ACCESS-LINK-03": {
+      "id": "RESULT-EMAIL-ACCESS-LINK-03",
+      "repo": "fap-api",
+      "branch": "codex/result-email-access-link-03",
+      "base": "main",
+      "status": "in_progress",
+      "title": "RESULT-EMAIL-ACCESS-LINK-03 send result access links by email",
+      "depends_on": [
+        "EMAIL-DIRECTMAIL-SMTP-READINESS-01",
+        "RESULT-EMAIL-GATE-POLICY-02"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User requested RESULT-EMAIL-ACCESS-LINK-03 to send DirectMail result-page access links after email binding while reusing existing result_access_token."
+        },
+        "dependency_email_directmail_smtp_readiness_01": {
+          "status": "pass",
+          "evidence": "EMAIL-DIRECTMAIL-SMTP-READINESS-01 merged as PR #1750 with merge commit 1f8b4ac77215020b17da5da1e1a0d531ed074ba1."
+        },
+        "dependency_result_email_gate_policy_02": {
+          "status": "pass",
+          "evidence": "RESULT-EMAIL-GATE-POLICY-02 merged as PR #1751 with merge commit 24cd5c83c8e55bb714725965211571dac59438e0."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "Backend email bind/outbox/result-access-token flow only; no production env write, real email send, deploy, CMS/content mutation, URL submission, Search Channel action, or fap-web change in this PR."
+        },
+        "php_artisan_test_filter_AttemptEmailBinding": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test --filter=AttemptEmailBinding --no-ansi"
+        },
+        "php_artisan_test_filter_ResultEmailGatedRead": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test --filter=ResultEmailGatedRead --no-ansi"
+        },
+        "php_artisan_test_filter_ResultAccessLinkTemplateDelivery": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan test --filter=ResultAccessLinkTemplateDelivery --no-ansi"
+        },
+        "php_artisan_route_list": {
+          "status": "pass",
+          "evidence": "cd backend && php artisan route:list --no-ansi"
+        },
+        "pint_test": {
+          "status": "pass",
+          "evidence": "cd backend && vendor/bin/pint --test"
+        },
+        "composer_validate_strict": {
+          "status": "pass",
+          "evidence": "cd backend && composer validate --strict"
+        },
+        "composer_audit_locked": {
+          "status": "pass",
+          "evidence": "cd backend && composer audit --locked --no-interaction --ignore-unreachable"
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "evidence": "pr-train-state.json parsed with python3 -m json.tool; pr-train.yaml parsed with yaml.safe_load."
+        },
+        "diff_hygiene": {
+          "status": "pass",
+          "evidence": "git diff --check"
+        },
+        "ci_verify_mbti": {
+          "status": "pass",
+          "evidence": "cd backend && bash scripts/ci_verify_mbti.sh"
+        },
+        "scope_cleanup": {
+          "status": "pass",
+          "evidence": "Reverted generated BIG5_OCEAN compiled artifact diffs produced by ci_verify_mbti.sh; remaining diff is confined to current PR scope."
+        },
+        "github_pr": {
+          "status": "pending",
+          "evidence": "Opened https://github.com/fermatmind/fap-api/pull/1752 from codex/result-email-access-link-03."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "merge_commit": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "next_task": "deploy-readiness after merge",
+      "sidecars": [
+        {
+          "id": "fap-web-result-email-access-copy-followup",
+          "status": "deferred_external_scope",
+          "summary": "fap-web UI copy/UX for optional result recovery remains outside this backend PR because the current fap-web worktree has an unrelated active dirty branch."
+        }
+      ],
+      "transitions": [
+        {
+          "at": "2026-05-29T01:55:00+08:00",
+          "status": "in_progress",
+          "summary": "Started backend RESULT-EMAIL-ACCESS-LINK-03 to queue DirectMail-ready result access links after owned public email binding using the existing result_access_token service."
+        },
+        {
+          "at": "2026-05-29T02:18:00+08:00",
+          "status": "local_validation_passed",
+          "summary": "Focused email binding, result token read, and result access link template tests passed; route list, Pint, composer validate/audit, JSON/YAML parse, diff check, and ci_verify_mbti passed locally."
+        },
+        {
+          "at": "2026-05-29T02:27:14+08:00",
+          "status": "pr_opened",
+          "summary": "Opened PR #1752 for RESULT-EMAIL-ACCESS-LINK-03 and queued GitHub checks."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26117,7 +26117,7 @@
       "depends_on": [
         "OPS-ADMIN-UI-01"
       ],
-      "commit_sha": "81a320a567962bddca2920134b1a9a83c0ac6563",
+      "commit_sha": "5e8637e3c9bfb4ea2a98a2697fbd76e8f335ddc4",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1752",
       "checks": {
         "local": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15870,3 +15870,56 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: RESULT-EMAIL-ACCESS-LINK-03 explicit approval required before implementation
+
+  - id: RESULT-EMAIL-ACCESS-LINK-03
+    repo: fap-api
+    branch: codex/result-email-access-link-03
+    base: main
+    title: "RESULT-EMAIL-ACCESS-LINK-03 send result access links by email"
+    train_scope: result_email_access_link
+    risk_level: p1_result_access_transactional_email
+    depends_on:
+      - EMAIL-DIRECTMAIL-SMTP-READINESS-01
+      - RESULT-EMAIL-GATE-POLICY-02
+    allowed_paths:
+      - backend/app/Services/Attempts/AttemptEmailBindingService.php
+      - backend/app/Services/Email/EmailOutboxService.php
+      - backend/app/Services/Results/ResultEmailReadAccessService.php
+      - backend/resources/views/emails/en/result_access_link.blade.php
+      - backend/resources/views/emails/zh/result_access_link.blade.php
+      - backend/tests/Feature/AttemptEmailBindingTest.php
+      - backend/tests/Feature/ResultEmailGatedReadTest.php
+      - backend/tests/Feature/Email/ResultAccessLinkTemplateDeliveryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - After an owned public result email binding, issue the existing result_access_token and queue a DirectMail-ready result access link email through the existing outbox.
+      - Reuse the existing result_access_token service and do not introduce a new token table, token format, or token issuance system.
+      - Treat emailed result_access_token as a time-limited bearer recovery link for public scales only; keep SDS/Clinical excluded by existing result-read guards.
+      - Keep access token and link out of plaintext payload_json and persisted sent body_html; encrypted payload remains authoritative for delivery.
+      - Do not mutate production env, send real email, deploy, mutate CMS/content, submit URLs, enqueue Search Channel actions, or modify fap-web in this PR.
+    validation:
+      - cd backend && php artisan test --filter=AttemptEmailBinding --no-ansi
+      - cd backend && php artisan test --filter=ResultEmailGatedRead --no-ansi
+      - cd backend && php artisan test --filter=ResultAccessLinkTemplateDelivery --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: RESULT-EMAIL-ACCESS-LINK-03 deploy-readiness required after merge

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15890,6 +15890,7 @@ prs:
       - backend/tests/Feature/AttemptEmailBindingTest.php
       - backend/tests/Feature/ResultEmailGatedReadTest.php
       - backend/tests/Feature/Email/ResultAccessLinkTemplateDeliveryTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -15902,6 +15903,7 @@ prs:
       - cd backend && php artisan test --filter=AttemptEmailBinding --no-ansi
       - cd backend && php artisan test --filter=ResultEmailGatedRead --no-ansi
       - cd backend && php artisan test --filter=ResultAccessLinkTemplateDelivery --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
       - cd backend && composer validate --strict


### PR DESCRIPTION
## What changed
- Queues a transactional result access link email after a successful result email binding.
- Reuses the existing `result_access_token` service; no new token system is introduced.
- Adds EN/ZH transactional email templates and keeps token-bearing URL/token data out of plaintext `payload_json` and persisted `body_html`.
- Allows valid result access tokens to work as bearer recovery links while preserving sensitive-scale gates.
- Updates PR train manifest/state for `RESULT-EMAIL-ACCESS-LINK-03`.

## Why
Users can now optionally bind an email for result recovery and receive a DirectMail-deliverable access link, while the result page itself remains accessible without forcing an email gate from `RESULT-EMAIL-GATE-POLICY-02`.

## Validation
- `php artisan test --filter=AttemptEmailBinding --no-ansi`
- `php artisan test --filter=ResultEmailGatedRead --no-ansi`
- `php artisan test --filter=ResultAccessLinkTemplateDelivery --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`
- `bash scripts/ci_verify_mbti.sh`

## Intentionally deferred
- No production env changes.
- No real email send from this PR.
- No deploy.
- No Search Channel or URL submission.
- No CMS/content mutation.
- No fap-web UX/copy changes in this PR.
