### PR TITLE
PR-HIRING-01A: Align EN careers content authority

### DIFF
--- a/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+++ b/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
@@ -25,11 +25,11 @@ final class ContentPagePublicApiTest extends TestCase
             '--source-dir' => '../content_baselines/content_pages',
         ])
             ->expectsOutputToContain('files_found=4')
-            ->expectsOutputToContain('pages_found=26')
-            ->expectsOutputToContain('will_create=26')
+            ->expectsOutputToContain('pages_found=27')
+            ->expectsOutputToContain('will_create=27')
             ->assertExitCode(0);
 
-        $this->assertSame(26, ContentPage::query()->withoutGlobalScopes()->count());
+        $this->assertSame(27, ContentPage::query()->withoutGlobalScopes()->count());
 
         $about = ContentPage::query()
             ->withoutGlobalScopes()

--- a/backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
@@ -110,7 +110,6 @@ final class EnParity03ContentPagesParityImportPackageTest extends TestCase
 
         $this->assertSame([
             'content-page-brand',
-            'content-page-careers',
             'content-page-charter',
             'content-page-policies',
         ], $missing);
@@ -137,8 +136,8 @@ final class EnParity03ContentPagesParityImportPackageTest extends TestCase
 
         $this->assertContains('https://fermatmind.com/zh/brand', $locs);
         $this->assertContains('https://fermatmind.com/en/about', $locs);
+        $this->assertContains('https://fermatmind.com/en/careers', $locs);
         $this->assertNotContains('https://fermatmind.com/en/brand', $locs);
-        $this->assertNotContains('https://fermatmind.com/en/careers', $locs);
         $this->assertNotContains('https://fermatmind.com/en/charter', $locs);
         $this->assertNotContains('https://fermatmind.com/en/foundation', $locs);
         $this->assertNotContains('https://fermatmind.com/en/policies', $locs);

--- a/content_baselines/content_pages/content_pages.en.json
+++ b/content_baselines/content_pages/content_pages.en.json
@@ -57,6 +57,34 @@
     "contentHtml": ""
   },
   {
+    "slug": "careers",
+    "path": "/careers",
+    "kind": "company",
+    "title": "Work With FermatMind",
+    "kicker": "Careers",
+    "summary": "A cautious overview of the kinds of work FermatMind may need over time, without announcing current openings, hiring timelines, employment terms, or an active recruiting process.",
+    "template": "careers",
+    "animationProfile": "editorial",
+    "locale": "en",
+    "publishedAt": "2026-05-30",
+    "updatedAt": "2026-05-30",
+    "effectiveAt": null,
+    "sourceDoc": "global-en-zh-content-pages-cms-draft-update-01 from human revision packages",
+    "isPublic": true,
+    "isIndexable": true,
+    "headings": [
+      "About this page",
+      "The work we care about",
+      "Possible collaboration areas",
+      "What we value in collaborators",
+      "Future contact and official channels"
+    ],
+    "seoTitle": "Work With FermatMind | FermatMind",
+    "metaDescription": "A cautious overview of the kinds of work FermatMind may need over time, without announcing current openings, hiring timelines, employment terms, or an active recruiting process.",
+    "contentMd": "# Work With FermatMind\n\n## About this page\nThis page describes the kinds of work FermatMind may need as the product develops. It does not announce current job openings, guarantee hiring, describe employment terms, or create a recruiting process. Official opportunities, if available, should be confirmed only through current official channels.\n\n## The work we care about\nFermatMind works on assessment interpretation, career exploration, product systems, content quality, and user-facing decision support. The work requires careful language, product judgment, engineering reliability, privacy awareness, and respect for the limits of assessment tools.\n\n## Possible collaboration areas\nDepending on future needs, relevant areas may include research and methodology, content and editing, product design, user research, frontend and backend engineering, data analysis, quality assurance, operations, and responsible growth. This list is descriptive and does not mean any role is currently open.\n\n## What we value in collaborators\nWe value clarity, careful reasoning, respect for human complexity, strong execution, and willingness to revise work when evidence changes. We also value sensitivity to privacy, psychological safety, and high-risk settings where assessment results can be misused.\n\n## Future contact and official channels\nIf FermatMind opens formal roles or collaboration channels, the relevant information should appear through official public channels. Until then, this page should be read as a directional overview, not as an invitation, job advertisement, hiring promise, or application instruction.",
+    "contentHtml": ""
+  },
+  {
     "slug": "privacy",
     "path": "/privacy",
     "kind": "policy",


### PR DESCRIPTION
## Problem summary
/en/careers is public at runtime, but content_baselines/content_pages/content_pages.en.json did not include a repo-backed careers entry. That blocked PR-HIRING-01 from applying uploaded hiring content safely.

## Root cause of /en/careers authority mismatch
Runtime /en/careers is served by the public content_pages API from an existing published CMS record. The record source_doc is global-en-zh-content-pages-cms-draft-update-01 from human revision packages. fap-web routes /en/careers through the generic content page API/LKG path and does not contain static careers fallback copy.

## Files changed
- content_baselines/content_pages/content_pages.en.json
- backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
- backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php

## Why this is not the hiring content update yet
This PR only aligns the repo baseline with the already published English careers authority. It does not add current roles or open-role content.

## Why no hiring assets were applied
PR-HIRING-01A is an authority-resolution PR. The uploaded hiring assets are reserved for the next PR-HIRING-01 content insertion task.

## Why no fap-web change
fap-web already renders careers through getContentPageWithLastKnownGood and the backend content_pages API. No static fallback or route change is needed.

## Why no new route
The existing /en/careers route and /api/v0.5/content-pages/careers API contract already serve the page.

## Why no JobPosting schema
This PR does not add job postings, structured job data, ATS, resume upload, or application forms.

## Validation results
- php artisan test --filter=ContentPage --no-ansi: passed
- php artisan test --filter=EnParity --no-ansi: passed
- php artisan test --filter=Sitemap --no-ansi: passed
- php artisan test --filter=SitemapSource --no-ansi: passed
- composer validate --strict: passed
- git diff --check: passed
- forbidden phrase scan on changed files: passed with no matches

## Next task
PR-HIRING-01 content insertion using uploaded hiring assets.

## Codex final review required
Yes.