### PR TITLE
ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model

### DIFF
--- a/backend/app/Filament/Ops/Pages/FunnelConversionPage.php
+++ b/backend/app/Filament/Ops/Pages/FunnelConversionPage.php
@@ -46,12 +46,12 @@ class FunnelConversionPage extends Page
         ],
         [
             'key' => 'submitted_attempts',
-            'label' => 'test_submit_success',
+            'label' => 'test_submit',
             'note' => 'Hard fact first, then attempt_submissions / results fallback',
         ],
         [
             'key' => 'first_view_attempts',
-            'label' => 'first_result_or_report_view',
+            'label' => 'result_view',
             'note' => 'Behavioral mirror: normalized result_view / report_view events',
         ],
         [
@@ -66,7 +66,7 @@ class FunnelConversionPage extends Page
         ],
         [
             'key' => 'unlocked_attempts',
-            'label' => 'unlock_success',
+            'label' => 'report_unlock',
             'note' => 'Hard fact: active benefit_grants; order status alone is not enough',
         ],
         [

--- a/backend/app/Filament/Ops/Widgets/FunnelWidget.php
+++ b/backend/app/Filament/Ops/Widgets/FunnelWidget.php
@@ -3,6 +3,8 @@
 namespace App\Filament\Ops\Widgets;
 
 use App\Filament\Ops\Support\OpsMetricsAccess;
+use App\Support\OrgContext;
+use App\Support\SchemaBaseline;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
 use Illuminate\Support\Facades\DB;
@@ -10,6 +12,22 @@ use Illuminate\Support\Facades\DB;
 class FunnelWidget extends BaseWidget
 {
     protected static bool $isLazy = false;
+
+    private const EMPTY_READ_MODEL_MESSAGE = 'No analytics_funnel_daily rows for this range. Run analytics:refresh-funnel-daily in a controlled task.';
+
+    /** @var array<string,string> */
+    private const CANONICAL_STAGES = [
+        'test_start' => 'started_attempts',
+        'test_submit' => 'submitted_attempts',
+        'result_view' => 'first_view_attempts',
+        'order_created' => 'order_created_attempts',
+        'payment_success' => 'paid_attempts',
+        'report_unlock' => 'unlocked_attempts',
+        'report_ready' => 'report_ready_attempts',
+        'pdf_download' => 'pdf_download_attempts',
+        'share_generate' => 'share_generated_attempts',
+        'share_click' => 'share_click_attempts',
+    ];
 
     public static function canView(): bool
     {
@@ -23,52 +41,49 @@ class FunnelWidget extends BaseWidget
 
     protected function getStats(): array
     {
-        $events = [
-            'attempt_start' => __('ops.widgets.attempt_start'),
-            'attempt_submit' => __('ops.widgets.attempt_submit'),
-            'paywall_view' => __('ops.widgets.paywall_view'),
-            'checkout' => __('ops.widgets.checkout'),
-            'payment_success' => __('ops.widgets.paid'),
-            'unlocked' => __('ops.widgets.unlocked'),
-        ];
-
-        $from = now()->subDays(7)->toDateString();
-
-        $rows = collect();
-        if (\App\Support\SchemaBaseline::hasTable('v_funnel_daily')) {
-            $rows = DB::table('v_funnel_daily')
-                ->where('day', '>=', $from)
-                ->whereIn('event_name', array_keys($events))
-                ->select('event_name', DB::raw('SUM(events_count) as total'))
-                ->groupBy('event_name')
-                ->get();
-        } elseif (\App\Support\SchemaBaseline::hasTable('events')) {
-            $rows = DB::table('events')
-                ->where('occurred_at', '>=', now()->subDays(7))
-                ->whereIn('event_name', array_keys($events))
-                ->select('event_name', DB::raw('COUNT(*) as total'))
-                ->groupBy('event_name')
-                ->get();
+        if (! SchemaBaseline::hasTable('analytics_funnel_daily')) {
+            return [$this->emptyReadModelStat()];
         }
 
-        if ($rows->isEmpty()) {
+        $orgId = max(0, (int) app(OrgContext::class)->orgId());
+        if ($orgId <= 0) {
             return [
                 Stat::make(__('ops.widgets.funnel'), __('ops.widgets.no_data'))
-                    ->description(__('ops.widgets.no_funnel_events_7d'))
+                    ->description(__('ops.widgets.select_org_to_view_metrics'))
                     ->color('gray'),
             ];
         }
 
-        $totals = [];
-        foreach ($rows as $row) {
-            $totals[(string) $row->event_name] = (int) ($row->total ?? 0);
+        $from = now()->subDays(6)->toDateString();
+        $to = now()->toDateString();
+
+        $query = DB::table('analytics_funnel_daily')
+            ->where('org_id', $orgId)
+            ->whereBetween('day', [$from, $to]);
+
+        $selects = ['COUNT(*) as row_count'];
+        foreach (self::CANONICAL_STAGES as $metric) {
+            $selects[] = 'SUM('.$metric.') as '.$metric;
+        }
+
+        $row = $query->selectRaw(implode(', ', $selects))->first();
+        if ((int) ($row->row_count ?? 0) <= 0) {
+            return [$this->emptyReadModelStat()];
         }
 
         $stats = [];
-        foreach ($events as $key => $label) {
-            $stats[] = Stat::make($label, (string) ($totals[$key] ?? 0));
+        foreach (self::CANONICAL_STAGES as $stage => $metric) {
+            $stats[] = Stat::make($stage, (string) ((int) ($row->{$metric} ?? 0)))
+                ->description('analytics_funnel_daily.'.$metric);
         }
 
         return $stats;
+    }
+
+    private function emptyReadModelStat(): Stat
+    {
+        return Stat::make(__('ops.widgets.funnel'), __('ops.widgets.no_data'))
+            ->description(self::EMPTY_READ_MODEL_MESSAGE)
+            ->color('gray');
     }
 }

--- a/backend/docs/seo/analytics-funnel-ops-read-model-repair-01.md
+++ b/backend/docs/seo/analytics-funnel-ops-read-model-repair-01.md
@@ -1,0 +1,58 @@
+# ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01
+
+## Purpose
+
+Connect the Ops 7-day funnel snapshot to the unified analytics funnel read model introduced by `ANALYTICS-FUNNEL-EVENT-TAXONOMY-01`.
+
+## Root Cause
+
+The full `/ops/funnel-conversion` page already used `analytics_funnel_daily`, but several display labels still exposed legacy stage names. The Ops dashboard `FunnelWidget` still read old `v_funnel_daily` or raw `events` rows with hardcoded legacy event names, so the 7-day snapshot could not be treated as the unified business funnel.
+
+## Repair
+
+- `FunnelWidget` now uses `analytics_funnel_daily` as the 7-day read model truth.
+- `v_funnel_daily` and raw `events` are no longer primary Ops 7-day funnel authority.
+- Widget labels now use canonical taxonomy stage names:
+  - `test_start`
+  - `test_submit`
+  - `result_view`
+  - `order_created`
+  - `payment_success`
+  - `report_unlock`
+  - `report_ready`
+  - `pdf_download`
+  - `share_generate`
+  - `share_click`
+- `/ops/funnel-conversion` keeps its existing read model query but displays canonical labels for `test_submit`, `result_view`, and `report_unlock`.
+
+## Empty State
+
+When the selected org has no `analytics_funnel_daily` rows in the 7-day range, the widget reports:
+
+`No analytics_funnel_daily rows for this range. Run analytics:refresh-funnel-daily in a controlled task.`
+
+It does not silently fall back to raw events and present them as canonical funnel data.
+
+## Deferred Stages
+
+The following funnel stages remain future or unavailable until the read model supports them explicitly:
+
+- `page_view` / visit
+- `checkout_start`
+- `membership_start`
+- `retest_start`
+- `historical_report_revisit`
+
+## Safety
+
+- No production analytics refresh was run.
+- No production DB mutation occurred.
+- No migration was added.
+- No scheduler behavior changed.
+- No GA or Baidu Tongji admin setting changed.
+- No Search Channel action or URL submission occurred.
+- `fap-web` was not modified.
+
+## Next Task
+
+`ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01`

--- a/backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json
@@ -1,0 +1,57 @@
+{
+  "schema_version": "1.0",
+  "task": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01",
+  "final_decision": "analytics_funnel_ops_read_model_repair_completed_ready_for_controlled_refresh_preflight",
+  "funnel_widget_source": "analytics_funnel_daily",
+  "legacy_sources_no_longer_primary": [
+    "v_funnel_daily",
+    "events"
+  ],
+  "canonical_display_stages": [
+    "test_start",
+    "test_submit",
+    "result_view",
+    "order_created",
+    "payment_success",
+    "report_unlock",
+    "report_ready",
+    "pdf_download",
+    "share_generate",
+    "share_click"
+  ],
+  "analytics_funnel_daily_columns": {
+    "test_start": "started_attempts",
+    "test_submit": "submitted_attempts",
+    "result_view": "first_view_attempts",
+    "order_created": "order_created_attempts",
+    "payment_success": "paid_attempts",
+    "report_unlock": "unlocked_attempts",
+    "report_ready": "report_ready_attempts",
+    "pdf_download": "pdf_download_attempts",
+    "share_generate": "share_generated_attempts",
+    "share_click": "share_click_attempts"
+  },
+  "funnel_conversion_page_labels_repaired": {
+    "test_submit_success": "test_submit",
+    "first_result_or_report_view": "result_view",
+    "unlock_success": "report_unlock"
+  },
+  "empty_state": "No analytics_funnel_daily rows for this range. Run analytics:refresh-funnel-daily in a controlled task.",
+  "production_refresh_run": false,
+  "production_db_mutation": false,
+  "migration_added": false,
+  "scheduler_changed": false,
+  "ga_admin_setting_changed": false,
+  "baidu_tongji_setting_changed": false,
+  "search_channel_action": false,
+  "url_submission": false,
+  "fap_web_modified": false,
+  "future_unavailable_stages": [
+    "page_view",
+    "checkout_start",
+    "membership_start",
+    "retest_start",
+    "historical_report_revisit"
+  ],
+  "next_task": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01"
+}

--- a/backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
@@ -312,13 +312,13 @@
 
             <div class="grid gap-5 xl:grid-cols-2">
                 <div class="space-y-3 text-sm leading-6 text-slate-700">
-                    <p><strong>Hard facts in v1:</strong> <code>test_start</code> from <code>attempts.created_at</code>, <code>order_created</code> from <code>orders.created_at</code>, <code>payment_success</code> from <code>orders.paid_at</code> with a payment-event fallback, <code>unlock_success</code> from active <code>benefit_grants</code>, and <code>report_ready</code> from ready/readable <code>report_snapshots</code>.</p>
-                    <p><strong>Behavioral / approximate stages:</strong> <code>first_result_or_report_view</code> comes from normalized view events. It is intentionally a single merged stage in v1 and stays downstream of submit in the authority chain.</p>
+                    <p><strong>Hard facts in v1:</strong> <code>test_start</code> from <code>attempts.created_at</code>, <code>order_created</code> from <code>orders.created_at</code>, <code>payment_success</code> from <code>orders.paid_at</code> with a payment-event fallback, <code>report_unlock</code> from active <code>benefit_grants</code>, and <code>report_ready</code> from ready/readable <code>report_snapshots</code>.</p>
+                    <p><strong>Behavioral / approximate stages:</strong> <code>result_view</code> comes from normalized view events. It is intentionally a single merged stage in v1 and stays downstream of submit in the authority chain.</p>
                     <p><strong>Explicitly non-authoritative in v1:</strong> PDF downloads, share generated, share clicks, paywall views, landing views, channel attribution, region comparisons, and any share-to-purchase revenue story.</p>
                 </div>
 
                 <ul class="space-y-2 text-sm leading-6 text-slate-700">
-                    <li><strong>Main stages:</strong> <code>test_start</code>, <code>test_submit_success</code>, <code>first_result_or_report_view</code>, <code>order_created</code>, <code>payment_success</code>, <code>unlock_success</code>, <code>report_ready</code>.</li>
+                    <li><strong>Main stages:</strong> <code>test_start</code>, <code>test_submit</code>, <code>result_view</code>, <code>order_created</code>, <code>payment_success</code>, <code>report_unlock</code>, <code>report_ready</code>.</li>
                     <li><strong>Trailing panels only:</strong> <code>pdf_download</code>, <code>share_generate</code>, <code>share_click</code>.</li>
                     <li><strong>Why paywall_view stays out:</strong> event taxonomy and attribution around paywall exposure are still too unstable to serve as the first authority stage.</li>
                     <li><strong>Why locale/scale only:</strong> they are the stable operating cuts today; region, channel, and attribution dimensions remain exploratory.</li>

--- a/backend/tests/Feature/Ops/FunnelConversionPageTest.php
+++ b/backend/tests/Feature/Ops/FunnelConversionPageTest.php
@@ -61,9 +61,12 @@ final class FunnelConversionPageTest extends TestCase
                 ->assertSee('PDF Panel')
                 ->assertSee('Share Panel')
                 ->assertSee('Stage Definition Note')
-                ->assertSee('test_submit_success')
-                ->assertSee('first_result_or_report_view')
-                ->assertSee('unlock_success')
+                ->assertSee('test_submit')
+                ->assertSee('result_view')
+                ->assertSee('report_unlock')
+                ->assertDontSee('test_submit_success')
+                ->assertDontSee('first_result_or_report_view')
+                ->assertDontSee('unlock_success')
                 ->assertSee('$38.98');
         } finally {
             Carbon::setTestNow();

--- a/backend/tests/Feature/Ops/FunnelWidgetTest.php
+++ b/backend/tests/Feature/Ops/FunnelWidgetTest.php
@@ -1,0 +1,154 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Widgets\FunnelWidget;
+use App\Support\OrgContext;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use ReflectionMethod;
+use Tests\TestCase;
+
+final class FunnelWidgetTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_funnel_widget_reads_analytics_funnel_daily_with_canonical_stage_labels(): void
+    {
+        Carbon::setTestNow('2026-01-09 12:00:00');
+
+        try {
+            $this->setOpsOrg(77);
+
+            DB::table('analytics_funnel_daily')->insert([
+                [
+                    'day' => '2026-01-08',
+                    'org_id' => 77,
+                    'scale_code' => 'MBTI',
+                    'locale' => 'en',
+                    'started_attempts' => 12,
+                    'submitted_attempts' => 10,
+                    'first_view_attempts' => 9,
+                    'order_created_attempts' => 4,
+                    'paid_attempts' => 3,
+                    'paid_revenue_cents' => 3898,
+                    'unlocked_attempts' => 2,
+                    'report_ready_attempts' => 2,
+                    'pdf_download_attempts' => 1,
+                    'share_generated_attempts' => 5,
+                    'share_click_attempts' => 6,
+                    'last_refreshed_at' => now(),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+                [
+                    'day' => '2026-01-09',
+                    'org_id' => 77,
+                    'scale_code' => 'MBTI',
+                    'locale' => 'zh-CN',
+                    'started_attempts' => 8,
+                    'submitted_attempts' => 7,
+                    'first_view_attempts' => 6,
+                    'order_created_attempts' => 3,
+                    'paid_attempts' => 2,
+                    'paid_revenue_cents' => 2599,
+                    'unlocked_attempts' => 2,
+                    'report_ready_attempts' => 1,
+                    'pdf_download_attempts' => 1,
+                    'share_generated_attempts' => 4,
+                    'share_click_attempts' => 3,
+                    'last_refreshed_at' => now(),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            ]);
+
+            $stats = $this->widgetStats();
+            $valuesByLabel = [];
+            foreach ($stats as $stat) {
+                $valuesByLabel[(string) $stat->getLabel()] = (string) $stat->getValue();
+            }
+
+            $this->assertSame('20', $valuesByLabel['test_start'] ?? null);
+            $this->assertSame('17', $valuesByLabel['test_submit'] ?? null);
+            $this->assertSame('15', $valuesByLabel['result_view'] ?? null);
+            $this->assertSame('7', $valuesByLabel['order_created'] ?? null);
+            $this->assertSame('5', $valuesByLabel['payment_success'] ?? null);
+            $this->assertSame('4', $valuesByLabel['report_unlock'] ?? null);
+            $this->assertSame('3', $valuesByLabel['report_ready'] ?? null);
+            $this->assertSame('2', $valuesByLabel['pdf_download'] ?? null);
+            $this->assertSame('9', $valuesByLabel['share_generate'] ?? null);
+            $this->assertSame('9', $valuesByLabel['share_click'] ?? null);
+
+            $this->assertArrayNotHasKey('attempt_start', $valuesByLabel);
+            $this->assertArrayNotHasKey('attempt_submit', $valuesByLabel);
+            $this->assertArrayNotHasKey('unlocked', $valuesByLabel);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_funnel_widget_does_not_fallback_to_raw_events_when_read_model_is_empty(): void
+    {
+        Carbon::setTestNow('2026-01-09 12:00:00');
+
+        try {
+            $this->setOpsOrg(77);
+            DB::table('events')->insert([
+                'id' => (string) Str::uuid(),
+                'event_code' => 'attempt_start',
+                'event_name' => 'attempt_start',
+                'org_id' => 77,
+                'user_id' => null,
+                'anon_id' => 'anon_widget_legacy',
+                'scale_code' => 'MBTI',
+                'scale_version' => 'v0.3',
+                'attempt_id' => null,
+                'channel' => 'web',
+                'region' => 'US',
+                'locale' => 'en',
+                'client_platform' => 'web',
+                'client_version' => 'test',
+                'meta_json' => json_encode(['legacy' => true], JSON_UNESCAPED_SLASHES),
+                'occurred_at' => now(),
+                'created_at' => now(),
+                'updated_at' => now(),
+            ]);
+
+            $stats = $this->widgetStats();
+
+            $this->assertCount(1, $stats);
+            $this->assertSame(__('ops.widgets.funnel'), (string) $stats[0]->getLabel());
+            $this->assertSame(__('ops.widgets.no_data'), (string) $stats[0]->getValue());
+            $this->assertSame(
+                'No analytics_funnel_daily rows for this range. Run analytics:refresh-funnel-daily in a controlled task.',
+                (string) $stats[0]->getDescription()
+            );
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    private function setOpsOrg(int $orgId): void
+    {
+        $context = app(OrgContext::class);
+        $context->set($orgId, null, null, null, OrgContext::KIND_TENANT);
+        app()->instance(OrgContext::class, $context);
+    }
+
+    /**
+     * @return list<object>
+     */
+    private function widgetStats(): array
+    {
+        $widget = app(FunnelWidget::class);
+        $method = new ReflectionMethod($widget, 'getStats');
+        $method->setAccessible(true);
+
+        return $method->invoke($widget);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1996,6 +1996,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_analytics_funnel_ops_read_model_changes(): void
+    {
+        $changed = [
+            'backend/app/Filament/Ops/Pages/FunnelConversionPage.php',
+            'backend/app/Filament/Ops/Widgets/FunnelWidget.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_content_asset_loader_changes(): void
     {
         $changed = [
@@ -2791,6 +2801,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isAnalyticsFunnelEventTaxonomyFile($file)) {
+                continue;
+            }
+
+            if ($this->isAnalyticsFunnelOpsReadModelFile($file)) {
                 continue;
             }
 
@@ -4246,6 +4260,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php',
             'backend/app/Services/Analytics/FunnelEventTaxonomy.php',
+        ], true);
+    }
+
+    private function isAnalyticsFunnelOpsReadModelFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Filament/Ops/Pages/FunnelConversionPage.php',
+            'backend/app/Filament/Ops/Widgets/FunnelWidget.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32120,5 +32120,118 @@
     },
     "sidecars": [],
     "next_task": "Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization"
+  },
+  "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01": {
+    "id": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-ops-read-model-repair-01",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01"
+    ],
+    "commit_sha": "7097df0e3c1eb871dba927d1473cb160f252df6c",
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "manifest/state authorization",
+        "status": "passed",
+        "summary": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json only for ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01."
+      },
+      {
+        "command": "php artisan test --filter=FunnelWidget --no-ansi",
+        "status": "passed",
+        "summary": "2 tests passed, 17 assertions."
+      },
+      {
+        "command": "php artisan test --filter=FunnelConversionPage --no-ansi",
+        "status": "passed",
+        "summary": "1 test passed, 17 assertions."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "status": "passed",
+        "summary": "2 tests passed, 27 assertions."
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "Route list rendered successfully with 207 routes."
+      },
+      {
+        "command": "vendor/bin/pint --test",
+        "status": "passed",
+        "summary": "Pint passed across 3645 files."
+      },
+      {
+        "command": "composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid."
+      },
+      {
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found."
+      },
+      {
+        "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json >/dev/null",
+        "status": "passed",
+        "summary": "Generated Ops read-model repair JSON parses."
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed",
+        "summary": "PR train state JSON parses."
+      },
+      {
+        "command": "python3 - <<'PY' import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()) PY",
+        "status": "passed",
+        "summary": "PR train manifest YAML parses."
+      },
+      {
+        "command": "git diff --check",
+        "status": "passed",
+        "summary": "No whitespace errors in unstaged diff."
+      },
+      {
+        "command": "fap-web reference status",
+        "status": "passed",
+        "summary": "Reference-only fap-web worktree is clean and was not modified."
+      },
+      {
+        "command": "git diff --cached --check",
+        "status": "passed",
+        "summary": "No whitespace errors in staged diff."
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T06:03:41+08:00",
+        "summary": "User authorized this scoped Ops read-model repair PR and manifest/state updates."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T06:03:41+08:00",
+        "summary": "Started from latest origin/main on scoped branch codex/analytics-funnel-ops-read-model-repair-01."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T06:07:06+08:00",
+        "summary": "Scoped local validation passed for Ops 7-day funnel read-model repair."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [],
+    "next_task": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32127,12 +32127,12 @@
     "branch": "codex/analytics-funnel-ops-read-model-repair-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01"
     ],
     "commit_sha": "10bdb0eb1009df0657d20a9692797d50dffec746",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1764",
     "checks": [
       {
         "command": "manifest/state authorization",
@@ -32224,6 +32224,11 @@
         "status": "local_checks_passed",
         "at": "2026-05-31T06:07:06+08:00",
         "summary": "Scoped local validation passed for Ops 7-day funnel read-model repair."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T06:09:59+08:00",
+        "summary": "Opened PR #1764 after scoped local validations passed."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32131,7 +32131,7 @@
     "depends_on": [
       "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01"
     ],
-    "commit_sha": "7097df0e3c1eb871dba927d1473cb160f252df6c",
+    "commit_sha": "10bdb0eb1009df0657d20a9692797d50dffec746",
     "pr_url": null,
     "checks": [
       {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32127,7 +32127,7 @@
     "branch": "codex/analytics-funnel-ops-read-model-repair-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model",
-    "status": "pr_open",
+    "status": "ci_fix_local_checks_passed",
     "depends_on": [
       "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01"
     ],
@@ -32203,6 +32203,21 @@
         "command": "git diff --cached --check",
         "status": "passed",
         "summary": "No whitespace errors in staged diff."
+      },
+      {
+        "command": "GitHub checks on PR #1764 initial run",
+        "status": "failed",
+        "summary": "verify-mbti-legacy and verify-mbti-v2 failed because BigFiveResultPageV2CoreBodyPreviewTest runtime freeze classifier did not yet allow the Ops funnel read-model files."
+      },
+      {
+        "command": "php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_analytics_funnel_ops_read_model_changes --no-ansi",
+        "status": "passed",
+        "summary": "1 test passed, 1 assertion after adding the narrow Ops funnel read-model freeze allowlist."
+      },
+      {
+        "command": "CI fix validation rerun",
+        "status": "passed",
+        "summary": "FunnelWidget, FunnelConversionPage, AnalyticsFunnelDailyBuilder, route:list, pint, composer validate, composer audit, JSON/YAML parse, and diff checks passed after the CI fix."
       }
     ],
     "failure_reason": null,
@@ -32229,6 +32244,11 @@
         "status": "pr_open",
         "at": "2026-05-31T06:09:59+08:00",
         "summary": "Opened PR #1764 after scoped local validations passed."
+      },
+      {
+        "status": "ci_fix_local_checks_passed",
+        "at": "2026-05-31T06:23:28+08:00",
+        "summary": "Added narrow BigFive runtime freeze allowlist for the Ops funnel read-model files and reran scoped validations."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16021,6 +16021,60 @@ prs:
     frontend_fallback_authority: false
     next_task: ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation
 
+
+
+  - id: ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01
+    repo: fap-api
+    branch: codex/analytics-funnel-ops-read-model-repair-01
+    base: main
+    title: "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model"
+    train_scope: analytics_funnel_ops_read_model_repair
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
+    allowed_paths:
+      - backend/app/Filament/Ops/Widgets/FunnelWidget.php
+      - backend/app/Filament/Ops/Pages/FunnelConversionPage.php
+      - backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
+      - backend/docs/seo/analytics-funnel-ops-read-model-repair-01.md
+      - backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json
+      - backend/tests/Feature/Ops/FunnelWidgetTest.php
+      - backend/tests/Feature/Ops/FunnelConversionPageTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Make the Ops dashboard 7-day FunnelWidget read analytics_funnel_daily as the read model truth.
+      - Stop presenting v_funnel_daily or raw events as the primary Ops 7-day funnel authority.
+      - Display canonical taxonomy stage labels for the supported analytics_funnel_daily columns.
+      - Update the /ops/funnel-conversion display labels from legacy stage names to canonical taxonomy names.
+      - Document that production refresh, DB writes, migrations, scheduler changes, GA/Baidu settings, Search Channel actions, URL submissions, and fap-web changes were not performed.
+    validation:
+      - cd backend && php artisan test --filter=FunnelWidget --no-ansi
+      - cd backend && php artisan test --filter=FunnelConversionPage --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01
+
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api
     branch: fix/content-packs-index-artifact-01

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16040,6 +16040,7 @@ prs:
       - backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json
       - backend/tests/Feature/Ops/FunnelWidgetTest.php
       - backend/tests/Feature/Ops/FunnelConversionPageTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -16052,6 +16053,7 @@ prs:
       - cd backend && php artisan test --filter=FunnelWidget --no-ansi
       - cd backend && php artisan test --filter=FunnelConversionPage --no-ansi
       - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_analytics_funnel_ops_read_model_changes --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
       - cd backend && composer validate --strict


### PR DESCRIPTION
## What changed
- Rewired the Ops dashboard 7-day FunnelWidget to aggregate analytics_funnel_daily by selected org and current 7-day range.
- Stopped presenting v_funnel_daily or raw events as primary Ops 7-day funnel authority.
- Updated /ops/funnel-conversion display labels and stage notes to canonical taxonomy names.
- Added docs/generated evidence, focused widget coverage, and train ledger entries.

## Why
Ops dashboard funnel visibility still used legacy event names after ANALYTICS-FUNNEL-EVENT-TAXONOMY-01. This PR connects the visible 7-day dashboard read model to the unified taxonomy contract without running production refreshes or mutating analytics data.

## Validation
- cd backend && php artisan test --filter=FunnelWidget --no-ansi
- cd backend && php artisan test --filter=FunnelConversionPage --no-ansi
- cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No production analytics refresh.
- No production DB mutation.
- No migration or scheduler change.
- No GA/Baidu admin setting change.
- No Search Channel action, URL submission, or fap-web modification.
- page_view, checkout_start, membership_start, retest_start, and historical_report_revisit remain future/unavailable until the read model supports them.