### PR TITLE
ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy

### DIFF
--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -11,22 +11,6 @@ use Illuminate\Support\Facades\DB;
 
 final class AnalyticsFunnelDailyBuilder
 {
-    private const FIRST_VIEW_EVENT_ALIASES = [
-        'result_view',
-        'report_view',
-        'report_viewed',
-        'clinical_combo_68_report_viewed',
-        'sds_20_report_viewed',
-    ];
-
-    private const PDF_EVENT_ALIASES = [
-        'report_pdf_view',
-    ];
-
-    private const SHARE_CLICK_EVENT_ALIASES = [
-        'share_click',
-    ];
-
     private const SUBMISSION_SUCCESS_STATES = [
         'succeeded',
         'success',
@@ -548,7 +532,7 @@ final class AnalyticsFunnelDailyBuilder
             $query->whereIn('org_id', $orgIds);
         }
 
-        $this->applyEventAliasFilter($query, self::FIRST_VIEW_EVENT_ALIASES);
+        $this->applyEventAliasFilter($query, FunnelEventTaxonomy::FIRST_RESULT_OR_REPORT_VIEW_ALIASES);
         $query->havingRaw('MIN(occurred_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
 
         return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
@@ -768,7 +752,7 @@ final class AnalyticsFunnelDailyBuilder
             $query->whereIn('org_id', $orgIds);
         }
 
-        $this->applyEventAliasFilter($query, self::PDF_EVENT_ALIASES);
+        $this->applyEventAliasFilter($query, FunnelEventTaxonomy::PDF_DOWNLOAD_ALIASES);
         $query->havingRaw('MIN(occurred_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
 
         return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
@@ -831,7 +815,7 @@ final class AnalyticsFunnelDailyBuilder
             $query->whereIn('events.org_id', $orgIds);
         }
 
-        $this->applyEventAliasFilter($query, self::SHARE_CLICK_EVENT_ALIASES, 'events');
+        $this->applyEventAliasFilter($query, FunnelEventTaxonomy::SHARE_CLICK_ALIASES, 'events');
 
         return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
     }

--- a/backend/app/Services/Analytics/FunnelEventTaxonomy.php
+++ b/backend/app/Services/Analytics/FunnelEventTaxonomy.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+final class FunnelEventTaxonomy
+{
+    public const PAGE_VIEW = 'page_view';
+
+    public const TEST_START = 'test_start';
+
+    public const QUESTION_ANSWER = 'question_answer';
+
+    public const TEST_SUBMIT = 'test_submit';
+
+    public const RESULT_VIEW = 'result_view';
+
+    public const CHECKOUT_START = 'checkout_start';
+
+    public const ORDER_CREATED = 'order_created';
+
+    public const PAYMENT_SUCCESS = 'payment_success';
+
+    public const REPORT_UNLOCK = 'report_unlock';
+
+    public const REPORT_READY = 'report_ready';
+
+    public const PDF_DOWNLOAD = 'pdf_download';
+
+    public const SHARE_GENERATE = 'share_generate';
+
+    public const SHARE_CLICK = 'share_click';
+
+    public const MEMBERSHIP_START = 'membership_start';
+
+    public const RETEST_START = 'retest_start';
+
+    public const HISTORICAL_REPORT_REVISIT = 'historical_report_revisit';
+
+    public const SOURCE_ATTRIBUTION = 'source_attribution';
+
+    /**
+     * @var list<string>
+     */
+    public const CANONICAL_EVENTS = [
+        self::PAGE_VIEW,
+        self::TEST_START,
+        self::QUESTION_ANSWER,
+        self::TEST_SUBMIT,
+        self::RESULT_VIEW,
+        self::CHECKOUT_START,
+        self::ORDER_CREATED,
+        self::PAYMENT_SUCCESS,
+        self::REPORT_UNLOCK,
+        self::REPORT_READY,
+        self::PDF_DOWNLOAD,
+        self::SHARE_GENERATE,
+        self::SHARE_CLICK,
+        self::MEMBERSHIP_START,
+        self::RETEST_START,
+        self::HISTORICAL_REPORT_REVISIT,
+        self::SOURCE_ATTRIBUTION,
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    public const LEGACY_ALIAS_MAP = [
+        'start_attempt' => self::TEST_START,
+        'submit_attempt' => self::TEST_SUBMIT,
+        'view_result' => self::RESULT_VIEW,
+        'create_order' => self::ORDER_CREATED,
+        'begin_checkout' => self::CHECKOUT_START,
+        'payment_confirmed' => self::PAYMENT_SUCCESS,
+        'purchase_success' => self::PAYMENT_SUCCESS,
+        'pay_success' => self::PAYMENT_SUCCESS,
+        'unlock_success' => self::REPORT_UNLOCK,
+        'clinical_unlock_success' => self::REPORT_UNLOCK,
+        'report_pdf_view' => self::PDF_DOWNLOAD,
+        'revisit_result' => self::HISTORICAL_REPORT_REVISIT,
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const FIRST_RESULT_OR_REPORT_VIEW_ALIASES = [
+        self::RESULT_VIEW,
+        'view_result',
+        'report_view',
+        'report_viewed',
+        'clinical_combo_68_report_viewed',
+        'sds_20_report_viewed',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const PDF_DOWNLOAD_ALIASES = [
+        self::PDF_DOWNLOAD,
+        'report_pdf_view',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const SHARE_CLICK_ALIASES = [
+        self::SHARE_CLICK,
+    ];
+
+    public static function canonicalize(string $eventName): string
+    {
+        $normalized = strtolower(trim($eventName));
+
+        return self::LEGACY_ALIAS_MAP[$normalized] ?? $normalized;
+    }
+
+    public static function isCanonical(string $eventName): bool
+    {
+        return in_array(strtolower(trim($eventName)), self::CANONICAL_EVENTS, true);
+    }
+}

--- a/backend/docs/seo/analytics-funnel-event-taxonomy-01.md
+++ b/backend/docs/seo/analytics-funnel-event-taxonomy-01.md
@@ -1,0 +1,72 @@
+# ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
+
+## Purpose
+
+This package defines the canonical FermatMind funnel event taxonomy and the backward-compatible legacy aliases required for `analytics_funnel_daily`.
+
+The implementation keeps production analytics rows untouched. It does not configure GA4 key events, does not change Baidu Tongji settings, does not run a production refresh, and does not mutate CMS or production data.
+
+## Canonical Events
+
+| Event | Definition | Source of truth |
+| --- | --- | --- |
+| `page_view` | Consented page view. | Browser analytics. |
+| `test_start` | A test attempt exists. | `attempts.created_at`. |
+| `question_answer` | A user answers a question. | Frontend event stream. |
+| `test_submit` | A test submit succeeds. | `attempts.submitted_at`, `attempt_submissions`, or result fallback. |
+| `result_view` | A result/report is viewed. | Backend result read events plus accepted legacy frontend aliases. |
+| `checkout_start` | User begins checkout flow. | Frontend checkout CTA / provider launch event. |
+| `order_created` | Backend order record exists. | `orders.created_at`. |
+| `payment_success` | Backend/payment provider confirms paid. | `orders.paid_at` and `payment_events`. |
+| `report_unlock` | Benefit/report access is granted. | Active `benefit_grants`. |
+| `report_ready` | Report snapshot is ready/readable. | `report_snapshots`. |
+| `pdf_download` | User downloads or opens a report PDF. | Report/PDF event aliases. |
+| `share_generate` | Share object is created. | `shares`. |
+| `share_click` | Share link is clicked. | `events.share_click`. |
+| `membership_start` | Membership starts or is attached. | Future membership fact source. |
+| `retest_start` | A real retest starts. | Future attempt relation/fact source. |
+| `historical_report_revisit` | Saved result/report is revisited. | Future result/history read event. |
+| `source_attribution` | Source/channel attribution is attached. | Sanitized tracking payload and backend dimensions. |
+
+## Legacy Alias Mapping
+
+| Legacy event | Canonical event | Handling |
+| --- | --- | --- |
+| `start_attempt` | `test_start` | Kept for existing frontend dispatch; canonical source remains `attempts.created_at`. |
+| `submit_attempt` | `test_submit` | Kept for existing frontend dispatch; canonical source remains backend submit facts. |
+| `view_result` | `result_view` | Added to `analytics_funnel_daily` first-view aliases. |
+| `create_order` | `order_created` | Kept as legacy order-created observation; do not collapse with checkout start. |
+| `begin_checkout` | `checkout_start` | GA4/browser alias only. |
+| `payment_confirmed` | `payment_success` | Treat as paid-state observation only when backend confirms paid. |
+| `purchase_success` | `payment_success` | GA purchase alias; backend payment facts remain authoritative. |
+| `pay_success` | `payment_success` | Big Five alias. |
+| `unlock_success` | `report_unlock` | Legacy event alias; canonical fact source is active `benefit_grants`. |
+| `clinical_unlock_success` | `report_unlock` | Clinical report unlock alias, scoped to report access. |
+| `report_pdf_view` | `pdf_download` | Legacy backend PDF event alias. |
+| `pdf_download` | `pdf_download` | Canonical PDF event. |
+| `revisit_result` | `historical_report_revisit` | Legacy MBTI result revisit alias. |
+
+## AnalyticsFunnelDailyBuilder Mapping
+
+`AnalyticsFunnelDailyBuilder` preserves the backend fact sources:
+
+- `test_start`: `attempts.created_at`
+- `test_submit`: `attempts.submitted_at`, successful `attempt_submissions`, and `results` fallback
+- `result_view`: `events.result_view`, `events.view_result`, and report-view variants
+- `order_created`: `orders.created_at`
+- `payment_success`: `orders.paid_at` and successful `payment_events`
+- `report_unlock`: active `benefit_grants`
+- `report_ready`: ready/readable `report_snapshots`
+- `pdf_download`: `events.pdf_download` and `events.report_pdf_view`
+- `share_generate`: `shares`
+- `share_click`: `events.share_click`
+
+## Deferred Items
+
+- GA4 key event configuration is deferred until the taxonomy is deployed and verified.
+- Production `analytics:refresh-funnel-daily` is deferred because it writes `analytics_funnel_daily`.
+- Membership, retest, historical revisit, and source-attribution dashboard metrics need future scoped implementation after this taxonomy baseline.
+
+## Next Task
+
+`ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01`

--- a/backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": "1.0",
+  "task": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01",
+  "final_decision": "analytics_funnel_event_taxonomy_completed_ready_for_ops_read_model_repair",
+  "canonical_events": [
+    "page_view",
+    "test_start",
+    "question_answer",
+    "test_submit",
+    "result_view",
+    "checkout_start",
+    "order_created",
+    "payment_success",
+    "report_unlock",
+    "report_ready",
+    "pdf_download",
+    "share_generate",
+    "share_click",
+    "membership_start",
+    "retest_start",
+    "historical_report_revisit",
+    "source_attribution"
+  ],
+  "legacy_aliases": {
+    "start_attempt": "test_start",
+    "submit_attempt": "test_submit",
+    "view_result": "result_view",
+    "create_order": "order_created",
+    "begin_checkout": "checkout_start",
+    "payment_confirmed": "payment_success",
+    "purchase_success": "payment_success",
+    "pay_success": "payment_success",
+    "unlock_success": "report_unlock",
+    "clinical_unlock_success": "report_unlock",
+    "report_pdf_view": "pdf_download",
+    "pdf_download": "pdf_download",
+    "revisit_result": "historical_report_revisit"
+  },
+  "analytics_funnel_daily_mapping": {
+    "test_start": {
+      "source": "attempts.created_at",
+      "metric": "started_attempts"
+    },
+    "test_submit": {
+      "source": "attempts.submitted_at|attempt_submissions|results fallback",
+      "metric": "submitted_attempts"
+    },
+    "result_view": {
+      "source": "events",
+      "aliases": [
+        "result_view",
+        "view_result",
+        "report_view",
+        "report_viewed",
+        "clinical_combo_68_report_viewed",
+        "sds_20_report_viewed"
+      ],
+      "metric": "first_view_attempts"
+    },
+    "order_created": {
+      "source": "orders.created_at",
+      "metric": "order_created_attempts"
+    },
+    "payment_success": {
+      "source": "orders.paid_at|payment_events",
+      "metric": "paid_attempts"
+    },
+    "report_unlock": {
+      "source": "active benefit_grants",
+      "legacy_metric": "unlocked_attempts"
+    },
+    "report_ready": {
+      "source": "ready report_snapshots",
+      "metric": "report_ready_attempts"
+    },
+    "pdf_download": {
+      "source": "events",
+      "aliases": [
+        "pdf_download",
+        "report_pdf_view"
+      ],
+      "metric": "pdf_download_attempts"
+    },
+    "share_generate": {
+      "source": "shares",
+      "metric": "share_generated_attempts"
+    },
+    "share_click": {
+      "source": "events.share_click",
+      "metric": "share_click_attempts"
+    }
+  },
+  "fact_sources_preserved": {
+    "test_start": true,
+    "test_submit": true,
+    "order_created": true,
+    "payment_success": true,
+    "report_unlock": true,
+    "report_ready": true,
+    "share_generate": true,
+    "share_click": true
+  },
+  "no_ga_admin_change": true,
+  "no_baidu_setting_change": true,
+  "no_production_refresh": true,
+  "no_production_db_mutation": true,
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "deferred_followups": [
+    "ops read model repair and production dry-run",
+    "GA4 key event mapping after taxonomy deployment",
+    "membership_start event contract",
+    "retest_start event contract",
+    "historical_report_revisit event contract",
+    "source attribution dashboard dimensions"
+  ],
+  "next_task": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01"
+}

--- a/backend/tests/Feature/SeoIntel/AnalyticsFunnelEventTaxonomy01Test.php
+++ b/backend/tests/Feature/SeoIntel/AnalyticsFunnelEventTaxonomy01Test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use App\Services\Analytics\FunnelEventTaxonomy;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class AnalyticsFunnelEventTaxonomy01Test extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    public function test_taxonomy_artifacts_define_canonical_events_and_legacy_aliases(): void
+    {
+        $backendPath = dirname(__DIR__, 3);
+        $docPath = $backendPath.'/docs/seo/analytics-funnel-event-taxonomy-01.md';
+        $jsonPath = $backendPath.'/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json';
+
+        $this->assertFileExists($docPath);
+        $this->assertFileExists($jsonPath);
+
+        $payload = json_decode((string) file_get_contents($jsonPath), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame('ANALYTICS-FUNNEL-EVENT-TAXONOMY-01', $payload['task'] ?? null);
+        $this->assertSame('analytics_funnel_event_taxonomy_completed_ready_for_ops_read_model_repair', $payload['final_decision'] ?? null);
+        $this->assertTrue((bool) ($payload['no_ga_admin_change'] ?? false));
+        $this->assertTrue((bool) ($payload['no_production_refresh'] ?? false));
+        $this->assertContains(FunnelEventTaxonomy::RESULT_VIEW, $payload['canonical_events'] ?? []);
+        $this->assertSame(FunnelEventTaxonomy::RESULT_VIEW, data_get($payload, 'legacy_aliases.view_result'));
+        $this->assertSame(FunnelEventTaxonomy::PDF_DOWNLOAD, data_get($payload, 'legacy_aliases.report_pdf_view'));
+        $this->assertSame(FunnelEventTaxonomy::REPORT_UNLOCK, data_get($payload, 'legacy_aliases.clinical_unlock_success'));
+    }
+
+    public function test_daily_builder_accepts_frontend_legacy_aliases_for_canonical_stages(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(123);
+        $day = CarbonImmutable::parse($scenario['day'].' 08:00:00');
+
+        $this->insertEvent(123, 'view_result', $scenario['attempt_c'], $day->addHours(4)->addMinutes(15));
+        $this->insertEvent(123, 'pdf_download', $scenario['attempt_c'], $day->addHours(4)->addMinutes(20));
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [123],
+        );
+
+        $rowsByLocale = collect($payload['rows'])->keyBy('locale');
+        $en = $rowsByLocale->get('en');
+        $zh = $rowsByLocale->get('zh-CN');
+
+        $this->assertNotNull($en);
+        $this->assertNotNull($zh);
+        $this->assertSame(2, (int) ($en['first_view_attempts'] ?? 0), 'result_view and legacy view_result must both feed the canonical result_view stage.');
+        $this->assertSame(2, (int) ($en['pdf_download_attempts'] ?? 0), 'report_pdf_view and pdf_download must both feed the canonical pdf_download stage.');
+        $this->assertSame(1, (int) ($zh['first_view_attempts'] ?? 0), 'Existing result_view canonical events must remain supported.');
+        $this->assertSame(1, (int) ($en['unlocked_attempts'] ?? 0), 'report_unlock remains backend fact driven by active benefit grants.');
+    }
+
+    public function test_taxonomy_helper_keeps_aliases_backward_compatible(): void
+    {
+        $this->assertSame(FunnelEventTaxonomy::TEST_START, FunnelEventTaxonomy::canonicalize('start_attempt'));
+        $this->assertSame(FunnelEventTaxonomy::TEST_SUBMIT, FunnelEventTaxonomy::canonicalize('submit_attempt'));
+        $this->assertSame(FunnelEventTaxonomy::RESULT_VIEW, FunnelEventTaxonomy::canonicalize('view_result'));
+        $this->assertSame(FunnelEventTaxonomy::ORDER_CREATED, FunnelEventTaxonomy::canonicalize('create_order'));
+        $this->assertSame(FunnelEventTaxonomy::PAYMENT_SUCCESS, FunnelEventTaxonomy::canonicalize('purchase_success'));
+        $this->assertSame(FunnelEventTaxonomy::REPORT_UNLOCK, FunnelEventTaxonomy::canonicalize('unlock_success'));
+        $this->assertSame(FunnelEventTaxonomy::HISTORICAL_REPORT_REVISIT, FunnelEventTaxonomy::canonicalize('revisit_result'));
+        $this->assertTrue(FunnelEventTaxonomy::isCanonical(FunnelEventTaxonomy::CHECKOUT_START));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2775,6 +2775,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isAnalyticsFunnelEventTaxonomyFile($file)) {
+                continue;
+            }
+
             if ($this->isEq60V5ReportAssetLayerChange($file)) {
                 continue;
             }
@@ -4211,6 +4215,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isResultEmailAccessLinkDeliveryFile(string $file): bool
     {
         return $file === 'backend/app/Services/Email/EmailOutboxService.php';
+    }
+
+    private function isAnalyticsFunnelEventTaxonomyFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php',
+            'backend/app/Services/Analytics/FunnelEventTaxonomy.php',
+        ], true);
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31906,5 +31906,103 @@
     },
     "sidecars": [],
     "next_task": "CAREER-1046-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation"
+  },
+  "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01": {
+    "id": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-event-taxonomy-01",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy",
+    "status": "local_checks_passed",
+    "depends_on": [],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "manifest/state authorization",
+        "status": "passed",
+        "summary": "User explicitly authorized adding only ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 to fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelEventTaxonomy01 --no-ansi",
+        "status": "passed",
+        "summary": "3 tests passed, 24 assertions."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "status": "passed",
+        "summary": "2 tests passed, 27 assertions."
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "Route list rendered successfully with 207 routes."
+      },
+      {
+        "command": "composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid."
+      },
+      {
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found."
+      },
+      {
+        "command": "vendor/bin/pint --test",
+        "status": "passed",
+        "summary": "Pint passed across 3641 files after formatting the new taxonomy class."
+      },
+      {
+        "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json >/dev/null",
+        "status": "passed",
+        "summary": "Generated analytics funnel taxonomy JSON parses."
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed",
+        "summary": "PR train state JSON parses."
+      },
+      {
+        "command": "python3 - <<'PY' import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()) PY",
+        "status": "passed",
+        "summary": "PR train manifest YAML parses."
+      },
+      {
+        "command": "git diff --check && git diff --cached --check",
+        "status": "passed",
+        "summary": "No whitespace errors in unstaged or cached diff."
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "User explicitly authorized this scoped backend implementation PR and the ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 manifest/state entry."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "Started implementation in an isolated worktree from origin/main because the primary fap-api worktree had unrelated dirty content-page changes."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T05:28:15+08:00",
+        "summary": "All scoped local validations passed in the isolated worktree."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [
+      "Primary fap-api worktree had unrelated dirty files on content/pr-hiring-01a-en-careers-authority; this task used an isolated worktree from origin/main."
+    ],
+    "next_task": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31913,10 +31913,10 @@
     "branch": "codex/analytics-funnel-event-taxonomy-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "265e1dcc58edd5a122627ff0e61594c5e3dbeeab",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1761",
     "checks": [
       {
         "command": "manifest/state authorization",
@@ -31993,6 +31993,11 @@
         "status": "local_checks_passed",
         "at": "2026-05-31T05:28:15+08:00",
         "summary": "All scoped local validations passed in the isolated worktree."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T05:31:00+08:00",
+        "summary": "Opened PR #1761 after local validations passed."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31913,7 +31913,7 @@
     "branch": "codex/analytics-funnel-event-taxonomy-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy",
-    "status": "pr_open",
+    "status": "ci_fix_local_checks_passed",
     "depends_on": [],
     "commit_sha": "265e1dcc58edd5a122627ff0e61594c5e3dbeeab",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1761",
@@ -31972,6 +31972,21 @@
         "command": "git diff --check && git diff --cached --check",
         "status": "passed",
         "summary": "No whitespace errors in unstaged or cached diff."
+      },
+      {
+        "command": "GitHub checks on PR #1761 initial run",
+        "status": "failed",
+        "summary": "verify-mbti-legacy and verify-mbti-v2 failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze classifier did not yet allow the analytics funnel taxonomy/read-model files."
+      },
+      {
+        "command": "php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi",
+        "status": "passed",
+        "summary": "1 test passed, 3 assertions after adding a narrow analytics funnel taxonomy allowlist to the freeze gate."
+      },
+      {
+        "command": "CI fix validation rerun",
+        "status": "passed",
+        "summary": "AnalyticsFunnelEventTaxonomy01, AnalyticsFunnelDailyBuilder, route:list, composer validate, composer audit, pint, JSON/YAML parse, and diff checks passed after the CI fix."
       }
     ],
     "failure_reason": null,
@@ -31998,6 +32013,11 @@
         "status": "pr_open",
         "at": "2026-05-31T05:31:00+08:00",
         "summary": "Opened PR #1761 after local validations passed."
+      },
+      {
+        "status": "ci_fix_local_checks_passed",
+        "at": "2026-05-31T05:40:00+08:00",
+        "summary": "Added a narrow test-side runtime freeze allowlist for the analytics funnel taxonomy/read-model files and reran scoped validations."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15969,3 +15969,52 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: RESULT-EMAIL-ACCESS-LINK-03 deploy-readiness required after merge
+
+  - id: ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
+    repo: fap-api
+    branch: codex/analytics-funnel-event-taxonomy-01
+    base: main
+    title: "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy"
+    train_scope: analytics_funnel_event_taxonomy
+    risk_level: p1_analytics_funnel_observability
+    depends_on: []
+    allowed_paths:
+      - backend/app/Services/Analytics/FunnelEventTaxonomy.php
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/docs/seo/analytics-funnel-event-taxonomy-01.md
+      - backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelEventTaxonomy01Test.php
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Define the canonical analytics funnel event taxonomy and backward-compatible aliases.
+      - Add backend alias normalization for analytics_funnel_daily result view and PDF stages.
+      - Preserve backend fact sources for attempt start, submit, order, payment, report unlock, report ready, share generation, and share click.
+      - Document that checkout_start, order_created, payment_success, and report_unlock are separate stages.
+      - Do not configure GA key events, run production analytics refresh, deploy, mutate CMS/DB, submit URLs, or touch Search Channel.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelEventTaxonomy01 --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -15985,6 +15985,7 @@ prs:
       - backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json
       - backend/tests/Feature/SeoIntel/AnalyticsFunnelEventTaxonomy01Test.php
       - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -15996,6 +15997,7 @@ prs:
     validation:
       - cd backend && php artisan test --filter=AnalyticsFunnelEventTaxonomy01 --no-ansi
       - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
       - cd backend && composer validate --strict


### PR DESCRIPTION
## What changed
- Added a canonical analytics funnel event taxonomy for visit/test/result/commerce/unlock/membership/revisit/source attribution events.
- Added legacy alias mapping so existing frontend/backend event names can be normalized without changing GA or Baidu settings in this PR.
- Updated `AnalyticsFunnelDailyBuilder` to consume shared result-view, PDF-download, and share-click alias lists.
- Added docs, generated JSON, focused tests, and the scoped PR-train manifest/state entry.

## Why
The current analytics funnel has event-name drift across fap-web, fap-api, GA/Baidu, and the ops read model. This PR establishes the backend canonical contract and backward-compatible aliases before repairing the ops read model.

## Validation
- `php artisan test --filter=AnalyticsFunnelEventTaxonomy01 --no-ansi`
- `php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi`
- `php artisan route:list --no-ansi`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `vendor/bin/pint --test`
- `python3 -m json.tool backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No GA key-event/admin configuration changes.
- No Baidu Tongji settings changes.
- No production analytics refresh or DB mutation.
- No fap-web tracking code change in this PR.
- No deployment, Search Channel action, or URL submission.

Repository rule impact: backend owns the canonical funnel taxonomy/read-model contract; frontend dispatch alignment remains a follow-up and must not replace backend attribution/read-model authority.
