### PR TITLE
CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01 split content pack artifact validation from MBTI and Big Five CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,11 +64,106 @@ jobs:
         working-directory: backend
         run: composer audit --locked --no-interaction --ignore-unreachable
 
+  content-pack-build-validate:
+    name: content-pack-build-validate
+    needs:
+      - hygiene
+      - supply-chain
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    env:
+      APP_ENV: testing
+      FAP_PACKS_DRIVER: local
+      FAP_PACKS_ROOT: ${{ github.workspace }}/content_packages
+      FAP_DEFAULT_REGION: CN_MAINLAND
+      FAP_DEFAULT_LOCALE: zh-CN
+      FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.3
+      FAP_DEFAULT_DIR_VERSION: MBTI-CN-v0.3
+      CONTENT_PACKS_INDEX_ARTIFACT_PATH: storage/app/private/content_packs_index/content-packs-index.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+          extensions: >
+            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3, pdo_mysql, redis
+
+      - name: Cache Composer
+        uses: actions/cache@v5
+        with:
+          path: |
+            backend/vendor
+            ~/.composer/cache/files
+          key: ${{ runner.os }}-php84-${{ hashFiles('backend/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php84-
+
+      - name: Prepare Laravel cache dirs
+        working-directory: backend
+        run: |
+          mkdir -p storage/framework/cache/data
+          mkdir -p storage/framework/views
+          mkdir -p storage/framework/sessions
+          mkdir -p storage/logs
+          mkdir -p storage/app/private/content_packs_index
+          mkdir -p storage/app/private/packs_v2_materialized
+          mkdir -p bootstrap/cache
+          chmod -R ug+rwX storage bootstrap/cache || true
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Ensure Laravel app key
+        working-directory: backend
+        run: |
+          if [ ! -f .env ]; then cp .env.example .env; fi
+          php artisan key:generate --force
+
+      - name: Build content packs index artifact
+        working-directory: backend
+        run: php artisan content-packs:index:build --output="$CONTENT_PACKS_INDEX_ARTIFACT_PATH" --json
+
+      - name: Validate content packs index artifact
+        working-directory: backend
+        run: |
+          php -r '
+          $path = getenv("CONTENT_PACKS_INDEX_ARTIFACT_PATH") ?: "storage/app/private/content_packs_index/content-packs-index.json";
+          $json = json_decode((string) file_get_contents($path), true);
+          if (! is_array($json)) { fwrite(STDERR, "artifact json invalid\n"); exit(1); }
+          if (($json["schema_version"] ?? "") !== "content_packs_index.artifact.v1") { fwrite(STDERR, "artifact schema invalid\n"); exit(1); }
+          if ((int) ($json["summary"]["item_count"] ?? 0) < 1) { fwrite(STDERR, "artifact item_count invalid\n"); exit(1); }
+          foreach (($json["items"] ?? []) as $item) {
+              foreach (["manifest_sha256", "version_sha256", "questions_sha256"] as $key) {
+                  if (! is_string($item[$key] ?? null) || ! preg_match("/^[a-f0-9]{64}$/", $item[$key])) {
+                      fwrite(STDERR, "artifact hash missing: {$key}\n");
+                      exit(1);
+                  }
+              }
+          }
+          echo "artifact ok items=".(int) ($json["summary"]["item_count"] ?? 0).PHP_EOL;
+          '
+          php artisan test --filter=ContentPacksIndexArtifact --no-ansi
+
+      - name: Upload content packs index artifact
+        uses: actions/upload-artifact@v7
+        with:
+          name: content-packs-index
+          path: backend/storage/app/private/content_packs_index/content-packs-index.json
+          if-no-files-found: error
+          retention-days: 1
+
   verify-mbti:
     name: verify-mbti-${{ matrix.mode }}
     needs:
       - hygiene
       - supply-chain
+      - content-pack-build-validate
     runs-on: ubuntu-latest
     timeout-minutes: 25
     strategy:
@@ -91,7 +186,9 @@ jobs:
       FEATURE_LEGACY_MBTI_REPORT_PAYLOAD_V2: ${{ matrix.FEATURE_LEGACY_MBTI_REPORT_PAYLOAD_V2 }}
       FEATURE_PAYMENT_WEBHOOK_V2: ${{ matrix.FEATURE_PAYMENT_WEBHOOK_V2 }}
       FEATURE_CONTENT_STORE_V2: ${{ matrix.FEATURE_CONTENT_STORE_V2 }}
-      RUN_BIG5_OCEAN_GATE: "1"
+      RUN_BIG5_OCEAN_GATE: "0"
+      CONTENT_PACKS_INDEX_ARTIFACT_ENABLED: "true"
+      CONTENT_PACKS_INDEX_ARTIFACT_PATH: storage/app/private/content_packs_index/content-packs-index.json
 
     steps:
       - name: Checkout
@@ -128,6 +225,7 @@ jobs:
           mkdir -p storage/framework/views
           mkdir -p storage/framework/sessions
           mkdir -p storage/logs
+          mkdir -p storage/app/private/content_packs_index
           mkdir -p storage/app/private/packs_v2_materialized
           mkdir -p bootstrap/cache
           chmod -R ug+rwX storage bootstrap/cache || true
@@ -135,6 +233,18 @@ jobs:
       - name: Install backend dependencies
         working-directory: backend
         run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Ensure Laravel app key
+        working-directory: backend
+        run: |
+          if [ ! -f .env ]; then cp .env.example .env; fi
+          php artisan key:generate --force
+
+      - name: Download content packs index artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: content-packs-index
+          path: backend/storage/app/private/content_packs_index
 
       - name: Run ci_verify_mbti
         run: bash ./backend/scripts/ci_verify_mbti.sh
@@ -147,3 +257,117 @@ jobs:
           path: backend/artifacts/verify_mbti
           if-no-files-found: ignore
           retention-days: 7
+
+  verify-bigfive:
+    name: verify-bigfive
+    needs:
+      - hygiene
+      - supply-chain
+      - content-pack-build-validate
+    runs-on: ubuntu-latest
+    timeout-minutes: 25
+    env:
+      APP_ENV: testing
+      DB_CONNECTION: sqlite
+      DB_DATABASE: /tmp/fap-ci-bigfive.sqlite
+      QUEUE_CONNECTION: sync
+      FAP_PACKS_DRIVER: local
+      FAP_PACKS_ROOT: ${{ github.workspace }}/content_packages
+      FAP_DEFAULT_REGION: CN_MAINLAND
+      FAP_DEFAULT_LOCALE: zh-CN
+      FAP_DEFAULT_PACK_ID: MBTI.cn-mainland.zh-CN.v0.3
+      FAP_DEFAULT_DIR_VERSION: MBTI-CN-v0.3
+      CONTENT_LOADER_CACHE_STORE: array
+      MBTI_RESPONSE_CACHE_STORE: array
+      CONTENT_PACKS_INDEX_ARTIFACT_ENABLED: "true"
+      CONTENT_PACKS_INDEX_ARTIFACT_PATH: storage/app/private/content_packs_index/content-packs-index.json
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: '8.4'
+          coverage: none
+          tools: composer:v2
+          extensions: >
+            mbstring, intl, curl, json, openssl, fileinfo, pdo, pdo_sqlite, sqlite3, pdo_mysql, redis
+
+      - name: Cache Composer
+        uses: actions/cache@v5
+        with:
+          path: |
+            backend/vendor
+            ~/.composer/cache/files
+          key: ${{ runner.os }}-php84-${{ hashFiles('backend/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php84-
+
+      - name: Prepare Laravel cache dirs
+        working-directory: backend
+        run: |
+          mkdir -p storage/framework/cache/data
+          mkdir -p storage/framework/views
+          mkdir -p storage/framework/sessions
+          mkdir -p storage/logs
+          mkdir -p storage/app/private/content_packs_index
+          mkdir -p storage/app/private/packs_v2_materialized
+          mkdir -p bootstrap/cache
+          chmod -R ug+rwX storage bootstrap/cache || true
+
+      - name: Install backend dependencies
+        working-directory: backend
+        run: composer install --no-interaction --prefer-dist --no-progress
+
+      - name: Ensure Laravel app key
+        working-directory: backend
+        run: |
+          if [ ! -f .env ]; then cp .env.example .env; fi
+          php artisan key:generate --force
+
+      - name: Download content packs index artifact
+        uses: actions/download-artifact@v7
+        with:
+          name: content-packs-index
+          path: backend/storage/app/private/content_packs_index
+
+      - name: Verify content packs index artifact is consumable
+        working-directory: backend
+        run: |
+          php -r '
+          require "vendor/autoload.php";
+          $app = require "bootstrap/app.php";
+          $app->make(Illuminate\Contracts\Console\Kernel::class)->bootstrap();
+          $driver = (string) config("content_packs.driver", "local");
+          $driver = $driver === "s3" ? "s3" : "local";
+          $root = $driver === "s3" ? (string) config("content_packs.cache_dir", "") : (string) config("content_packs.root", "");
+          $defaults = [
+              "default_pack_id" => (string) config("content_packs.default_pack_id", ""),
+              "default_dir_version" => (string) config("content_packs.default_dir_version", ""),
+              "default_region" => (string) config("content_packs.default_region", ""),
+              "default_locale" => (string) config("content_packs.default_locale", ""),
+              "region_fallbacks" => (array) config("content_packs.region_fallbacks", []),
+              "locale_fallback" => (bool) config("content_packs.locale_fallback", false),
+          ];
+          $artifact = app(App\Services\Content\ContentPacksIndexArtifactStore::class)->readConfigured($root, $driver, $defaults);
+          if (! is_array($artifact) || ! (bool) ($artifact["ok"] ?? false) || count((array) ($artifact["items"] ?? [])) < 1) {
+              fwrite(STDERR, "content packs index artifact is not consumable\n");
+              exit(1);
+          }
+          echo "artifact consumer ok items=".count((array) ($artifact["items"] ?? [])).PHP_EOL;
+          '
+
+      - name: Prepare sqlite baseline
+        working-directory: backend
+        run: |
+          bash scripts/ci/prepare_sqlite.sh
+          php artisan fap:schema:verify
+
+      - name: Run Big Five content and business gates
+        working-directory: backend
+        run: |
+          bash scripts/ci/verify_big5_norms.sh
+          php artisan content:lint --pack=BIG5_OCEAN --pack-version=v1
+          php artisan content:compile --pack=BIG5_OCEAN --pack-version=v1
+          php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi

--- a/backend/app/Services/Content/ContentPacksIndexArtifactStore.php
+++ b/backend/app/Services/Content/ContentPacksIndexArtifactStore.php
@@ -116,6 +116,12 @@ final class ContentPacksIndexArtifactStore
             foreach (['manifest_path', 'questions_path', 'version_path'] as $pathKey) {
                 $artifactItem[$pathKey] = $this->artifactPathValue($packsRoot, (string) ($item[$pathKey] ?? ''));
             }
+            foreach (['manifest', 'questions', 'version'] as $prefix) {
+                $hash = $this->fileHash((string) ($item[$prefix.'_path'] ?? ''));
+                if ($hash !== null) {
+                    $artifactItem[$prefix.'_sha256'] = $hash;
+                }
+            }
 
             $items[] = $artifactItem;
         }
@@ -178,6 +184,7 @@ final class ContentPacksIndexArtifactStore
 
                 return null;
             }
+            unset($hydrated['manifest_sha256'], $hydrated['questions_sha256'], $hydrated['version_sha256']);
 
             $items[] = $hydrated;
         }
@@ -206,10 +213,21 @@ final class ContentPacksIndexArtifactStore
             if ($signature === null) {
                 return false;
             }
-            if ((int) ($item[$prefix.'_mtime'] ?? -1) !== (int) ($signature['mtime'] ?? -2)) {
+            if ((int) ($item[$prefix.'_size'] ?? -1) !== (int) ($signature['size'] ?? -2)) {
                 return false;
             }
-            if ((int) ($item[$prefix.'_size'] ?? -1) !== (int) ($signature['size'] ?? -2)) {
+
+            $expectedHash = trim((string) ($item[$prefix.'_sha256'] ?? ''));
+            if ($expectedHash !== '') {
+                $actualHash = $this->fileHash($path);
+                if ($actualHash === null || ! hash_equals($expectedHash, $actualHash)) {
+                    return false;
+                }
+
+                continue;
+            }
+
+            if ((int) ($item[$prefix.'_mtime'] ?? -1) !== (int) ($signature['mtime'] ?? -2)) {
                 return false;
             }
         }
@@ -296,6 +314,21 @@ final class ContentPacksIndexArtifactStore
             'mtime' => (int) $mtimeRaw,
             'size' => (int) $sizeRaw,
         ];
+    }
+
+    private function fileHash(string $path): ?string
+    {
+        if ($path === '' || ! File::isFile($path)) {
+            return null;
+        }
+
+        try {
+            $hash = hash_file('sha256', $path);
+        } catch (\Throwable $e) {
+            return null;
+        }
+
+        return is_string($hash) && $hash !== '' ? $hash : null;
     }
 
     private function warn(string $event, array $context): void

--- a/backend/scripts/ci_verify_mbti.sh
+++ b/backend/scripts/ci_verify_mbti.sh
@@ -30,6 +30,8 @@ export FAP_PACKS_DRIVER=local
 export FAP_PACKS_ROOT="${REPO_DIR}/content_packages"
 export FAP_PACKS_CACHE_DIR="${FAP_PACKS_CACHE_DIR:-storage/app/private/content_packs_cache}"
 export FAP_S3_PREFIX="${FAP_S3_PREFIX:-content_packages/}"
+export CONTENT_PACKS_INDEX_ARTIFACT_ENABLED="${CONTENT_PACKS_INDEX_ARTIFACT_ENABLED:-false}"
+export CONTENT_PACKS_INDEX_ARTIFACT_PATH="${CONTENT_PACKS_INDEX_ARTIFACT_PATH:-storage/app/private/content_packs_index/content-packs-index.json}"
 
 # MBTI defaults (avoid resolver picking default)
 export FAP_DEFAULT_REGION=CN_MAINLAND
@@ -56,6 +58,56 @@ if [[ ! -f ".env" ]]; then
   ENV_CREATED=1
 fi
 php artisan key:generate --force >/dev/null 2>&1 || true
+
+if [[ "$CONTENT_PACKS_INDEX_ARTIFACT_ENABLED" == "true" || "$CONTENT_PACKS_INDEX_ARTIFACT_ENABLED" == "1" ]]; then
+  ARTIFACT_PATH="$CONTENT_PACKS_INDEX_ARTIFACT_PATH"
+  if [[ "$ARTIFACT_PATH" != /* ]]; then
+    ARTIFACT_PATH="$BACKEND_DIR/$ARTIFACT_PATH"
+  fi
+
+  if [[ ! -f "$ARTIFACT_PATH" ]]; then
+    echo "[CI][FAIL] content packs index artifact enabled but missing: $ARTIFACT_PATH" >&2
+    exit 17
+  fi
+
+  BACKEND_DIR="$BACKEND_DIR" php -r '
+$backendDir = rtrim((string) getenv("BACKEND_DIR"), "/");
+require $backendDir . "/vendor/autoload.php";
+$app = require $backendDir . "/bootstrap/app.php";
+$kernel = $app->make(Illuminate\Contracts\Console\Kernel::class);
+$kernel->bootstrap();
+
+$driver = (string) config("content_packs.driver", "local");
+$driver = $driver === "s3" ? "s3" : "local";
+$root = $driver === "s3"
+    ? (string) config("content_packs.cache_dir", "")
+    : (string) config("content_packs.root", "");
+$root = trim($root);
+if ($root !== "" && ! str_starts_with($root, "/") && ! preg_match("/^[A-Za-z]:[\/\\\\]/", $root)) {
+    $root = rtrim(base_path($root), "/\\\\");
+}
+$defaults = [
+    "default_pack_id" => (string) config("content_packs.default_pack_id", ""),
+    "default_dir_version" => (string) config("content_packs.default_dir_version", ""),
+    "default_region" => (string) config("content_packs.default_region", ""),
+    "default_locale" => (string) config("content_packs.default_locale", ""),
+    "region_fallbacks" => (array) config("content_packs.region_fallbacks", []),
+    "locale_fallback" => (bool) config("content_packs.locale_fallback", false),
+];
+$artifact = app(App\Services\Content\ContentPacksIndexArtifactStore::class)
+    ->readConfigured($root, $driver, $defaults);
+if (! is_array($artifact) || ! (bool) ($artifact["ok"] ?? false)) {
+    fwrite(STDERR, "[CI][FAIL] content packs index artifact is not readable by runtime config\n");
+    exit(17);
+}
+$items = (array) ($artifact["items"] ?? []);
+if (count($items) < 1) {
+    fwrite(STDERR, "[CI][FAIL] content packs index artifact has no items\n");
+    exit(17);
+}
+echo "[CI] content packs index artifact OK items=".count($items)."\n";
+'
+fi
 
 # Prepare sqlite + seed scales registry/slugs
 bash "$BACKEND_DIR/scripts/ci/prepare_sqlite.sh"

--- a/backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+++ b/backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
@@ -63,6 +63,9 @@ final class ContentPacksIndexArtifactTest extends TestCase
         $payload = json_decode((string) File::get($this->artifactPath), true);
         $this->assertSame(ContentPacksIndexArtifactStore::SCHEMA_VERSION, (string) ($payload['schema_version'] ?? ''));
         $this->assertSame(1, (int) ($payload['summary']['item_count'] ?? 0));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($payload['items'][0]['manifest_sha256'] ?? ''));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($payload['items'][0]['version_sha256'] ?? ''));
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($payload['items'][0]['questions_sha256'] ?? ''));
         $this->assertSame(
             'default/CN_MAINLAND/zh-CN/MBTI-CN-v-test/manifest.json',
             (string) ($payload['items'][0]['manifest_path'] ?? '')
@@ -140,6 +143,33 @@ final class ContentPacksIndexArtifactTest extends TestCase
         $this->assertSame('PACK_A', (string) ($fromArtifact['items'][0]['pack_id'] ?? ''));
     }
 
+    public function test_artifact_hash_validation_survives_checkout_mtime_drift(): void
+    {
+        $dirVersion = 'MBTI-CN-v-test';
+        $packDir = $this->makePackDir($dirVersion);
+        $this->writePack($packDir, 'PACK_A', $dirVersion, 'v-test');
+
+        $store = app(ContentPacksIndexArtifactStore::class);
+        $store->write(app(ContentPacksIndex::class)->getIndex(true), $this->artifactPath);
+
+        $this->touchPackFiles($packDir, time() + 5);
+        $this->forgetIndexCache();
+        config()->set('content_packs.index_artifact_enabled', true);
+
+        $index = new ContentPacksIndex($store, new class extends \App\Services\Content\ContentPacksIndexFallbackScanner
+        {
+            public function scan(string $packsRootFs, string $driver, array $defaults): array
+            {
+                throw new \RuntimeException('fallback scanner should not run when only mtimes drift');
+            }
+        });
+
+        $fromArtifact = $index->getIndex(false);
+
+        $this->assertTrue((bool) ($fromArtifact['ok'] ?? false));
+        $this->assertSame('PACK_A', (string) ($fromArtifact['items'][0]['pack_id'] ?? ''));
+    }
+
     private function makePackDir(string $dirVersion): string
     {
         $packDir = $this->packsRoot.DIRECTORY_SEPARATOR.'default'
@@ -207,5 +237,14 @@ final class ContentPacksIndexArtifactTest extends TestCase
                 ],
             ], JSON_UNESCAPED_UNICODE)
         );
+    }
+
+    private function touchPackFiles(string $packDir, int $timestamp): void
+    {
+        foreach (['manifest.json', 'version.json', 'questions.json'] as $file) {
+            $path = $packDir.DIRECTORY_SEPARATOR.$file;
+            touch($path, $timestamp);
+            clearstatcache(true, $path);
+        }
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-30T22:22:42Z",
+  "updated_at": "2026-05-31T07:03:28+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -32262,8 +32262,8 @@
   "CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-index-responsibility-shrink-01",
-    "status": "pr_open",
-    "commit_sha": "c22422007167a4cc80b31adabe85320cc727d2d8",
+    "status": "merged",
+    "commit_sha": "94ca5501ed044435b804cdef190050dda0da5ef4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1765",
     "checks": {
       "dependency": {
@@ -32314,12 +32314,16 @@
         "status": "pass",
         "command": "git diff --check",
         "evidence": "Whitespace check passed before staging."
+      },
+      "github_required_checks": {
+        "status": "pass",
+        "evidence": "PR #1765 required GitHub checks passed before squash merge."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-30T22:41:35Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "status": "authorized",
@@ -32340,6 +32344,11 @@
         "status": "pr_open",
         "at": "2026-05-30T22:22:42Z",
         "summary": "Opened PR #1765 for CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01."
+      },
+      {
+        "status": "merged_reconciled",
+        "at": "2026-05-31T06:52:16+08:00",
+        "summary": "Reconciled PR #1765 as merged; origin/main contains merge commit 94ca5501ed044435b804cdef190050dda0da5ef4 and the remote task branch is deleted."
       }
     ],
     "scope_validation": {
@@ -32350,6 +32359,130 @@
     "sidecars": [
       "Primary fap-api worktree has unrelated analytics funnel changes; this task uses an isolated worktree from origin/main."
     ],
-    "next_task": "Phase 4 content pack build/validate CI job decomposition requires explicit authorization"
+    "next_task": "CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01 authorized for Phase 4 CI artifact consumer split"
+  },
+  "CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01": {
+    "repo": "fap-api",
+    "branch": "fix/content-packs-ci-artifact-consumer-split-01",
+    "status": "committed",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized adding CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01 to PR train manifest/state, creating branch fix/content-packs-ci-artifact-consumer-split-01 from latest main, doing only Phase 4 CI artifact consumer split, and reconciling Phase 3 state ledger as merged."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "CONTENT-PACKS-INDEX-ARTIFACT-01 and CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01 are merged into origin/main."
+      },
+      "content_pack_build_validate_job": {
+        "status": "pass",
+        "evidence": "Workflow now builds content-packs-index artifact, validates schema/count/hash fields, and uploads artifact named content-packs-index."
+      },
+      "artifact_unit_tests": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi",
+        "evidence": "5 tests passed, 21 assertions."
+      },
+      "artifact_build_command": {
+        "status": "pass",
+        "command": "cd backend && php artisan content-packs:index:build --output=storage/app/private/content_packs_index/content-packs-index.json --json",
+        "evidence": "Command exited 0 and emitted item_count=7."
+      },
+      "mbti_artifact_consumer": {
+        "status": "pass",
+        "command": "cd backend && CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json RUN_BIG5_OCEAN_GATE=0 bash scripts/ci_verify_mbti.sh",
+        "evidence": "Artifact preflight reported items=7 and full MBTI CI path exited 0."
+      },
+      "bigfive_norms_gate": {
+        "status": "pass",
+        "command": "cd backend && CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json bash scripts/ci/verify_big5_norms.sh",
+        "evidence": "PASS groups=7 checksum=8fa3fccc0f2f7db08c92512d89a47027bf8445a1f350fe125108f11eb04748ef."
+      },
+      "bigfive_content_lint_compile": {
+        "status": "pass",
+        "command": "cd backend && php artisan content:lint --pack=BIG5_OCEAN --pack-version=v1 && php artisan content:compile --pack=BIG5_OCEAN --pack-version=v1",
+        "evidence": "Both commands exited 0; compile generated temporary compiled diffs that were restored before staging."
+      },
+      "bigfive_tests": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi",
+        "evidence": "820 tests passed, 61430 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "207 routes listed."
+      },
+      "migration_pretend": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force",
+        "evidence": "Command exited 0; no real database mutation performed."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Services/Content/ContentPacksIndexArtifactStore.php tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php",
+        "evidence": "2 files passed."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); YAML.load_file('.github/workflows/ci.yml')\"",
+        "evidence": "State JSON, manifest YAML, and CI workflow YAML parsed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are restricted to CI workflow, MBTI CI script, content pack artifact store/test, and PR train manifest/state."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check",
+        "evidence": "Whitespace check passed before staging."
+      },
+      "commit_created": {
+        "status": "pass",
+        "evidence": "Local commit created; exact PR head SHA is reported outside the self-referential state file and will be reconciled after PR creation/checks."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T06:52:16+08:00",
+        "summary": "User authorized Phase 4 CI artifact consumer split and Phase 3 state reconciliation."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T06:52:16+08:00",
+        "summary": "Started from origin/main in isolated worktree /Users/rainie/Desktop/GitHub/fap-api-content-packs-ci-artifact-consumer-split-01."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T07:02:42+08:00",
+        "summary": "Content pack artifact build/validate job, MBTI artifact consumer path, Big Five artifact consumer gates, route list, migration pretend, Pint, Composer validate, JSON/YAML parse, and diff check passed."
+      },
+      {
+        "status": "committed",
+        "at": "2026-05-31T07:03:13+08:00",
+        "summary": "Committed Phase 4 CI artifact consumer split; PR head SHA will be reconciled after push/PR creation."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": null
+    },
+    "sidecars": [
+      "Primary fap-api worktree has unrelated dirty changes; this task uses an isolated worktree from origin/main."
+    ],
+    "next_task": "Open PR for Phase 4 CI artifact consumer split; do not merge until required GitHub checks pass."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T07:03:28+08:00",
+  "updated_at": "2026-05-31T07:04:11+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -32364,9 +32364,9 @@
   "CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-ci-artifact-consumer-split-01",
-    "status": "committed",
+    "status": "pr_open",
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1768",
     "checks": {
       "authorization": {
         "status": "pass",
@@ -32447,6 +32447,10 @@
       "commit_created": {
         "status": "pass",
         "evidence": "Local commit created; exact PR head SHA is reported outside the self-referential state file and will be reconciled after PR creation/checks."
+      },
+      "pr_created": {
+        "status": "pass",
+        "evidence": "Opened GitHub PR #1768."
       }
     },
     "failure_reason": null,
@@ -32473,6 +32477,11 @@
         "status": "committed",
         "at": "2026-05-31T07:03:13+08:00",
         "summary": "Committed Phase 4 CI artifact consumer split; PR head SHA will be reconciled after push/PR creation."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T07:04:11+08:00",
+        "summary": "Opened PR #1768 for CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16190,3 +16190,62 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: Phase 4 content pack build/validate CI job decomposition requires explicit authorization
+
+  - id: CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01
+    repo: fap-api
+    branch: fix/content-packs-ci-artifact-consumer-split-01
+    base: main
+    title: "CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01 split content pack artifact validation from MBTI and Big Five CI"
+    train_scope: content_packs_ci_artifact_consumer_split
+    risk_level: p1_ci_memory_and_runtime_hardening
+    depends_on:
+      - CONTENT-PACKS-INDEX-ARTIFACT-01 merged
+      - CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01 merged
+    allowed_paths:
+      - .github/workflows/ci.yml
+      - backend/scripts/ci_verify_mbti.sh
+      - backend/app/Services/Content/ContentPacksIndexArtifactStore.php
+      - backend/tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add a dedicated CI content pack index build/validate job that uploads the content-packs-index artifact.
+      - Make MBTI legacy/v2 CI jobs download and consume the validated content-packs-index artifact.
+      - Split Big Five content/business gates into their own CI job that consumes the same content-packs-index artifact.
+      - Make CI artifact validation portable across GitHub jobs without relying on checkout-local mtimes.
+      - Preserve public API contracts, ContentPacksIndex getIndex/find return shape, content package semantics, and fallback scanning.
+      - Reconcile CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01 train state as merged.
+    do_not:
+      - Change public API response contracts.
+      - Change content package source files or question/item semantics.
+      - Remove the fallback scan path.
+      - Enable artifact runtime use by default outside explicit CI env.
+      - Refactor deploy workflow or production deployment gates.
+      - Refactor MBTI, Big Five, report, attempt, scoring, or content pack publishing business runtime beyond CI artifact consumption.
+      - Modify fap-web, CMS, DB, migrations, Search Channel, URL submission, deploy, or production env.
+    validation:
+      - cd backend && php artisan test --filter=ContentPacksIndexArtifact --no-ansi
+      - cd backend && php artisan content-packs:index:build --output=storage/app/private/content_packs_index/content-packs-index.json --json
+      - cd backend && CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json RUN_BIG5_OCEAN_GATE=0 bash scripts/ci_verify_mbti.sh
+      - cd backend && CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json bash scripts/ci/verify_big5_norms.sh
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && composer validate --strict
+      - cd backend && vendor/bin/pint --test
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - JSON/YAML parse
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: Phase 4 deploy workflow parity requires explicit authorization


### PR DESCRIPTION
## What changed

- Added a dedicated GitHub Actions `content-pack-build-validate` job that builds `content-packs-index.json`, validates schema/count/hash fields, runs focused artifact tests, and uploads the artifact as `content-packs-index`.
- Split MBTI and Big Five CI consumers so they download and consume the prebuilt content pack index artifact instead of silently falling back to directory scans.
- Hardened `ContentPacksIndexArtifactStore` with source file SHA-256 validation so uploaded/downloaded artifacts survive checkout mtime drift across CI jobs.
- Added focused coverage proving artifact hash validation remains valid when source mtimes drift.
- Reconciled Phase 3 PR train state as merged and added this Phase 4 manifest/state entry.

## Why

Phase 4 separates content pack index build/validate from MBTI and Big Five business tests. This keeps one authoritative artifact path for consumers, reduces repeated runtime directory/index work in CI, and fails fast when the artifact is missing or invalid.

## Validation commands

```bash
cd /Users/rainie/Desktop/GitHub/fap-api-content-packs-ci-artifact-consumer-split-01/backend
php artisan route:list --no-ansi
php artisan test --filter=ContentPacksIndexArtifact --no-ansi
php artisan content-packs:index:build --output=storage/app/private/content_packs_index/content-packs-index.json --json
CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json RUN_BIG5_OCEAN_GATE=0 bash scripts/ci_verify_mbti.sh
CONTENT_PACKS_INDEX_ARTIFACT_ENABLED=true CONTENT_PACKS_INDEX_ARTIFACT_PATH=storage/app/private/content_packs_index/content-packs-index.json bash scripts/ci/verify_big5_norms.sh
php artisan content:lint --pack=BIG5_OCEAN --pack-version=v1
php artisan content:compile --pack=BIG5_OCEAN --pack-version=v1
php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi
APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
vendor/bin/pint --test app/Services/Content/ContentPacksIndexArtifactStore.php tests/Unit/Services/Content/ContentPacksIndexArtifactTest.php
composer validate --strict
cd .. && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
cd .. && ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); YAML.load_file(".github/workflows/ci.yml")'
cd .. && git diff --check
```

## Intentionally deferred

- No deploy workflow parity changes.
- No public API contract changes.
- No CMS, DB, migration, or production cache mutation.
- No content pack schema/content ownership changes.
- No MBTI or Big Five business logic changes beyond CI artifact consumption.

## Repository rule impact

This PR does not introduce a new content surface or change runtime content ownership. It keeps content packs backend-authoritative and only changes CI artifact production/consumption for existing backend tests.

## Residual risks

- GitHub Actions artifact behavior is now explicitly part of the CI contract and must be verified by remote checks.
- Deploy workflow artifact parity remains out of scope and requires a separate authorized follow-up if desired.
