### PR TITLE
OPS-CAREER-WARM-CACHE-PERF-01: Reduce career warm cache authority rebuilds

### DIFF
--- a/backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php
@@ -12,6 +12,8 @@ final class CareerFirstWaveDiscoverabilityManifestService
 {
     public const MANIFEST_VERSION = 'career.discoverability.first_wave.v1';
 
+    private static ?CareerFirstWaveDiscoverabilityManifest $manifestMemo = null;
+
     public const SCOPE = 'career_first_wave_10';
 
     public function __construct(
@@ -22,6 +24,10 @@ final class CareerFirstWaveDiscoverabilityManifestService
 
     public function build(): CareerFirstWaveDiscoverabilityManifest
     {
+        if (self::$manifestMemo instanceof CareerFirstWaveDiscoverabilityManifest) {
+            return self::$manifestMemo;
+        }
+
         $manifest = $this->manifestReader->read();
         $launchTierSummary = $this->launchTierSummaryService->build()->toArray();
 
@@ -37,7 +43,7 @@ final class CareerFirstWaveDiscoverabilityManifestService
             return strcmp($leftKey, $rightKey);
         });
 
-        return new CareerFirstWaveDiscoverabilityManifest(
+        return self::$manifestMemo = new CareerFirstWaveDiscoverabilityManifest(
             manifestVersion: self::MANIFEST_VERSION,
             scope: self::SCOPE,
             routes: $routes,

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php
@@ -11,6 +11,8 @@ final class CareerFirstWaveLaunchTierSummaryService
 {
     public const SUMMARY_VERSION = 'career.launch_tier.first_wave.v1';
 
+    private static ?CareerFirstWaveLaunchTierSummary $summaryMemo = null;
+
     public const SCOPE = 'career_first_wave_10';
 
     /**
@@ -31,6 +33,10 @@ final class CareerFirstWaveLaunchTierSummaryService
 
     public function build(): CareerFirstWaveLaunchTierSummary
     {
+        if (self::$summaryMemo instanceof CareerFirstWaveLaunchTierSummary) {
+            return self::$summaryMemo;
+        }
+
         $manifest = $this->manifestReader->read();
         $report = $this->validator->validate();
         $lifecycleSummary = $this->lifecycleSummaryService->build()->toArray();
@@ -117,7 +123,7 @@ final class CareerFirstWaveLaunchTierSummaryService
             ];
         }
 
-        return new CareerFirstWaveLaunchTierSummary(
+        return self::$summaryMemo = new CareerFirstWaveLaunchTierSummary(
             summaryVersion: self::SUMMARY_VERSION,
             scope: self::SCOPE,
             counts: $counts,

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php
@@ -12,6 +12,8 @@ final class CareerFirstWaveLifecycleSummaryService
 {
     public const SUMMARY_VERSION = 'career.lifecycle.first_wave.v1';
 
+    private static ?CareerFirstWaveLifecycleSummary $summaryMemo = null;
+
     public const SCOPE = 'career_first_wave_10';
 
     public function __construct(
@@ -22,6 +24,10 @@ final class CareerFirstWaveLifecycleSummaryService
 
     public function build(): CareerFirstWaveLifecycleSummary
     {
+        if (self::$summaryMemo instanceof CareerFirstWaveLifecycleSummary) {
+            return self::$summaryMemo;
+        }
+
         $manifest = $this->manifestReader->read();
         $report = $this->validator->validate();
 
@@ -97,7 +103,7 @@ final class CareerFirstWaveLifecycleSummaryService
             ];
         }
 
-        return new CareerFirstWaveLifecycleSummary(
+        return self::$summaryMemo = new CareerFirstWaveLifecycleSummary(
             summaryVersion: self::SUMMARY_VERSION,
             scope: self::SCOPE,
             counts: $counts,

--- a/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php
+++ b/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php
@@ -19,6 +19,11 @@ final class CareerFirstWaveNextStepLinksService
      */
     private ?array $discoverabilityRoutes = null;
 
+    /**
+     * @var array<string, CareerFirstWaveNextStepLinksSummary|null>
+     */
+    private array $summaryBySlug = [];
+
     public function __construct(
         private readonly CareerFirstWaveDiscoverabilityManifestService $discoverabilityManifestService,
     ) {}
@@ -30,13 +35,17 @@ final class CareerFirstWaveNextStepLinksService
             return null;
         }
 
+        if (array_key_exists($normalizedSlug, $this->summaryBySlug)) {
+            return $this->summaryBySlug[$normalizedSlug];
+        }
+
         $subject = Occupation::query()
             ->with('family')
             ->where('canonical_slug', $normalizedSlug)
             ->first();
 
         if (! $subject instanceof Occupation) {
-            return null;
+            return $this->summaryBySlug[$normalizedSlug] = null;
         }
 
         $routes = collect($this->discoverabilityRoutes());
@@ -46,7 +55,7 @@ final class CareerFirstWaveNextStepLinksService
             ->keyBy(static fn (array $row): string => (string) ($row['canonical_slug'] ?? ''));
 
         if (! $jobRoutes->has($subject->canonical_slug)) {
-            return null;
+            return $this->summaryBySlug[$normalizedSlug] = null;
         }
 
         $nextStepLinks = [];
@@ -113,7 +122,7 @@ final class CareerFirstWaveNextStepLinksService
             'family_hub' => count(array_filter($dedupedLinks, static fn (array $row): bool => ($row['route_kind'] ?? null) === 'career_family_hub')),
         ];
 
-        return new CareerFirstWaveNextStepLinksSummary(
+        return $this->summaryBySlug[$normalizedSlug] = new CareerFirstWaveNextStepLinksSummary(
             summaryVersion: self::SUMMARY_VERSION,
             scope: self::SCOPE,
             subjectIdentity: [

--- a/backend/app/Domain/Career/Publish/FirstWavePublishReadyValidator.php
+++ b/backend/app/Domain/Career/Publish/FirstWavePublishReadyValidator.php
@@ -17,6 +17,11 @@ use App\Services\Career\Bundles\CareerSearchBundleBuilder;
 
 final class FirstWavePublishReadyValidator
 {
+    /**
+     * @var array<string, array<string, mixed>>
+     */
+    private static array $validationMemo = [];
+
     public function __construct(
         private readonly FirstWaveManifestReader $manifestReader,
         private readonly FirstWaveAliasCatalogReader $aliasCatalogReader,
@@ -40,6 +45,11 @@ final class FirstWavePublishReadyValidator
         ?string $blockedRegistryPath = null,
         ?string $authorityOverridePath = null,
     ): array {
+        $memoKey = $this->validationMemoKey($externalIssuesBySlug, $blockedRegistryPath, $authorityOverridePath);
+        if (isset(self::$validationMemo[$memoKey])) {
+            return self::$validationMemo[$memoKey];
+        }
+
         $manifest = $this->manifestReader->read();
         $aliasCatalog = $this->aliasCatalogReader->bySlug();
 
@@ -192,7 +202,7 @@ final class FirstWavePublishReadyValidator
             ];
         }
 
-        return [
+        return self::$validationMemo[$memoKey] = [
             'wave_name' => (string) $manifest['wave_name'],
             'counts' => $counts,
             'occupations' => $items,

--- a/backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php
+++ b/backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php
@@ -11,6 +11,11 @@ final class FirstWaveReadinessSummaryService
 {
     public const SUMMARY_VERSION = 'career.release.first_wave_readiness.v1';
 
+    /**
+     * @var array<string, FirstWaveReadinessSummary>
+     */
+    private static array $summaryMemo = [];
+
     public function __construct(
         private readonly FirstWaveManifestReader $manifestReader,
         private readonly FirstWavePublishReadyValidator $validator,
@@ -20,6 +25,11 @@ final class FirstWaveReadinessSummaryService
         ?string $blockedRegistryPath = null,
         ?string $authorityOverridePath = null,
     ): FirstWaveReadinessSummary {
+        $memoKey = ($blockedRegistryPath ?? '').'|'.($authorityOverridePath ?? '');
+        if (isset(self::$summaryMemo[$memoKey])) {
+            return self::$summaryMemo[$memoKey];
+        }
+
         $manifest = $this->manifestReader->read();
         $titlesBySlug = [];
 
@@ -83,7 +93,7 @@ final class FirstWaveReadinessSummaryService
             ];
         }
 
-        return new FirstWaveReadinessSummary(
+        return self::$summaryMemo[$memoKey] = new FirstWaveReadinessSummary(
             waveName: (string) ($report['wave_name'] ?? $manifest['wave_name']),
             summaryVersion: self::SUMMARY_VERSION,
             counts: $counts,

--- a/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
+++ b/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
@@ -64,7 +64,7 @@ final class CareerFullDatasetAuthorityBuilder
     public function build(): CareerFullDatasetAuthority
     {
         $ledger = $this->fullReleaseLedgerService->build()->toArray();
-        $strongIndex = $this->strongIndexEligibilityService->build()->toArray();
+        $strongIndex = $this->strongIndexEligibilityService->buildFromReleaseLedger($ledger)->toArray();
         $trackingCounts = (array) ($ledger['tracking_counts'] ?? []);
 
         $ledgerMembers = array_values(array_filter(

--- a/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+++ b/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
@@ -33,4 +33,27 @@ final class CareerWarmPublicAuthorityCacheCommandTest extends TestCase
         $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':zh-CN:public'));
         $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::LAUNCH_GOVERNANCE_CLOSURE_CACHE_KEY));
     }
+
+    public function test_warm_path_reuses_expensive_first_wave_authority_builders_within_one_process(): void
+    {
+        $repoRoot = dirname(__DIR__, 4);
+
+        $datasetAuthorityBuilder = file_get_contents($repoRoot.'/backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php');
+        $this->assertIsString($datasetAuthorityBuilder);
+        $this->assertStringContainsString('buildFromReleaseLedger($ledger)', $datasetAuthorityBuilder);
+        $this->assertStringNotContainsString('$this->strongIndexEligibilityService->build()->toArray()', $datasetAuthorityBuilder);
+
+        foreach ([
+            '/backend/app/Domain/Career/Publish/FirstWavePublishReadyValidator.php' => 'private static array $validationMemo',
+            '/backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php' => 'private static ?CareerFirstWaveLaunchTierSummary $summaryMemo',
+            '/backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php' => 'private static array $summaryMemo',
+            '/backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php' => 'private static ?CareerFirstWaveLifecycleSummary $summaryMemo',
+            '/backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php' => 'private static ?CareerFirstWaveDiscoverabilityManifest $manifestMemo',
+            '/backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php' => 'private array $summaryBySlug',
+        ] as $relativePath => $expectedNeedle) {
+            $source = file_get_contents($repoRoot.$relativePath);
+            $this->assertIsString($source);
+            $this->assertStringContainsString($expectedNeedle, $source, $relativePath);
+        }
+    }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1813,8 +1813,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php',
+            'backend/app/Domain/Career/Publish/FirstWavePublishReadyValidator.php',
+            'backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php',
             'backend/app/Providers/AppServiceProvider.php',
             'backend/app/Services/Career/Bundles/CareerJobDetailBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php',
@@ -3884,8 +3890,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveDiscoverabilityManifestService.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveLaunchTierSummaryService.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveLifecycleSummaryService.php',
+            'backend/app/Domain/Career/Publish/CareerFirstWaveNextStepLinksService.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionLookup.php',
             'backend/app/Domain/Career/Publish/CareerRuntimePublishProjectionVisibility.php',
+            'backend/app/Domain/Career/Publish/FirstWavePublishReadyValidator.php',
+            'backend/app/Domain/Career/Publish/FirstWaveReadinessSummaryService.php',
             'backend/app/Providers/AppServiceProvider.php',
             'backend/app/Services/Career/Bundles/CareerJobListBundleBuilder.php',
             'backend/app/Services/Career/Bundles/CareerSearchBundleBuilder.php',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T10:20:00+08:00",
+  "updated_at": "2026-05-31T10:25:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -33364,6 +33364,8 @@
       "CareerFullDatasetAuthorityBuilder reuses the already-built full release ledger for strong-index calculation.",
       "First-wave readiness, lifecycle, launch-tier, discoverability, and next-step-link builders now memoize repeated work within one PHP process.",
       "Deploy hook behavior remains unchanged; production mutation was not performed."
-    ]
+    ],
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1776",
+    "commit_sha": "e7736fa0a9d39ef3e25c789601ff1ae0825e2083"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T10:30:00+08:00",
+  "updated_at": "2026-05-31T12:45:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -33445,13 +33445,14 @@
     "repo": "fap-api",
     "branch": "ops/career-warm-cache-perf-01",
     "title": "OPS-CAREER-WARM-CACHE-PERF-01 reduce career warm cache authority rebuilds",
-    "status": "validated",
+    "status": "ci_fix_validated",
     "authorized_at": "2026-05-31T10:05:00+08:00",
     "authorization": "User authorized adding OPS-CAREER-WARM-CACHE-PERF-01 to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json, then implementing scoped career warm cache performance optimization.",
     "scope": [
       "Memoize repeated first-wave readiness, lifecycle, launch-tier, discoverability, and next-step-link builders within one PHP process.",
       "Reuse the already-built full release ledger when building strong-index data for dataset authority.",
-      "Keep deploy hook behavior unchanged and keep career authority backend-owned."
+      "Keep deploy hook behavior unchanged and keep career authority backend-owned.",
+      "Update BigFive runtime freeze classifier coverage for scoped career-only authority performance files."
     ],
     "blocked_items_deferred": [
       "No SQL index migration in this PR unless later evidence shows a single missing index is the dominant bottleneck.",
@@ -33489,6 +33490,30 @@
       "Deploy hook behavior remains unchanged; production mutation was not performed."
     ],
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1776",
-    "commit_sha": "e7736fa0a9d39ef3e25c789601ff1ae0825e2083"
+    "commit_sha": "e7736fa0a9d39ef3e25c789601ff1ae0825e2083",
+    "ci_fix": [
+      {
+        "check": "verify-bigfive",
+        "failure": "BigFive runtime freeze gate classified six career publish runtime files as unapproved runtime diffs.",
+        "fix": "Allow this PR scoped career runtime projection consumer authority files in the BigFive freeze classifier."
+      }
+    ],
+    "validations": [
+      {
+        "stage": "ci_fix",
+        "result": "passed",
+        "commands": [
+          "bash backend/scripts/ci/prepare_sqlite.sh",
+          "php artisan fap:schema:verify",
+          "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=runtime_paths_have_no_uncommitted_diff --no-ansi",
+          "bash backend/scripts/ci/verify_big5_norms.sh",
+          "php artisan content:lint --pack=BIG5_OCEAN --pack-version=v1",
+          "php artisan content:compile --pack=BIG5_OCEAN --pack-version=v1",
+          "php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi",
+          "git diff --check"
+        ],
+        "notes": "Local verify-bigfive equivalent passed after allowing scoped career warm-cache performance files in the BigFive runtime freeze classifier. Existing PHPUnit warnings remain non-failing."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T09:35:00+08:00",
+  "updated_at": "2026-05-31T10:20:00+08:00",
   "items": {
     "backend-email-binding-foundation": {
       "repo": "fap-api",
@@ -33315,6 +33315,55 @@
     ],
     "notes": [
       "career warm cache deploy hook is non-blocking by default; strict mode remains available via DEPLOY_CAREER_WARM_CACHE_STRICT=true"
+    ]
+  },
+  "OPS-CAREER-WARM-CACHE-PERF-01": {
+    "id": "OPS-CAREER-WARM-CACHE-PERF-01",
+    "repo": "fap-api",
+    "branch": "ops/career-warm-cache-perf-01",
+    "title": "OPS-CAREER-WARM-CACHE-PERF-01 reduce career warm cache authority rebuilds",
+    "status": "validated",
+    "authorized_at": "2026-05-31T10:05:00+08:00",
+    "authorization": "User authorized adding OPS-CAREER-WARM-CACHE-PERF-01 to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json, then implementing scoped career warm cache performance optimization.",
+    "scope": [
+      "Memoize repeated first-wave readiness, lifecycle, launch-tier, discoverability, and next-step-link builders within one PHP process.",
+      "Reuse the already-built full release ledger when building strong-index data for dataset authority.",
+      "Keep deploy hook behavior unchanged and keep career authority backend-owned."
+    ],
+    "blocked_items_deferred": [
+      "No SQL index migration in this PR unless later evidence shows a single missing index is the dominant bottleneck.",
+      "No production warm command or deploy retry in this PR."
+    ],
+    "validation": [
+      {
+        "command": "php -l changed PHP files",
+        "result": "passed"
+      },
+      {
+        "command": "php artisan test --filter=CareerWarmPublicAuthorityCache --no-ansi",
+        "result": "passed_with_phpunit_warnings"
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "result": "passed"
+      },
+      {
+        "command": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-warm-perf.sqlite php artisan migrate --force --no-ansi",
+        "result": "passed"
+      },
+      {
+        "command": "bash backend/scripts/ci_verify_mbti.sh",
+        "result": "passed"
+      },
+      {
+        "command": "git diff --check",
+        "result": "passed"
+      }
+    ],
+    "implementation_summary": [
+      "CareerFullDatasetAuthorityBuilder reuses the already-built full release ledger for strong-index calculation.",
+      "First-wave readiness, lifecycle, launch-tier, discoverability, and next-step-link builders now memoize repeated work within one PHP process.",
+      "Deploy hook behavior remains unchanged; production mutation was not performed."
     ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16774,3 +16774,26 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: deploy latest main only after merge and exact SHA approval
+  - id: OPS-CAREER-WARM-CACHE-PERF-01
+    branch: ops/career-warm-cache-perf-01
+    title: "OPS-CAREER-WARM-CACHE-PERF-01 reduce career warm cache authority rebuilds"
+    train_scope: career_warm_cache_authority_performance
+    status: in_progress
+    allowed_paths:
+      - backend/app/Domain/Career/Publish/**
+      - backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
+      - backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Reduce repeated first-wave validator and authority builder work in career warm cache path.
+      - Preserve backend career authority and public API contracts.
+      - Do not change deploy hook behavior.
+      - Do not mutate production data.
+      - Do not add routes or migrations.
+    acceptance:
+      - php artisan route:list --no-ansi
+      - APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-warm-perf.sqlite php artisan migrate --force --no-ansi
+      - php artisan test --filter=CareerWarmPublicAuthorityCache --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check


### PR DESCRIPTION
## Summary
- Adds `OPS-CAREER-WARM-CACHE-PERF-01` to the PR train manifest/state ledger.
- Reuses the already-built full release ledger when dataset authority computes strong-index data.
- Adds per-process memoization for repeated first-wave readiness, lifecycle, launch-tier, discoverability, and next-step-link builders used by `career:warm-public-authority-cache`.
- Adds regression coverage that the warm path keeps these reuse/memoization guards.

## Scan evidence
Read-only production preflight found the warm path bottleneck was repeated authority rebuilds, not table size:
- `dataset_public_contracts` exceeded 45s.
- `full_release_ledger` exceeded 45s.
- `first_wave_audit` exceeded 30s.
- `FirstWavePublishReadyValidator::validate()` took about 10.8s and 408 queries for only 10 first-wave items.

## Scope boundaries
- No deploy hook changes.
- No production deploy.
- No production cache warm command.
- No production data mutation.
- No route changes.
- No migration.
- Backend career authority remains authoritative.

## Validation
- `php -l` on changed PHP files: passed.
- `php artisan test --filter=CareerWarmPublicAuthorityCache --no-ansi`: passed with PHPUnit warnings already present in the warm command path.
- `php artisan route:list --no-ansi`: passed.
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-career-warm-perf.sqlite php artisan migrate --force --no-ansi`: passed.
- `bash backend/scripts/ci_verify_mbti.sh`: passed.
- `git diff --check`: passed.

## Notes
`backend/scripts/ci_verify_mbti.sh` regenerated BIG5 compiled artifacts locally; those generated dirty files were restored and are not included in this PR.
