### PR TITLE
CONTENT-PACKS-INDEX-ARTIFACT-01 precompile content pack index artifact

### DIFF
--- a/backend/app/Console/Commands/ContentPacksIndexBuild.php
+++ b/backend/app/Console/Commands/ContentPacksIndexBuild.php
@@ -1,0 +1,65 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Content\ContentPacksIndex;
+use App\Services\Content\ContentPacksIndexArtifactStore;
+use Illuminate\Console\Command;
+
+final class ContentPacksIndexBuild extends Command
+{
+    protected $signature = 'content-packs:index:build
+        {--output= : Optional output path for content-packs-index.json}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Build the precompiled content pack index artifact without changing public API contracts.';
+
+    public function handle(ContentPacksIndex $index, ContentPacksIndexArtifactStore $artifacts): int
+    {
+        try {
+            $snapshot = $index->getIndex(true);
+            if (! (bool) ($snapshot['ok'] ?? false)) {
+                throw new \RuntimeException('content pack index scan did not produce an ok snapshot');
+            }
+
+            $path = $this->outputPath($artifacts);
+            $result = $artifacts->write($snapshot, $path);
+
+            $payload = [
+                'status' => 'materialized',
+                'path' => (string) ($result['path'] ?? $path),
+                'schema_version' => ContentPacksIndexArtifactStore::SCHEMA_VERSION,
+                'item_count' => (int) ($result['item_count'] ?? 0),
+            ];
+
+            if ((bool) $this->option('json')) {
+                $this->line((string) json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('status=materialized');
+            $this->line('path='.$payload['path']);
+            $this->line('schema_version='.$payload['schema_version']);
+            $this->line('item_count='.$payload['item_count']);
+
+            return self::SUCCESS;
+        } catch (\Throwable $e) {
+            $this->error($e->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+
+    private function outputPath(ContentPacksIndexArtifactStore $artifacts): string
+    {
+        $output = $this->option('output');
+        if ($output !== null && trim((string) $output) !== '') {
+            return trim((string) $output);
+        }
+
+        return $artifacts->configuredPath();
+    }
+}

--- a/backend/app/Services/Content/ContentPacksIndex.php
+++ b/backend/app/Services/Content/ContentPacksIndex.php
@@ -16,6 +16,10 @@ final class ContentPacksIndex
 {
     public const CACHE_TTL_SECONDS = 30;
 
+    public function __construct(
+        private ?ContentPacksIndexArtifactStore $artifactStore = null,
+    ) {}
+
     public function getIndex(bool $refresh = false): array
     {
         $driver = (string) config('content_packs.driver', 'local');
@@ -32,6 +36,17 @@ final class ContentPacksIndex
         $cache = $this->cacheStore();
 
         if (! $refresh) {
+            $artifact = $this->artifactStore()->readConfigured($packsRootFs, $driver, $defaults);
+            if (is_array($artifact)) {
+                try {
+                    $cache->put($cacheKey, $artifact, self::CACHE_TTL_SECONDS);
+                } catch (\Throwable $e) {
+                    // Artifact reads are already bounded by file signatures; cache write failure is non-fatal.
+                }
+
+                return $artifact;
+            }
+
             try {
                 $cached = $cache->get($cacheKey);
             } catch (\Throwable $e) {
@@ -147,6 +162,15 @@ final class ContentPacksIndex
         } catch (\Throwable $e) {
             return Cache::store();
         }
+    }
+
+    private function artifactStore(): ContentPacksIndexArtifactStore
+    {
+        if (! $this->artifactStore instanceof ContentPacksIndexArtifactStore) {
+            $this->artifactStore = app(ContentPacksIndexArtifactStore::class);
+        }
+
+        return $this->artifactStore;
     }
 
     private function normalizeFilesystemRoot(string $path): string

--- a/backend/app/Services/Content/ContentPacksIndexArtifactStore.php
+++ b/backend/app/Services/Content/ContentPacksIndexArtifactStore.php
@@ -1,0 +1,309 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+
+final class ContentPacksIndexArtifactStore
+{
+    public const SCHEMA_VERSION = 'content_packs_index.artifact.v1';
+
+    public const FILENAME = 'content-packs-index.json';
+
+    public function isEnabled(): bool
+    {
+        return (bool) config('content_packs.index_artifact_enabled', false);
+    }
+
+    public function configuredPath(): string
+    {
+        return $this->normalizeOutputPath((string) config('content_packs.index_artifact_path', ''));
+    }
+
+    public function readConfigured(string $packsRootFs, string $driver, array $defaults): ?array
+    {
+        if (! $this->isEnabled()) {
+            return null;
+        }
+
+        $path = $this->configuredPath();
+        if ($path === '' || ! File::isFile($path)) {
+            return null;
+        }
+
+        return $this->read($path, $packsRootFs, $driver, $defaults);
+    }
+
+    public function read(string $path, string $packsRootFs, string $driver, array $defaults): ?array
+    {
+        $path = $this->normalizeOutputPath($path);
+        if ($path === '' || ! File::isFile($path)) {
+            return null;
+        }
+
+        try {
+            $raw = File::get($path);
+        } catch (\Throwable $e) {
+            $this->warn('CONTENT_PACKS_INDEX_ARTIFACT_READ_FAILED', [
+                'path' => $path,
+                'exception' => $e::class,
+            ]);
+
+            return null;
+        }
+
+        $payload = json_decode($raw, true);
+        if (! is_array($payload)) {
+            $this->warn('CONTENT_PACKS_INDEX_ARTIFACT_JSON_INVALID', [
+                'path' => $path,
+            ]);
+
+            return null;
+        }
+
+        return $this->hydrate($payload, $packsRootFs, $driver, $defaults, $path);
+    }
+
+    public function write(array $index, string $path): array
+    {
+        $path = $this->normalizeOutputPath($path);
+        if ($path === '') {
+            throw new \RuntimeException('content pack index artifact output path is required');
+        }
+
+        $payload = $this->buildPayload($index);
+        $encoded = json_encode($payload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT);
+        if (! is_string($encoded)) {
+            throw new \RuntimeException('failed to encode content pack index artifact');
+        }
+
+        $dir = dirname($path);
+        File::ensureDirectoryExists($dir, 0750);
+
+        $tmpPath = $dir.DIRECTORY_SEPARATOR.'.'.basename($path).'.tmp.'.bin2hex(random_bytes(8));
+        try {
+            File::put($tmpPath, $encoded.PHP_EOL);
+            if (! @rename($tmpPath, $path)) {
+                throw new \RuntimeException('failed to move content pack index artifact into place');
+            }
+        } finally {
+            if (File::exists($tmpPath)) {
+                @unlink($tmpPath);
+            }
+        }
+
+        return [
+            'path' => $path,
+            'schema_version' => self::SCHEMA_VERSION,
+            'item_count' => count((array) ($payload['items'] ?? [])),
+        ];
+    }
+
+    public function buildPayload(array $index): array
+    {
+        $packsRoot = rtrim((string) ($index['packs_root'] ?? ''), '/\\');
+        $items = [];
+
+        foreach ((array) ($index['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $artifactItem = $item;
+            foreach (['manifest_path', 'questions_path', 'version_path'] as $pathKey) {
+                $artifactItem[$pathKey] = $this->artifactPathValue($packsRoot, (string) ($item[$pathKey] ?? ''));
+            }
+
+            $items[] = $artifactItem;
+        }
+
+        return [
+            'schema_version' => self::SCHEMA_VERSION,
+            'generated_at' => now('UTC')->toIso8601String(),
+            'driver' => (string) ($index['driver'] ?? 'local'),
+            'packs_root' => $packsRoot,
+            'defaults' => (array) ($index['defaults'] ?? []),
+            'items' => $items,
+            'by_pack_id' => (array) ($index['by_pack_id'] ?? []),
+            'summary' => [
+                'item_count' => count($items),
+            ],
+        ];
+    }
+
+    private function hydrate(array $payload, string $packsRootFs, string $driver, array $defaults, string $path): ?array
+    {
+        if ((string) ($payload['schema_version'] ?? '') !== self::SCHEMA_VERSION) {
+            $this->warn('CONTENT_PACKS_INDEX_ARTIFACT_SCHEMA_INVALID', ['path' => $path]);
+
+            return null;
+        }
+
+        if ((string) ($payload['driver'] ?? '') !== $driver) {
+            $this->warn('CONTENT_PACKS_INDEX_ARTIFACT_DRIVER_MISMATCH', [
+                'path' => $path,
+                'artifact_driver' => (string) ($payload['driver'] ?? ''),
+                'runtime_driver' => $driver,
+            ]);
+
+            return null;
+        }
+
+        if ((array) ($payload['defaults'] ?? []) !== $defaults) {
+            $this->warn('CONTENT_PACKS_INDEX_ARTIFACT_DEFAULTS_MISMATCH', ['path' => $path]);
+
+            return null;
+        }
+
+        $items = [];
+        foreach ((array) ($payload['items'] ?? []) as $item) {
+            if (! is_array($item)) {
+                return null;
+            }
+
+            $hydrated = $item;
+            foreach (['manifest_path', 'questions_path', 'version_path'] as $pathKey) {
+                $hydrated[$pathKey] = $this->hydratePath($packsRootFs, (string) ($item[$pathKey] ?? ''));
+            }
+
+            if (! $this->isArtifactItemValid($hydrated)) {
+                $this->warn('CONTENT_PACKS_INDEX_ARTIFACT_ITEM_INVALID', [
+                    'path' => $path,
+                    'pack_id' => (string) ($hydrated['pack_id'] ?? ''),
+                    'dir_version' => (string) ($hydrated['dir_version'] ?? ''),
+                ]);
+
+                return null;
+            }
+
+            $items[] = $hydrated;
+        }
+
+        return [
+            'ok' => true,
+            'driver' => $driver,
+            'packs_root' => $packsRootFs,
+            'defaults' => $defaults,
+            'items' => $items,
+            'by_pack_id' => (array) ($payload['by_pack_id'] ?? []),
+        ];
+    }
+
+    private function isArtifactItemValid(array $item): bool
+    {
+        foreach (['pack_id', 'dir_version', 'manifest_path', 'questions_path', 'version_path'] as $required) {
+            if (trim((string) ($item[$required] ?? '')) === '') {
+                return false;
+            }
+        }
+
+        foreach (['manifest', 'questions', 'version'] as $prefix) {
+            $path = (string) ($item[$prefix.'_path'] ?? '');
+            $signature = $this->fileSignature($path);
+            if ($signature === null) {
+                return false;
+            }
+            if ((int) ($item[$prefix.'_mtime'] ?? -1) !== (int) ($signature['mtime'] ?? -2)) {
+                return false;
+            }
+            if ((int) ($item[$prefix.'_size'] ?? -1) !== (int) ($signature['size'] ?? -2)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function artifactPathValue(string $packsRoot, string $path): string
+    {
+        if ($path === '') {
+            return '';
+        }
+
+        $pathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        $rootNorm = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $packsRoot), '/');
+        if ($rootNorm !== '' && str_starts_with($pathNorm, $rootNorm.'/')) {
+            return substr($pathNorm, strlen($rootNorm) + 1);
+        }
+
+        return $path;
+    }
+
+    private function hydratePath(string $packsRootFs, string $path): string
+    {
+        $path = trim($path);
+        if ($path === '' || $this->isAbsolutePath($path)) {
+            return $path;
+        }
+
+        return rtrim($packsRootFs, '/\\').DIRECTORY_SEPARATOR.str_replace('/', DIRECTORY_SEPARATOR, $path);
+    }
+
+    private function normalizeOutputPath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '';
+        }
+
+        if ($this->isAbsolutePath($path)) {
+            return $path;
+        }
+
+        return base_path($path);
+    }
+
+    private function isAbsolutePath(string $path): bool
+    {
+        if ($path === '') {
+            return false;
+        }
+
+        if (str_starts_with($path, '/') || str_starts_with($path, '\\')) {
+            return true;
+        }
+
+        return (bool) preg_match('/^[A-Za-z]:[\/\\\\]/', $path);
+    }
+
+    /**
+     * @return array{mtime:int,size:int}|null
+     */
+    private function fileSignature(string $path): ?array
+    {
+        if ($path === '' || ! File::isFile($path)) {
+            return null;
+        }
+
+        try {
+            $mtimeRaw = @filemtime($path);
+            $sizeRaw = @filesize($path);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if (! is_int($mtimeRaw) && ! is_numeric($mtimeRaw)) {
+            return null;
+        }
+        if (! is_int($sizeRaw) && ! is_numeric($sizeRaw)) {
+            return null;
+        }
+
+        return [
+            'mtime' => (int) $mtimeRaw,
+            'size' => (int) $sizeRaw,
+        ];
+    }
+
+    private function warn(string $event, array $context): void
+    {
+        if (! (bool) config('content_packs.debug_log', false)) {
+            return;
+        }
+
+        Log::warning($event, $context);
+    }
+}

--- a/backend/config/content_packs.php
+++ b/backend/config/content_packs.php
@@ -31,6 +31,8 @@ return [
     'mbti_response_cache_store' => env('MBTI_RESPONSE_CACHE_STORE', 'hot_redis'),
     'mbti_lookup_cache_ttl_seconds' => (int) env('MBTI_LOOKUP_CACHE_TTL_SECONDS', 600),
     'mbti_questions_cache_ttl_seconds' => (int) env('MBTI_QUESTIONS_CACHE_TTL_SECONDS', 600),
+    'index_artifact_enabled' => (bool) env('CONTENT_PACKS_INDEX_ARTIFACT_ENABLED', false),
+    'index_artifact_path' => env('CONTENT_PACKS_INDEX_ARTIFACT_PATH', storage_path('app/private/content_packs_index/content-packs-index.json')),
     'debug_log' => (bool) env('FAP_PACKS_DEBUG_LOG', false),
 
     // ✅ CI/服务器建议强约束：默认 pack_id 明确指向你的主包，避免回退到 GLOBAL/en

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1985,6 +1985,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ));
     }
 
+    public function test_runtime_freeze_classifier_ignores_content_packs_index_artifact_phase2_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ContentPacksIndexBuild.php',
+            'backend/app/Services/Content/ContentPacksIndex.php',
+            'backend/app/Services/Content/ContentPacksIndexArtifactStore.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_content_asset_loader_changes(): void
     {
         $changed = [
@@ -2346,6 +2357,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isSitemapSourceCacheCommandFile($file)) {
+                continue;
+            }
+
+            if ($this->isContentPacksIndexArtifactRuntimeFile($file)) {
                 continue;
             }
 
@@ -2979,6 +2994,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSitemapSourceCacheCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php';
+    }
+
+    private function isContentPacksIndexArtifactRuntimeFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ContentPacksIndexBuild.php',
+            'backend/app/Services/Content/ContentPacksIndex.php',
+            'backend/app/Services/Content/ContentPacksIndexArtifactStore.php',
+        ], true);
     }
 
     private function isContentReleaseRevalidateAutomationFile(string $file): bool

--- a/backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
@@ -1,0 +1,186 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Content;
+
+use App\Services\Content\ContentPacksIndex;
+use App\Services\Content\ContentPacksIndexArtifactStore;
+use App\Support\CacheKeys;
+use Illuminate\Support\Facades\Cache;
+use Illuminate\Support\Facades\File;
+use Tests\TestCase;
+
+final class ContentPacksIndexArtifactTest extends TestCase
+{
+    private string $packsRoot;
+
+    private string $artifactPath;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->packsRoot = sys_get_temp_dir().'/content_pack_artifact_'.uniqid('', true);
+        $this->artifactPath = sys_get_temp_dir().'/content_pack_artifact_index_'.uniqid('', true).'.json';
+
+        File::ensureDirectoryExists($this->packsRoot);
+
+        config()->set('content_packs.driver', 'local');
+        config()->set('content_packs.root', $this->packsRoot);
+        config()->set('content_packs.default_pack_id', 'PACK_A');
+        config()->set('content_packs.default_dir_version', 'MBTI-CN-v-test');
+        config()->set('content_packs.default_region', 'CN_MAINLAND');
+        config()->set('content_packs.default_locale', 'zh-CN');
+        config()->set('content_packs.index_artifact_enabled', false);
+        config()->set('content_packs.index_artifact_path', $this->artifactPath);
+
+        $this->forgetIndexCache();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->forgetIndexCache();
+        File::deleteDirectory($this->packsRoot);
+        if (File::exists($this->artifactPath)) {
+            File::delete($this->artifactPath);
+        }
+
+        parent::tearDown();
+    }
+
+    public function test_artifact_round_trip_matches_scanned_index_contract(): void
+    {
+        $dirVersion = 'MBTI-CN-v-test';
+        $this->writePack($this->makePackDir($dirVersion), 'PACK_A', $dirVersion, 'v-test');
+
+        $index = app(ContentPacksIndex::class);
+        $scanned = $index->getIndex(true);
+
+        $store = app(ContentPacksIndexArtifactStore::class);
+        $store->write($scanned, $this->artifactPath);
+
+        $payload = json_decode((string) File::get($this->artifactPath), true);
+        $this->assertSame(ContentPacksIndexArtifactStore::SCHEMA_VERSION, (string) ($payload['schema_version'] ?? ''));
+        $this->assertSame(1, (int) ($payload['summary']['item_count'] ?? 0));
+        $this->assertSame(
+            'default/CN_MAINLAND/zh-CN/MBTI-CN-v-test/manifest.json',
+            (string) ($payload['items'][0]['manifest_path'] ?? '')
+        );
+
+        $this->forgetIndexCache();
+        config()->set('content_packs.index_artifact_enabled', true);
+
+        $fromArtifact = $index->getIndex(false);
+        $this->assertTrue((bool) ($fromArtifact['ok'] ?? false));
+        $this->assertSame($scanned['by_pack_id'], $fromArtifact['by_pack_id']);
+        $this->assertSame($scanned['items'], $fromArtifact['items']);
+    }
+
+    public function test_stale_artifact_falls_back_to_streaming_scan(): void
+    {
+        $dirVersion = 'MBTI-CN-v-test';
+        $packDir = $this->makePackDir($dirVersion);
+        $this->writePack($packDir, 'PACK_A', $dirVersion, 'v-test');
+
+        $index = app(ContentPacksIndex::class);
+        app(ContentPacksIndexArtifactStore::class)->write($index->getIndex(true), $this->artifactPath);
+
+        $this->writePack($packDir, 'PACK_B', $dirVersion, 'v-test-2');
+        $this->forgetIndexCache();
+        config()->set('content_packs.index_artifact_enabled', true);
+        config()->set('content_packs.default_pack_id', 'PACK_B');
+
+        $fresh = $index->getIndex(false);
+
+        $this->assertTrue((bool) ($fresh['ok'] ?? false));
+        $this->assertCount(1, (array) ($fresh['items'] ?? []));
+        $this->assertSame('PACK_B', (string) ($fresh['items'][0]['pack_id'] ?? ''));
+        $this->assertSame('v-test-2', (string) ($fresh['items'][0]['content_package_version'] ?? ''));
+    }
+
+    public function test_build_command_writes_artifact_without_enabling_runtime_contract_change(): void
+    {
+        $dirVersion = 'MBTI-CN-v-test';
+        $this->writePack($this->makePackDir($dirVersion), 'PACK_A', $dirVersion, 'v-test');
+
+        $this->artisan('content-packs:index:build', [
+            '--output' => $this->artifactPath,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $payload = json_decode((string) File::get($this->artifactPath), true);
+        $this->assertSame(ContentPacksIndexArtifactStore::SCHEMA_VERSION, (string) ($payload['schema_version'] ?? ''));
+        $this->assertSame(1, (int) ($payload['summary']['item_count'] ?? 0));
+        $this->assertFalse((bool) config('content_packs.index_artifact_enabled'));
+    }
+
+    private function makePackDir(string $dirVersion): string
+    {
+        $packDir = $this->packsRoot.DIRECTORY_SEPARATOR.'default'
+            .DIRECTORY_SEPARATOR.'CN_MAINLAND'
+            .DIRECTORY_SEPARATOR.'zh-CN'
+            .DIRECTORY_SEPARATOR.$dirVersion;
+
+        File::ensureDirectoryExists($packDir);
+
+        return $packDir;
+    }
+
+    private function forgetIndexCache(): void
+    {
+        foreach (['hot_redis', null] as $store) {
+            try {
+                $store === null
+                    ? Cache::forget(CacheKeys::packsIndex())
+                    : Cache::store($store)->forget(CacheKeys::packsIndex());
+            } catch (\Throwable $e) {
+                // Test environments may not define every production cache store.
+            }
+        }
+    }
+
+    private function writePack(
+        string $packDir,
+        string $packId,
+        string $dirVersion,
+        string $contentVersion
+    ): void {
+        file_put_contents(
+            $packDir.DIRECTORY_SEPARATOR.'manifest.json',
+            json_encode([
+                'schema_version' => 'pack-manifest@v1',
+                'pack_id' => $packId,
+                'scale_code' => 'MBTI',
+                'region' => 'CN_MAINLAND',
+                'locale' => 'zh-CN',
+                'content_package_version' => $contentVersion,
+                'assets' => [
+                    'questions' => ['questions.json'],
+                ],
+            ], JSON_UNESCAPED_UNICODE)
+        );
+
+        file_put_contents(
+            $packDir.DIRECTORY_SEPARATOR.'version.json',
+            json_encode([
+                'pack_id' => $packId,
+                'content_package_version' => $contentVersion,
+                'dir_version' => $dirVersion,
+            ], JSON_UNESCAPED_UNICODE)
+        );
+
+        file_put_contents(
+            $packDir.DIRECTORY_SEPARATOR.'questions.json',
+            json_encode([
+                [
+                    'question_id' => 'q1',
+                    'text' => 'Q1',
+                    'options' => [
+                        ['code' => 'A', 'text' => 'Option A'],
+                    ],
+                ],
+            ], JSON_UNESCAPED_UNICODE)
+        );
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32029,5 +32029,91 @@
       "Primary fap-api worktree had unrelated dirty files on content/pr-hiring-01a-en-careers-authority; this task used an isolated worktree from origin/main."
     ],
     "next_task": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation"
+  },
+  "CONTENT-PACKS-INDEX-ARTIFACT-01": {
+    "repo": "fap-api",
+    "branch": "fix/content-packs-index-artifact-01",
+    "status": "local_checks_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency": {
+        "status": "pass",
+        "evidence": "PR #1753 is merged and origin/main is the base for this isolated worktree."
+      },
+      "content_packs_index_artifact": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi",
+        "evidence": "3 tests passed, 14 assertions."
+      },
+      "content_packs_index_manifest_consistency": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi",
+        "evidence": "3 tests passed, 12 assertions."
+      },
+      "bigfive_runtime_freeze_classifier": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi",
+        "evidence": "141 tests passed, 488 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "207 routes listed."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3642 files checked."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')\"",
+        "evidence": "PR train state JSON and manifest YAML parsed."
+      },
+      "mbti_ci": {
+        "status": "pass",
+        "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+        "evidence": "Full script exited 0 on latest origin/main base after Phase 2 changes."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "Whitespace check passed before staging."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-30T21:19:09Z",
+        "summary": "User authorized adding the missing PR train manifest/state entry and creating fix/content-packs-index-artifact-01 from latest main for Phase 2 only."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-30T21:19:09Z",
+        "summary": "Started Phase 2 in an isolated clean worktree because the original fap-api worktree had unrelated dirty content page baseline/test files."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-30T21:36:18Z",
+        "summary": "Focused content pack artifact tests, manifest consistency, Big Five runtime freeze classifier, route list, Pint, Composer validate, JSON/YAML parse, git diff --check, and full ci_verify_mbti passed on latest origin/main."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": null
+    },
+    "sidecars": [],
+    "next_task": "Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-29T09:00:00Z",
+  "updated_at": "2026-05-30T21:41:10Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -32033,9 +32033,9 @@
   "CONTENT-PACKS-INDEX-ARTIFACT-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-index-artifact-01",
-    "status": "local_checks_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "7e0cc715e03b105e51c9556596212c48bb962868",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1763",
     "checks": {
       "dependency": {
         "status": "pass",
@@ -32106,6 +32106,11 @@
         "status": "local_checks_passed",
         "at": "2026-05-30T21:36:18Z",
         "summary": "Focused content pack artifact tests, manifest consistency, Big Five runtime freeze classifier, route list, Pint, Composer validate, JSON/YAML parse, git diff --check, and full ci_verify_mbti passed on latest origin/main."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-30T21:41:10Z",
+        "summary": "Opened PR #1763 for CONTENT-PACKS-INDEX-ARTIFACT-01."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16020,3 +16020,60 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation
+
+  - id: CONTENT-PACKS-INDEX-ARTIFACT-01
+    repo: fap-api
+    branch: fix/content-packs-index-artifact-01
+    base: main
+    title: "CONTENT-PACKS-INDEX-ARTIFACT-01 precompile content pack index artifact"
+    train_scope: content_packs_index_artifact
+    risk_level: p1_ci_memory_and_runtime_hardening
+    depends_on:
+      - PR #1753 merged
+    allowed_paths:
+      - backend/app/Services/Content/ContentPacksIndex.php
+      - backend/app/Services/Content/ContentPacksIndexArtifactStore.php
+      - backend/app/Console/Commands/ContentPacksIndexBuild.php
+      - backend/config/content_packs.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a precompiled content pack index artifact path for tests and internal services.
+      - Keep public API contracts and ContentPacksIndex find/getIndex return shape backward-compatible.
+      - Prefer artifact reads only when explicitly enabled by config; keep streaming directory scan as fallback.
+      - Add focused tests proving artifact/source consistency and stale artifact fallback.
+      - Do not refactor CI workflows; Phase 4 owns CI job decomposition.
+    do_not:
+      - Change public API response contracts.
+      - Change content package source files or question/item semantics.
+      - Remove the ContentPacksIndex streaming fallback path.
+      - Refactor MBTI, Big Five, report, attempt, scoring, or content pack publishing runtime.
+      - Modify fap-web, CMS, DB, migrations, Search Channel, URL submission, deploy, or production env.
+    validation:
+      - cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi
+      - cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - cd backend && vendor/bin/pint --test
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && composer validate --strict
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization


### PR DESCRIPTION
## Summary

Adds Phase 2 support for a precompiled content pack index artifact without changing the public API contract or removing the streaming scan fallback.

## What changed

- Added `content-packs:index:build` to generate `content-packs-index.json`.
- Added `ContentPacksIndexArtifactStore` with schema/freshness validation, atomic writes, and path hydration.
- Updated `ContentPacksIndex` to prefer the artifact only when explicitly enabled by config, falling back to the existing streaming directory scan.
- Added config for artifact enablement/path, default disabled.
- Added focused artifact round-trip/stale fallback/build command tests.
- Updated the Big Five runtime freeze classifier to allow the exact Phase 2 content-pack artifact runtime files.
- Added the authorized PR train manifest/state entry.

## Why

Phase 1 fixed the immediate CI memory path by streaming directory traversal. This PR prepares a longer-term stable operating path by introducing a precompiled content pack index artifact for tests/internal services, while preserving current runtime behavior and contracts.

## Public contract decision

No public API contract is changed. `ContentPacksIndex` still returns the same internal index shape, and artifact use is opt-in through config. The streaming scan remains the fallback path.

## Repository rule impact

Backend content packs remain backend-authoritative. This PR adds an optional generated index artifact for internal/test consumption and does not introduce CMS, frontend, or public editorial fallback authority.

## Validation

- `cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi` — passed, 3 tests / 14 assertions
- `cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi` — passed, 3 tests / 12 assertions
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi` — passed, 141 tests / 488 assertions
- `cd backend && bash scripts/ci_verify_mbti.sh` — passed on latest `origin/main`
- `cd backend && vendor/bin/pint --test` — passed, 3642 files
- `cd backend && php artisan route:list --no-ansi` — passed, 207 routes
- `cd backend && composer validate --strict` — passed
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` — passed
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"` — passed
- `git diff --check` — passed
- `git diff --cached --check` — passed

## Intentionally deferred

- Phase 3: shrink `ContentPacksIndex` into artifact loader/schema validator/minimal fallback.
- Phase 4: split content pack build/validate into a dedicated CI job and make MBTI/Big Five business tests consume the artifact.
- No public API response changes.
- No content package source changes.
- No fap-web changes.
- No deploy, Search Channel action, URL submission, CMS mutation, DB mutation, or migration.

## Residual risk

Artifact use is default-disabled. Enabling it in a runtime environment should be done separately with explicit validation that the artifact is generated from the same content pack source tree and refreshed when content packs change.
