### PR TITLE
OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01: Keep deploy unblocked by career warm cache

### DIFF
--- a/deploy.php
+++ b/deploy.php
@@ -446,11 +446,40 @@ task('artisan:scales:seed-default', function () {
 task('career:warm-public-authority-cache', function () {
     $timeoutSeconds = (int) (getenv('DEPLOY_CAREER_WARM_CACHE_TIMEOUT') ?: 600);
     $timeoutSeconds = max(180, $timeoutSeconds);
+    $strictWarmCache = filter_var((string) (getenv('DEPLOY_CAREER_WARM_CACHE_STRICT') ?: ''), FILTER_VALIDATE_BOOLEAN);
+    $skipWarmCache = filter_var((string) (getenv('DEPLOY_SKIP_CAREER_WARM_CACHE') ?: ''), FILTER_VALIDATE_BOOLEAN);
 
-    run(sprintf(
+    if ($skipWarmCache) {
+        writeln('<comment>Skipping career:warm-public-authority-cache because DEPLOY_SKIP_CAREER_WARM_CACHE=true</comment>');
+
+        return;
+    }
+
+    $command = sprintf(
         'timeout %d {{bin/php}} %s career:warm-public-authority-cache --no-interaction --ansi',
         $timeoutSeconds,
         deployPlaceholderPathArg('{{release_path}}', 'backend/artisan'),
+    );
+
+    if ($strictWarmCache) {
+        run($command);
+
+        return;
+    }
+
+    run(sprintf(
+        <<<'BASH'
+set +e
+%s
+status=$?
+set -e
+if [ "$status" -ne 0 ]; then
+  echo "career_warm_public_authority_cache_nonblocking_failure=$status"
+  echo "Continuing deploy because DEPLOY_CAREER_WARM_CACHE_STRICT is not true."
+fi
+exit 0
+BASH,
+        $command,
     ));
 });
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32872,5 +32872,102 @@
     ],
     "sidecars": [],
     "next_task": "Wait for GitHub checks and Codex final review; do not merge or deploy from this PR."
+  },
+  "OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01": {
+    "id": "OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01",
+    "repo": "fap-api",
+    "branch": "ops/release-train-career-warm-cache-nonblocking-01",
+    "base": "main",
+    "title": "OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01 keep deploy unblocked by career warm cache",
+    "status": "validated",
+    "depends_on": [
+      "OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01 merged"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User requested making deploy not blocked by career warm cache, then deploying #1770 and optimizing career warm cache separately."
+      },
+      "deploy_safety_boundary": {
+        "status": "pass",
+        "evidence": "This implementation does not run deploy, retry deploy, unlock production, kill processes, migrate, mutate CMS, submit URLs, or touch Search Channel."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "git_diff_check": null,
+      "git_diff_cached_check": null
+    },
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "User authorized first making deploy non-blocking on career warm cache before retrying production deploy."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "Started from latest origin/main in isolated worktree."
+      }
+    ],
+    "sidecars": [
+      "Production deploy run 26699308650 failed because career:warm-public-authority-cache timed out; stale deploy lock was cleaned before this PR."
+    ],
+    "next_task": "After merge, rerun deploy targeting latest main with exact SHA approval.",
+    "validation": [
+      {
+        "command": "php -l deploy.php",
+        "result": "passed"
+      },
+      {
+        "command": "python3 -m py_compile tests/ops/test_backend_deploy_adapter.py",
+        "result": "passed"
+      },
+      {
+        "command": "python3 -m unittest tests.ops.test_backend_deploy_adapter",
+        "result": "passed"
+      },
+      {
+        "command": "python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json",
+        "result": "passed"
+      },
+      {
+        "command": "python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json",
+        "result": "passed_with_existing_placeholder_gh_422_warning"
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json",
+        "result": "passed"
+      },
+      {
+        "command": "python3 -c \"import yaml; yaml.safe_load(open('docs/codex/pr-train.yaml'))\"",
+        "result": "passed"
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "result": "passed"
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-warm.sqlite php artisan migrate --force --no-ansi",
+        "result": "passed"
+      },
+      {
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "result": "passed"
+      },
+      {
+        "command": "git diff --check",
+        "result": "passed"
+      }
+    ],
+    "notes": [
+      "career warm cache deploy hook is non-blocking by default; strict mode remains available via DEPLOY_CAREER_WARM_CACHE_STRICT=true"
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16571,3 +16571,55 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization
+
+  - id: OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01
+    repo: fap-api
+    branch: ops/release-train-career-warm-cache-nonblocking-01
+    base: main
+    title: "OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01 keep deploy unblocked by career warm cache"
+    train_scope: release_train_career_warm_cache_nonblocking
+    risk_level: p1_deploy_reliability
+    depends_on:
+      - OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01 merged
+    allowed_paths:
+      - deploy.php
+      - tests/ops/test_backend_deploy_adapter.py
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Make career:warm-public-authority-cache non-blocking by default during Deployer production release.
+      - Add DEPLOY_CAREER_WARM_CACHE_STRICT=true to preserve fail-closed warm-cache behavior when explicitly required.
+      - Add DEPLOY_SKIP_CAREER_WARM_CACHE=true to skip the warm-cache task explicitly.
+      - Keep deploy symlink, healthcheck, queue restart, sitemap warm, and public-content guard behavior otherwise unchanged.
+      - Do not optimize Career public authority queries in this PR.
+    do_not:
+      - Run production deploy.
+      - Retry failed deployment.
+      - Unlock production deploy state.
+      - Kill production processes.
+      - Change database schema or migrations.
+      - Modify fap-web, content_packs, CMS content, Search Channel, or URL submission.
+    validation:
+      - php -l deploy.php
+      - python3 -m py_compile tests/ops/test_backend_deploy_adapter.py
+      - python3 -m unittest tests.ops.test_backend_deploy_adapter
+      - python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json
+      - python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    deploy_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: deploy latest main only after merge and exact SHA approval

--- a/tests/ops/test_backend_deploy_adapter.py
+++ b/tests/ops/test_backend_deploy_adapter.py
@@ -242,6 +242,19 @@ class ReleaseTrainDeployAdapterIntegrationTest(unittest.TestCase):
         self.assertNotIn("ROLLBACK_COMMAND", env)
 
 
+class DeployPhpCareerWarmCachePolicyTest(unittest.TestCase):
+    def test_career_warm_cache_is_nonblocking_by_default_with_strict_override(self):
+        deploy_php = (ROOT / "deploy.php").read_text(encoding="utf-8")
+
+        self.assertIn("DEPLOY_CAREER_WARM_CACHE_STRICT", deploy_php)
+        self.assertIn("DEPLOY_SKIP_CAREER_WARM_CACHE", deploy_php)
+        self.assertIn("career_warm_public_authority_cache_nonblocking_failure", deploy_php)
+        self.assertIn("Continuing deploy because DEPLOY_CAREER_WARM_CACHE_STRICT is not true.", deploy_php)
+        self.assertIn("if ($strictWarmCache)", deploy_php)
+        self.assertIn("run($command);", deploy_php)
+        self.assertIn("exit 0", deploy_php)
+
+
 class _FakeGitHub:
     def get_pull_request(self, repo, pr_number):
         return {"head": {"sha": _head_sha()}}


### PR DESCRIPTION
## Summary
- Makes `career:warm-public-authority-cache` non-blocking by default in `deploy.php` so production deploy is not blocked by warm-cache timeout.
- Adds explicit strict override: `DEPLOY_CAREER_WARM_CACHE_STRICT=true` preserves blocking behavior.
- Adds explicit skip override: `DEPLOY_SKIP_CAREER_WARM_CACHE=true` skips the warm task.
- Adds ops regression coverage for deploy adapter policy.
- Adds PR train manifest/state entries for this scoped hotfix.

## Context
Deploy run `26699308650` for SHA `1832765a88b8df16efe86142671e549ecf13f85c` failed at `career:warm-public-authority-cache` while the current symlink remained on the old release. The stale deploy lock was cleaned separately before this PR. This PR does not retry deployment and does not optimize the career cache query path.

## Scope boundaries
- No production deploy.
- No deploy retry.
- No unlock/kill process operation.
- No database migration.
- No career cache query optimization.
- No content changes.

## Validation
- `php -l deploy.php` passed.
- `python3 -m py_compile tests/ops/test_backend_deploy_adapter.py` passed.
- `python3 -m unittest tests.ops.test_backend_deploy_adapter` passed.
- `python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json` passed.
- `python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json` passed with existing placeholder `gh` 422 warning from example SHA.
- `python3 -m json.tool docs/codex/pr-train-state.json` passed.
- YAML parse for `docs/codex/pr-train.yaml` passed.
- `php artisan route:list --no-ansi` passed.
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-warm.sqlite php artisan migrate --force --no-ansi` passed.
- `bash backend/scripts/ci_verify_mbti.sh` passed.
- `git diff --check` passed.

## Next after merge
After this PR is merged, retrying production deploy for #1770 still requires fresh exact-SHA deployment approval.
