### PR TITLE
PR-FDN-02A: Add daily giving ledger backend MVP

### DIFF
--- a/backend/app/Filament/Ops/Resources/DailyGivingRecordResource.php
+++ b/backend/app/Filament/Ops/Resources/DailyGivingRecordResource.php
@@ -1,0 +1,270 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources;
+
+use App\Filament\Ops\Resources\DailyGivingRecordResource\Pages;
+use App\Filament\Ops\Support\ContentAccess;
+use App\Models\DailyGivingRecord;
+use Filament\Forms;
+use Filament\Forms\Form;
+use Filament\Resources\Resource;
+use Filament\Tables;
+use Filament\Tables\Table;
+use Illuminate\Database\Eloquent\Builder;
+
+class DailyGivingRecordResource extends Resource
+{
+    protected static ?string $model = DailyGivingRecord::class;
+
+    protected static ?string $slug = 'daily-giving-records';
+
+    protected static ?string $recordTitleAttribute = 'record_code';
+
+    protected static ?string $navigationIcon = 'heroicon-o-heart';
+
+    protected static ?string $navigationGroup = 'Content';
+
+    public static function canViewAny(): bool
+    {
+        return ContentAccess::canRead();
+    }
+
+    public static function canCreate(): bool
+    {
+        return ContentAccess::canWrite();
+    }
+
+    public static function canEdit($record): bool
+    {
+        return ContentAccess::canWrite();
+    }
+
+    public static function canDelete($record): bool
+    {
+        return false;
+    }
+
+    public static function getNavigationLabel(): string
+    {
+        return 'Daily Giving Records';
+    }
+
+    public static function getModelLabel(): string
+    {
+        return 'Daily Giving Record';
+    }
+
+    public static function getPluralModelLabel(): string
+    {
+        return 'Daily Giving Records';
+    }
+
+    public static function form(Form $form): Form
+    {
+        return $form->schema([
+            Forms\Components\Hidden::make('org_id')->default(0),
+            Forms\Components\Grid::make(['default' => 1, 'xl' => 12])
+                ->schema([
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Giving Record')
+                            ->schema([
+                                Forms\Components\TextInput::make('record_code')
+                                    ->required()
+                                    ->maxLength(255)
+                                    ->disabled(fn (?DailyGivingRecord $record): bool => $record !== null)
+                                    ->helperText('Auto-generated on create. Format: FM-GIVING-YYYY-MM-NNN'),
+                                Forms\Components\DatePicker::make('donation_date')
+                                    ->required(),
+                                Forms\Components\TextInput::make('recipient_name')
+                                    ->required()
+                                    ->maxLength(255),
+                                Forms\Components\TextInput::make('recipient_official_url')
+                                    ->url()
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('amount_minor')
+                                    ->numeric()
+                                    ->helperText('Amount in minor units (cents/fen).'),
+                                Forms\Components\TextInput::make('currency')
+                                    ->maxLength(8)
+                                    ->helperText('ISO 4217 currency code, e.g. USD, CNY.'),
+                                Forms\Components\Select::make('donation_status')
+                                    ->required()
+                                    ->native(false)
+                                    ->options([
+                                        DailyGivingRecord::DONATION_PLANNED => 'Planned',
+                                        DailyGivingRecord::DONATION_COMPLETED => 'Completed',
+                                        DailyGivingRecord::DONATION_VERIFIED => 'Verified',
+                                        DailyGivingRecord::DONATION_VOIDED => 'Voided',
+                                    ])
+                                    ->default(DailyGivingRecord::DONATION_PLANNED),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Proof')
+                            ->schema([
+                                Forms\Components\Select::make('proof_status')
+                                    ->required()
+                                    ->native(false)
+                                    ->options([
+                                        DailyGivingRecord::PROOF_NONE => 'None',
+                                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'Redacted Pending',
+                                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'Redacted Available',
+                                        DailyGivingRecord::PROOF_WITHHELD => 'Withheld',
+                                    ])
+                                    ->default(DailyGivingRecord::PROOF_NONE),
+                                Forms\Components\TextInput::make('proof_public_url')
+                                    ->url()
+                                    ->maxLength(2048),
+                                Forms\Components\TextInput::make('proof_private_path')
+                                    ->maxLength(2048)
+                                    ->helperText('Admin-only. Never exposed publicly.'),
+                                Forms\Components\Textarea::make('proof_redaction_notes')
+                                    ->rows(2)
+                                    ->maxLength(2000)
+                                    ->helperText('Admin-only. Not exposed publicly.'),
+                                Forms\Components\TextInput::make('receipt_reference_redacted')
+                                    ->maxLength(255),
+                                Forms\Components\TextInput::make('receipt_reference_private')
+                                    ->maxLength(255)
+                                    ->helperText('Admin-only. Never exposed publicly.'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Social Links')
+                            ->schema([
+                                Forms\Components\TextInput::make('social_x_url')
+                                    ->url()
+                                    ->maxLength(2048)
+                                    ->label('X (Twitter) URL'),
+                                Forms\Components\TextInput::make('social_linkedin_url')
+                                    ->url()
+                                    ->maxLength(2048)
+                                    ->label('LinkedIn URL'),
+                                Forms\Components\TextInput::make('social_weibo_url')
+                                    ->url()
+                                    ->maxLength(2048)
+                                    ->label('Weibo URL'),
+                                Forms\Components\TextInput::make('social_xiaohongshu_url')
+                                    ->url()
+                                    ->maxLength(2048)
+                                    ->label('Xiaohongshu URL'),
+                                Forms\Components\KeyValue::make('social_other_links')
+                                    ->label('Other Social Links'),
+                            ])
+                            ->columns(2),
+                        Forms\Components\Section::make('Notes')
+                            ->schema([
+                                Forms\Components\Textarea::make('public_notes')
+                                    ->rows(3)
+                                    ->maxLength(5000),
+                                Forms\Components\Textarea::make('internal_notes')
+                                    ->rows(3)
+                                    ->maxLength(5000)
+                                    ->helperText('Admin-only. Never exposed publicly.'),
+                            ]),
+                    ])->columnSpan(['xl' => 8]),
+                    Forms\Components\Group::make([
+                        Forms\Components\Section::make('Publication')
+                            ->schema([
+                                Forms\Components\Toggle::make('is_public')
+                                    ->default(false)
+                                    ->helperText('Must meet all publication criteria to appear publicly.'),
+                                Forms\Components\Toggle::make('is_indexable')
+                                    ->default(false)
+                                    ->helperText('Not yet enabled for sitemap/llms. Deferred to PR-FDN-SEO-01.'),
+                                Forms\Components\DateTimePicker::make('published_at'),
+                            ]),
+                    ])->columnSpan(['xl' => 4]),
+                ]),
+        ]);
+    }
+
+    public static function table(Table $table): Table
+    {
+        return $table
+            ->columns([
+                Tables\Columns\TextColumn::make('record_code')
+                    ->searchable()
+                    ->copyable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('donation_date')
+                    ->date()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('recipient_name')
+                    ->searchable()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('amount_minor')
+                    ->numeric()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('currency')
+                    ->toggleable(isToggledHiddenByDefault: true),
+                Tables\Columns\TextColumn::make('donation_status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        DailyGivingRecord::DONATION_COMPLETED => 'success',
+                        DailyGivingRecord::DONATION_VERIFIED => 'success',
+                        DailyGivingRecord::DONATION_PLANNED => 'warning',
+                        DailyGivingRecord::DONATION_VOIDED => 'danger',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('proof_status')
+                    ->badge()
+                    ->color(fn (string $state): string => match ($state) {
+                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'success',
+                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'warning',
+                        DailyGivingRecord::PROOF_WITHHELD => 'gray',
+                        default => 'gray',
+                    })
+                    ->sortable(),
+                Tables\Columns\IconColumn::make('is_public')
+                    ->boolean()
+                    ->sortable(),
+                Tables\Columns\TextColumn::make('published_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->placeholder('Not published'),
+                Tables\Columns\TextColumn::make('updated_at')
+                    ->dateTime()
+                    ->sortable()
+                    ->toggleable(isToggledHiddenByDefault: true),
+            ])
+            ->filters([
+                Tables\Filters\SelectFilter::make('donation_status')
+                    ->options([
+                        DailyGivingRecord::DONATION_PLANNED => 'Planned',
+                        DailyGivingRecord::DONATION_COMPLETED => 'Completed',
+                        DailyGivingRecord::DONATION_VERIFIED => 'Verified',
+                        DailyGivingRecord::DONATION_VOIDED => 'Voided',
+                    ]),
+                Tables\Filters\SelectFilter::make('proof_status')
+                    ->options([
+                        DailyGivingRecord::PROOF_NONE => 'None',
+                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'Redacted Pending',
+                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'Redacted Available',
+                        DailyGivingRecord::PROOF_WITHHELD => 'Withheld',
+                    ]),
+                Tables\Filters\TernaryFilter::make('is_public'),
+            ])
+            ->defaultSort('donation_date', 'desc')
+            ->actions([
+                Tables\Actions\EditAction::make(),
+            ])
+            ->bulkActions([]);
+    }
+
+    public static function getPages(): array
+    {
+        return [
+            'index' => Pages\ListDailyGivingRecords::route('/'),
+            'create' => Pages\CreateDailyGivingRecord::route('/create'),
+            'edit' => Pages\EditDailyGivingRecord::route('/{record}/edit'),
+        ];
+    }
+
+    public static function getEloquentQuery(): Builder
+    {
+        return parent::getEloquentQuery()->withoutGlobalScopes()->where('org_id', 0);
+    }
+}

--- a/backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/CreateDailyGivingRecord.php
+++ b/backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/CreateDailyGivingRecord.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\DailyGivingRecordResource\Pages;
+
+use App\Filament\Ops\Resources\DailyGivingRecordResource;
+use App\Models\DailyGivingRecord;
+use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Support\Carbon;
+
+class CreateDailyGivingRecord extends CreateRecord
+{
+    protected static string $resource = DailyGivingRecordResource::class;
+
+    protected function mutateFormDataBeforeCreate(array $data): array
+    {
+        if (empty($data['record_code'])) {
+            $date = isset($data['donation_date'])
+                ? Carbon::parse($data['donation_date'])
+                : now();
+            $count = DailyGivingRecord::query()
+                ->whereYear('donation_date', $date->year)
+                ->whereMonth('donation_date', $date->month)
+                ->count();
+            $data['record_code'] = sprintf(
+                'FM-GIVING-%s-%s',
+                $date->format('Y-m'),
+                str_pad((string) ($count + 1), 3, '0', STR_PAD_LEFT),
+            );
+        }
+
+        return $data;
+    }
+}

--- a/backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/EditDailyGivingRecord.php
+++ b/backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/EditDailyGivingRecord.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\DailyGivingRecordResource\Pages;
+
+use App\Filament\Ops\Resources\DailyGivingRecordResource;
+use Filament\Actions;
+use Filament\Resources\Pages\EditRecord;
+
+class EditDailyGivingRecord extends EditRecord
+{
+    protected static string $resource = DailyGivingRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\DeleteAction::make(),
+        ];
+    }
+}

--- a/backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/ListDailyGivingRecords.php
+++ b/backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/ListDailyGivingRecords.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Filament\Ops\Resources\DailyGivingRecordResource\Pages;
+
+use App\Filament\Ops\Resources\DailyGivingRecordResource;
+use Filament\Actions;
+use Filament\Resources\Pages\ListRecords;
+
+class ListDailyGivingRecords extends ListRecords
+{
+    protected static string $resource = DailyGivingRecordResource::class;
+
+    protected function getHeaderActions(): array
+    {
+        return [
+            Actions\CreateAction::make(),
+        ];
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/Foundation/DailyGivingRecordController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Foundation/DailyGivingRecordController.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\API\V0_5\Foundation;
+
+use App\Http\Controllers\Controller;
+use App\Http\Resources\Foundation\DailyGivingRecordResource;
+use App\Models\DailyGivingRecord;
+use Illuminate\Http\JsonResponse;
+use Illuminate\Http\Request;
+
+final class DailyGivingRecordController extends Controller
+{
+    public function index(Request $request): JsonResponse
+    {
+        $perPage = min((int) ($request->input('per_page', 20)), 100);
+        $sort = in_array((string) $request->input('sort', 'donation_date'), ['donation_date', 'published_at', 'amount_minor'], true)
+            ? (string) $request->input('sort', 'donation_date')
+            : 'donation_date';
+        $order = strtolower((string) $request->input('order', 'desc')) === 'asc' ? 'asc' : 'desc';
+
+        $query = DailyGivingRecord::query()
+            ->publishedPublic()
+            ->orderBy($sort, $order);
+
+        $paginator = $query->paginate($perPage);
+
+        $items = DailyGivingRecordResource::collection($paginator->items())->resolve();
+
+        return response()->json([
+            'ok' => true,
+            'items' => $items,
+            'pagination' => [
+                'current_page' => $paginator->currentPage(),
+                'per_page' => $paginator->perPage(),
+                'total' => $paginator->total(),
+                'last_page' => $paginator->lastPage(),
+            ],
+        ]);
+    }
+
+    public function show(string $recordCode): JsonResponse
+    {
+        $record = DailyGivingRecord::query()
+            ->publishedPublic()
+            ->where('record_code', $recordCode)
+            ->first();
+
+        if (! $record) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'NOT_FOUND',
+                'message' => 'Giving record not found.',
+            ], 404);
+        }
+
+        return response()->json([
+            'ok' => true,
+            'record' => (new DailyGivingRecordResource($record))->resolve(),
+        ]);
+    }
+
+    public function months(): JsonResponse
+    {
+        $months = DailyGivingRecord::query()
+            ->publishedPublic()
+            ->select('donation_date')
+            ->distinct()
+            ->orderBy('donation_date', 'desc')
+            ->pluck('donation_date')
+            ->map(fn ($date): string => $date instanceof \Illuminate\Support\Carbon ? $date->format('Y-m') : substr((string) $date, 0, 7))
+            ->unique()
+            ->values()
+            ->all();
+
+        return response()->json([
+            'ok' => true,
+            'months' => $months,
+        ]);
+    }
+
+    public function monthRecords(string $yearMonth): JsonResponse
+    {
+        if (! preg_match('/^(\d{4})-(\d{2})$/', $yearMonth, $matches)) {
+            return response()->json([
+                'ok' => false,
+                'error_code' => 'INVALID_ARGUMENT',
+                'message' => 'Invalid year_month format. Use YYYY-MM.',
+            ], 422);
+        }
+
+        $year = (int) $matches[1];
+        $month = (int) $matches[2];
+
+        $items = DailyGivingRecord::query()
+            ->publishedPublic()
+            ->whereYear('donation_date', $year)
+            ->whereMonth('donation_date', $month)
+            ->orderBy('donation_date', 'desc')
+            ->get();
+
+        return response()->json([
+            'ok' => true,
+            'month' => $yearMonth,
+            'items' => DailyGivingRecordResource::collection($items)->resolve(),
+        ]);
+    }
+}

--- a/backend/app/Http/Resources/Foundation/DailyGivingRecordResource.php
+++ b/backend/app/Http/Resources/Foundation/DailyGivingRecordResource.php
@@ -1,0 +1,21 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Resources\Foundation;
+
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/**
+ * @property \App\Models\DailyGivingRecord $resource
+ */
+final class DailyGivingRecordResource extends JsonResource
+{
+    public static $wrap = null;
+
+    public function toArray(Request $request): array
+    {
+        return $this->resource->toPublicArray();
+    }
+}

--- a/backend/app/Models/DailyGivingRecord.php
+++ b/backend/app/Models/DailyGivingRecord.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+
+class DailyGivingRecord extends Model
+{
+    use HasFactory;
+
+    public const DONATION_PLANNED = 'planned';
+
+    public const DONATION_COMPLETED = 'completed';
+
+    public const DONATION_VERIFIED = 'verified';
+
+    public const DONATION_VOIDED = 'voided';
+
+    public const PROOF_NONE = 'none';
+
+    public const PROOF_REDACTED_PENDING = 'redacted_pending';
+
+    public const PROOF_REDACTED_AVAILABLE = 'redacted_available';
+
+    public const PROOF_WITHHELD = 'withheld';
+
+    public const DONATION_STATUSES = [
+        self::DONATION_PLANNED,
+        self::DONATION_COMPLETED,
+        self::DONATION_VERIFIED,
+        self::DONATION_VOIDED,
+    ];
+
+    public const PROOF_STATUSES = [
+        self::PROOF_NONE,
+        self::PROOF_REDACTED_PENDING,
+        self::PROOF_REDACTED_AVAILABLE,
+        self::PROOF_WITHHELD,
+    ];
+
+    public const PUBLISHABLE_DONATION_STATUSES = [
+        self::DONATION_COMPLETED,
+        self::DONATION_VERIFIED,
+    ];
+
+    public const PUBLISHABLE_PROOF_STATUSES = [
+        self::PROOF_REDACTED_AVAILABLE,
+        self::PROOF_WITHHELD,
+        self::PROOF_NONE,
+    ];
+
+    protected $table = 'daily_giving_records';
+
+    protected $fillable = [
+        'org_id',
+        'record_code',
+        'donation_date',
+        'recipient_name',
+        'recipient_official_url',
+        'amount_minor',
+        'currency',
+        'donation_status',
+        'proof_status',
+        'proof_public_url',
+        'proof_private_path',
+        'proof_redaction_notes',
+        'receipt_reference_redacted',
+        'receipt_reference_private',
+        'social_x_url',
+        'social_linkedin_url',
+        'social_weibo_url',
+        'social_xiaohongshu_url',
+        'social_other_links',
+        'public_notes',
+        'internal_notes',
+        'is_public',
+        'is_indexable',
+        'published_at',
+        'created_by_admin_user_id',
+        'updated_by_admin_user_id',
+    ];
+
+    protected function casts(): array
+    {
+        return [
+            'org_id' => 'integer',
+            'donation_date' => 'date',
+            'amount_minor' => 'integer',
+            'is_public' => 'boolean',
+            'is_indexable' => 'boolean',
+            'published_at' => 'datetime',
+            'social_other_links' => 'array',
+            'created_by_admin_user_id' => 'integer',
+            'updated_by_admin_user_id' => 'integer',
+        ];
+    }
+
+    public function scopePublishedPublic(Builder $query): Builder
+    {
+        return $query
+            ->where('is_public', true)
+            ->whereNotNull('published_at')
+            ->where('published_at', '<=', now())
+            ->whereIn('donation_status', self::PUBLISHABLE_DONATION_STATUSES);
+    }
+
+    public function isPublishable(): bool
+    {
+        return $this->is_public
+            && $this->published_at !== null
+            && $this->published_at->lte(now())
+            && $this->donation_date !== null
+            && $this->recipient_name !== null
+            && $this->recipient_name !== ''
+            && $this->recipient_official_url !== null
+            && $this->recipient_official_url !== ''
+            && in_array($this->donation_status, self::PUBLISHABLE_DONATION_STATUSES, true)
+            && in_array($this->proof_status, self::PUBLISHABLE_PROOF_STATUSES, true);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function toPublicArray(): array
+    {
+        return [
+            'record_code' => $this->record_code,
+            'donation_date' => $this->donation_date?->toDateString(),
+            'recipient_name' => $this->recipient_name,
+            'recipient_official_url' => $this->recipient_official_url,
+            'amount_minor' => $this->amount_minor,
+            'currency' => $this->currency,
+            'donation_status' => $this->donation_status,
+            'proof_status' => $this->proof_status,
+            'proof_public_url' => $this->proof_public_url,
+            'receipt_reference_redacted' => $this->receipt_reference_redacted,
+            'social_x_url' => $this->social_x_url,
+            'social_linkedin_url' => $this->social_linkedin_url,
+            'social_weibo_url' => $this->social_weibo_url,
+            'social_xiaohongshu_url' => $this->social_xiaohongshu_url,
+            'social_other_links' => $this->social_other_links,
+            'public_notes' => $this->public_notes,
+            'published_at' => $this->published_at?->toDateTimeString(),
+        ];
+    }
+}

--- a/backend/database/factories/DailyGivingRecordFactory.php
+++ b/backend/database/factories/DailyGivingRecordFactory.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\DailyGivingRecord;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<DailyGivingRecord>
+ */
+class DailyGivingRecordFactory extends Factory
+{
+    protected $model = DailyGivingRecord::class;
+
+    public function definition(): array
+    {
+        return [
+            'org_id' => 0,
+            'record_code' => 'FM-GIVING-'.now()->format('Y-m').'-'.str_pad((string) fake()->unique()->numberBetween(1, 999), 3, '0', STR_PAD_LEFT),
+            'donation_date' => Carbon::create(2026, fake()->numberBetween(1, 6), fake()->numberBetween(1, 28)),
+            'recipient_name' => 'United Nations Foundation',
+            'recipient_official_url' => 'https://unfoundation.org',
+            'amount_minor' => fake()->numberBetween(10000, 500000),
+            'currency' => 'USD',
+            'donation_status' => DailyGivingRecord::DONATION_COMPLETED,
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_public_url' => null,
+            'proof_private_path' => null,
+            'proof_redaction_notes' => null,
+            'receipt_reference_redacted' => 'REF-'.strtoupper(fake()->lexify('??????')),
+            'receipt_reference_private' => null,
+            'social_x_url' => null,
+            'social_linkedin_url' => null,
+            'social_weibo_url' => null,
+            'social_xiaohongshu_url' => null,
+            'social_other_links' => null,
+            'public_notes' => 'FermatMind independent giving record.',
+            'internal_notes' => null,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now(),
+            'created_by_admin_user_id' => null,
+            'updated_by_admin_user_id' => null,
+        ];
+    }
+
+    public function planned(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'donation_status' => DailyGivingRecord::DONATION_PLANNED,
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+    }
+
+    public function completed(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'donation_status' => DailyGivingRecord::DONATION_COMPLETED,
+        ]);
+    }
+
+    public function verified(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'donation_status' => DailyGivingRecord::DONATION_VERIFIED,
+        ]);
+    }
+
+    public function voided(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'donation_status' => DailyGivingRecord::DONATION_VOIDED,
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+    }
+
+    public function notPublic(): static
+    {
+        return $this->state(fn (array $attributes): array => [
+            'is_public' => false,
+            'published_at' => null,
+        ]);
+    }
+}

--- a/backend/database/migrations/2026_05_30_000100_create_daily_giving_records_table.php
+++ b/backend/database/migrations/2026_05_30_000100_create_daily_giving_records_table.php
@@ -44,6 +44,6 @@ return new class extends Migration
 
     public function down(): void
     {
-        Schema::dropIfExists('daily_giving_records');
+        // Intentionally no-op to satisfy production-safe migration policy.
     }
 };

--- a/backend/database/migrations/2026_05_30_000100_create_daily_giving_records_table.php
+++ b/backend/database/migrations/2026_05_30_000100_create_daily_giving_records_table.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('daily_giving_records', static function (Blueprint $table): void {
+            $table->id();
+            $table->unsignedBigInteger('org_id')->default(0);
+            $table->string('record_code')->unique();
+            $table->date('donation_date');
+            $table->string('recipient_name');
+            $table->string('recipient_official_url')->nullable();
+            $table->bigInteger('amount_minor')->nullable();
+            $table->string('currency', 8)->nullable();
+            $table->string('donation_status')->default('planned');
+            $table->string('proof_status')->default('none');
+            $table->string('proof_public_url')->nullable();
+            $table->string('proof_private_path')->nullable();
+            $table->text('proof_redaction_notes')->nullable();
+            $table->string('receipt_reference_redacted')->nullable();
+            $table->string('receipt_reference_private')->nullable();
+            $table->string('social_x_url')->nullable();
+            $table->string('social_linkedin_url')->nullable();
+            $table->string('social_weibo_url')->nullable();
+            $table->string('social_xiaohongshu_url')->nullable();
+            $table->json('social_other_links')->nullable();
+            $table->text('public_notes')->nullable();
+            $table->text('internal_notes')->nullable();
+            $table->boolean('is_public')->default(false);
+            $table->boolean('is_indexable')->default(false);
+            $table->timestamp('published_at')->nullable();
+            $table->unsignedBigInteger('created_by_admin_user_id')->nullable();
+            $table->unsignedBigInteger('updated_by_admin_user_id')->nullable();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('daily_giving_records');
+    }
+};

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3151,6 +3151,74 @@
                 ]
             }
         },
+        "/api/v0.5/foundation/giving-records": {
+            "get": {
+                "operationId": "get_api_v0_5_foundation_giving_records",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Foundation\\DailyGivingRecordController@index",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/foundation/giving-records/months": {
+            "get": {
+                "operationId": "get_api_v0_5_foundation_giving_records_months",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Foundation\\DailyGivingRecordController@months",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/foundation/giving-records/months/{yearMonth}": {
+            "get": {
+                "operationId": "get_api_v0_5_foundation_giving_records_months_yearmonth_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Foundation\\DailyGivingRecordController@monthRecords",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
+        "/api/v0.5/foundation/giving-records/{recordCode}": {
+            "get": {
+                "operationId": "get_api_v0_5_foundation_giving_records_recordcode_",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Foundation\\DailyGivingRecordController@show",
+                "x-laravel-middleware": [
+                    "api"
+                ]
+            }
+        },
         "/api/v0.5/internal/career/crosswalk/override/{slug}": {
             "get": {
                 "operationId": "get_api_v0_5_internal_career_crosswalk_override_slug_",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -71,6 +71,7 @@ use App\Http\Controllers\API\V0_5\Cms\PersonalityDesktopCloneController;
 use App\Http\Controllers\API\V0_5\Cms\ResearchReportController;
 use App\Http\Controllers\API\V0_5\Cms\SupportArticleController;
 use App\Http\Controllers\API\V0_5\Cms\TopicController;
+use App\Http\Controllers\API\V0_5\Foundation\DailyGivingRecordController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkOverrideController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkPatchController;
 use App\Http\Controllers\API\V0_5\Internal\Career\CareerCrosswalkReviewQueueController;
@@ -491,6 +492,10 @@ Route::prefix('v0.5')->group(function () {
     Route::get('/career/datasets/occupations/method', [CareerDatasetMethodController::class, 'show']);
     Route::get('/seo/sitemap-source', [SitemapSourceController::class, 'index'])
         ->name('seo.sitemap-source');
+    Route::get('/foundation/giving-records/months', [DailyGivingRecordController::class, 'months']);
+    Route::get('/foundation/giving-records/months/{yearMonth}', [DailyGivingRecordController::class, 'monthRecords']);
+    Route::get('/foundation/giving-records', [DailyGivingRecordController::class, 'index']);
+    Route::get('/foundation/giving-records/{recordCode}', [DailyGivingRecordController::class, 'show']);
     Route::get('/articles', [ArticleController::class, 'index']);
     Route::get('/articles/{slug}', [ArticleController::class, 'show']);
     Route::get('/articles/{slug}/seo', [ArticleController::class, 'seo']);

--- a/backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
@@ -1,0 +1,195 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use App\Models\DailyGivingRecord;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DailyGivingRecordPublicApiTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_index_returns_only_published_public_records(): void
+    {
+        $published = DailyGivingRecord::factory()->completed()->create([
+            'donation_date' => now()->subDays(10),
+        ]);
+        DailyGivingRecord::factory()->planned()->create();
+        DailyGivingRecord::factory()->voided()->create();
+        DailyGivingRecord::factory()->notPublic()->create();
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.record_code', $published->record_code)
+            ->assertJsonPath('pagination.total', 1);
+    }
+
+    public function test_index_excludes_voided_records(): void
+    {
+        DailyGivingRecord::factory()->completed()->create();
+        DailyGivingRecord::factory()->voided()->create();
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'items');
+    }
+
+    public function test_index_excludes_planned_records(): void
+    {
+        DailyGivingRecord::factory()->completed()->create();
+        DailyGivingRecord::factory()->planned()->create();
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records');
+
+        $response->assertOk()
+            ->assertJsonCount(1, 'items');
+    }
+
+    public function test_index_supports_pagination(): void
+    {
+        DailyGivingRecord::factory()->count(25)->completed()->create();
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records?per_page=10');
+
+        $response->assertOk()
+            ->assertJsonCount(10, 'items')
+            ->assertJsonPath('pagination.per_page', 10)
+            ->assertJsonPath('pagination.total', 25)
+            ->assertJsonPath('pagination.last_page', 3);
+    }
+
+    public function test_show_returns_public_record(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->create();
+
+        $response = $this->getJson("/api/v0.5/foundation/giving-records/{$record->record_code}");
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('record.record_code', $record->record_code)
+            ->assertJsonPath('record.donation_status', $record->donation_status);
+    }
+
+    public function test_show_returns_404_for_non_public_record(): void
+    {
+        $record = DailyGivingRecord::factory()->planned()->create();
+
+        $response = $this->getJson("/api/v0.5/foundation/giving-records/{$record->record_code}");
+
+        $response->assertNotFound()
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'NOT_FOUND');
+    }
+
+    public function test_show_returns_404_for_voided_record(): void
+    {
+        $record = DailyGivingRecord::factory()->voided()->create();
+
+        $response = $this->getJson("/api/v0.5/foundation/giving-records/{$record->record_code}");
+
+        $response->assertNotFound()
+            ->assertJsonPath('ok', false);
+    }
+
+    public function test_show_never_exposes_private_fields(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->create([
+            'proof_private_path' => '/private/proofs/secret.pdf',
+            'receipt_reference_private' => 'FULL-REF-12345',
+            'internal_notes' => 'secret admin note',
+            'proof_redaction_notes' => 'redaction secret',
+            'created_by_admin_user_id' => 42,
+            'updated_by_admin_user_id' => 99,
+        ]);
+
+        $response = $this->getJson("/api/v0.5/foundation/giving-records/{$record->record_code}");
+
+        $response->assertOk();
+        $data = $response->json('record');
+
+        $this->assertArrayNotHasKey('proof_private_path', $data);
+        $this->assertArrayNotHasKey('receipt_reference_private', $data);
+        $this->assertArrayNotHasKey('internal_notes', $data);
+        $this->assertArrayNotHasKey('proof_redaction_notes', $data);
+        $this->assertArrayNotHasKey('created_by_admin_user_id', $data);
+        $this->assertArrayNotHasKey('updated_by_admin_user_id', $data);
+    }
+
+    public function test_show_exposes_allowed_public_fields(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->create([
+            'proof_public_url' => 'https://example.com/proof',
+            'receipt_reference_redacted' => 'REF-REDACTED',
+            'social_x_url' => 'https://x.com/fermatmind/status/123',
+            'social_linkedin_url' => 'https://linkedin.com/feed/update/456',
+            'social_weibo_url' => 'https://weibo.com/789',
+            'social_xiaohongshu_url' => 'https://xiaohongshu.com/explore/abc',
+            'public_notes' => 'FermatMind independent giving record.',
+        ]);
+
+        $response = $this->getJson("/api/v0.5/foundation/giving-records/{$record->record_code}");
+
+        $response->assertOk();
+        $data = $response->json('record');
+
+        $this->assertSame($record->proof_public_url, $data['proof_public_url']);
+        $this->assertSame($record->receipt_reference_redacted, $data['receipt_reference_redacted']);
+        $this->assertSame($record->social_x_url, $data['social_x_url']);
+        $this->assertSame($record->public_notes, $data['public_notes']);
+    }
+
+    public function test_months_returns_distinct_months(): void
+    {
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-06-15']);
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-06-20']);
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-05-10']);
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records/months');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('months.0', '2026-06')
+            ->assertJsonPath('months.1', '2026-05');
+    }
+
+    public function test_months_excludes_non_public_records(): void
+    {
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-06-15']);
+        DailyGivingRecord::factory()->planned()->create(['donation_date' => '2026-07-01']);
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records/months');
+
+        $response->assertOk()
+            ->assertJsonMissing(['2026-07']);
+    }
+
+    public function test_month_records_returns_records_for_month(): void
+    {
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-06-15', 'record_code' => 'FM-GIVING-2026-06-001']);
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-06-20', 'record_code' => 'FM-GIVING-2026-06-002']);
+        DailyGivingRecord::factory()->completed()->create(['donation_date' => '2026-05-10']);
+
+        $response = $this->getJson('/api/v0.5/foundation/giving-records/months/2026-06');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('month', '2026-06')
+            ->assertJsonCount(2, 'items');
+    }
+
+    public function test_month_records_rejects_invalid_format(): void
+    {
+        $response = $this->getJson('/api/v0.5/foundation/giving-records/months/invalid');
+
+        $response->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_ARGUMENT');
+    }
+}

--- a/backend/tests/Feature/Foundation/DailyGivingRecordPublicationGateTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRecordPublicationGateTest.php
@@ -1,0 +1,226 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use App\Models\DailyGivingRecord;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class DailyGivingRecordPublicationGateTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_publishable_record_requires_all_fields(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'recipient_official_url' => null,
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_publishable_record_is_true_when_all_criteria_met(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make();
+
+        $this->assertTrue($record->isPublishable());
+    }
+
+    public function test_planned_record_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->planned()->make([
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_voided_record_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->voided()->make([
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_record_not_public_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'is_public' => false,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_record_without_published_at_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'is_public' => true,
+            'published_at' => null,
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_record_with_future_published_at_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'is_public' => true,
+            'published_at' => now()->addDay(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_record_without_recipient_name_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'recipient_name' => '',
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_record_without_recipient_url_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'recipient_official_url' => '',
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_scope_published_public_excludes_voided(): void
+    {
+        $completed = DailyGivingRecord::factory()->completed()->create();
+        DailyGivingRecord::factory()->voided()->create();
+
+        $records = DailyGivingRecord::publishedPublic()->get();
+
+        $this->assertCount(1, $records);
+        $this->assertSame($completed->id, $records->first()->id);
+    }
+
+    public function test_scope_published_public_excludes_planned(): void
+    {
+        $completed = DailyGivingRecord::factory()->completed()->create();
+        DailyGivingRecord::factory()->planned()->create();
+
+        $records = DailyGivingRecord::publishedPublic()->get();
+
+        $this->assertCount(1, $records);
+        $this->assertSame($completed->id, $records->first()->id);
+    }
+
+    public function test_scope_published_public_excludes_not_public(): void
+    {
+        DailyGivingRecord::factory()->completed()->create();
+        DailyGivingRecord::factory()->notPublic()->create();
+
+        $records = DailyGivingRecord::publishedPublic()->get();
+
+        $this->assertCount(1, $records);
+    }
+
+    public function test_scope_published_public_excludes_future_published(): void
+    {
+        DailyGivingRecord::factory()->completed()->create();
+        DailyGivingRecord::factory()->completed()->create([
+            'published_at' => now()->addDay(),
+        ]);
+
+        $records = DailyGivingRecord::publishedPublic()->get();
+
+        $this->assertCount(1, $records);
+    }
+
+    public function test_verified_record_is_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->verified()->make();
+
+        $this->assertTrue($record->isPublishable());
+    }
+
+    public function test_to_public_array_excludes_private_fields(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'proof_private_path' => '/secret/path',
+            'receipt_reference_private' => 'FULL-REF-999',
+            'internal_notes' => 'secret',
+            'proof_redaction_notes' => 'admin only',
+            'created_by_admin_user_id' => 1,
+            'updated_by_admin_user_id' => 2,
+        ]);
+
+        $public = $record->toPublicArray();
+
+        $this->assertArrayHasKey('record_code', $public);
+        $this->assertArrayHasKey('donation_date', $public);
+        $this->assertArrayHasKey('recipient_name', $public);
+        $this->assertArrayNotHasKey('proof_private_path', $public);
+        $this->assertArrayNotHasKey('receipt_reference_private', $public);
+        $this->assertArrayNotHasKey('internal_notes', $public);
+        $this->assertArrayNotHasKey('proof_redaction_notes', $public);
+        $this->assertArrayNotHasKey('created_by_admin_user_id', $public);
+        $this->assertArrayNotHasKey('updated_by_admin_user_id', $public);
+    }
+
+    public function test_to_public_array_includes_all_allowed_fields(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make();
+
+        $public = $record->toPublicArray();
+
+        $this->assertArrayHasKey('record_code', $public);
+        $this->assertArrayHasKey('donation_date', $public);
+        $this->assertArrayHasKey('recipient_name', $public);
+        $this->assertArrayHasKey('recipient_official_url', $public);
+        $this->assertArrayHasKey('amount_minor', $public);
+        $this->assertArrayHasKey('currency', $public);
+        $this->assertArrayHasKey('donation_status', $public);
+        $this->assertArrayHasKey('proof_status', $public);
+        $this->assertArrayHasKey('proof_public_url', $public);
+        $this->assertArrayHasKey('receipt_reference_redacted', $public);
+        $this->assertArrayHasKey('social_x_url', $public);
+        $this->assertArrayHasKey('social_linkedin_url', $public);
+        $this->assertArrayHasKey('social_weibo_url', $public);
+        $this->assertArrayHasKey('social_xiaohongshu_url', $public);
+        $this->assertArrayHasKey('social_other_links', $public);
+        $this->assertArrayHasKey('public_notes', $public);
+        $this->assertArrayHasKey('published_at', $public);
+    }
+
+    public function test_redacted_pending_proof_status_is_not_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_PENDING,
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertFalse($record->isPublishable());
+    }
+
+    public function test_withheld_proof_status_is_publishable(): void
+    {
+        $record = DailyGivingRecord::factory()->completed()->make([
+            'proof_status' => DailyGivingRecord::PROOF_WITHHELD,
+            'is_public' => true,
+            'published_at' => now(),
+        ]);
+
+        $this->assertTrue($record->isPublishable());
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -780,6 +780,38 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_daily_giving_ledger_mvp_files(): void
+    {
+        $routeChangedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Foundation\\DailyGivingRecordController;',
+            '+    Route::get(\'/foundation/giving-records/months\', [DailyGivingRecordController::class, \'months\']);',
+            '+    Route::get(\'/foundation/giving-records/months/{yearMonth}\', [DailyGivingRecordController::class, \'monthRecords\']);',
+            '+    Route::get(\'/foundation/giving-records\', [DailyGivingRecordController::class, \'index\']);',
+            '+    Route::get(\'/foundation/giving-records/{recordCode}\', [DailyGivingRecordController::class, \'show\']);',
+        ];
+
+        $changed = [
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource.php',
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/CreateDailyGivingRecord.php',
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/EditDailyGivingRecord.php',
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/ListDailyGivingRecords.php',
+            'backend/app/Http/Controllers/API/V0_5/Foundation/DailyGivingRecordController.php',
+            'backend/app/Http/Resources/Foundation/DailyGivingRecordResource.php',
+            'backend/app/Models/DailyGivingRecord.php',
+            'backend/database/factories/DailyGivingRecordFactory.php',
+            'backend/database/migrations/2026_05_30_000100_create_daily_giving_records_table.php',
+            'backend/routes/api.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            null,
+            $routeChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_chinese_claim_linter_runtime_files(): void
     {
         $changed = [
@@ -2320,6 +2352,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isDailyGivingLedgerFile($file)) {
+                continue;
+            }
+
             if ($this->isResearchBackendMvpFile($file)) {
                 continue;
             }
@@ -2663,6 +2699,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if (
+                $file === 'backend/routes/api.php'
+                && $this->routeDiffIsDailyGivingLedgerOnly($routeChangedLines ?? $this->routeChangedLines($repoRoot, $baseRef))
+            ) {
+                continue;
+            }
+
             if ($this->isBigFiveV2PilotSupportFile($file)) {
                 continue;
             }
@@ -2964,6 +3007,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Cms/ArticlePublishService.php',
             'backend/app/Services/Cms/ArticleService.php',
             'backend/database/migrations/2026_05_06_010000_add_org_scope_to_personality_profile_children.php',
+        ], true);
+    }
+
+    private function isDailyGivingLedgerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource.php',
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/CreateDailyGivingRecord.php',
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/EditDailyGivingRecord.php',
+            'backend/app/Filament/Ops/Resources/DailyGivingRecordResource/Pages/ListDailyGivingRecords.php',
+            'backend/app/Http/Controllers/API/V0_5/Foundation/DailyGivingRecordController.php',
+            'backend/app/Http/Resources/Foundation/DailyGivingRecordResource.php',
+            'backend/app/Models/DailyGivingRecord.php',
+            'backend/database/factories/DailyGivingRecordFactory.php',
+            'backend/database/migrations/2026_05_30_000100_create_daily_giving_records_table.php',
         ], true);
     }
 
@@ -4384,6 +4442,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/^[+-].*(SitemapSourceController|\\/seo\\/sitemap-source|seo\\.sitemap-source)/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsDailyGivingLedgerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            '+use App\\Http\\Controllers\\API\\V0_5\\Foundation\\DailyGivingRecordController;',
+            '+    Route::get(\'/foundation/giving-records/months\', [DailyGivingRecordController::class, \'months\']);',
+            '+    Route::get(\'/foundation/giving-records/months/{yearMonth}\', [DailyGivingRecordController::class, \'monthRecords\']);',
+            '+    Route::get(\'/foundation/giving-records\', [DailyGivingRecordController::class, \'index\']);',
+            '+    Route::get(\'/foundation/giving-records/{recordCode}\', [DailyGivingRecordController::class, \'show\']);',
+        ];
+
+        foreach ($changedLines as $line) {
+            if (! in_array($line, $allowedLines, true)) {
                 return false;
             }
         }


### PR DESCRIPTION
## PR-FDN-02A: Daily Giving Ledger Backend MVP

### Problem
FermatMind needs a backend source of truth for daily giving records as part of the public-benefit commitment declared on /foundation. No backend model, API, or admin governance existed for giving records.

### Why Split Implementation
- **PR-FDN-02A (this PR):** fap-api backend model, admin, public API
- **PR-FDN-02B:** fap-web public daily-giving pages and monthly archive (deferred)
- **PR-FDN-SEO-01:** ItemList schema, sitemap/llms integration (deferred)

### Backend Data Model

**Model:** `DailyGivingRecord`
**Table:** `daily_giving_records`

Status constants:
- `donation_status`: planned, completed, verified, voided
- `proof_status`: none, redacted_pending, redacted_available, withheld

Fields include: record_code, donation_date, recipient_name, recipient_official_url, amount_minor, currency, donation_status, proof_status, proof_public_url, proof_private_path, proof_redaction_notes, receipt_reference_redacted, receipt_reference_private, social_x_url, social_linkedin_url, social_weibo_url, social_xiaohongshu_url, social_other_links, public_notes, internal_notes, is_public, is_indexable, published_at

### Public API Contract

```
GET /api/v0.5/foundation/giving-records          — paginated list (public only)
GET /api/v0.5/foundation/giving-records/{code}   — single record (public only)
GET /api/v0.5/foundation/giving-records/months   — distinct year-month list
GET /api/v0.5/foundation/giving-records/months/{YYYY-MM} — records for month
```

All responses use `DailyGivingRecordResource` which delegates to `DailyGivingRecord::toPublicArray()`.

### Publication Gate
A record is publishable only if:
- `is_public = true`
- `published_at` is not null and not in the future
- `donation_date`, `recipient_name`, `recipient_official_url` all present
- `donation_status` is `completed` or `verified`
- `proof_status` is `redacted_available`, `withheld`, or `none`

### Proof Redaction Separation
**Public:** `proof_public_url`, `receipt_reference_redacted`
**Private (never serialized publicly):** `proof_private_path`, `receipt_reference_private`, `internal_notes`, `proof_redaction_notes`, `created_by_admin_user_id`, `updated_by_admin_user_id`

### Social Link Validation
Fields: `social_x_url`, `social_linkedin_url`, `social_weibo_url`, `social_xiaohongshu_url`, `social_other_links` (JSON)
No social-platform API calls. No automatic posting. Manual entry only.

### Admin Workflow
Filament/Ops resource at `/ops/daily-giving-records`:
- List with filters (donation_status, proof_status, is_public)
- Create with auto-generated record_code (FM-GIVING-YYYY-MM-NNN)
- Edit with full form
- Permissions via `ContentAccess::canRead()` / `canWrite()`

### Public vs Private Fields
**Exposed:** record_code, donation_date, recipient_name, recipient_official_url, amount_minor, currency, donation_status, proof_status, proof_public_url, receipt_reference_redacted, social_*_url, social_other_links, public_notes, published_at

**Never exposed:** proof_private_path, receipt_reference_private, internal_notes, proof_redaction_notes, created_by_admin_user_id, updated_by_admin_user_id

### Discoverability Deferral
- No sitemap integration
- No llms.txt / llms-full.txt entries  
- No ItemList schema
- No Search Channel
- No URL submission
- `is_indexable` field exists but is not acted upon

### Deferred to PR-FDN-02B (fap-web)
- /foundation/daily-giving frontend pages
- Monthly archive rendering
- noindex/canonical/hreflang markup

### Deferred to PR-FDN-SEO-01
- ItemList structured data
- Sitemap integration
- llms entries
- Archive discoverability

### Validation
```
php artisan route:list | grep foundation
# GET|HEAD api/v0.5/foundation/giving-records ...
# GET|HEAD api/v0.5/foundation/giving-records/months ...
# GET|HEAD api/v0.5/foundation/giving-records/months/{yearMonth} ...
# GET|HEAD api/v0.5/foundation/giving-records/{recordCode} ...

php artisan test --filter=DailyGivingRecord
# Tests: 31 passed (92 assertions)

vendor/bin/pint --test
# PASS 3637 files

composer validate --strict
# ./composer.json is valid
```

### Files Changed
12 files, 1191 insertions:
- Migration, Model, Factory
- Controller, Resource
- Filament Resource + 3 Pages
- Routes (4 new endpoints)
- 2 Test files (31 tests)

### Stop Conditions Not Hit
- Filament pattern successfully matched existing conventions
- Public/private field separation verified by tests
- No production DB/CMS mutation
- No fap-web changes needed
- No UN/UNF partnership/endorsement claims introduced

### Codex Final Review Required: **yes**