### PR TITLE
CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01 shrink ContentPacksIndex to artifact loader and minimal fallback

### DIFF
--- a/backend/app/Services/Content/ContentPacksIndex.php
+++ b/backend/app/Services/Content/ContentPacksIndex.php
@@ -8,9 +8,6 @@ use App\Support\CacheKeys;
 use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\File;
 use Illuminate\Support\Facades\Log;
-use RecursiveDirectoryIterator;
-use RecursiveIteratorIterator;
-use SplFileInfo;
 
 final class ContentPacksIndex
 {
@@ -18,6 +15,7 @@ final class ContentPacksIndex
 
     public function __construct(
         private ?ContentPacksIndexArtifactStore $artifactStore = null,
+        private ?ContentPacksIndexFallbackScanner $fallbackScanner = null,
     ) {}
 
     public function getIndex(bool $refresh = false): array
@@ -63,39 +61,7 @@ final class ContentPacksIndex
             }
         }
 
-        if ($packsRootFs === '' || ! File::isDirectory($packsRootFs)) {
-            Log::error('CONTENT_PACKS_ROOT_INVALID', [
-                'driver' => $driver,
-                'packs_root' => $packsRootFs,
-            ]);
-
-            return [
-                'ok' => false,
-                'driver' => $driver,
-                'packs_root' => $packsRootFs,
-                'defaults' => $defaults,
-                'items' => [],
-                'by_pack_id' => [],
-            ];
-        }
-
-        $scanned = $this->scanIndex($packsRootFs, $defaults);
-        $items = (array) ($scanned['items'] ?? []);
-        if ($items === []) {
-            Log::error('CONTENT_PACKS_INDEX_EMPTY', [
-                'driver' => $driver,
-                'packs_root' => $packsRootFs,
-            ]);
-        }
-
-        $index = [
-            'ok' => true,
-            'driver' => $driver,
-            'packs_root' => $packsRootFs,
-            'defaults' => $defaults,
-            'items' => $items,
-            'by_pack_id' => (array) ($scanned['by_pack_id'] ?? []),
-        ];
+        $index = $this->fallbackScanner()->scan($packsRootFs, $driver, $defaults);
 
         try {
             $cache->put($cacheKey, $index, self::CACHE_TTL_SECONDS);
@@ -173,6 +139,15 @@ final class ContentPacksIndex
         return $this->artifactStore;
     }
 
+    private function fallbackScanner(): ContentPacksIndexFallbackScanner
+    {
+        if (! $this->fallbackScanner instanceof ContentPacksIndexFallbackScanner) {
+            $this->fallbackScanner = app(ContentPacksIndexFallbackScanner::class);
+        }
+
+        return $this->fallbackScanner;
+    }
+
     private function normalizeFilesystemRoot(string $path): string
     {
         $path = trim($path);
@@ -201,15 +176,6 @@ final class ContentPacksIndex
         return (bool) preg_match('/^[A-Za-z]:[\/\\\\]/', $path);
     }
 
-    private function debugLog(string $event, array $context = []): void
-    {
-        if (! (bool) config('content_packs.debug_log', false)) {
-            return;
-        }
-
-        Log::warning($event, $context);
-    }
-
     private function defaults(): array
     {
         return [
@@ -220,263 +186,6 @@ final class ContentPacksIndex
             'region_fallbacks' => (array) config('content_packs.region_fallbacks', []),
             'locale_fallback' => (bool) config('content_packs.locale_fallback', false),
         ];
-    }
-
-    private function scanIndex(string $packsRootFs, array $defaults): array
-    {
-        $items = [];
-        $seen = [];
-        $byPackId = [];
-        $latest = [];
-        $rootNorm = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $packsRootFs), '/');
-
-        $stats = [
-            'manifests_seen' => 0,
-            'skipped_deprecated' => 0,
-            'skipped_manifest_json_invalid' => 0,
-            'skipped_manifest_consistency' => 0,
-            'skipped_version_invalid' => 0,
-            'skipped_questions_invalid' => 0,
-            'skipped_duplicate' => 0,
-            'accepted' => 0,
-        ];
-
-        foreach ($this->manifestFilesUnder($packsRootFs) as $file) {
-            $stats['manifests_seen']++;
-
-            $manifestPath = $file->getPathname();
-            $manifestPathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $manifestPath);
-            if (str_contains($manifestPathNorm, '/_deprecated/')) {
-                $stats['skipped_deprecated']++;
-
-                continue;
-            }
-
-            // 正式修复：
-            // 不再强制要求 manifest 路径里必须包含 /default/
-            // 只要 manifest/version/questions 三件套一致，就视为有效 legacy pack。
-
-            try {
-                $manifestRaw = File::get($manifestPath);
-            } catch (\Throwable $e) {
-                continue;
-            }
-
-            $manifest = json_decode($manifestRaw, true);
-            if (! is_array($manifest)) {
-                $stats['skipped_manifest_json_invalid']++;
-
-                continue;
-            }
-
-            $packId = trim((string) ($manifest['pack_id'] ?? ''));
-            if ($packId === '') {
-                continue;
-            }
-
-            $packDir = dirname($manifestPath);
-            $dirVersion = basename($packDir);
-            if (! $this->isManifestConsistent($manifest, $dirVersion, $packId)) {
-                $stats['skipped_manifest_consistency']++;
-
-                continue;
-            }
-
-            $versionPath = $packDir.DIRECTORY_SEPARATOR.'version.json';
-            $version = $this->readJsonFile($versionPath);
-            if (! is_array($version)) {
-                $stats['skipped_version_invalid']++;
-
-                continue;
-            }
-            if (! $this->isVersionConsistent(
-                $version,
-                $packId,
-                (string) ($manifest['content_package_version'] ?? ''),
-                $dirVersion
-            )) {
-                $stats['skipped_version_invalid']++;
-
-                continue;
-            }
-
-            $questionsPath = $packDir.DIRECTORY_SEPARATOR.'questions.json';
-            if (! File::exists($questionsPath)) {
-                $stats['skipped_questions_invalid']++;
-
-                continue;
-            }
-            if (! $this->isValidJsonArrayDocument($questionsPath)) {
-                $stats['skipped_questions_invalid']++;
-
-                continue;
-            }
-
-            $key = $packId.'|'.$dirVersion;
-            if (isset($seen[$key])) {
-                $stats['skipped_duplicate']++;
-
-                continue;
-            }
-
-            $packPath = $this->relativePath($rootNorm, $packDir);
-            $manifestSig = $this->fileSignature($manifestPath);
-            $versionSig = $this->fileSignature($versionPath);
-            $questionsSig = $this->fileSignature($questionsPath);
-            if ($manifestSig === null || $versionSig === null || $questionsSig === null) {
-                continue;
-            }
-
-            $updatedAt = max(
-                (int) ($manifestSig['mtime'] ?? 0),
-                (int) ($versionSig['mtime'] ?? 0),
-                (int) ($questionsSig['mtime'] ?? 0)
-            );
-
-            $stats['accepted']++;
-
-            $items[] = [
-                'pack_id' => $packId,
-                'dir_version' => $dirVersion,
-                'content_package_version' => (string) ($manifest['content_package_version'] ?? ''),
-                'scale_code' => (string) ($manifest['scale_code'] ?? ''),
-                'region' => (string) ($manifest['region'] ?? ''),
-                'locale' => (string) ($manifest['locale'] ?? ''),
-                'pack_path' => $packPath,
-                'manifest_path' => $manifestPath,
-                'questions_path' => $questionsPath,
-                'version_path' => $versionPath,
-                'manifest_mtime' => (int) ($manifestSig['mtime'] ?? 0),
-                'manifest_size' => (int) ($manifestSig['size'] ?? 0),
-                'version_mtime' => (int) ($versionSig['mtime'] ?? 0),
-                'version_size' => (int) ($versionSig['size'] ?? 0),
-                'questions_mtime' => (int) ($questionsSig['mtime'] ?? 0),
-                'questions_size' => (int) ($questionsSig['size'] ?? 0),
-                'updated_at' => $updatedAt,
-            ];
-
-            $this->recordByPackIdVersion(
-                $byPackId,
-                $latest,
-                $packId,
-                $dirVersion,
-                $updatedAt
-            );
-
-            $seen[$key] = true;
-        }
-
-        usort($items, function (array $a, array $b): int {
-            $cmp = strcmp((string) ($a['pack_id'] ?? ''), (string) ($b['pack_id'] ?? ''));
-            if ($cmp !== 0) {
-                return $cmp;
-            }
-
-            return strcmp((string) ($a['dir_version'] ?? ''), (string) ($b['dir_version'] ?? ''));
-        });
-
-        $this->debugLog('CONTENT_PACKS_INDEX_SCAN_SUMMARY', [
-            'packs_root' => $packsRootFs,
-            'stats' => $stats,
-        ]);
-
-        return [
-            'items' => $items,
-            'by_pack_id' => $this->finalizeByPackId($byPackId, $latest, $defaults),
-        ];
-    }
-
-    private function recordByPackIdVersion(
-        array &$byPackId,
-        array &$latest,
-        string $packId,
-        string $dirVersion,
-        int $updatedAt
-    ): void {
-        if ($packId === '' || $dirVersion === '') {
-            return;
-        }
-
-        if (! isset($byPackId[$packId])) {
-            $byPackId[$packId] = [
-                'default_dir_version' => '',
-                'versions' => [],
-            ];
-        }
-
-        $byPackId[$packId]['versions'][$dirVersion] = true;
-
-        if (! isset($latest[$packId]) || $updatedAt > (int) ($latest[$packId]['updated_at'] ?? 0)) {
-            $latest[$packId] = [
-                'dir_version' => $dirVersion,
-                'updated_at' => $updatedAt,
-            ];
-        }
-    }
-
-    private function finalizeByPackId(array $byPackId, array $latest, array $defaults): array
-    {
-        $defaultPackId = (string) ($defaults['default_pack_id'] ?? '');
-        $defaultDirVersion = (string) ($defaults['default_dir_version'] ?? '');
-
-        foreach ($byPackId as $packId => $info) {
-            $versions = array_keys((array) ($info['versions'] ?? []));
-            sort($versions, SORT_STRING);
-
-            $default = '';
-            if ($packId === $defaultPackId && $defaultDirVersion !== '') {
-                $default = $defaultDirVersion;
-            } else {
-                $default = (string) ($latest[$packId]['dir_version'] ?? '');
-                if ($default === '') {
-                    $default = (string) ($versions[0] ?? '');
-                }
-            }
-
-            $byPackId[$packId] = [
-                'default_dir_version' => $default,
-                'versions' => $versions,
-            ];
-        }
-
-        ksort($byPackId, SORT_STRING);
-
-        return $byPackId;
-    }
-
-    /**
-     * @return \Generator<int, SplFileInfo>
-     */
-    private function manifestFilesUnder(string $packsRootFs): \Generator
-    {
-        $iterator = new RecursiveIteratorIterator(
-            new RecursiveDirectoryIterator($packsRootFs, RecursiveDirectoryIterator::SKIP_DOTS),
-            RecursiveIteratorIterator::LEAVES_ONLY
-        );
-
-        foreach ($iterator as $file) {
-            if (! $file instanceof SplFileInfo || ! $file->isFile()) {
-                continue;
-            }
-
-            if ($file->getFilename() !== 'manifest.json') {
-                continue;
-            }
-
-            yield $file;
-        }
-    }
-
-    private function relativePath(string $rootNorm, string $path): string
-    {
-        $pathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $path);
-        $rootNorm = rtrim($rootNorm, '/');
-
-        if ($rootNorm !== '' && str_starts_with($pathNorm, $rootNorm.'/')) {
-            return substr($pathNorm, strlen($rootNorm) + 1);
-        }
-
-        return ltrim($pathNorm, '/');
     }
 
     private function findInItems(array $items, string $packId, string $dirVersion): ?array
@@ -538,6 +247,7 @@ final class ContentPacksIndex
         }
 
         try {
+            clearstatcache(true, $path);
             $mtimeRaw = @filemtime($path);
             $sizeRaw = @filesize($path);
         } catch (\Throwable $e) {
@@ -571,119 +281,5 @@ final class ContentPacksIndex
 
         return (int) ($item[$mtimeKey] ?? -1) === (int) ($signature['mtime'] ?? -2)
             && (int) ($item[$sizeKey] ?? -1) === (int) ($signature['size'] ?? -2);
-    }
-
-    private function readJsonFile(string $path): ?array
-    {
-        if ($path === '' || ! File::isFile($path)) {
-            return null;
-        }
-
-        try {
-            $raw = File::get($path);
-        } catch (\Throwable $e) {
-            return null;
-        }
-
-        $decoded = json_decode($raw, true);
-
-        return is_array($decoded) ? $decoded : null;
-    }
-
-    private function isValidJsonArrayDocument(string $path): bool
-    {
-        if ($path === '' || ! File::isFile($path)) {
-            return false;
-        }
-
-        $firstMeaningfulByte = $this->firstNonWhitespaceByte($path);
-        if ($firstMeaningfulByte === null) {
-            return false;
-        }
-
-        return $firstMeaningfulByte === '[' || $firstMeaningfulByte === '{';
-    }
-
-    private function firstNonWhitespaceByte(string $path): ?string
-    {
-        $handle = @fopen($path, 'rb');
-        if (! is_resource($handle)) {
-            return null;
-        }
-
-        try {
-            while (! feof($handle)) {
-                $chunk = fread($handle, 8192);
-                if (! is_string($chunk) || $chunk === '') {
-                    continue;
-                }
-
-                $length = strlen($chunk);
-                for ($index = 0; $index < $length; $index++) {
-                    $char = $chunk[$index];
-                    if (! ctype_space($char)) {
-                        return $char;
-                    }
-                }
-            }
-        } finally {
-            fclose($handle);
-        }
-
-        return null;
-    }
-
-    private function isManifestConsistent(array $manifest, string $dirVersion, string $packId): bool
-    {
-        $schemaVersion = (string) ($manifest['schema_version'] ?? '');
-        if ($schemaVersion !== 'pack-manifest@v1') {
-            return false;
-        }
-
-        if ((string) ($manifest['pack_id'] ?? '') !== $packId) {
-            return false;
-        }
-        if ((string) ($manifest['content_package_version'] ?? '') === '') {
-            return false;
-        }
-
-        foreach (['scale_code', 'region', 'locale'] as $required) {
-            if (trim((string) ($manifest[$required] ?? '')) === '') {
-                return false;
-            }
-        }
-
-        if ($dirVersion === '') {
-            return false;
-        }
-
-        return true;
-    }
-
-    private function isVersionConsistent(
-        array $version,
-        string $manifestPackId,
-        string $manifestContentVersion,
-        string $dirVersion
-    ): bool {
-        $versionPackId = trim((string) ($version['pack_id'] ?? ''));
-        $versionContentVersion = trim((string) ($version['content_package_version'] ?? ''));
-        $versionDir = trim((string) ($version['dir_version'] ?? ''));
-
-        if ($versionPackId === '' || $versionContentVersion === '' || $versionDir === '') {
-            return false;
-        }
-
-        if ($versionPackId !== $manifestPackId) {
-            return false;
-        }
-        if ($versionContentVersion !== $manifestContentVersion) {
-            return false;
-        }
-        if ($versionDir !== $dirVersion) {
-            return false;
-        }
-
-        return true;
     }
 }

--- a/backend/app/Services/Content/ContentPacksIndexFallbackScanner.php
+++ b/backend/app/Services/Content/ContentPacksIndexFallbackScanner.php
@@ -1,0 +1,457 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Content;
+
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Log;
+use RecursiveDirectoryIterator;
+use RecursiveIteratorIterator;
+use SplFileInfo;
+
+class ContentPacksIndexFallbackScanner
+{
+    public function scan(string $packsRootFs, string $driver, array $defaults): array
+    {
+        if ($packsRootFs === '' || ! File::isDirectory($packsRootFs)) {
+            Log::error('CONTENT_PACKS_ROOT_INVALID', [
+                'driver' => $driver,
+                'packs_root' => $packsRootFs,
+            ]);
+
+            return [
+                'ok' => false,
+                'driver' => $driver,
+                'packs_root' => $packsRootFs,
+                'defaults' => $defaults,
+                'items' => [],
+                'by_pack_id' => [],
+            ];
+        }
+
+        $scanned = $this->scanIndex($packsRootFs, $defaults);
+        $items = (array) ($scanned['items'] ?? []);
+        if ($items === []) {
+            Log::error('CONTENT_PACKS_INDEX_EMPTY', [
+                'driver' => $driver,
+                'packs_root' => $packsRootFs,
+            ]);
+        }
+
+        return [
+            'ok' => true,
+            'driver' => $driver,
+            'packs_root' => $packsRootFs,
+            'defaults' => $defaults,
+            'items' => $items,
+            'by_pack_id' => (array) ($scanned['by_pack_id'] ?? []),
+        ];
+    }
+
+    private function scanIndex(string $packsRootFs, array $defaults): array
+    {
+        $items = [];
+        $seen = [];
+        $byPackId = [];
+        $latest = [];
+        $rootNorm = rtrim(str_replace(DIRECTORY_SEPARATOR, '/', $packsRootFs), '/');
+
+        $stats = [
+            'manifests_seen' => 0,
+            'skipped_deprecated' => 0,
+            'skipped_manifest_json_invalid' => 0,
+            'skipped_manifest_consistency' => 0,
+            'skipped_version_invalid' => 0,
+            'skipped_questions_invalid' => 0,
+            'skipped_duplicate' => 0,
+            'accepted' => 0,
+        ];
+
+        foreach ($this->manifestFilesUnder($packsRootFs) as $file) {
+            $stats['manifests_seen']++;
+
+            $manifestPath = $file->getPathname();
+            $manifestPathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $manifestPath);
+            if (str_contains($manifestPathNorm, '/_deprecated/')) {
+                $stats['skipped_deprecated']++;
+
+                continue;
+            }
+
+            try {
+                $manifestRaw = File::get($manifestPath);
+            } catch (\Throwable $e) {
+                continue;
+            }
+
+            $manifest = json_decode($manifestRaw, true);
+            if (! is_array($manifest)) {
+                $stats['skipped_manifest_json_invalid']++;
+
+                continue;
+            }
+
+            $packId = trim((string) ($manifest['pack_id'] ?? ''));
+            if ($packId === '') {
+                continue;
+            }
+
+            $packDir = dirname($manifestPath);
+            $dirVersion = basename($packDir);
+            if (! $this->isManifestConsistent($manifest, $dirVersion, $packId)) {
+                $stats['skipped_manifest_consistency']++;
+
+                continue;
+            }
+
+            $versionPath = $packDir.DIRECTORY_SEPARATOR.'version.json';
+            $version = $this->readJsonFile($versionPath);
+            if (! is_array($version)) {
+                $stats['skipped_version_invalid']++;
+
+                continue;
+            }
+            if (! $this->isVersionConsistent(
+                $version,
+                $packId,
+                (string) ($manifest['content_package_version'] ?? ''),
+                $dirVersion
+            )) {
+                $stats['skipped_version_invalid']++;
+
+                continue;
+            }
+
+            $questionsPath = $packDir.DIRECTORY_SEPARATOR.'questions.json';
+            if (! File::exists($questionsPath)) {
+                $stats['skipped_questions_invalid']++;
+
+                continue;
+            }
+            if (! $this->isValidJsonArrayDocument($questionsPath)) {
+                $stats['skipped_questions_invalid']++;
+
+                continue;
+            }
+
+            $key = $packId.'|'.$dirVersion;
+            if (isset($seen[$key])) {
+                $stats['skipped_duplicate']++;
+
+                continue;
+            }
+
+            $packPath = $this->relativePath($rootNorm, $packDir);
+            $manifestSig = $this->fileSignature($manifestPath);
+            $versionSig = $this->fileSignature($versionPath);
+            $questionsSig = $this->fileSignature($questionsPath);
+            if ($manifestSig === null || $versionSig === null || $questionsSig === null) {
+                continue;
+            }
+
+            $updatedAt = max(
+                (int) ($manifestSig['mtime'] ?? 0),
+                (int) ($versionSig['mtime'] ?? 0),
+                (int) ($questionsSig['mtime'] ?? 0)
+            );
+
+            $stats['accepted']++;
+
+            $items[] = [
+                'pack_id' => $packId,
+                'dir_version' => $dirVersion,
+                'content_package_version' => (string) ($manifest['content_package_version'] ?? ''),
+                'scale_code' => (string) ($manifest['scale_code'] ?? ''),
+                'region' => (string) ($manifest['region'] ?? ''),
+                'locale' => (string) ($manifest['locale'] ?? ''),
+                'pack_path' => $packPath,
+                'manifest_path' => $manifestPath,
+                'questions_path' => $questionsPath,
+                'version_path' => $versionPath,
+                'manifest_mtime' => (int) ($manifestSig['mtime'] ?? 0),
+                'manifest_size' => (int) ($manifestSig['size'] ?? 0),
+                'version_mtime' => (int) ($versionSig['mtime'] ?? 0),
+                'version_size' => (int) ($versionSig['size'] ?? 0),
+                'questions_mtime' => (int) ($questionsSig['mtime'] ?? 0),
+                'questions_size' => (int) ($questionsSig['size'] ?? 0),
+                'updated_at' => $updatedAt,
+            ];
+
+            $this->recordByPackIdVersion(
+                $byPackId,
+                $latest,
+                $packId,
+                $dirVersion,
+                $updatedAt
+            );
+
+            $seen[$key] = true;
+        }
+
+        usort($items, function (array $a, array $b): int {
+            $cmp = strcmp((string) ($a['pack_id'] ?? ''), (string) ($b['pack_id'] ?? ''));
+            if ($cmp !== 0) {
+                return $cmp;
+            }
+
+            return strcmp((string) ($a['dir_version'] ?? ''), (string) ($b['dir_version'] ?? ''));
+        });
+
+        $this->debugLog('CONTENT_PACKS_INDEX_SCAN_SUMMARY', [
+            'packs_root' => $packsRootFs,
+            'stats' => $stats,
+        ]);
+
+        return [
+            'items' => $items,
+            'by_pack_id' => $this->finalizeByPackId($byPackId, $latest, $defaults),
+        ];
+    }
+
+    private function recordByPackIdVersion(
+        array &$byPackId,
+        array &$latest,
+        string $packId,
+        string $dirVersion,
+        int $updatedAt
+    ): void {
+        if ($packId === '' || $dirVersion === '') {
+            return;
+        }
+
+        if (! isset($byPackId[$packId])) {
+            $byPackId[$packId] = [
+                'default_dir_version' => '',
+                'versions' => [],
+            ];
+        }
+
+        $byPackId[$packId]['versions'][$dirVersion] = true;
+
+        if (! isset($latest[$packId]) || $updatedAt > (int) ($latest[$packId]['updated_at'] ?? 0)) {
+            $latest[$packId] = [
+                'dir_version' => $dirVersion,
+                'updated_at' => $updatedAt,
+            ];
+        }
+    }
+
+    private function finalizeByPackId(array $byPackId, array $latest, array $defaults): array
+    {
+        $defaultPackId = (string) ($defaults['default_pack_id'] ?? '');
+        $defaultDirVersion = (string) ($defaults['default_dir_version'] ?? '');
+
+        foreach ($byPackId as $packId => $info) {
+            $versions = array_keys((array) ($info['versions'] ?? []));
+            sort($versions, SORT_STRING);
+
+            $default = '';
+            if ($packId === $defaultPackId && $defaultDirVersion !== '') {
+                $default = $defaultDirVersion;
+            } else {
+                $default = (string) ($latest[$packId]['dir_version'] ?? '');
+                if ($default === '') {
+                    $default = (string) ($versions[0] ?? '');
+                }
+            }
+
+            $byPackId[$packId] = [
+                'default_dir_version' => $default,
+                'versions' => $versions,
+            ];
+        }
+
+        ksort($byPackId, SORT_STRING);
+
+        return $byPackId;
+    }
+
+    /**
+     * @return \Generator<int, SplFileInfo>
+     */
+    private function manifestFilesUnder(string $packsRootFs): \Generator
+    {
+        $iterator = new RecursiveIteratorIterator(
+            new RecursiveDirectoryIterator($packsRootFs, RecursiveDirectoryIterator::SKIP_DOTS),
+            RecursiveIteratorIterator::LEAVES_ONLY
+        );
+
+        foreach ($iterator as $file) {
+            if (! $file instanceof SplFileInfo || ! $file->isFile()) {
+                continue;
+            }
+
+            if ($file->getFilename() !== 'manifest.json') {
+                continue;
+            }
+
+            yield $file;
+        }
+    }
+
+    private function relativePath(string $rootNorm, string $path): string
+    {
+        $pathNorm = str_replace(DIRECTORY_SEPARATOR, '/', $path);
+        $rootNorm = rtrim($rootNorm, '/');
+
+        if ($rootNorm !== '' && str_starts_with($pathNorm, $rootNorm.'/')) {
+            return substr($pathNorm, strlen($rootNorm) + 1);
+        }
+
+        return ltrim($pathNorm, '/');
+    }
+
+    /**
+     * @return array{mtime:int,size:int}|null
+     */
+    private function fileSignature(string $path): ?array
+    {
+        if ($path === '' || ! File::isFile($path)) {
+            return null;
+        }
+
+        try {
+            clearstatcache(true, $path);
+            $mtimeRaw = @filemtime($path);
+            $sizeRaw = @filesize($path);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        if (! is_int($mtimeRaw) && ! is_numeric($mtimeRaw)) {
+            return null;
+        }
+        if (! is_int($sizeRaw) && ! is_numeric($sizeRaw)) {
+            return null;
+        }
+
+        return [
+            'mtime' => (int) $mtimeRaw,
+            'size' => (int) $sizeRaw,
+        ];
+    }
+
+    private function readJsonFile(string $path): ?array
+    {
+        if ($path === '' || ! File::isFile($path)) {
+            return null;
+        }
+
+        try {
+            $raw = File::get($path);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : null;
+    }
+
+    private function isValidJsonArrayDocument(string $path): bool
+    {
+        if ($path === '' || ! File::isFile($path)) {
+            return false;
+        }
+
+        $firstMeaningfulByte = $this->firstNonWhitespaceByte($path);
+        if ($firstMeaningfulByte === null) {
+            return false;
+        }
+
+        return $firstMeaningfulByte === '[' || $firstMeaningfulByte === '{';
+    }
+
+    private function firstNonWhitespaceByte(string $path): ?string
+    {
+        $handle = @fopen($path, 'rb');
+        if (! is_resource($handle)) {
+            return null;
+        }
+
+        try {
+            while (! feof($handle)) {
+                $chunk = fread($handle, 8192);
+                if (! is_string($chunk) || $chunk === '') {
+                    continue;
+                }
+
+                $length = strlen($chunk);
+                for ($index = 0; $index < $length; $index++) {
+                    $char = $chunk[$index];
+                    if (! ctype_space($char)) {
+                        return $char;
+                    }
+                }
+            }
+        } finally {
+            fclose($handle);
+        }
+
+        return null;
+    }
+
+    private function isManifestConsistent(array $manifest, string $dirVersion, string $packId): bool
+    {
+        $schemaVersion = (string) ($manifest['schema_version'] ?? '');
+        if ($schemaVersion !== 'pack-manifest@v1') {
+            return false;
+        }
+
+        if ((string) ($manifest['pack_id'] ?? '') !== $packId) {
+            return false;
+        }
+        if ((string) ($manifest['content_package_version'] ?? '') === '') {
+            return false;
+        }
+
+        foreach (['scale_code', 'region', 'locale'] as $required) {
+            if (trim((string) ($manifest[$required] ?? '')) === '') {
+                return false;
+            }
+        }
+
+        if ($dirVersion === '') {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function isVersionConsistent(
+        array $version,
+        string $manifestPackId,
+        string $manifestContentVersion,
+        string $dirVersion
+    ): bool {
+        $versionPackId = trim((string) ($version['pack_id'] ?? ''));
+        $versionContentVersion = trim((string) ($version['content_package_version'] ?? ''));
+        $versionDir = trim((string) ($version['dir_version'] ?? ''));
+
+        if ($versionPackId === '' || $versionContentVersion === '' || $versionDir === '') {
+            return false;
+        }
+
+        if ($versionPackId !== $manifestPackId) {
+            return false;
+        }
+        if ($versionContentVersion !== $manifestContentVersion) {
+            return false;
+        }
+        if ($versionDir !== $dirVersion) {
+            return false;
+        }
+
+        return true;
+    }
+
+    private function debugLog(string $event, array $context = []): void
+    {
+        if (! (bool) config('content_packs.debug_log', false)) {
+            return;
+        }
+
+        Log::warning($event, $context);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2006,6 +2006,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_content_packs_index_phase3_responsibility_shrink(): void
+    {
+        $changed = [
+            'backend/app/Services/Content/ContentPacksIndex.php',
+            'backend/app/Services/Content/ContentPacksIndexFallbackScanner.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_bigfive_v2_content_asset_loader_changes(): void
     {
         $changed = [
@@ -3016,6 +3026,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Commands/ContentPacksIndexBuild.php',
             'backend/app/Services/Content/ContentPacksIndex.php',
             'backend/app/Services/Content/ContentPacksIndexArtifactStore.php',
+            'backend/app/Services/Content/ContentPacksIndexFallbackScanner.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
@@ -115,6 +115,31 @@ final class ContentPacksIndexArtifactTest extends TestCase
         $this->assertFalse((bool) config('content_packs.index_artifact_enabled'));
     }
 
+    public function test_artifact_hit_does_not_invoke_fallback_scanner(): void
+    {
+        $dirVersion = 'MBTI-CN-v-test';
+        $this->writePack($this->makePackDir($dirVersion), 'PACK_A', $dirVersion, 'v-test');
+
+        $store = app(ContentPacksIndexArtifactStore::class);
+        $store->write(app(ContentPacksIndex::class)->getIndex(true), $this->artifactPath);
+
+        $this->forgetIndexCache();
+        config()->set('content_packs.index_artifact_enabled', true);
+
+        $index = new ContentPacksIndex($store, new class extends \App\Services\Content\ContentPacksIndexFallbackScanner
+        {
+            public function scan(string $packsRootFs, string $driver, array $defaults): array
+            {
+                throw new \RuntimeException('fallback scanner should not run on artifact hit');
+            }
+        });
+
+        $fromArtifact = $index->getIndex(false);
+
+        $this->assertTrue((bool) ($fromArtifact['ok'] ?? false));
+        $this->assertSame('PACK_A', (string) ($fromArtifact['items'][0]['pack_id'] ?? ''));
+    }
+
     private function makePackDir(string $dirVersion): string
     {
         $packDir = $this->packsRoot.DIRECTORY_SEPARATOR.'default'

--- a/backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
@@ -88,6 +88,7 @@ final class ContentPacksIndexManifestConsistencyTest extends TestCase
 
         // mutate manifest/version to a new pack_id in the same dir_version
         $this->writePack($packDir, 'PACK_B', $dirVersion, 'v-test-2');
+        $this->touchPackFiles($packDir, time() + 2);
 
         $stale = $index->find('PACK_A', $dirVersion);
         $this->assertFalse((bool) ($stale['ok'] ?? false));
@@ -174,5 +175,14 @@ final class ContentPacksIndexManifestConsistencyTest extends TestCase
                 ],
             ], JSON_UNESCAPED_UNICODE)
         );
+    }
+
+    private function touchPackFiles(string $packDir, int $timestamp): void
+    {
+        foreach (['manifest.json', 'version.json', 'questions.json'] as $filename) {
+            touch($packDir.DIRECTORY_SEPARATOR.$filename, $timestamp);
+        }
+
+        clearstatcache(true);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-30T21:41:10Z",
+  "updated_at": "2026-05-30T22:22:42Z",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -32258,5 +32258,98 @@
     },
     "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01"
+  },
+  "CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01": {
+    "repo": "fap-api",
+    "branch": "fix/content-packs-index-responsibility-shrink-01",
+    "status": "pr_open",
+    "commit_sha": "c22422007167a4cc80b31adabe85320cc727d2d8",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1765",
+    "checks": {
+      "dependency": {
+        "status": "pass",
+        "evidence": "CONTENT-PACKS-INDEX-ARTIFACT-01 was merged as PR #1763 and origin/main contains merge commit 12a66f8c08949f430625d678b83e104fceda213c."
+      },
+      "content_packs_index_artifact": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi",
+        "evidence": "4 tests passed, 16 assertions."
+      },
+      "content_packs_index_manifest_consistency": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi",
+        "evidence": "3 tests passed, 12 assertions."
+      },
+      "bigfive_runtime_freeze_classifier": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi",
+        "evidence": "142 tests passed, 489 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "207 routes listed."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "3645 files checked."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')\"",
+        "evidence": "PR train state JSON and manifest YAML parsed."
+      },
+      "mbti_ci": {
+        "status": "pass",
+        "command": "cd backend && bash scripts/ci_verify_mbti.sh",
+        "evidence": "Full script exited 0 after Phase 3 ContentPacksIndex responsibility split."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "Whitespace check passed before staging."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-30T22:09:52Z",
+        "summary": "User confirmed PR id CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01, branch fix/content-packs-index-responsibility-shrink-01, and title for Phase 3."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-30T22:09:52Z",
+        "summary": "Started Phase 3 in an isolated worktree from origin/main because the primary fap-api worktree had unrelated analytics changes."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-30T22:20:46Z",
+        "summary": "Focused content pack tests, Big Five runtime freeze classifier, route list, Pint, Composer validate, JSON/YAML parse, git diff --check, and full ci_verify_mbti passed."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-30T22:22:42Z",
+        "summary": "Opened PR #1765 for CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [
+      "Primary fap-api worktree has unrelated analytics funnel changes; this task uses an isolated worktree from origin/main."
+    ],
+    "next_task": "Phase 4 content pack build/validate CI job decomposition requires explicit authorization"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16133,3 +16133,60 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization
+
+  - id: CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01
+    repo: fap-api
+    branch: fix/content-packs-index-responsibility-shrink-01
+    base: main
+    title: "CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01 shrink ContentPacksIndex to artifact loader and minimal fallback"
+    train_scope: content_packs_index_responsibility_shrink
+    risk_level: p1_ci_memory_and_runtime_hardening
+    depends_on:
+      - CONTENT-PACKS-INDEX-ARTIFACT-01 merged
+    allowed_paths:
+      - backend/app/Services/Content/ContentPacksIndex.php
+      - backend/app/Services/Content/ContentPacksIndexFallbackScanner.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Shrink ContentPacksIndex into artifact/cache orchestration, find(), and minimal freshness fallback behavior.
+      - Move streaming source-directory traversal and manifest/version/questions source validation into a dedicated fallback scanner.
+      - Keep artifact schema, public API contracts, getIndex/find return shape, and content package semantics backward-compatible.
+      - Preserve fallback scanning for missing, disabled, invalid, or stale artifacts.
+      - Do not refactor CI workflows; Phase 4 owns content pack build/validate job decomposition.
+    do_not:
+      - Change public API response contracts.
+      - Change content package source files or question/item semantics.
+      - Remove the fallback scan path.
+      - Enable artifact runtime use by default.
+      - Refactor MBTI, Big Five, report, attempt, scoring, or content pack publishing runtime beyond the exact ContentPacksIndex responsibility split.
+      - Modify fap-web, CMS, DB, migrations, Search Channel, URL submission, deploy, production env, or CI workflow files.
+    validation:
+      - cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi
+      - cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - cd backend && vendor/bin/pint --test
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && composer validate --strict
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: Phase 4 content pack build/validate CI job decomposition requires explicit authorization


### PR DESCRIPTION
## Summary

Phase 3 narrows `ContentPacksIndex` to artifact/cache orchestration, `find()`, and minimal freshness fallback behavior. Source-directory traversal plus manifest/version/questions validation now lives in `ContentPacksIndexFallbackScanner`.

## What changed

- Added `ContentPacksIndexFallbackScanner` for streaming source directory scan and source validation.
- Updated `ContentPacksIndex` to delegate fallback scans instead of owning the full scan/validation implementation.
- Kept artifact loading, short cache orchestration, `getIndex()` shape, and `find()` shape backward-compatible.
- Added a test proving an artifact hit does not invoke fallback scanner.
- Made stale manifest test deterministic by forcing file signature changes.
- Added the Phase 3 runtime freeze classifier allowlist and PR train manifest/state entry.

## Why

Phase 2 introduced the precompiled artifact path. This PR reduces long-term operational risk by separating the steady artifact/cache orchestration path from the heavier source-directory fallback scanner, without changing public contracts or CI workflows.

## Public contract decision

No public API contract changes. `ContentPacksIndex::getIndex()` and `ContentPacksIndex::find()` keep their existing response shape. Artifact runtime use remains controlled by existing config and is not enabled by default.

## Repository rule impact

Backend content packs remain backend-authoritative. This PR is an internal service responsibility split only; it does not add CMS, frontend, or public editorial fallback authority.

## Validation

- `cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi` — passed, 4 tests / 16 assertions
- `cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi` — passed, 3 tests / 12 assertions
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreview --no-ansi` — passed, 142 tests / 489 assertions
- `cd backend && bash scripts/ci_verify_mbti.sh` — passed
- `cd backend && vendor/bin/pint --test` — passed, 3645 files
- `cd backend && php artisan route:list --no-ansi` — passed, 207 routes
- `cd backend && composer validate --strict` — passed
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` — passed
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml')"` — passed
- `git diff --check` — passed
- `git diff --cached --check` — passed

## Intentionally deferred

- Phase 4: content pack build/validate dedicated CI job and MBTI/Big Five test consumption of artifact.
- No CI workflow refactor.
- No public API response changes.
- No content package source changes.
- No artifact runtime enablement by default.
- No fap-web changes.
- No deploy, Search Channel action, URL submission, CMS mutation, DB mutation, or migration.

## Residual risk

The fallback scanner still exists by design for missing, disabled, invalid, or stale artifacts. Phase 4 should decide how CI consumes the artifact and where build/validate ownership lives.
