### PR TITLE
ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 fix share_click SQL compatibility

### DIFF
--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -819,26 +819,34 @@ final class AnalyticsFunnelDailyBuilder
             return [];
         }
 
-        $attemptExpression = SchemaBaseline::hasTable('shares')
+        $hasShares = SchemaBaseline::hasTable('shares') && SchemaBaseline::hasColumn('events', 'share_id');
+        $attemptExpression = $hasShares
             ? 'COALESCE(events.attempt_id, shares.attempt_id)'
             : 'events.attempt_id';
 
-        $query = DB::table('events')
+        $shareClickEvents = DB::table('events')
             ->selectRaw($attemptExpression.' as attempt_id')
-            ->selectRaw('MIN(events.occurred_at) as stage_at')
-            ->groupByRaw($attemptExpression)
-            ->havingRaw($attemptExpression.' is not null')
-            ->havingRaw('MIN(events.occurred_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
+            ->selectRaw('events.occurred_at as stage_at')
+            ->whereNotNull('events.occurred_at');
 
-        if (SchemaBaseline::hasTable('shares')) {
-            $query->leftJoin('shares', 'shares.id', '=', 'events.share_id');
+        if ($hasShares) {
+            $shareClickEvents->leftJoin('shares', 'shares.id', '=', 'events.share_id');
         }
 
         if ($orgIds !== []) {
-            $query->whereIn('events.org_id', $orgIds);
+            $shareClickEvents->whereIn('events.org_id', $orgIds);
         }
 
-        $this->applyEventAliasFilter($query, FunnelEventTaxonomy::SHARE_CLICK_ALIASES, 'events');
+        $this->applyEventAliasFilter($shareClickEvents, FunnelEventTaxonomy::SHARE_CLICK_ALIASES, 'events');
+
+        $query = DB::query()
+            ->fromSub($shareClickEvents, 'share_click_events')
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->select('attempt_id')
+            ->selectRaw('MIN(stage_at) as stage_at')
+            ->groupBy('attempt_id')
+            ->havingRaw('MIN(stage_at) between ? and ?', [$from->toDateTimeString(), $to->toDateTimeString()]);
 
         return $this->rowsToAttemptMap($query->get()->all(), 'attempt_id', 'stage_at');
     }

--- a/backend/docs/seo/analytics-funnel-refresh-dry-run-sql-fix-02.md
+++ b/backend/docs/seo/analytics-funnel-refresh-dry-run-sql-fix-02.md
@@ -1,0 +1,59 @@
+# ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02
+
+## Purpose
+
+Production dry-run for `analytics:refresh-funnel-daily` advanced beyond the earlier benefit grant unlock blocker after SQL-FIX-01, then failed in the `share_click` stage with:
+
+`SQLSTATE[42S22]: Unknown column 'events.attempt_id' in 'having clause'`
+
+The dry-run was no-write, and `analytics_funnel_daily` before/after counts remained unchanged.
+
+## Fix
+
+`AnalyticsFunnelDailyBuilder::collectShareClickMap()` now resolves the share click attempt relationship in a subquery before aggregation.
+
+The source subquery selects:
+
+- resolved `attempt_id` from `events.attempt_id` or `shares.attempt_id`;
+- `events.occurred_at` as `stage_at`;
+- only share click aliases;
+- the requested org scope.
+
+The outer query then groups by the resolved `attempt_id` alias and filters on `MIN(stage_at)`. It no longer references `events.attempt_id`, `shares.attempt_id`, or `COALESCE(events.attempt_id, shares.attempt_id)` directly in `HAVING`.
+
+## Similar Query Sweep
+
+The focused regression coverage captures generated builder SQL and asserts that table-qualified attempt-id expressions are not emitted in `HAVING` for the known compatibility-sensitive paths:
+
+- `events.attempt_id`
+- `shares.attempt_id`
+- `benefit_grants.attempt_id`
+- `orders.target_attempt_id`
+
+Existing SQL-FIX-01 coverage for `benefit_grants` remains in place.
+
+## Business Semantics
+
+- `share_click` still counts valid share click events tied to a valid attempt.
+- If `events.attempt_id` is present, it is used.
+- If `events.attempt_id` is absent but `shares.attempt_id` is available through `events.share_id`, fallback remains valid.
+- Unrelated share click events without a valid attempt relationship do not count.
+- Org/date scope remains preserved.
+- No analytics schema change was made.
+
+## Explicit Non-actions
+
+- No production refresh was run.
+- No non-dry-run refresh was run in production.
+- No production DB mutation was performed.
+- No migration was added.
+- No scheduler change was made.
+- No GA/Baidu setting was changed.
+- No Search Channel action or URL submission was performed.
+- No write guard behavior was added; that remains a later PR.
+
+## Next Task
+
+After deployment, rerun the bounded production dry-run only:
+
+`ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PROD-DRY-RUN-01-R3`

--- a/backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-02.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-02.v1.json
@@ -1,0 +1,49 @@
+{
+  "schema_version": "analytics_funnel_refresh_dry_run_sql_fix_02.v1",
+  "task": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02",
+  "final_decision": "analytics_funnel_refresh_dry_run_sql_fix_02_completed_ready_for_backend_deploy",
+  "production_r2_failure": {
+    "command": "php artisan analytics:refresh-funnel-daily --from=2026-05-25 --to=2026-05-31 --org=0 --dry-run --no-ansi",
+    "failed_stage": "share_click",
+    "error": "Unknown column 'events.attempt_id' in 'having clause'",
+    "before_count": 0,
+    "after_count": 0,
+    "production_write_observed": false
+  },
+  "root_cause": "share_click aggregation resolved COALESCE(events.attempt_id, shares.attempt_id) in the grouped query and referenced the same table-qualified attempt-id expression in HAVING.",
+  "fix_strategy": {
+    "share_click_subquery_resolution": true,
+    "outer_query_groups_by_resolved_attempt_id_alias": true,
+    "outer_having_filters_min_stage_at_only": true,
+    "invalid_table_qualified_attempt_id_having_removed": true
+  },
+  "business_semantics_preserved": {
+    "event_attempt_id_counts": true,
+    "share_attempt_id_fallback_counts": true,
+    "unrelated_share_events_excluded": true,
+    "org_scope_preserved": true,
+    "date_scope_preserved": true
+  },
+  "similar_query_sweep": {
+    "benefit_grants_attempt_id_having_regression_covered": true,
+    "events_attempt_id_having_regression_covered": true,
+    "shares_attempt_id_having_regression_covered": true,
+    "orders_target_attempt_id_having_regression_covered": true
+  },
+  "production_actions": {
+    "deploy_performed": false,
+    "production_refresh_performed": false,
+    "production_db_mutation_performed": false,
+    "migration_performed": false,
+    "scheduler_changed": false,
+    "ga_baidu_setting_changed": false,
+    "search_channel_action_performed": false,
+    "url_submission_performed": false
+  },
+  "write_guard_added": false,
+  "expected_next_validation": {
+    "command": "php artisan analytics:refresh-funnel-daily --from=2026-05-25 --to=2026-05-31 --org=0 --dry-run --no-ansi",
+    "expected": "dry-run proceeds beyond share_click without table-qualified attempt-id HAVING SQL error"
+  },
+  "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02"
+}

--- a/backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix02Test.php
+++ b/backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix02Test.php
@@ -1,0 +1,169 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Events\QueryExecuted;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class AnalyticsFunnelRefreshDryRunSqlFix02Test extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    public function test_share_click_counts_when_event_attempt_id_is_present(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(247);
+        $day = CarbonImmutable::parse($scenario['day'].' 08:00:00');
+
+        $this->insertShareClickEvent(247, $scenario['attempt_b'], $day->addHours(3)->addMinutes(35));
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [247],
+        );
+
+        $shareClicks = collect($payload['rows'])->sum(
+            static fn (array $row): int => (int) ($row['share_click_attempts'] ?? 0)
+        );
+
+        $this->assertSame(2, $shareClicks);
+    }
+
+    public function test_share_click_counts_through_share_attempt_fallback_when_event_attempt_id_is_absent(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(248);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [248],
+        );
+
+        $rowsByLocale = collect($payload['rows'])->keyBy('locale');
+
+        $this->assertSame(1, (int) ($rowsByLocale->get('en')['share_click_attempts'] ?? 0));
+    }
+
+    public function test_unrelated_share_click_events_do_not_count(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(249);
+        $day = CarbonImmutable::parse($scenario['day'].' 08:00:00');
+
+        $this->insertShareClickEvent(249, null, $day->addHours(2));
+        $this->insertShareClickEvent(250, $scenario['attempt_b'], $day->addHours(3)->addMinutes(35));
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [249],
+        );
+
+        $shareClicks = collect($payload['rows'])->sum(
+            static fn (array $row): int => (int) ($row['share_click_attempts'] ?? 0)
+        );
+
+        $this->assertSame(1, $shareClicks);
+    }
+
+    public function test_share_click_query_no_longer_uses_events_attempt_id_in_having_context(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(251);
+        $queries = [];
+
+        DB::listen(static function (QueryExecuted $query) use (&$queries): void {
+            $queries[] = strtolower($query->sql);
+        });
+
+        app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [251],
+        );
+
+        $combinedSql = implode("\n", $queries);
+
+        $this->assertStringContainsString('share_click_events', $combinedSql);
+        $this->assertStringNotContainsString('having coalesce(events.attempt_id', $combinedSql);
+        $this->assertDoesNotMatchRegularExpression(
+            '/having[^\n]*(?:`?events`?\s*\.\s*`?attempt_id`?|events\.attempt_id|`?shares`?\s*\.\s*`?attempt_id`?|shares\.attempt_id)/',
+            $combinedSql
+        );
+    }
+
+    public function test_dry_run_refresh_completes_past_share_click_stage_without_writing_rows(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(252);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [252],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('attempted_rows=2')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_builder_queries_do_not_emit_table_qualified_attempt_id_having_shapes(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(253);
+        $queries = [];
+
+        DB::listen(static function (QueryExecuted $query) use (&$queries): void {
+            $queries[] = strtolower($query->sql);
+        });
+
+        app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($scenario['day']),
+            new \DateTimeImmutable($scenario['day']),
+            [253],
+        );
+
+        $combinedSql = implode("\n", $queries);
+
+        $this->assertDoesNotMatchRegularExpression(
+            '/having[^\n]*(?:`?events`?\s*\.\s*`?attempt_id`?|events\.attempt_id|`?shares`?\s*\.\s*`?attempt_id`?|shares\.attempt_id|`?benefit_grants`?\s*\.\s*`?attempt_id`?|benefit_grants\.attempt_id|`?orders`?\s*\.\s*`?target_attempt_id`?|orders\.target_attempt_id)/',
+            $combinedSql
+        );
+    }
+
+    private function insertShareClickEvent(
+        int $orgId,
+        ?string $attemptId,
+        CarbonImmutable $occurredAt,
+        ?string $shareId = null,
+    ): void {
+        DB::table('events')->insert([
+            'id' => (string) Str::uuid(),
+            'event_code' => 'share_click',
+            'event_name' => 'share_click',
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => $attemptId ? 'anon_'.$attemptId : null,
+            'session_id' => 'session_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 8),
+            'request_id' => 'req_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 12),
+            'attempt_id' => $attemptId,
+            'meta_json' => json_encode(['attempt_id' => $attemptId, 'share_id' => $shareId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'share_id' => $shareId,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+            'scale_code' => 'MBTI',
+            'channel' => 'web',
+            'region' => 'US',
+            'locale' => 'en',
+        ]);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -23570,7 +23570,7 @@
       "INDEXNOW-LIVE-00"
     ],
     "commit_sha": "96363c840426a49575787bf6292f5d65c7be6f84",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1775",
     "checks": {
       "dependency": {
         "status": "pass",
@@ -33425,6 +33425,11 @@
         "status": "local_checks_passed",
         "at": "2026-05-31T00:00:00+08:00",
         "summary": "Scoped local validation passed for the share_click SQL compatibility fix."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "Opened PR #1775 after scoped local validations passed."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -19606,7 +19606,7 @@
       "depends_on": [
         "RESULT-EN-PARITY-03"
       ],
-      "commit_sha": null,
+      "commit_sha": "f58c1bd2828de45735f719f5f73b05537ccfe947",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1671",
       "checks": {
         "dependency_result_en_parity_00": {
@@ -32195,6 +32195,11 @@
         "summary": "No whitespace errors in unstaged diff."
       },
       {
+        "command": "git diff --cached --check",
+        "status": "passed",
+        "summary": "No whitespace errors in staged diff."
+      },
+      {
         "command": "fap-web reference status",
         "status": "passed",
         "summary": "Reference-only fap-web worktree is clean and was not modified."
@@ -32367,7 +32372,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "git_diff_check": "passed",
-      "git_diff_cached_check": null
+      "git_diff_cached_check": "passed"
     },
     "sidecars": [
       "Reference-only fap-web worktree had unrelated dirty changes before and after this task; no fap-web files were modified.",
@@ -33316,5 +33321,118 @@
     "notes": [
       "career warm cache deploy hook is non-blocking by default; strict mode remains available via DEPLOY_CAREER_WARM_CACHE_STRICT=true"
     ]
+  },
+  "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02": {
+    "id": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-refresh-dry-run-sql-fix-02",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 fix share_click SQL compatibility",
+    "status": "in_progress",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01"
+    ],
+    "commit_sha": "f678306b52eed2572c0815fbd7ad1aaef15cd71b",
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "manifest/state authorization",
+        "status": "passed",
+        "summary": "User explicitly authorized adding only ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "status": "passed",
+        "summary": "2 tests passed, 27 assertions."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix01 --no-ansi",
+        "status": "passed",
+        "summary": "3 tests passed, 8 assertions."
+      },
+      {
+        "command": "php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix02 --no-ansi",
+        "status": "passed",
+        "summary": "6 tests passed, 11 assertions."
+      },
+      {
+        "command": "php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi",
+        "status": "passed",
+        "summary": "1 test passed, 11 assertions."
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "Route list rendered successfully with 207 routes."
+      },
+      {
+        "command": "vendor/bin/pint --test",
+        "status": "passed",
+        "summary": "Pint passed across 3649 files."
+      },
+      {
+        "command": "composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid."
+      },
+      {
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found."
+      },
+      {
+        "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-02.v1.json >/dev/null",
+        "status": "passed",
+        "summary": "Generated SQL fix 02 JSON parses."
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed",
+        "summary": "PR train state JSON parses."
+      },
+      {
+        "command": "python3 - <<'PY' import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok') PY",
+        "status": "passed",
+        "summary": "PR train manifest YAML parses."
+      },
+      {
+        "command": "git diff --check",
+        "status": "passed",
+        "summary": "No whitespace errors in unstaged diff."
+      },
+      {
+        "command": "fap-web reference status",
+        "status": "passed",
+        "summary": "Reference-only fap-web worktree was checked and not modified by this task."
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "User authorized the scoped share_click SQL compatibility fix PR and manifest/state updates."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "Started from latest origin/main on scoped branch codex/analytics-funnel-refresh-dry-run-sql-fix-02."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T00:00:00+08:00",
+        "summary": "Scoped local validation passed for the share_click SQL compatibility fix."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": null
+    },
+    "sidecars": [],
+    "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16126,6 +16126,57 @@ prs:
     frontend_fallback_authority: false
     next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01
 
+  - id: ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02
+    repo: fap-api
+    branch: codex/analytics-funnel-refresh-dry-run-sql-fix-02
+    base: main
+    title: "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 fix share_click SQL compatibility"
+    train_scope: analytics_funnel_refresh_dry_run_sql_fix
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01
+    allowed_paths:
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/docs/seo/analytics-funnel-refresh-dry-run-sql-fix-02.md
+      - backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-02.v1.json
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix01Test.php
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelRefreshDryRunSqlFix02Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Fix production SQL compatibility for the analytics_funnel_daily share_click aggregation.
+      - Preserve share_click semantics for events.attempt_id and shares.attempt_id fallback through events.share_id.
+      - Sweep AnalyticsFunnelDailyBuilder generated query paths for table-qualified attempt-id HAVING shapes.
+      - Keep production refresh, production DB writes, migrations, scheduler changes, GA/Baidu settings, Search Channel actions, URL submissions, and write guards out of scope.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix01 --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix02 --no-ansi
+      - cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-02.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02
+
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api
     branch: fix/content-packs-index-artifact-01


### PR DESCRIPTION
## What changed
- Changed `AnalyticsFunnelDailyBuilder::collectShareClickMap()` to resolve share-click attempt IDs in a subquery before aggregation.
- Added regression coverage for direct `events.attempt_id`, `shares.attempt_id` fallback, unrelated share events, and invalid table-qualified attempt-id HAVING shapes.
- Added FIX-02 docs/generated evidence and scoped PR train manifest/state entries.

## Why
Production dry-run advanced beyond SQL-FIX-01 and then failed in the share_click stage with `Unknown column events.attempt_id in having clause`. The fix mirrors the SQL-FIX-01 pattern so production MySQL does not need to resolve table-qualified attempt-id expressions in `HAVING`.

## Validation
- `cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi`
- `cd backend && php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix01 --no-ansi`
- `cd backend && php artisan test --filter=AnalyticsFunnelRefreshDryRunSqlFix02 --no-ansi`
- `cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/analytics-funnel-refresh-dry-run-sql-fix-02.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Deferred
- No production deploy.
- No production refresh or DB mutation.
- No migration or scheduler change.
- No GA/Baidu setting change.
- No Search Channel action or URL submission.
- No write guard behavior; that remains a later PR.
