### PR TITLE
PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation

### DIFF
--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -338,6 +338,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->exec(PHP_BINARY.' '.base_path('artisan').' storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
+        $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('commerce:repair-paid-orders --limit=50')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('commerce:repair-post-commit-failed --limit=50')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();

--- a/backend/docs/runbooks/alipay-pending-compensation.md
+++ b/backend/docs/runbooks/alipay-pending-compensation.md
@@ -1,0 +1,66 @@
+# Alipay Pending Payment Compensation
+
+## Purpose
+
+Alipay can confirm a payment while the local webhook path does not persist a
+payment event. In that case the order remains `created` or `pending`, and the
+existing paid-order repair scheduler cannot grant report access because the
+order has not transitioned to `paid`.
+
+The scheduled compensation job queries stale Alipay orders and only mutates an
+order when Alipay confirms a terminal paid state.
+
+## Scheduled Command
+
+```bash
+php artisan commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15
+```
+
+Runtime policy:
+
+- Runs every five minutes through Laravel scheduler.
+- Uses `withoutOverlapping`.
+- Includes stale `created` and `pending` Alipay orders.
+- Does not pass `--close-expired`, so it does not automatically close or expire
+  unpaid historical orders.
+- Keeps the query window conservative with `--limit=50`.
+
+## Manual Diagnosis
+
+Use dry-run before any targeted repair:
+
+```bash
+php artisan commerce:compensate-pending-orders --provider=alipay --order=<order_no> --dry-run --include-created --only-stale
+```
+
+Expected paid confirmation shape:
+
+```text
+queried_count=1
+paid_count=1
+failed_count=0
+unresolved_count=0
+unsupported_count=0
+```
+
+## Manual Targeted Repair
+
+Only after provider confirmation:
+
+```bash
+php artisan commerce:compensate-pending-orders --provider=alipay --order=<order_no> --include-created --only-stale
+```
+
+Then verify:
+
+- `orders.payment_state=paid`
+- `orders.grant_state=granted`
+- active `benefit_grants` row exists
+- `unified_access_projections.access_state=ready`
+- `exact_result_entry.ready_to_enter=true`
+
+## Non-Goals
+
+- Do not use this scheduler to submit URLs or trigger Search Channel.
+- Do not use this scheduler to mutate CMS/content.
+- Do not enable `--close-expired` without a separate risk review.

--- a/backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
+++ b/backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use App\Console\Kernel;
+use Illuminate\Console\Scheduling\Event;
+use Illuminate\Console\Scheduling\Schedule;
+use ReflectionMethod;
+use Tests\TestCase;
+
+final class AlipayPendingCompensationSchedulerTest extends TestCase
+{
+    public function test_alipay_pending_compensation_is_registered_conservatively(): void
+    {
+        $event = $this->scheduledEventFor('commerce:compensate-pending-orders');
+
+        $this->assertNotNull($event);
+        $this->assertStringContainsString('--provider=alipay', (string) $event->command);
+        $this->assertStringContainsString('--include-created', (string) $event->command);
+        $this->assertStringContainsString('--limit=50', (string) $event->command);
+        $this->assertStringContainsString('--older-than-minutes=15', (string) $event->command);
+        $this->assertStringNotContainsString('--close-expired', (string) $event->command);
+        $this->assertSame('*/5 * * * *', $event->expression);
+        $this->assertTrue($event->withoutOverlapping);
+    }
+
+    private function scheduledEventFor(string $needle): ?Event
+    {
+        $schedule = new Schedule;
+        $kernel = $this->app->make(Kernel::class);
+        $method = new ReflectionMethod($kernel, 'schedule');
+        $method->setAccessible(true);
+        $method->invoke($kernel, $schedule);
+
+        foreach ($schedule->events() as $event) {
+            if (str_contains((string) $event->command, $needle)) {
+                return $event;
+            }
+        }
+
+        return null;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1337,6 +1337,18 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_alipay_pending_compensation_scheduler_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Kernel.php',
+        ];
+        $kernelChangedLines = [
+            "+        \$schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15')->everyFiveMinutes()->withoutOverlapping();",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_privacy_logs_dsar_key_rotation_changes(): void
     {
         $changed = [
@@ -2933,6 +2945,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsArticleEditorialPackageDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -4463,6 +4476,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleCoverPropagationSmoke\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsAlipayPendingCompensationSchedulerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/commerce:compensate-pending-orders|--provider=alipay|--include-created|--limit=50|--older-than-minutes=15|everyFiveMinutes|withoutOverlapping/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32613,5 +32613,108 @@
       "Primary fap-api worktree has unrelated dirty files; PR-POL-01 is implemented in an isolated worktree from origin/main."
     ],
     "next_task": "post-merge cleanup only after PR-POL-01 merge"
+  },
+  "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01": {
+    "id": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01",
+    "repo": "fap-api",
+    "branch": "codex/payment-alipay-pending-compensation-scheduler-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "title": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 to fap-api pr-train manifest/state."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to scheduler registration, focused scheduler test, optional runbook, and pr-train metadata; no production env, CMS/content, deploy, Search Channel, URL submission, or fap-web changes."
+      },
+      "scheduler_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi",
+        "evidence": "PASS: 1 test, 8 assertions."
+      },
+      "pending_compensation_command_regression": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=CommercePendingCompensationCommand --no-ansi",
+        "evidence": "PASS: 1 test, 6 assertions."
+      },
+      "pending_lifecycle_regression": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi",
+        "evidence": "PASS: 2 tests, 15 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS: 207 routes listed."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "PASS: 3645 files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS: composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS: no security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+        "evidence": "PASS: JSON and YAML parsed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check",
+        "evidence": "PASS before staging; cached diff empty at check time."
+      },
+      "fap_web_reference_status": {
+        "status": "pass",
+        "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
+        "evidence": "PASS: no fap-web changes reported."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-30T22:19:28Z",
+        "summary": "User authorized manifest/state update for PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-30T22:19:28Z",
+        "summary": "Started scoped backend PR to schedule conservative Alipay pending payment compensation."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-30T22:24:10Z",
+        "summary": "Scheduler focused test, compensation regressions, route list, Pint, Composer validate/audit, JSON/YAML parse, fap-web reference status, and diff checks passed."
+      },
+      {
+        "status": "scope_validated",
+        "at": "2026-05-30T22:24:55Z",
+        "summary": "Path-limited staging includes only Kernel scheduler, Alipay scheduler test, runbook, and pr-train metadata."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [],
+    "next_task": "deploy-readiness required after merge"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32619,7 +32619,7 @@
     "repo": "fap-api",
     "branch": "codex/payment-alipay-pending-compensation-scheduler-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "github_checks_failed_fix_prepared",
     "title": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation",
     "commit_sha": "d265ad35424f51c7f7d9a62a0a7cd701368276ad",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1766",
@@ -32681,6 +32681,21 @@
         "status": "pass",
         "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
         "evidence": "PASS: no fap-web changes reported."
+      },
+      "github_checks_failure_inspection": {
+        "status": "fail_inspected",
+        "command": "gh run view 26696608778 --log-failed",
+        "evidence": "verify-mbti-legacy and verify-mbti-v2 failed because BigFiveResultPageV2CoreBodyPreviewTest classified backend/app/Console/Kernel.php as MBTI-impacting runtime change."
+      },
+      "mbti_runtime_freeze_retry": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi",
+        "evidence": "PASS: 143 tests, 495 assertions after adding the Alipay scheduler-only Kernel classifier exemption."
+      },
+      "scheduler_test_retry": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi",
+        "evidence": "PASS: 1 test, 8 assertions."
       }
     },
     "failure_reason": null,
@@ -32712,6 +32727,16 @@
         "status": "pr_open",
         "at": "2026-05-30T22:28:37Z",
         "summary": "Opened PR #1766 for PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01."
+      },
+      {
+        "status": "github_checks_failed",
+        "at": "2026-05-30T22:32:30Z",
+        "summary": "GitHub verify-mbti-legacy and verify-mbti-v2 failed on BigFiveResultPageV2CoreBodyPreviewTest because the scheduler-only Kernel change is not yet exempted by the runtime-freeze classifier."
+      },
+      {
+        "status": "github_checks_failed_fix_prepared",
+        "at": "2026-05-30T22:45:00Z",
+        "summary": "User authorized adding BigFiveResultPageV2CoreBodyPreviewTest to current PR scope; local runtime-freeze retry and scheduler focused test passed."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32619,10 +32619,10 @@
     "repo": "fap-api",
     "branch": "codex/payment-alipay-pending-compensation-scheduler-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "title": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d265ad35424f51c7f7d9a62a0a7cd701368276ad",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1766",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -32707,6 +32707,11 @@
         "status": "scope_validated",
         "at": "2026-05-30T22:24:55Z",
         "summary": "Path-limited staging includes only Kernel scheduler, Alipay scheduler test, runbook, and pr-train metadata."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-30T22:28:37Z",
+        "summary": "Opened PR #1766 for PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16304,3 +16304,210 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: post-merge cleanup only after PR-POL-01 merge
+
+  - id: PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01
+    repo: fap-api
+    branch: codex/payment-alipay-pending-compensation-scheduler-01
+    base: main
+    title: "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01 schedule Alipay pending payment compensation"
+    train_scope: payment_alipay_pending_compensation_scheduler
+    risk_level: p1_payment_fulfillment_reliability
+    allowed_paths:
+      - backend/app/Console/Kernel.php
+      - backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
+      - backend/docs/runbooks/alipay-pending-compensation.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Register the existing Alipay pending-order compensation command in Laravel scheduler with a conservative stale window and batch limit.
+      - Query stale Alipay created/pending orders and transition only provider-confirmed paid orders into the existing paid/order repair chain.
+      - Keep expiration/close behavior disabled; do not add --close-expired in this PR.
+      - Add focused scheduler registration coverage and an operations runbook for dry-run and targeted repair.
+      - Do not mutate production env, deploy, mutate CMS/content, submit URLs, enqueue Search Channel actions, or modify fap-web in this PR.
+    validation:
+      - cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi
+      - cd backend && php artisan test --filter=CommercePendingCompensationCommand --no-ansi
+      - cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: deploy-readiness required after merge
+
+  - id: ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
+    repo: fap-api
+    branch: codex/analytics-funnel-event-taxonomy-01
+    base: main
+    title: "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy"
+    train_scope: analytics_funnel_event_taxonomy
+    risk_level: p1_analytics_funnel_observability
+    depends_on: []
+    allowed_paths:
+      - backend/app/Services/Analytics/FunnelEventTaxonomy.php
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/docs/seo/analytics-funnel-event-taxonomy-01.md
+      - backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelEventTaxonomy01Test.php
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Define the canonical analytics funnel event taxonomy and backward-compatible aliases.
+      - Add backend alias normalization for analytics_funnel_daily result view and PDF stages.
+      - Preserve backend fact sources for attempt start, submit, order, payment, report unlock, report ready, share generation, and share click.
+      - Document that checkout_start, order_created, payment_success, and report_unlock are separate stages.
+      - Do not configure GA key events, run production analytics refresh, deploy, mutate CMS/DB, submit URLs, or touch Search Channel.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelEventTaxonomy01 --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-event-taxonomy-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation
+
+  - id: ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01
+    repo: fap-api
+    branch: codex/analytics-funnel-ops-read-model-repair-01
+    base: main
+    title: "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01 connect Ops 7-day funnel to unified taxonomy read model"
+    train_scope: analytics_funnel_ops_read_model_repair
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
+    allowed_paths:
+      - backend/app/Filament/Ops/Widgets/FunnelWidget.php
+      - backend/app/Filament/Ops/Pages/FunnelConversionPage.php
+      - backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
+      - backend/docs/seo/analytics-funnel-ops-read-model-repair-01.md
+      - backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json
+      - backend/tests/Feature/Ops/FunnelWidgetTest.php
+      - backend/tests/Feature/Ops/FunnelConversionPageTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Make the Ops dashboard 7-day FunnelWidget read analytics_funnel_daily as the read model truth.
+      - Stop presenting v_funnel_daily or raw events as the primary Ops 7-day funnel authority.
+      - Display canonical taxonomy stage labels for the supported analytics_funnel_daily columns.
+      - Update the /ops/funnel-conversion display labels from legacy stage names to canonical taxonomy names.
+      - Document that production refresh, DB writes, migrations, scheduler changes, GA/Baidu settings, Search Channel actions, URL submissions, and fap-web changes were not performed.
+    validation:
+      - cd backend && php artisan test --filter=FunnelWidget --no-ansi
+      - cd backend && php artisan test --filter=FunnelConversionPage --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_analytics_funnel_ops_read_model_changes --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-read-model-repair-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01
+
+  - id: CONTENT-PACKS-INDEX-ARTIFACT-01
+    repo: fap-api
+    branch: fix/content-packs-index-artifact-01
+    base: main
+    title: "CONTENT-PACKS-INDEX-ARTIFACT-01 precompile content pack index artifact"
+    train_scope: content_packs_index_artifact
+    risk_level: p1_ci_memory_and_runtime_hardening
+    depends_on:
+      - PR #1753 merged
+    allowed_paths:
+      - backend/app/Services/Content/ContentPacksIndex.php
+      - backend/app/Services/Content/ContentPacksIndexArtifactStore.php
+      - backend/app/Console/Commands/ContentPacksIndexBuild.php
+      - backend/config/content_packs.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexManifestConsistencyTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a precompiled content pack index artifact path for tests and internal services.
+      - Keep public API contracts and ContentPacksIndex find/getIndex return shape backward-compatible.
+      - Prefer artifact reads only when explicitly enabled by config; keep streaming directory scan as fallback.
+      - Add focused tests proving artifact/source consistency and stale artifact fallback.
+      - Do not refactor CI workflows; Phase 4 owns CI job decomposition.
+    do_not:
+      - Change public API response contracts.
+      - Change content package source files or question/item semantics.
+      - Remove the ContentPacksIndex streaming fallback path.
+      - Refactor MBTI, Big Five, report, attempt, scoring, or content pack publishing runtime.
+      - Modify fap-web, CMS, DB, migrations, Search Channel, URL submission, deploy, or production env.
+    validation:
+      - cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi
+      - cd backend && php artisan test --filter=ContentPacksIndexManifestConsistency --no-ansi
+      - cd backend && bash scripts/ci_verify_mbti.sh
+      - cd backend && vendor/bin/pint --test
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && composer validate --strict
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization


### PR DESCRIPTION
## What changed
- Registered `commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15` in Laravel scheduler every five minutes with `withoutOverlapping()`.
- Added focused scheduler coverage asserting provider scope, stale window, batch limit, no `--close-expired`, five-minute cadence, and overlap protection.
- Added an Alipay pending compensation runbook for dry-run, targeted repair, and post-repair verification.
- Registered `PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01` in the PR train manifest/state.

## Why
A production Alipay payment was confirmed paid by provider query while the local order stayed `pending`, so the existing `commerce:repair-paid-orders` scheduler could not grant access. This schedules the existing provider-confirmed pending compensation path without adding automatic close/expire behavior.

## Validation
- `cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi`
- `cd backend && php artisan test --filter=CommercePendingCompensationCommand --no-ansi`
- `cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`
- `cd /Users/rainie/Desktop/GitHub/fap-web && git status --short`

## Intentionally deferred
- No production deploy in this PR.
- No production env changes.
- No payment close/expire scheduling.
- No broad historical backlog batch execution.
- No Search Channel, URL submission, CMS/content, or fap-web changes.

## Repository rule impact
Payment fulfillment remains backend-authoritative. This PR only schedules an existing backend compensation command and documents the operational runbook; it does not move authority to frontend or CMS fallback logic.
