### PR TITLE
ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01 fix production dry-run SQL compatibility

### DIFF
--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -644,34 +644,57 @@ final class AnalyticsFunnelDailyBuilder
             return [];
         }
 
-        $query = DB::table('benefit_grants')
-            ->whereRaw("lower(coalesce(benefit_grants.status, '')) = ?", ['active'])
-            ->selectRaw(
-                SchemaBaseline::hasTable('orders')
-                    ? 'COALESCE(benefit_grants.attempt_id, orders.target_attempt_id) as attempt_id'
-                    : 'benefit_grants.attempt_id as attempt_id'
-            )
-            ->selectRaw('MIN(benefit_grants.created_at) as stage_at')
-            ->havingRaw('MIN(benefit_grants.created_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+        $hasGrantAttemptId = SchemaBaseline::hasColumn('benefit_grants', 'attempt_id');
+        $hasOrders = SchemaBaseline::hasTable('orders');
 
-        if (SchemaBaseline::hasTable('orders')) {
-            $query->leftJoin('orders', function ($join): void {
+        if (! $hasGrantAttemptId && ! $hasOrders) {
+            return [];
+        }
+
+        $attemptExpression = match (true) {
+            $hasGrantAttemptId && $hasOrders => 'COALESCE(benefit_grants.attempt_id, orders.target_attempt_id)',
+            $hasGrantAttemptId => 'benefit_grants.attempt_id',
+            default => 'orders.target_attempt_id',
+        };
+
+        $grantAttempts = DB::table('benefit_grants')
+            ->whereRaw("lower(coalesce(benefit_grants.status, '')) = ?", ['active'])
+            ->selectRaw($attemptExpression.' as attempt_id')
+            ->selectRaw('benefit_grants.created_at as stage_at');
+
+        if ($hasOrders) {
+            $grantAttempts->leftJoin('orders', function ($join): void {
                 $join->on('orders.id', '=', 'benefit_grants.source_order_id');
 
                 if (SchemaBaseline::hasColumn('benefit_grants', 'order_no')) {
                     $join->orOn('orders.order_no', '=', 'benefit_grants.order_no');
                 }
-            })->groupByRaw('COALESCE(benefit_grants.attempt_id, orders.target_attempt_id)')
-                ->havingRaw('COALESCE(benefit_grants.attempt_id, orders.target_attempt_id) is not null');
-        } else {
-            $query->groupBy('benefit_grants.attempt_id')
-                ->whereNotNull('benefit_grants.attempt_id')
-                ->where('benefit_grants.attempt_id', '!=', '');
+            });
+        }
+
+        if (SchemaBaseline::hasColumn('benefit_grants', 'revoked_at')) {
+            $grantAttempts->whereNull('benefit_grants.revoked_at');
+        }
+
+        if (SchemaBaseline::hasColumn('benefit_grants', 'expires_at')) {
+            $grantAttempts->where(function (QueryBuilder $query): void {
+                $query->whereNull('benefit_grants.expires_at')
+                    ->orWhere('benefit_grants.expires_at', '>', now());
+            });
         }
 
         if ($orgIds !== []) {
-            $query->whereIn('benefit_grants.org_id', $orgIds);
+            $grantAttempts->whereIn('benefit_grants.org_id', $orgIds);
         }
+
+        $query = DB::query()
+            ->fromSub($grantAttempts, 'grant_attempts')
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->select('attempt_id')
+            ->selectRaw('MIN(stage_at) as stage_at')
+            ->groupBy('attempt_id')
+            ->havingRaw('MIN(stage_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
 
         return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
     }

--- a/backend/docs/seo/analytics-funnel-refresh-dry-run-sql-fix-01.md
+++ b/backend/docs/seo/analytics-funnel-refresh-dry-run-sql-fix-01.md
@@ -1,0 +1,48 @@
+# ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01
+
+## Purpose
+
+Production dry-run for `analytics:refresh-funnel-daily` failed during the benefit grant unlock stage with:
+
+`SQLSTATE[42S22]: Unknown column 'benefit_grants.attempt_id' in 'having clause'`
+
+The dry-run was no-write, and before/after `analytics_funnel_daily` counts remained unchanged. The blocker was query compatibility, not an approved production refresh.
+
+## Fix
+
+`AnalyticsFunnelDailyBuilder::collectUnlockSuccessMap()` now resolves the grant-to-attempt relationship in a subquery and aggregates the outer query by the resolved `attempt_id` alias. The outer `HAVING` clause only checks `MIN(stage_at)`, so it no longer references `benefit_grants.attempt_id` directly in an invalid HAVING context.
+
+## Business Semantics
+
+- `report_unlock` / `unlock_success` remains based on active benefit grants.
+- Revoked grants are excluded when `revoked_at` exists.
+- Expired grants are excluded when `expires_at` exists.
+- Grants without a valid attempt relationship are excluded.
+- Attempt relationship resolution still prefers `benefit_grants.attempt_id` and falls back to `orders.target_attempt_id` through `source_order_id` or `order_no`.
+- Org/date/scale scoping remains owned by the existing analytics builder flow.
+
+## Explicit Non-actions
+
+- No production refresh was run.
+- No non-dry-run refresh was run in production.
+- No production DB mutation was performed.
+- No migration was added.
+- No scheduler change was made.
+- No GA/Baidu setting was changed.
+- No Search Channel action or URL submission was performed.
+- No write guard was added in this PR; that remains a separate follow-up after production dry-run succeeds.
+
+## Validation Focus
+
+The focused regression coverage verifies:
+
+- active benefit grants count as `unlocked_attempts`;
+- inactive, expired, and unrelated grants do not count;
+- dry-run completes without writing `analytics_funnel_daily`;
+- the previous invalid `HAVING COALESCE(benefit_grants.attempt_id...)` query shape is no longer emitted.
+
+## Next Task
+
+After deployment, rerun the bounded production dry-run only:
+
+`ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PROD-DRY-RUN-01-R2`

--- a/backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-01.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-01.v1.json
@@ -1,0 +1,40 @@
+{
+  "schema_version": "1.0",
+  "task": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01",
+  "final_decision": "analytics_funnel_refresh_dry_run_sql_fix_completed_ready_for_backend_deploy",
+  "production_failure": {
+    "command": "php artisan analytics:refresh-funnel-daily --from=2026-05-25 --to=2026-05-31 --org=0 --dry-run --no-ansi",
+    "error_summary": "SQLSTATE[42S22]: Unknown column 'benefit_grants.attempt_id' in 'having clause'",
+    "stage": "report_unlock / unlock_success benefit_grants aggregation"
+  },
+  "root_cause": "The unlock aggregation repeated COALESCE(benefit_grants.attempt_id, orders.target_attempt_id) in HAVING after grouping, which was not production MySQL compatible.",
+  "fix": {
+    "file": "backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php",
+    "method": "collectUnlockSuccessMap",
+    "strategy": "Resolve attempt_id in a subquery, then aggregate the outer query by the resolved alias and HAVING MIN(stage_at).",
+    "invalid_having_reference_removed": true
+  },
+  "business_semantics_preserved": {
+    "active_grants_count": true,
+    "inactive_grants_count": false,
+    "expired_grants_count": false,
+    "revoked_grants_count": false,
+    "grants_without_attempt_relation_count": false,
+    "org_scope_preserved": true,
+    "date_scope_preserved": true,
+    "scale_scope_preserved_by_attempt_dimensions": true
+  },
+  "production_actions": {
+    "deploy_performed": false,
+    "production_refresh_performed": false,
+    "production_db_mutation_performed": false,
+    "migration_added": false,
+    "scheduler_changed": false,
+    "ga_baidu_settings_changed": false,
+    "search_channel_action_performed": false,
+    "url_submission_performed": false
+  },
+  "write_guard_added": false,
+  "write_guard_deferred_to": "ANALYTICS-FUNNEL-REFRESH-WRITE-GUARD-01 after production dry-run succeeds",
+  "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01, then ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PROD-DRY-RUN-01-R2"
+}

--- a/backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix01Test.php
+++ b/backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix01Test.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class AnalyticsFunnelRefreshDryRunSqlFix01Test extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    public function test_active_benefit_grant_counts_as_report_unlock_while_inactive_expired_and_unrelated_grants_do_not(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(144);
+        $day = CarbonImmutable::parse($scenario['day'].' 08:00:00');
+
+        $this->insertGrantForSqlFix(
+            orgId: 144,
+            attemptId: $scenario['attempt_b'],
+            createdAt: $day->addHours(3)->addMinutes(45),
+            status: 'inactive',
+        );
+        $this->insertGrantForSqlFix(
+            orgId: 144,
+            attemptId: $scenario['attempt_c'],
+            createdAt: $day->addHours(4)->addMinutes(45),
+            status: 'active',
+            expiresAt: $day->subDay(),
+        );
+        $this->insertGrantForSqlFix(
+            orgId: 144,
+            attemptId: null,
+            createdAt: $day->addHours(5),
+            status: 'active',
+        );
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [144],
+        );
+
+        $unlockedAttempts = collect($payload['rows'])->sum(
+            static fn (array $row): int => (int) ($row['unlocked_attempts'] ?? 0)
+        );
+
+        $this->assertSame(1, $unlockedAttempts);
+    }
+
+    public function test_dry_run_refresh_completes_and_writes_no_analytics_funnel_daily_rows(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(145);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [145],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('attempted_rows=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_unlock_query_no_longer_uses_benefit_grants_attempt_id_in_having_context(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(146);
+        $queries = [];
+
+        DB::listen(static function (QueryExecuted $query) use (&$queries): void {
+            $queries[] = strtolower($query->sql);
+        });
+
+        app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [146],
+        );
+
+        $combinedSql = implode("\n", $queries);
+
+        $this->assertStringNotContainsString(
+            'having coalesce(benefit_grants.attempt_id',
+            $combinedSql
+        );
+        $this->assertStringContainsString('from (select', $combinedSql);
+        $this->assertStringContainsString('benefit_grants', $combinedSql);
+    }
+
+    private function insertGrantForSqlFix(
+        int $orgId,
+        ?string $attemptId,
+        CarbonImmutable $createdAt,
+        string $status,
+        ?CarbonImmutable $expiresAt = null,
+    ): void {
+        $row = [
+            'id' => $grantId = (string) Str::uuid(),
+            'org_id' => $orgId,
+            'user_id' => null,
+            'benefit_code' => 'MBTI_REPORT_FULL',
+            'scope' => 'attempt',
+            'attempt_id' => $attemptId,
+            'status' => $status,
+            'benefit_type' => 'report',
+            'benefit_ref' => 'full_'.$grantId,
+            'order_no' => null,
+            'source_order_id' => (string) Str::uuid(),
+            'source_event_id' => null,
+            'expires_at' => $expiresAt,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ];
+
+        if (! Schema::hasColumn('benefit_grants', 'expires_at')) {
+            unset($row['expires_at']);
+        }
+
+        DB::table('benefit_grants')->insert($row);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -23565,7 +23565,7 @@
   "SEARCH-CHANNEL-LIVE-01-PREFLIGHT": {
     "repo": "fap-api",
     "branch": "codex/search-channel-live-01-preflight",
-    "status": "in_progress",
+    "status": "pr_open",
     "depends_on": [
       "INDEXNOW-LIVE-00"
     ],
@@ -32269,8 +32269,8 @@
     "depends_on": [
       "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "31374f79d9e3671b80bc0383bcdc7d37b9bb2099",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1772",
     "checks": [
       {
         "command": "manifest/state authorization",
@@ -32357,6 +32357,11 @@
         "status": "local_checks_passed",
         "at": "2026-05-31T09:13:16+08:00",
         "summary": "Scoped local validation passed for the analytics funnel dry-run SQL compatibility fix."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T09:23:00+08:00",
+        "summary": "Opened PR #1772 after scoped local validation passed."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -23476,7 +23476,7 @@
   "INDEXNOW-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/indexnow-live-00-readiness-contract",
-    "status": "in_progress",
+    "status": "local_checks_passed",
     "depends_on": [
       "BAIDU-LIVE-00"
     ],
@@ -23569,7 +23569,7 @@
     "depends_on": [
       "INDEXNOW-LIVE-00"
     ],
-    "commit_sha": null,
+    "commit_sha": "96363c840426a49575787bf6292f5d65c7be6f84",
     "pr_url": null,
     "checks": {
       "dependency": {
@@ -28361,7 +28361,7 @@
     "depends_on": [
       "RESULT-EN-PARITY-05"
     ],
-    "commit_sha": null,
+    "commit_sha": "d137d244fd7fca4544a9c94e23be2878700c15e6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1675",
     "checks": {
       "dependency_result_en_parity_00": {
@@ -32258,6 +32258,117 @@
     },
     "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01"
+  },
+  "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01": {
+    "id": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-refresh-dry-run-sql-fix-01",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01 fix production dry-run SQL compatibility",
+    "status": "in_progress",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "manifest/state authorization",
+        "status": "passed",
+        "summary": "User explicitly authorized adding only ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01 to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "status": "passed",
+        "summary": "2 tests completed with warnings, 27 assertions."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix01 --no-ansi",
+        "status": "passed",
+        "summary": "3 tests completed with warnings, 8 assertions."
+      },
+      {
+        "command": "php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi",
+        "status": "passed",
+        "summary": "1 test completed with warnings, 11 assertions."
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "Route list rendered successfully with 207 routes."
+      },
+      {
+        "command": "vendor/bin/pint --test",
+        "status": "passed",
+        "summary": "Pint passed across 3648 files."
+      },
+      {
+        "command": "composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid."
+      },
+      {
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found."
+      },
+      {
+        "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-01.v1.json >/dev/null",
+        "status": "passed",
+        "summary": "Generated SQL fix JSON parses."
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed",
+        "summary": "PR train state JSON parses."
+      },
+      {
+        "command": "python3 - <<'PY' import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()) PY",
+        "status": "passed",
+        "summary": "PR train manifest YAML parses."
+      },
+      {
+        "command": "git diff --check",
+        "status": "passed",
+        "summary": "No whitespace errors in unstaged diff."
+      },
+      {
+        "command": "fap-web reference status",
+        "status": "sidecar",
+        "summary": "Reference-only fap-web worktree has unrelated dirty changes and was not modified by this task."
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T09:13:16+08:00",
+        "summary": "User authorized the scoped SQL compatibility fix PR and manifest/state updates."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T09:13:16+08:00",
+        "summary": "Started from latest origin/main on scoped branch codex/analytics-funnel-refresh-dry-run-sql-fix-01 in an isolated worktree."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T09:13:16+08:00",
+        "summary": "Scoped local validation passed for the analytics funnel dry-run SQL compatibility fix."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": null
+    },
+    "sidecars": [
+      "Reference-only fap-web worktree had unrelated dirty changes before and after this task; no fap-web files were modified.",
+      "Composer dependencies were installed in the isolated worktree because vendor/ was absent."
+    ],
+    "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01"
   },
   "CONTENT-PACKS-INDEX-RESPONSIBILITY-SHRINK-01": {
     "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16077,6 +16077,55 @@ prs:
     frontend_fallback_authority: false
     next_task: ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01
 
+  - id: ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01
+    repo: fap-api
+    branch: codex/analytics-funnel-refresh-dry-run-sql-fix-01
+    base: main
+    title: "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01 fix production dry-run SQL compatibility"
+    train_scope: analytics_funnel_refresh_dry_run_sql_fix
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01
+    allowed_paths:
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/docs/seo/analytics-funnel-refresh-dry-run-sql-fix-01.md
+      - backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-01.v1.json
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Fix production SQL compatibility for the analytics_funnel_daily benefit grant unlock aggregation.
+      - Preserve report_unlock / unlock_success semantics as active benefit grants with valid attempt relationships.
+      - Exclude inactive, expired, revoked, and unrelated grants.
+      - Keep production refresh, production DB writes, migrations, scheduler changes, GA/Baidu settings, Search Channel actions, URL submissions, and write guards out of scope.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix01 --no-ansi
+      - cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01
+
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api
     branch: fix/content-packs-index-artifact-01


### PR DESCRIPTION
## What changed
- Reworked `AnalyticsFunnelDailyBuilder::collectUnlockSuccessMap()` to resolve grant attempt relationships in a subquery before aggregation.
- Removed the production-incompatible `HAVING COALESCE(benefit_grants.attempt_id, ...)` query shape.
- Added focused regression coverage for active, inactive, expired, and unrelated benefit grants plus dry-run no-write behavior.
- Added SEO/generated closeout docs and initialized the scoped PR train ledger entry.

## Why
Production dry-run for `analytics:refresh-funnel-daily` failed in the benefit grant unlock stage with `Unknown column benefit_grants.attempt_id in having clause`. The command must be able to complete dry-run before any controlled refresh apply can be considered.

## Validation
- `php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi`
- `php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix01 --no-ansi`
- `php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production dry-run rerun.
- No non-dry-run refresh.
- No production DB mutation.
- No migration.
- No scheduler change.
- No deploy.
- No write guard; that remains a separate follow-up after dry-run succeeds.
- No fap-web changes.