### PR TITLE
PR-POL-01A: Add English policies content authority

### DIFF
--- a/backend/docs/seo/en-parity-03-content-pages-parity-import-package.md
+++ b/backend/docs/seo/en-parity-03-content-pages-parity-import-package.md
@@ -39,12 +39,9 @@ The importer remains operator-run. No production import is executed.
 The following Chinese baseline pages have no English content page counterpart in the current repository baseline and are deferred to human-reviewed draft/import work:
 
 - `brand`
-- `careers`
 - `charter`
-- `foundation`
-- `policies`
 
-The package intentionally does not invent body copy for these pages.
+The package intentionally does not invent body copy for these pages. English `foundation`, `careers`, and `policies` now have repo-backed baseline authority and are no longer treated as deferred missing counterparts by this package.
 
 ## Validation
 
@@ -66,7 +63,7 @@ git diff --check
 
 ## Deferred Items
 
-- Human-reviewed English copy for `brand`, `careers`, `charter`, `foundation`, and `policies`.
+- Human-reviewed English copy for `brand` and `charter`.
 - Production CMS import or publish approval.
 - fap-web runtime restoration for hard/soft 404 pages.
 - Sitemap, llms, JSON-LD, and FAQ parity gates remain EN-PARITY-07.

--- a/backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json
+++ b/backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json
@@ -45,13 +45,15 @@
     "english_copy_creation_mode": "import_package_metadata_only"
   },
   "current_baseline_summary": {
-    "content_pages_en_count": 4,
+    "content_pages_en_count": 7,
     "content_pages_zh_count": 9,
     "help_pages_en_count": 6,
     "help_pages_zh_count": 6,
-    "total_rows": 25,
+    "total_rows": 28,
     "existing_authority_pairs": [
       "about",
+      "careers",
+      "foundation",
       "help-about",
       "help-contact",
       "help-faq",
@@ -59,15 +61,13 @@
       "help-team",
       "help-used-and-mentioned",
       "method-boundaries",
+      "policies",
       "privacy",
       "terms"
     ],
     "missing_english_counterparts": [
       "brand",
-      "careers",
-      "charter",
-      "foundation",
-      "policies"
+      "charter"
     ],
     "missing_chinese_counterparts": []
   },
@@ -87,41 +87,8 @@
       "entity_type": "content_page",
       "source_locale": "zh-CN",
       "target_locale": "en",
-      "source_slug": "careers",
-      "translation_group_id": "content-page-careers",
-      "target_publication_state": "draft_import_candidate",
-      "body_status": "requires_human_translation",
-      "sitemap_llms_exposure_allowed": false,
-      "claim_boundary_required": true
-    },
-    {
-      "entity_type": "content_page",
-      "source_locale": "zh-CN",
-      "target_locale": "en",
       "source_slug": "charter",
       "translation_group_id": "content-page-charter",
-      "target_publication_state": "draft_import_candidate",
-      "body_status": "requires_human_translation",
-      "sitemap_llms_exposure_allowed": false,
-      "claim_boundary_required": true
-    },
-    {
-      "entity_type": "content_page",
-      "source_locale": "zh-CN",
-      "target_locale": "en",
-      "source_slug": "foundation",
-      "translation_group_id": "content-page-foundation",
-      "target_publication_state": "draft_import_candidate",
-      "body_status": "requires_human_translation",
-      "sitemap_llms_exposure_allowed": false,
-      "claim_boundary_required": true
-    },
-    {
-      "entity_type": "content_page",
-      "source_locale": "zh-CN",
-      "target_locale": "en",
-      "source_slug": "policies",
-      "translation_group_id": "content-page-policies",
       "target_publication_state": "draft_import_candidate",
       "body_status": "requires_human_translation",
       "sitemap_llms_exposure_allowed": false,

--- a/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+++ b/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
@@ -25,11 +25,11 @@ final class ContentPagePublicApiTest extends TestCase
             '--source-dir' => '../content_baselines/content_pages',
         ])
             ->expectsOutputToContain('files_found=4')
-            ->expectsOutputToContain('pages_found=27')
-            ->expectsOutputToContain('will_create=27')
+            ->expectsOutputToContain('pages_found=28')
+            ->expectsOutputToContain('will_create=28')
             ->assertExitCode(0);
 
-        $this->assertSame(27, ContentPage::query()->withoutGlobalScopes()->count());
+        $this->assertSame(28, ContentPage::query()->withoutGlobalScopes()->count());
 
         $about = ContentPage::query()
             ->withoutGlobalScopes()

--- a/backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
+++ b/backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php
@@ -39,13 +39,10 @@ final class EnParity03ContentPagesParityImportPackageTest extends TestCase
         $this->assertFalse((bool) data_get($payload, 'content_generation_policy.mass_english_generation_allowed'));
         $this->assertFalse((bool) data_get($payload, 'content_generation_policy.draft_exposure_allowed_in_sitemap_llms'));
 
-        $this->assertSame(25, data_get($payload, 'current_baseline_summary.total_rows'));
+        $this->assertSame(28, data_get($payload, 'current_baseline_summary.total_rows'));
         $this->assertSame([
             'brand',
-            'careers',
             'charter',
-            'foundation',
-            'policies',
         ], data_get($payload, 'current_baseline_summary.missing_english_counterparts'));
 
         foreach ($payload['deferred_import_candidates'] ?? [] as $candidate) {
@@ -111,7 +108,6 @@ final class EnParity03ContentPagesParityImportPackageTest extends TestCase
         $this->assertSame([
             'content-page-brand',
             'content-page-charter',
-            'content-page-policies',
         ], $missing);
         $this->assertFalse((bool) ($matrix['frontend_fallback_authority_used'] ?? true));
         $this->assertFalse((bool) ($matrix['summary']['counterpart_lookup_uses_slug_guessing_only'] ?? true));
@@ -137,10 +133,10 @@ final class EnParity03ContentPagesParityImportPackageTest extends TestCase
         $this->assertContains('https://fermatmind.com/zh/brand', $locs);
         $this->assertContains('https://fermatmind.com/en/about', $locs);
         $this->assertContains('https://fermatmind.com/en/careers', $locs);
+        $this->assertContains('https://fermatmind.com/en/policies', $locs);
         $this->assertNotContains('https://fermatmind.com/en/brand', $locs);
         $this->assertNotContains('https://fermatmind.com/en/charter', $locs);
         $this->assertNotContains('https://fermatmind.com/en/foundation', $locs);
-        $this->assertNotContains('https://fermatmind.com/en/policies', $locs);
     }
 
     private function mockScaleRegistry(): ScaleRegistry

--- a/content_baselines/content_pages/content_pages.en.json
+++ b/content_baselines/content_pages/content_pages.en.json
@@ -134,6 +134,31 @@
     "contentHtml": ""
   },
   {
+    "slug": "policies",
+    "path": "/policies",
+    "kind": "policy",
+    "title": "Policy Overview",
+    "kicker": "Policy",
+    "summary": "A repo-backed overview of FermatMind policy, privacy, assessment boundary, and support resources.",
+    "template": "policy",
+    "animationProfile": "policy",
+    "locale": "en",
+    "publishedAt": "2026-04-21",
+    "updatedAt": "2026-05-31",
+    "effectiveAt": "2026-04-21",
+    "sourceDoc": "content_pages.en.policies_authority.baseline",
+    "isPublic": true,
+    "isIndexable": true,
+    "headings": [
+      "Policy scope",
+      "Related policy pages",
+      "Assessment and result boundaries",
+      "Support"
+    ],
+    "contentMd": "## Policy scope\n\nThis page provides a repo-backed overview for FermatMind policy resources. It points users to the full policy pages that govern privacy, terms of use, assessment boundaries, and support.\n\n## Related policy pages\n\n- [Privacy Policy](/en/privacy)\n- [Terms of Use](/en/terms)\n- [Assessment Method and Boundaries](/en/method-boundaries)\n\n## Assessment and result boundaries\n\nFermatMind assessment results are structured self-understanding and decision-support materials. They should not be treated as a sole authority for high-impact decisions.\n\n## Support\n\nFor questions about policy pages, reports, orders, or support requests, use the support resources published on FermatMind.",
+    "contentHtml": ""
+  },
+  {
     "slug": "method-boundaries",
     "path": "/method-boundaries",
     "kind": "policy",


### PR DESCRIPTION
## Summary
- Adds a minimal repo-backed `/en/policies` content baseline record so PR-POL-01 can safely update existing English policies authority in a follow-up content-only PR.
- Updates focused content-page and EN parity expectations from `policies` missing to `policies` authority-backed.
- Updates the EN-PARITY-03 generated/report artifact to leave only `brand` and `charter` as missing English content-page counterparts.

## Scope
- fap-api content authority only.
- No fap-web change.
- No route change.
- No schema change.
- No sitemap or llms policy change.
- No CMS/DB mutation, migration, deploy, cache clear, Search Channel, or URL submission.

## Files changed
- `content_baselines/content_pages/content_pages.en.json`
- `backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php`
- `backend/tests/Feature/SeoIntel/EnParity03ContentPagesParityImportPackageTest.php`
- `backend/docs/seo/en-parity-03-content-pages-parity-import-package.md`
- `backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json`

## Authority note
This PR intentionally does not use the uploaded PR-POL-01 v2 dashboard Markdown body. It only creates the missing `/en/policies` repo-backed authority record required before PR-POL-01 can replace both `/zh/policies` and `/en/policies` content from v2 assets.

## Validation
- `php artisan test --filter=EnParity03ContentPagesParityImportPackageTest --no-ansi`: exit code 0, 4 PHPUnit warnings from existing fixture/file-access behavior.
- `php artisan test --filter=ContentPagePublicApiTest --no-ansi`: exit code 0, 3 PHPUnit warnings from existing fixture/file-access behavior.
- `composer validate --strict`: passed.
- `python3 -m json.tool content_baselines/content_pages/content_pages.en.json >/dev/null`: passed.
- `python3 -m json.tool backend/docs/seo/generated/en-parity-03-content-pages-parity-import-package.v1.json >/dev/null`: passed.
- `git diff --check`: passed.
- New `/en/policies` record forbidden scan: no matches.

## Next step after merge
After this PR merges, rerun PR-POL-01 dashboard content implementation from uploaded v2 assets against existing `/zh/policies` and `/en/policies` records.
