### PR TITLE
OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01: Bind run job to production environment

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -97,21 +97,12 @@ jobs:
           name: release-train-dry-run
           path: artifacts/dry-run.json
 
-  production-gate:
-    name: Production deployment approval
-    needs: dry-run
+  run-train:
+    name: Run release train
+    needs: validate
     if: ${{ github.event.inputs.mode == 'run' && github.event.inputs.allow_deploy == 'true' && github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     environment: production
-    steps:
-      - name: Deployment approval gate
-        run: echo "Production environment approval captured"
-
-  run-train:
-    name: Run release train
-    needs: production-gate
-    if: ${{ github.event.inputs.mode == 'run' && github.event.inputs.dry_run != 'true' }}
-    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - name: Execute train
@@ -135,4 +126,3 @@ jobs:
         with:
           name: release-train-run
           path: artifacts/run.json
-

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32877,9 +32877,9 @@
     "id": "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01",
     "repo": "fap-api",
     "branch": "ops/release-train-workflow-production-env-binding-01",
-    "status": "local_validation_passed",
-    "commit_sha": null,
-    "pr_url": null,
+    "status": "pr_open",
+    "commit_sha": "c17da937",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1771",
     "checks": {
       "authorization": {
         "status": "pass",
@@ -32949,7 +32949,12 @@
       },
       "scope_validation": {
         "status": "pass",
-        "result": "Current PR staged scope is limited to release-train workflow/docs/tests/train metadata. Out-of-scope local Alipay scheduler files are left unstaged and untouched."
+        "result": "Committed PR scope is limited to release-train workflow/docs/tests/train metadata. Earlier observed Alipay scheduler files were not staged into this PR."
+      },
+      "pr_created": {
+        "status": "pass",
+        "command": "gh pr create --base main --head ops/release-train-workflow-production-env-binding-01",
+        "result": "https://github.com/fermatmind/fap-api/pull/1771"
       }
     },
     "failure_reason": null,
@@ -32958,13 +32963,14 @@
     "local_cleanup_executed": false,
     "scope_validation": {
       "allowed_paths_only": true,
-      "git_diff_check": null,
-      "git_diff_cached_check": null,
-      "out_of_scope_local_dirty_left_unstaged": [
+      "git_diff_check": "pass",
+      "git_diff_cached_check": "pass",
+      "observed_out_of_scope_local_dirty_not_staged_in_pr": [
         "backend/bootstrap/app.php",
         "backend/docs/runbooks/alipay-pending-compensation.md",
         "backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php"
-      ]
+      ],
+      "final_worktree_out_of_scope_dirty": "none observed before PR state bookkeeping commit"
     },
     "transitions": [
       {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T08:28:00+08:00",
+  "updated_at": "2026-05-31T09:10:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -32872,5 +32872,118 @@
     ],
     "sidecars": [],
     "next_task": "Wait for GitHub checks and Codex final review; do not merge or deploy from this PR."
+  },
+  "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01": {
+    "id": "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01",
+    "repo": "fap-api",
+    "branch": "ops/release-train-workflow-production-env-binding-01",
+    "status": "local_validation_passed",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User provided explicit implementation PR goal for workflow production environment binding; no deploy, no mode=run, no production approval."
+      },
+      "workspace_safety": {
+        "status": "pass",
+        "evidence": "Started from clean fap-api main at 1832765a88b8df16efe86142671e549ecf13f85c and created ops/release-train-workflow-production-env-binding-01."
+      },
+      "deploy_safety_boundary": {
+        "status": "pass",
+        "evidence": "No deploy, production SSH, production mutation, production approval, rollback, merge, Search Channel action, or URL submission performed."
+      },
+      "json_validation": {
+        "status": "pass",
+        "command": "python3 -m json.tool ops/release-train/examples/release-train.example.json; python3 -m json.tool docs/codex/pr-train-state.json"
+      },
+      "yaml_validation": {
+        "status": "pass",
+        "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release-train.yml').read_text()); yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\""
+      },
+      "manifest_validate": {
+        "status": "pass",
+        "command": "python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json"
+      },
+      "manifest_plan": {
+        "status": "pass",
+        "command": "python3 ops/release-train/release_train.py plan --manifest ops/release-train/examples/release-train.example.json"
+      },
+      "manifest_dry_run": {
+        "status": "pass",
+        "command": "python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json",
+        "note": "Dry-run exited ok=true; example placeholder SHA/scope notes remain non-mutating offline notes."
+      },
+      "ops_unittest": {
+        "status": "pass",
+        "command": "python3 -m unittest discover tests/ops",
+        "result": "30 tests passed"
+      },
+      "deploy_wrapper_syntax": {
+        "status": "pass",
+        "command": "bash -n backend/scripts/deploy/deploy_backend.sh"
+      },
+      "wrapper_fail_closed_default": {
+        "status": "pass",
+        "command": "bash backend/scripts/deploy/deploy_backend.sh; test $? -ne 0",
+        "result": "Failed closed with MISSING_RELEASE_NAME."
+      },
+      "wrapper_dry_run": {
+        "status": "pass",
+        "command": "DEPLOY_DRY_RUN=true ALLOW_PRODUCTION_DEPLOY=true ALLOW_REAL_DEPLOY=false DEPLOY_ENV=production BACKEND_DEPLOY_SHA=$(git rev-parse HEAD) RELEASE_NAME=workflow-env-binding-dry-run-test bash backend/scripts/deploy/deploy_backend.sh",
+        "result": "deploy_result=skipped; no Deployer execution."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "result": "207 routes listed"
+      },
+      "migration_pretend": {
+        "status": "pass",
+        "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force"
+      },
+      "ci_verify_mbti": {
+        "status": "pass",
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "result": "Full MBTI CI verify path completed successfully."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "result": "Current PR staged scope is limited to release-train workflow/docs/tests/train metadata. Out-of-scope local Alipay scheduler files are left unstaged and untouched."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": null,
+      "git_diff_cached_check": null,
+      "out_of_scope_local_dirty_left_unstaged": [
+        "backend/bootstrap/app.php",
+        "backend/docs/runbooks/alipay-pending-compensation.md",
+        "backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php"
+      ]
+    },
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T09:05:00+08:00",
+        "summary": "User supplied OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01 implementation scope."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T09:05:00+08:00",
+        "summary": "Binding deploy-capable release-train run job to GitHub production environment without deployment."
+      },
+      {
+        "status": "local_validation_passed",
+        "at": "2026-05-31T09:10:00+08:00",
+        "summary": "Validated workflow binding change locally without deploy, mode=run, production approval, rollback, or production mutation."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "Open PR and keep production deploy disabled; manual GitHub production branch restriction remains required."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16310,6 +16310,63 @@ prs:
     frontend_fallback_authority: false
     next_task: explicit production deployment approval remains required after review
 
+  - id: OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01
+    repo: fap-api
+    branch: ops/release-train-workflow-production-env-binding-01
+    base: main
+    title: "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01 bind run job to production environment"
+    train_scope: release_train_workflow_production_environment_binding
+    risk_level: p0_deploy_guarded_workflow
+    depends_on:
+      - OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01 merged and dry-run validated
+    allowed_paths:
+      - .github/workflows/release-train.yml
+      - tests/ops/test_release_train_workflow.py
+      - docs/ops/release-train.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Bind the actual release-train run job to GitHub environment production.
+      - Keep validate, plan, and dry-run paths outside production environment approval.
+      - Guard the deploy-capable run job with mode=run, allow_deploy=true, and dry_run!=true.
+      - Document that production environment branch restriction to main remains a manual GitHub setting.
+      - Add static tests for workflow dry-run safety and production environment binding.
+    do_not:
+      - Do not deploy, run mode=run, approve production, mutate production, or run SSH.
+      - Do not modify .github/workflows/deploy.yml or .github/workflows/ci.yml.
+      - Do not modify deploy.php, backend app/business code, migrations, content baselines, CMS, DB, production env, fap-web, sitemap, llms, Search Channel, or URL submission files.
+      - Do not enable rollback, frontend deploy, auto merge, or production approval bypass.
+      - Do not print, read, create, update, or delete secret values.
+    validation:
+      - python3 -m json.tool ops/release-train/examples/release-train.example.json >/dev/null
+      - python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json
+      - python3 ops/release-train/release_train.py plan --manifest ops/release-train/examples/release-train.example.json
+      - python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json
+      - python3 -m unittest discover tests/ops
+      - bash -n backend/scripts/deploy/deploy_backend.sh
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release-train.yml').read_text()); print('workflow yaml ok')"
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('train yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+      - bash backend/scripts/ci_verify_mbti.sh
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: false }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: after merge restrict GitHub production environment branch policy to main and rerun dry-run/readiness
+
   - id: PR-POL-01
     repo: fap-api
     branch: content/pr-pol-01-policies-dashboard

--- a/docs/ops/release-train.md
+++ b/docs/ops/release-train.md
@@ -27,7 +27,8 @@
 - New workflow is `workflow_dispatch` only.
 - Default and safe mode is dry-run.
 - `allow_deploy` gates run behavior.
-- Production execution depends on GitHub Environment approval (`environment: production`).
+- Production execution depends on GitHub Environment approval on the actual
+  deploy-capable `run-train` job (`environment: production`).
 - Wrapper execution is fail-closed:
   - Missing/disabled deploy command -> `DEPLOY_COMMAND_NOT_CONFIGURED`.
   - Missing rollback command -> `ROLLBACK_COMMAND_NOT_CONFIGURED`.
@@ -47,7 +48,21 @@
 - No `cancel-in-progress` use.
 
 ## Environment and approvals
-`run-train` depends on a `production` job gate and uses `environment: production`.
+`validate` and `dry-run` jobs do not use a production environment and must not
+request production approval. The deploy-capable `run-train` job is the job that
+declares `environment: production`, so GitHub production protection rules and
+environment-scoped secrets apply to the same job that can invoke
+`release_train.py run`.
+
+`run-train` is guarded by all of the following workflow inputs:
+
+- `mode == run`
+- `allow_deploy == true`
+- `dry_run != true`
+
+This keeps dry-run validation outside production approval while making the
+future real backend run path wait for the production environment reviewer before
+the job can access production environment secrets.
 
 ## Manifest
 Top-level fields:

--- a/tests/ops/test_release_train_workflow.py
+++ b/tests/ops/test_release_train_workflow.py
@@ -1,0 +1,37 @@
+import unittest
+from pathlib import Path
+
+import yaml
+
+
+ROOT = Path(__file__).resolve().parents[2]
+WORKFLOW = ROOT / ".github/workflows/release-train.yml"
+
+
+class ReleaseTrainWorkflowTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.workflow = yaml.safe_load(WORKFLOW.read_text())
+        cls.jobs = cls.workflow["jobs"]
+
+    def test_dry_run_job_does_not_use_production_environment(self):
+        dry_run = self.jobs["dry-run"]
+
+        self.assertNotIn("environment", dry_run)
+        self.assertIn("dry_run == 'true'", dry_run["if"])
+
+    def test_run_train_is_the_production_environment_job(self):
+        run_train = self.jobs["run-train"]
+
+        self.assertEqual(run_train["needs"], "validate")
+        self.assertEqual(run_train["environment"], "production")
+        self.assertIn("mode == 'run'", run_train["if"])
+        self.assertIn("allow_deploy == 'true'", run_train["if"])
+        self.assertIn("dry_run != 'true'", run_train["if"])
+
+    def test_no_separate_approval_only_production_gate_remains(self):
+        self.assertNotIn("production-gate", self.jobs)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Problem summary

The release train workflow previously used a separate approval-only `production-gate` job, while the actual deploy-capable `run-train` job did not declare the GitHub `production` environment. That meant approval existed near the production path, but not on the job that can execute production actions.

## What changed

- Bound the actual `run-train` job in `.github/workflows/release-train.yml` to `environment: production`.
- Removed the separate approval-only `production-gate` job.
- Guarded `run-train` with `mode == run`, `allow_deploy == true`, and `dry_run != true`.
- Kept validate and dry-run paths outside the production environment so dry-run does not request production approval.
- Added static workflow tests for the environment binding and dry-run separation.
- Updated release-train docs and PR-train manifest/state entries for this scoped ops PR.

## Why

The deploy-capable job itself must be protected by GitHub Environment approval. A separate gate can be bypassed structurally if a later job is not also environment-bound.

## Production safety

No deploy was run. No `mode=run` workflow dispatch was executed. No rollback, SSH, production mutation, migration, cache clear, or process restart was performed. This PR only changes workflow/docs/tests/train metadata.

Manual GitHub setting still required: the `production` environment should restrict deployment branches to `main` so branch workflow runs cannot execute production deployments without the intended branch policy.

## Validation

- `python3 -m json.tool ops/release-train/examples/release-train.example.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `.github/workflows/release-train.yml` and `docs/codex/pr-train.yaml`
- `python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json`
- `python3 ops/release-train/release_train.py plan --manifest ops/release-train/examples/release-train.example.json`
- `python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json`
- `python3 -m unittest discover tests/ops`
- `bash -n backend/scripts/deploy/deploy_backend.sh`
- `bash backend/scripts/deploy/deploy_backend.sh; test $? -ne 0`
- Dry-run wrapper invocation with `DEPLOY_DRY_RUN=true` and production deploy disabled for real execution
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi --force`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred

- No production deployment.
- No workflow `mode=run` dispatch.
- No frontend changes.
- No backend business logic changes.
- No rollback automation changes.
- No auto-merge.

## Codex final review required

yes
