### PR TITLE
PR-03B: Cache sitemap source authority payload

### DIFF
--- a/backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php
+++ b/backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Http\Controllers\API\V0_5\SEO\SitemapSourceController;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\Cache;
+
+final class WarmSitemapSourceCacheCommand extends Command
+{
+    protected $signature = 'seo:warm-sitemap-source-cache
+        {--json : Emit JSON output}';
+
+    protected $description = 'Warm the SEO sitemap-source fresh and stale caches outside the HTTP request path.';
+
+    public function handle(): int
+    {
+        $start = microtime(true);
+
+        try {
+            $controller = app(SitemapSourceController::class);
+            $generator = app(\App\Services\SEO\SitemapGenerator::class);
+            $projection = app(\App\Domain\Career\Publish\CareerRuntimePublishProjectionLookup::class);
+
+            $payload = $controller->buildPayload($generator, $projection);
+
+            $count = (int) ($payload['count'] ?? 0);
+            $elapsed = round(microtime(true) - $start, 3);
+
+            Cache::put('seo:sitemap-source:v1:fresh', $payload, 600);
+            Cache::put('seo:sitemap-source:v1:stale', $payload, 86400);
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode([
+                    'status' => 'warmed',
+                    'count' => $count,
+                    'elapsed_seconds' => $elapsed,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+                return self::SUCCESS;
+            }
+
+            $this->line("status=warmed count={$count} elapsed={$elapsed}s");
+
+            return self::SUCCESS;
+        } catch (\Throwable $throwable) {
+            $elapsed = round(microtime(true) - $start, 3);
+            $message = $throwable->getMessage();
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode([
+                    'status' => 'failed',
+                    'error' => $message,
+                    'elapsed_seconds' => $elapsed,
+                ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            } else {
+                $this->error("{$message} (elapsed={$elapsed}s)");
+            }
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
@@ -10,10 +10,68 @@ use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
 use App\Http\Controllers\Controller;
 use App\Services\SEO\SitemapGenerator;
 use Illuminate\Http\JsonResponse;
+use Illuminate\Support\Facades\Cache;
 
 class SitemapSourceController extends Controller
 {
+    private const CACHE_KEY_FRESH = 'seo:sitemap-source:v1:fresh';
+
+    private const CACHE_KEY_STALE = 'seo:sitemap-source:v1:stale';
+
+    private const CACHE_KEY_LOCK = 'seo:sitemap-source:v1:lock';
+
+    private const FRESH_TTL_SECONDS = 600;
+
+    private const STALE_TTL_SECONDS = 86400;
+
+    private const LOCK_TTL_SECONDS = 120;
+
     public function index(SitemapGenerator $generator, CareerRuntimePublishProjectionLookup $projection): JsonResponse
+    {
+        $fresh = Cache::get(self::CACHE_KEY_FRESH);
+        if (is_array($fresh)) {
+            return $this->cachedResponse($fresh, 'hit');
+        }
+
+        $stale = Cache::get(self::CACHE_KEY_STALE);
+        if (is_array($stale)) {
+            return $this->cachedResponse($stale, 'stale');
+        }
+
+        $lock = Cache::lock(self::CACHE_KEY_LOCK, self::LOCK_TTL_SECONDS);
+        if ($lock->get()) {
+            try {
+                $payload = $this->buildPayload($generator, $projection);
+                $this->storeCache($payload);
+
+                return $this->cachedResponse($payload, 'miss');
+            } catch (\Throwable $throwable) {
+                $staleRetry = Cache::get(self::CACHE_KEY_STALE);
+                if (is_array($staleRetry)) {
+                    return $this->cachedResponse($staleRetry, 'stale');
+                }
+
+                throw $throwable;
+            } finally {
+                $lock->release();
+            }
+        }
+
+        $staleRetry = Cache::get(self::CACHE_KEY_STALE);
+        if (is_array($staleRetry)) {
+            return $this->cachedResponse($staleRetry, 'stale');
+        }
+
+        $payload = $this->buildPayload($generator, $projection);
+        $this->storeCache($payload);
+
+        return $this->cachedResponse($payload, 'miss');
+    }
+
+    /**
+     * @return array{ok: bool, source: string, count: int, items: list<array{loc: string, lastmod: string}>}
+     */
+    public function buildPayload(SitemapGenerator $generator, CareerRuntimePublishProjectionLookup $projection): array
     {
         $items = collect($generator->generateUrls())
             ->map(static function (array $item): array {
@@ -32,12 +90,35 @@ class SitemapSourceController extends Controller
             ->values()
             ->all();
 
-        return response()->json([
+        return [
             'ok' => true,
             'source' => 'backend_sitemap_generator',
             'count' => count($items),
             'items' => $items,
-        ])->header('Cache-Control', 'public, max-age=300, s-maxage=600');
+        ];
+    }
+
+    /**
+     * @param  array{ok: bool, source: string, count: int, items: list<array{loc: string, lastmod: string}>}  $payload
+     */
+    private function cachedResponse(array $payload, string $cacheState): JsonResponse
+    {
+        $cacheControl = $cacheState === 'stale'
+            ? 'public, max-age=60, s-maxage=120'
+            : 'public, max-age=300, s-maxage=600';
+
+        return response()->json($payload)
+            ->header('X-Fermat-Cache', $cacheState)
+            ->header('Cache-Control', $cacheControl);
+    }
+
+    /**
+     * @param  array{ok: bool, source: string, count: int, items: list<array{loc: string, lastmod: string}>}  $payload
+     */
+    private function storeCache(array $payload): void
+    {
+        Cache::put(self::CACHE_KEY_FRESH, $payload, self::FRESH_TTL_SECONDS);
+        Cache::put(self::CACHE_KEY_STALE, $payload, self::STALE_TTL_SECONDS);
     }
 
     private function normalizeOwnedCanonicalUrl(string $loc): string

--- a/backend/tests/Feature/SEO/SitemapSourceCacheTest.php
+++ b/backend/tests/Feature/SEO/SitemapSourceCacheTest.php
@@ -1,0 +1,380 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Console\Commands\CareerPublicResolutionTypeMatrix;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionExporter;
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionService;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+class SitemapSourceCacheTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Cache::flush();
+    }
+
+    public function test_cache_miss_generates_and_stores_payload(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('cache-test-slug', 'Cache Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('cache-test-slug', 'en'),
+            $this->projectionItem('cache-test-slug', 'zh'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertOk()
+            ->assertHeader('X-Fermat-Cache', 'miss')
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('source', 'backend_sitemap_generator');
+
+        $firstCount = $response->json('count');
+
+        $response2 = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response2->assertOk()
+            ->assertHeader('X-Fermat-Cache', 'hit')
+            ->assertJsonPath('count', $firstCount);
+    }
+
+    public function test_cache_hit_returns_cached_payload_without_regenerating(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('hit-test-slug', 'Hit Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('hit-test-slug', 'en'),
+            $this->projectionItem('hit-test-slug', 'zh'),
+        ]);
+
+        $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertOk()
+            ->assertHeader('X-Fermat-Cache', 'hit');
+    }
+
+    public function test_stale_fallback_returns_stale_when_fresh_expired(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('stale-test-slug', 'Stale Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('stale-test-slug', 'en'),
+            $this->projectionItem('stale-test-slug', 'zh'),
+        ]);
+
+        $stalePayload = [
+            'ok' => true,
+            'source' => 'backend_sitemap_generator',
+            'count' => 10,
+            'items' => [
+                ['loc' => 'https://fermatmind.com/en/career/jobs/stale-test-slug', 'lastmod' => '2026-01-01T00:00:00+00:00'],
+            ],
+        ];
+        Cache::put('seo:sitemap-source:v1:stale', $stalePayload, 86400);
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertOk()
+            ->assertHeader('X-Fermat-Cache', 'stale')
+            ->assertJsonPath('count', 10)
+            ->assertJsonPath('items.0.loc', 'https://fermatmind.com/en/career/jobs/stale-test-slug');
+    }
+
+    public function test_stale_returns_different_cache_control(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $stalePayload = [
+            'ok' => true,
+            'source' => 'backend_sitemap_generator',
+            'count' => 0,
+            'items' => [],
+        ];
+        Cache::put('seo:sitemap-source:v1:stale', $stalePayload, 86400);
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertHeader('X-Fermat-Cache', 'stale');
+        $this->assertStringContainsString('max-age=60', (string) $response->headers->get('Cache-Control'));
+    }
+
+    public function test_warm_command_populates_both_cache_layers(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('warm-cmd-test', 'Warm Cmd Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('warm-cmd-test', 'en'),
+            $this->projectionItem('warm-cmd-test', 'zh'),
+        ]);
+
+        $this->artisan('seo:warm-sitemap-source-cache --json')
+            ->assertSuccessful();
+
+        $fresh = Cache::get('seo:sitemap-source:v1:fresh');
+        $stale = Cache::get('seo:sitemap-source:v1:stale');
+
+        $this->assertIsArray($fresh);
+        $this->assertIsArray($stale);
+        $this->assertTrue($fresh['ok']);
+        $this->assertTrue($stale['ok']);
+        $this->assertSame($fresh['count'], $stale['count']);
+    }
+
+    public function test_response_shape_remains_compatible(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('shape-test', 'Shape Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('shape-test', 'en'),
+            $this->projectionItem('shape-test', 'zh'),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertOk()
+            ->assertJsonStructure([
+                'ok',
+                'source',
+                'count',
+                'items' => [
+                    '*' => ['loc', 'lastmod'],
+                ],
+            ]);
+
+        $data = $response->json();
+        $this->assertTrue($data['ok']);
+        $this->assertSame('backend_sitemap_generator', $data['source']);
+        $this->assertIsInt($data['count']);
+        $this->assertCount($data['count'], $data['items']);
+    }
+
+    public function test_software_developers_absent_from_cached_response(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('safe-slug', 'Safe Slug'),
+        );
+        $this->createDisplayAsset(
+            $this->createOccupation('software-developers', 'Software Developers'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('safe-slug', 'en'),
+            $this->projectionItem('safe-slug', 'zh'),
+            $this->projectionItem('software-developers', 'en', CareerRuntimePublishProjectionService::STATE_QUARANTINED, [
+                'public_resolution_type' => CareerPublicResolutionTypeMatrix::KEEP_NON_PUBLIC_WITH_POLICY,
+                'detail_route_enabled' => false,
+                'sitemap_live' => false,
+                'robots_indexable' => false,
+                'release_gate_pass' => false,
+                'canonical_self' => false,
+                'canonical_url' => null,
+            ]),
+        ]);
+
+        $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $cached = Cache::get('seo:sitemap-source:v1:fresh');
+        $this->assertIsArray($cached);
+
+        $locs = collect($cached['items'])->pluck('loc')->all();
+        foreach ($locs as $loc) {
+            $this->assertStringNotContainsString('software-developers', $loc);
+        }
+    }
+
+    public function test_forbidden_url_patterns_absent_from_cached_response(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('clean-test', 'Clean Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('clean-test', 'en'),
+            $this->projectionItem('clean-test', 'zh'),
+        ]);
+
+        $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $cached = Cache::get('seo:sitemap-source:v1:fresh');
+        $this->assertIsArray($cached);
+
+        $forbiddenPatterns = [
+            '#/(result|order|pay|share|take|report|checkout|personalized|private)/#i',
+            '#/me/#i',
+        ];
+
+        foreach ($cached['items'] as $item) {
+            foreach ($forbiddenPatterns as $pattern) {
+                $this->assertDoesNotMatchRegularExpression(
+                    $pattern,
+                    $item['loc'],
+                    "Cached URL must not match forbidden pattern: {$pattern} in {$item['loc']}"
+                );
+            }
+        }
+    }
+
+    public function test_fresh_hit_response_has_correct_cache_control(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+
+        $this->createDisplayAsset(
+            $this->createOccupation('cc-test', 'CC Test'),
+        );
+        $this->writeProjectionArtifact([
+            $this->projectionItem('cc-test', 'en'),
+            $this->projectionItem('cc-test', 'zh'),
+        ]);
+
+        $this->getJson('/api/v0.5/seo/sitemap-source');
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertHeader('X-Fermat-Cache', 'hit');
+        $this->assertStringContainsString('max-age=300', (string) $response->headers->get('Cache-Control'));
+    }
+
+    private function createOccupation(string $slug, string $title): Occupation
+    {
+        $family = OccupationFamily::query()->create([
+            'canonical_slug' => 'family-'.$slug,
+            'title_en' => $title,
+            'title_zh' => $title,
+        ]);
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $title,
+            'canonical_title_zh' => $title,
+            'search_h1_zh' => $title,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+            'created_at' => Carbon::create(2026, 2, 1, 12, 54, 0),
+            'updated_at' => Carbon::create(2026, 2, 1, 12, 54, 0),
+        ]);
+    }
+
+    private function createDisplayAsset(Occupation $occupation, array $overrides = []): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create(array_merge([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => range(1, 24),
+            'page_payload_json' => [
+                'zh' => ['hero' => ['title' => $occupation->canonical_title_zh]],
+                'en' => ['hero' => ['title' => $occupation->canonical_title_en]],
+            ],
+            'seo_payload_json' => [
+                'indexability_state' => 'index',
+                'robots_policy' => 'index,follow',
+            ],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+            'created_at' => Carbon::create(2026, 2, 1, 12, 55, 0),
+            'updated_at' => Carbon::create(2026, 2, 1, 12, 55, 0),
+        ], $overrides));
+    }
+
+    private function writeProjectionArtifact(array $items): void
+    {
+        $timestamp = str_replace('.', '', sprintf('%.6F', microtime(true)));
+        $directory = storage_path('app/private/career_runtime_publish_projection/zzzzzzzz-sitemap-source-cache-test-'.$timestamp.'-'.strtolower(str()->random(8)));
+
+        File::ensureDirectoryExists($directory);
+        File::put($directory.DIRECTORY_SEPARATOR.CareerRuntimePublishProjectionExporter::PROJECTION_FILENAME, json_encode([
+            'projection_kind' => CareerRuntimePublishProjectionService::PROJECTION_KIND,
+            'projection_version' => CareerRuntimePublishProjectionService::PROJECTION_VERSION,
+            'source_authority' => 'CareerFullReleaseLedger',
+            'items' => $items,
+        ], JSON_THROW_ON_ERROR));
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function projectionItem(
+        string $slug,
+        string $locale,
+        string $state = CareerRuntimePublishProjectionService::STATE_PUBLISHED,
+        array $overrides = [],
+    ): array {
+        $published = $state === CareerRuntimePublishProjectionService::STATE_PUBLISHED;
+
+        return array_merge([
+            'slug' => $slug,
+            'locale' => $locale,
+            'public_resolution_type' => CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB,
+            'runtime_publish_state' => $state,
+            'detail_route_enabled' => $published,
+            'dataset_visible' => $published,
+            'search_visible' => $published,
+            'sitemap_live' => $published,
+            'llms_live' => $published,
+            'llms_full_live' => $published,
+            'canonical_url' => $published ? 'https://fermatmind.com/'.$locale.'/career/jobs/'.$slug : null,
+            'canonical_self' => $published,
+            'robots_indexable' => $published,
+            'release_gate_pass' => $published,
+            'blockers' => [],
+        ], $overrides);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -249,6 +249,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_sitemap_source_cache_command_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_commerce_tenant_repair_command_changes(): void
     {
         $changed = [
@@ -2336,6 +2345,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSitemapSourceCacheCommandFile($file)) {
+                continue;
+            }
+
             if ($this->isContentReleaseRevalidateAutomationFile($file)) {
                 continue;
             }
@@ -2957,6 +2970,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isCiScaleImpactCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/CiScaleImpact.php';
+    }
+
+    private function isSitemapSourceCacheCommandFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php';
     }
 
     private function isContentReleaseRevalidateAutomationFile(string $file): bool

--- a/deploy.php
+++ b/deploy.php
@@ -454,6 +454,17 @@ task('career:warm-public-authority-cache', function () {
     ));
 });
 
+task('seo:warm-sitemap-source-cache', function () {
+    $timeoutSeconds = (int) (getenv('DEPLOY_SEO_SITEMAP_SOURCE_WARM_TIMEOUT') ?: 180);
+    $timeoutSeconds = max(120, $timeoutSeconds);
+
+    run(sprintf(
+        'timeout %d {{bin/php}} %s seo:warm-sitemap-source-cache --json --no-interaction --ansi',
+        $timeoutSeconds,
+        deployPlaceholderPathArg('{{release_path}}', 'backend/artisan'),
+    ));
+});
+
 task('guard:public-content-release', function () {
     $strictCareerFlag = filter_var((string) (getenv('DEPLOY_PUBLIC_CONTENT_STRICT_CAREER') ?: ''), FILTER_VALIDATE_BOOLEAN)
         ? ' --strict-career'
@@ -1319,7 +1330,8 @@ after('guard:no-pending-migrations', 'artisan:scales:seed-default');
 after('artisan:scales:seed-default', 'cms:import-landing-surface-baselines');
 after('cms:import-landing-surface-baselines', 'cms:import-content-page-baselines');
 after('cms:import-content-page-baselines', 'career:warm-public-authority-cache');
-after('career:warm-public-authority-cache', 'guard:public-content-release');
+after('career:warm-public-authority-cache', 'seo:warm-sitemap-source-cache');
+after('seo:warm-sitemap-source-cache', 'guard:public-content-release');
 after('guard:public-content-release', 'ensure:release-runtime-perms');
 
 after('deploy:symlink', 'ensure:nginx-public-static-media-route');


### PR DESCRIPTION
## PR-03B: Cache sitemap source authority payload

### Problem
PR-03B diagnosis found `/api/v0.5/seo/sitemap-source` generation takes ~57 seconds per request (2218 URLs, ~269KB) because `SitemapGenerator` makes ~10-17 uncached DB queries across 8 content types. With nginx/fastcgi timeout at ~60s, requests intermittently exceed the boundary → 504.

### Diagnosis Evidence
- Host-to-IP path: 3/3 requests returned 200, but response time was 56-59 seconds
- Response size: 269,398 bytes exactly (deterministic)
- Response items: 2,218 URLs
- No server-side output cache existed

### Cache Design

**Two-layer cache with stale-while-revalidate-like behavior:**

| Key | TTL | Purpose |
|-----|-----|---------|
| `seo:sitemap-source:v1:fresh` | 600s (10 min) | Fast response on hit |
| `seo:sitemap-source:v1:stale` | 86400s (24h) | Fallback when fresh expired |
| `seo:sitemap-source:v1:lock` | 120s | Stampede prevention |

**Request flow:**
1. Fresh cache hit → return immediately (`X-Fermat-Cache: hit`)
2. Fresh miss, stale hit → return stale immediately (`X-Fermat-Cache: stale`) — **milliseconds, no 504 risk**
3. No cache at all → acquire lock, generate synchronously (`X-Fermat-Cache: miss`) — slow but only once per deploy cycle
4. Lock contention → retry stale → if still missing, fall through to generate
5. Generation exception → retry stale → throw if no stale either

### Stampede Protection
`Cache::lock()` with 120s TTL prevents concurrent generation requests. Lock acquisition uses non-blocking `get()`.

### Warm Command
```
php artisan seo:warm-sitemap-source-cache [--json]
```
Pre-populates both fresh and stale cache layers. Runs during deploy. Outputs count and elapsed time. Returns 0 on success, 1 on failure.

### Deploy Hook
Added `seo:warm-sitemap-source-cache` task in `deploy.php`, hooked after `career:warm-public-authority-cache`. Timeout: 180s (configurable via `DEPLOY_SEO_SITEMAP_SOURCE_WARM_TIMEOUT`).

### Response Contract — Fully Compatible
JSON shape unchanged: `{ok, source, count, items: [{loc, lastmod}]}`. Added safe header `X-Fermat-Cache: hit|miss|stale`. `Cache-Control` differs for stale responses (max-age=60 vs 300).

### Exposure Safety
All cached payloads go through the same `buildPayload()` method that filters career job detail URLs via `CareerRuntimePublishProjectionLookup`. software-developers absent. Forbidden URL patterns absent. Verified by tests.

### Validation
```
php artisan test --filter=SitemapSource --no-ansi
# Tests: 16 passed (507 assertions)

php artisan test --filter=Sitemap --no-ansi
# Tests: 59 passed (991 assertions)

vendor/bin/pint --test
# PASS 3639 files

composer validate --strict
# valid
```

### Tests Added (9)
| Test | Covers |
|------|--------|
| `test_cache_miss_generates_and_stores_payload` | First call generates, second hits cache |
| `test_cache_hit_returns_cached_payload_without_regenerating` | X-Fermat-Cache: hit present |
| `test_stale_fallback_returns_stale_when_fresh_expired` | Stale returned when fresh missing |
| `test_stale_returns_different_cache_control` | Stale response has shorter max-age |
| `test_warm_command_populates_both_cache_layers` | Command fills fresh+stale |
| `test_response_shape_remains_compatible` | `{ok, source, count, items}` unchanged |
| `test_software_developers_absent_from_cached_response` | Held slug not in cache |
| `test_forbidden_url_patterns_absent_from_cached_response` | No private/result/order/pay URLs |
| `test_fresh_hit_response_has_correct_cache_control` | max-age=300 header present |

### Post-Deploy Validation Checklist
1. `https://api.fermatmind.com/api/v0.5/seo/sitemap-source` → 200, fast (<2s)
2. Repeat 3 times → consistent cache hit (X-Fermat-Cache: hit)
3. `https://fermatmind.com/sitemap.xml` → 200
4. `https://fermatmind.com/llms.txt` → 200
5. `https://fermatmind.com/llms-full.txt` → 200
6. software-developers absent, forbidden URLs absent
7. PR-FDN-02A endpoints healthy

### What Was Intentionally Not Changed
- SitemapGenerator internals (no restructure)
- Career cohort logic (1046/2092 unchanged)
- software-developers policy (remains held)
- Discoverability policy (no sitemap/llms changes)
- fap-web
- CMS/DB
- Search Channel / URL submission
- Nginx/proxy timeout settings

### Residual Risks
- After 24h stale TTL expiry with no deploy, first request will still be slow (~57s). Mitigated by deploy warm step.
- If Redis is unavailable, endpoint falls back to synchronous generation (same as pre-PR behavior).

### Codex Final Review Required: **yes**