### PR TITLE
PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -39,6 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
+        $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('eq60:psychometrics --window=last_90_days')->weeklyOn(1, '04:20')->withoutOverlapping();

--- a/backend/docs/runbooks/alipay-pending-compensation.md
+++ b/backend/docs/runbooks/alipay-pending-compensation.md
@@ -19,11 +19,29 @@ php artisan commerce:compensate-pending-orders --provider=alipay --include-creat
 Runtime policy:
 
 - Runs every five minutes through Laravel scheduler.
+- Must be registered in `bootstrap/app.php` via `withSchedule`; this is the
+  runtime scheduler source used by the production Laravel 11 bootstrap.
 - Uses `withoutOverlapping`.
 - Includes stale `created` and `pending` Alipay orders.
 - Does not pass `--close-expired`, so it does not automatically close or expire
   unpaid historical orders.
 - Keeps the query window conservative with `--limit=50`.
+
+## Scheduler Runner Verification
+
+The command being present in `app/Console/Kernel.php` is not sufficient for the
+current bootstrap path. Verify the runtime scheduler and the server runner
+separately:
+
+```bash
+php artisan schedule:list --json | jq -r '.[] | select(.command | contains("commerce:compensate-pending-orders"))'
+```
+
+Production must also have a process manager, cron, or timer that invokes
+Laravel's scheduler, for example `php artisan schedule:run` every minute or
+`php artisan schedule:work` under a process supervisor. If the command appears
+in `schedule:list` but the runner is absent, automatic compensation will not
+execute.
 
 ## Manual Diagnosis
 

--- a/backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
+++ b/backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
@@ -4,42 +4,39 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Commerce;
 
-use App\Console\Kernel;
-use Illuminate\Console\Scheduling\Event;
-use Illuminate\Console\Scheduling\Schedule;
-use ReflectionMethod;
+use Symfony\Component\Process\Process;
 use Tests\TestCase;
 
 final class AlipayPendingCompensationSchedulerTest extends TestCase
 {
     public function test_alipay_pending_compensation_is_registered_conservatively(): void
     {
-        $event = $this->scheduledEventFor('commerce:compensate-pending-orders');
+        $events = $this->scheduleListEvents();
+        $event = collect($events)->first(
+            fn (array $event): bool => str_contains((string) ($event['command'] ?? ''), 'commerce:compensate-pending-orders')
+        );
 
-        $this->assertNotNull($event);
-        $this->assertStringContainsString('--provider=alipay', (string) $event->command);
-        $this->assertStringContainsString('--include-created', (string) $event->command);
-        $this->assertStringContainsString('--limit=50', (string) $event->command);
-        $this->assertStringContainsString('--older-than-minutes=15', (string) $event->command);
-        $this->assertStringNotContainsString('--close-expired', (string) $event->command);
-        $this->assertSame('*/5 * * * *', $event->expression);
-        $this->assertTrue($event->withoutOverlapping);
+        $this->assertNotNull($event, 'schedule:list did not include the Alipay pending compensation command.');
+        $this->assertStringContainsString('--provider=alipay', (string) $event['command']);
+        $this->assertStringContainsString('--include-created', (string) $event['command']);
+        $this->assertStringContainsString('--limit=50', (string) $event['command']);
+        $this->assertStringContainsString('--older-than-minutes=15', (string) $event['command']);
+        $this->assertStringNotContainsString('--close-expired', (string) $event['command']);
+        $this->assertSame('*/5 * * * *', $event['expression']);
     }
 
-    private function scheduledEventFor(string $needle): ?Event
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function scheduleListEvents(): array
     {
-        $schedule = new Schedule;
-        $kernel = $this->app->make(Kernel::class);
-        $method = new ReflectionMethod($kernel, 'schedule');
-        $method->setAccessible(true);
-        $method->invoke($kernel, $schedule);
+        $process = new Process([PHP_BINARY, base_path('artisan'), 'schedule:list', '--json', '--no-ansi'], base_path());
+        $process->mustRun();
 
-        foreach ($schedule->events() as $event) {
-            if (str_contains((string) $event->command, $needle)) {
-                return $event;
-            }
-        }
+        $decoded = json_decode($process->getOutput(), true);
 
-        return null;
+        $this->assertIsArray($decoded);
+
+        return $decoded;
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32752,10 +32752,10 @@
     "repo": "fap-api",
     "branch": "codex/payment-alipay-scheduler-bootstrap-02",
     "base": "main",
-    "status": "committed",
+    "status": "pr_open",
     "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler",
-    "commit_sha": "739e9c21fb84f7e41e819a7addec8ee12eb92195",
-    "pr_url": null,
+    "commit_sha": "fecc207643c37dba0d411eda305a376d6eb3a2db",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1774",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -32809,6 +32809,15 @@
         "status": "pass",
         "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
         "evidence": "PASS: no fap-web changes reported."
+      },
+      "pr_created": {
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1774",
+        "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler"
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR opened; remote checks not completed at ledger update time."
       }
     },
     "failure_reason": null,
@@ -32840,6 +32849,11 @@
         "status": "committed",
         "at": "2026-05-31T01:29:00Z",
         "summary": "Committed scoped runtime scheduler bootstrap fix at 739e9c21fb84f7e41e819a7addec8ee12eb92195."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T01:32:00Z",
+        "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1774 after local validation passed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32747,6 +32747,104 @@
     "sidecars": [],
     "next_task": "deploy-readiness required after merge"
   },
+  "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02": {
+    "id": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02",
+    "repo": "fap-api",
+    "branch": "codex/payment-alipay-scheduler-bootstrap-02",
+    "base": "main",
+    "status": "committed",
+    "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler",
+    "commit_sha": "739e9c21fb84f7e41e819a7addec8ee12eb92195",
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 to fap-api pr-train manifest/state."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to bootstrap scheduler registration, focused scheduler-list test, optional Alipay compensation runbook, and pr-train metadata; no production compensation, production env, CMS/content, deploy, Search Channel, URL submission, or fap-web changes."
+      },
+      "scheduler_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi",
+        "evidence": "PASS: 1 test, 8 assertions; test invokes actual php artisan schedule:list --json process."
+      },
+      "schedule_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan schedule:list --no-ansi",
+        "evidence": "PASS: schedule:list includes php artisan commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15 on */5 * * * *."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS: 207 routes listed."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "PASS: 3647 files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS: composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS: no security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+        "evidence": "PASS: JSON and YAML parsed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check",
+        "evidence": "PASS before staging; cached diff empty at check time."
+      },
+      "fap_web_reference_status": {
+        "status": "pass",
+        "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
+        "evidence": "PASS: no fap-web changes reported."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T01:03:39Z",
+        "summary": "User authorized manifest/state update for PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T01:03:39Z",
+        "summary": "Implementing runtime bootstrap scheduler registration and schedule:list-focused coverage."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T01:26:00Z",
+        "summary": "Runtime bootstrap scheduler registration, schedule:list verification, route list, Pint, Composer validate/audit, JSON/YAML parse, fap-web reference status, and diff checks passed."
+      },
+      {
+        "status": "committed",
+        "at": "2026-05-31T01:29:00Z",
+        "summary": "Committed scoped runtime scheduler bootstrap fix at 739e9c21fb84f7e41e819a7addec8ee12eb92195."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "Run validation, open PR, and after merge perform deploy-readiness plus production scheduler runner verification."
+  },
   "OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01": {
     "id": "OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01",
     "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16410,6 +16410,51 @@ prs:
     frontend_fallback_authority: false
     next_task: deploy-readiness required after merge
 
+  - id: PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02
+    repo: fap-api
+    branch: codex/payment-alipay-scheduler-bootstrap-02
+    base: main
+    title: "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler"
+    train_scope: payment_alipay_scheduler_bootstrap
+    risk_level: p1_payment_fulfillment_reliability
+    depends_on:
+      - PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01
+    allowed_paths:
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
+      - backend/docs/runbooks/alipay-pending-compensation.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Register the existing Alipay pending compensation command in the Laravel 11 runtime scheduler source, `bootstrap/app.php`.
+      - Update focused coverage to validate the actual `schedule:list` output includes the Alipay compensation command.
+      - Document scheduler runner verification so production can distinguish command registration from runner availability.
+      - Do not run production compensation, mutate production data, deploy, mutate CMS/content, submit URLs, enqueue Search Channel actions, or modify fap-web in this PR.
+    validation:
+      - cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi
+      - cd backend && php artisan schedule:list --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: deploy-readiness and production scheduler runner verification required after merge
+
   - id: ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
     repo: fap-api
     branch: codex/analytics-funnel-event-taxonomy-01


### PR DESCRIPTION
## What changed
- Registered the existing Alipay pending-order compensation command in Laravel 11 runtime scheduler source: backend/bootstrap/app.php.
- Updated Alipay scheduler coverage to invoke actual php artisan schedule:list --json instead of reflecting the legacy App\Console\Kernel schedule method.
- Expanded the Alipay pending compensation runbook with runtime scheduler source and scheduler runner verification notes.
- Added the authorized PR train manifest/state entry for PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02.

## Why
Production showed backend/app/Console/Kernel.php contained the scheduler line, but the runtime schedule:list did not include it because production uses bootstrap/app.php withSchedule. This PR registers the command at the active runtime scheduler source.

## Validation
- cd backend && php artisan test --filter=AlipayPendingCompensationScheduler --no-ansi
- cd backend && php artisan schedule:list --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No production compensation was run.
- No deploy was performed.
- No production env, CMS/content, Search Channel, URL submission, or fap-web changes.
- Production scheduler runner setup remains a post-merge/deploy-readiness verification item: schedule:list registration is necessary but not sufficient unless schedule:run/schedule:work is actually invoked on the server.
