### PR TITLE
PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 classify Alipay owner mismatch paid orders

### DIFF
--- a/backend/docs/commerce/alipay-owner-mismatch-review-03.md
+++ b/backend/docs/commerce/alipay-owner-mismatch-review-03.md
@@ -1,0 +1,77 @@
+# PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03
+
+## Executive Summary
+
+Read-only production verification found eight Alipay orders with
+`payment_state=paid` and `grant_state!=granted` that are blocked by
+`ATTEMPT_OWNER_MISMATCH`.
+
+The automatic Alipay pending compensation scheduler is running, but owner
+mismatch remains intentionally outside automatic repair. The scheduler should
+not grant entitlements or bypass ownership guards for these orders.
+
+## Scope
+
+This packet is a repair-preflight review only. It records the current safe
+classification and future repair policy for the eight owner-mismatch items.
+
+No production repair, production compensation, raw log read, CMS mutation,
+deploy, Search Channel action, URL submission, or fap-web change was performed
+for this PR.
+
+## Findings
+
+The eight paid/no-grant orders split into two operational groups:
+
+- One item is a historical state inconsistency. It already has active
+  entitlement evidence and a ready unified access projection, but
+  `orders.grant_state` is stale. This can be considered for a future
+  state-sync-only repair after explicit approval.
+- Seven items are paid and have result rows, but lack active benefit grants and
+  unified access projections. They require human ownership review before any
+  controlled repair.
+
+All eight have rejected payment events with `ATTEMPT_OWNER_MISMATCH`. This is a
+blocking semantic reject reason and must remain outside automatic scheduler
+repair.
+
+## Pending Compensation Context
+
+The reconciled pending backlog is a separate issue. The sampled pending orders
+that were updated by the scheduler do not have `external_trade_no`,
+`provider_trade_no`, provider session references, or payment events. Their
+attempts show `query_unknown`, so provider lookup cannot safely confirm payment.
+
+This PR does not change pending compensation behavior.
+
+## Future Repair Policy
+
+Future work should be split:
+
+1. A controlled state-sync repair for the one item that already has active grant
+   and ready projection evidence.
+2. A separate human-reviewed owner-mismatch decision packet for the seven items
+   without active grants.
+3. A controlled repair only for items whose ownership is explicitly approved.
+
+Confirmed or unresolved owner mismatch must not be repaired automatically.
+
+## Validation Contract
+
+The generated JSON for this PR is the machine-readable source for the focused
+test. It asserts:
+
+- eight current paid/no-grant owner-mismatch items;
+- one state-sync candidate;
+- seven human-review candidates;
+- automatic owner-mismatch repair is forbidden;
+- production mutation gates are closed.
+
+## Final Decision
+
+`owner_mismatch_review_completed_ready_for_controlled_repair_planning`
+
+## Next Task
+
+`PAYMENT-ALIPAY-OWNER-MISMATCH-CONTROLLED-REPAIR-04` only after explicit future
+approval.

--- a/backend/docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json
+++ b/backend/docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json
@@ -1,0 +1,186 @@
+{
+  "schema_version": "alipay-owner-mismatch-review-03.v1",
+  "task": "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03",
+  "final_decision": "owner_mismatch_review_completed_ready_for_controlled_repair_planning",
+  "production_revision_observed": "498363c648ff363c106275677a8205472c0631ea",
+  "checked_at": "2026-05-31T04:31:33Z",
+  "read_only": true,
+  "raw_logs_read": false,
+  "manual_compensation_executed": false,
+  "manual_repair_executed": false,
+  "owner_mismatch_error_code": "ATTEMPT_OWNER_MISMATCH",
+  "paid_no_grant_current_count": 8,
+  "classification_summary": {
+    "safe_order_grant_state_sync_after_approval": 1,
+    "human_ownership_review_required": 7,
+    "automatic_repair_forbidden": 7,
+    "confirmed_true_owner_mismatch_repair_forbidden": true
+  },
+  "classification_rules": [
+    {
+      "classification": "safe_order_grant_state_sync_after_approval",
+      "required_evidence": [
+        "payment_state=paid",
+        "grant_state is not granted",
+        "active benefit_grants evidence exists by approved non-PII linkage",
+        "unified_access_projection is ready",
+        "result exists"
+      ],
+      "allowed_future_action": "state_sync_only_after_explicit_controlled_repair_approval",
+      "automatic_scheduler_allowed": false
+    },
+    {
+      "classification": "human_ownership_review_required",
+      "required_evidence": [
+        "payment_state=paid",
+        "result exists",
+        "no active benefit grant",
+        "missing unified_access_projection",
+        "payment event rejected with ATTEMPT_OWNER_MISMATCH"
+      ],
+      "allowed_future_action": "human_review_before_any_controlled_repair",
+      "automatic_scheduler_allowed": false
+    },
+    {
+      "classification": "automatic_repair_forbidden",
+      "required_evidence": [
+        "confirmed or unresolved owner mismatch",
+        "payment event rejected with ATTEMPT_OWNER_MISMATCH"
+      ],
+      "allowed_future_action": "none_until_human_owner_review_confirms_safe_repair",
+      "automatic_scheduler_allowed": false
+    }
+  ],
+  "classified_items": [
+    {
+      "item_ref": "owner_mismatch_01",
+      "classification": "safe_order_grant_state_sync_after_approval",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": true,
+      "unified_access_projection_ready": true,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false,
+      "notes": "Historical lifecycle state inconsistency candidate; future repair should sync order grant_state/status only after explicit approval."
+    },
+    {
+      "item_ref": "owner_mismatch_02",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    },
+    {
+      "item_ref": "owner_mismatch_03",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    },
+    {
+      "item_ref": "owner_mismatch_04",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    },
+    {
+      "item_ref": "owner_mismatch_05",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    },
+    {
+      "item_ref": "owner_mismatch_06",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    },
+    {
+      "item_ref": "owner_mismatch_07",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    },
+    {
+      "item_ref": "owner_mismatch_08",
+      "classification": "human_ownership_review_required",
+      "payment_state": "paid",
+      "grant_state": "not_started",
+      "result_exists": true,
+      "active_benefit_grant_exists": false,
+      "unified_access_projection_ready": false,
+      "payment_event_status": "rejected",
+      "payment_event_error_code": "ATTEMPT_OWNER_MISMATCH",
+      "future_write_allowed_without_new_approval": false
+    }
+  ],
+  "pending_compensation_context": {
+    "reconciled_pending_sample_count": 300,
+    "orders_with_external_trade_no": 0,
+    "orders_with_provider_trade_no": 0,
+    "attempts_with_external_trade_no": 0,
+    "attempts_with_provider_trade_no": 0,
+    "attempts_with_provider_session_ref": 0,
+    "with_any_payment_event": 0,
+    "attempts_query_unknown": 300,
+    "interpretation": "Scheduler can mark these pending orders as reconciled, but provider lookup lacks trade/session identifiers and returns query_unknown."
+  },
+  "future_controlled_repair_requirements": [
+    "explicit future approval phrase",
+    "fresh read-only snapshot before any write",
+    "state-sync-only item must still have active grant and ready projection",
+    "human-review items require approved ownership comparison before repair",
+    "stop if an item appears to be a real cross-owner mismatch"
+  ],
+  "automatic_scheduler_policy": {
+    "owner_mismatch_auto_grant_allowed": false,
+    "owner_mismatch_auto_projection_allowed": false,
+    "owner_mismatch_auto_state_sync_allowed": false,
+    "reason": "ATTEMPT_OWNER_MISMATCH is a semantic ownership guard and must not be bypassed by automatic pending compensation."
+  },
+  "no_production_repair": true,
+  "no_manual_compensation": true,
+  "no_raw_log_read": true,
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_fap_web_change": true,
+  "next_task": "PAYMENT-ALIPAY-OWNER-MISMATCH-CONTROLLED-REPAIR-04"
+}

--- a/backend/docs/runbooks/alipay-owner-mismatch-review.md
+++ b/backend/docs/runbooks/alipay-owner-mismatch-review.md
@@ -1,0 +1,53 @@
+# Alipay Owner Mismatch Review
+
+## Purpose
+
+This runbook covers Alipay orders that are already marked `paid` but remain
+blocked from entitlement repair because the payment event or repair guard found
+`ATTEMPT_OWNER_MISMATCH`.
+
+Owner mismatch is a trust-boundary condition. It must not be folded into the
+automatic Alipay pending compensation scheduler.
+
+## Read-Only Review Rules
+
+- Do not run `commerce:compensate-pending-orders` for these orders.
+- Do not run `commerce:repair-paid-orders` for these orders.
+- Do not read raw logs.
+- Do not print order numbers, attempt IDs, user IDs, anon IDs, emails, provider
+  trade numbers, access tokens, or payment payloads.
+- Use aggregate counts and one-way hashes when an item needs stable tracking.
+- Treat unresolved owner mismatch as a blocker for automatic repair.
+
+## Classification
+
+Use the following buckets:
+
+- `safe_order_grant_state_sync_after_approval`: the order already has an active
+  benefit grant and a ready unified access projection, but `orders.grant_state`
+  remains stale. A future controlled repair may sync lifecycle state only after
+  explicit approval.
+- `human_ownership_review_required`: the order is paid and has a result, but no
+  active benefit grant or ready access projection exists. A human must compare
+  order ownership, attempt ownership, and payment context before any repair.
+- `automatic_repair_forbidden`: true or unresolved owner mismatch. The scheduler
+  must not auto-grant or bypass the owner guard.
+
+## Future Controlled Repair Requirements
+
+Before any write:
+
+1. Confirm exact scoped approval phrase for a controlled owner-mismatch repair.
+2. Re-run a read-only snapshot and confirm counts have not drifted.
+3. For state-sync-only items, verify active grant and ready projection still
+   exist before syncing order lifecycle fields.
+4. For human-review items, verify ownership using approved internal context
+   without exposing PII in command output or PR artifacts.
+5. Stop if any item looks like a real cross-owner payment or attempt mismatch.
+
+## Non-Goals
+
+- No production repair in the review PR.
+- No automatic scheduler bypass for `ATTEMPT_OWNER_MISMATCH`.
+- No Search Channel action, URL submission, CMS mutation, deploy, or frontend
+  change.

--- a/backend/tests/Feature/Commerce/AlipayOwnerMismatchReview03Test.php
+++ b/backend/tests/Feature/Commerce/AlipayOwnerMismatchReview03Test.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Commerce;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class AlipayOwnerMismatchReview03Test extends TestCase
+{
+    #[Test]
+    public function owner_mismatch_review_artifacts_exist_with_closed_write_gates(): void
+    {
+        $reportPath = base_path('docs/commerce/alipay-owner-mismatch-review-03.md');
+        $runbookPath = base_path('docs/runbooks/alipay-owner-mismatch-review.md');
+        $generatedPath = base_path('docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($runbookPath);
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('alipay-owner-mismatch-review-03.v1', $generated['schema_version'] ?? null);
+        $this->assertSame('PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03', $generated['task'] ?? null);
+        $this->assertSame('ATTEMPT_OWNER_MISMATCH', $generated['owner_mismatch_error_code'] ?? null);
+        $this->assertSame(8, $generated['paid_no_grant_current_count'] ?? null);
+
+        $summary = $generated['classification_summary'] ?? [];
+        $this->assertSame(1, $summary['safe_order_grant_state_sync_after_approval'] ?? null);
+        $this->assertSame(7, $summary['human_ownership_review_required'] ?? null);
+        $this->assertSame(7, $summary['automatic_repair_forbidden'] ?? null);
+        $this->assertTrue($summary['confirmed_true_owner_mismatch_repair_forbidden'] ?? false);
+
+        $items = $generated['classified_items'] ?? [];
+        $this->assertCount(8, $items);
+        $this->assertCount(1, array_filter(
+            $items,
+            static fn (array $item): bool => ($item['classification'] ?? null) === 'safe_order_grant_state_sync_after_approval'
+        ));
+        $this->assertCount(7, array_filter(
+            $items,
+            static fn (array $item): bool => ($item['classification'] ?? null) === 'human_ownership_review_required'
+        ));
+
+        foreach ($items as $item) {
+            $this->assertSame('ATTEMPT_OWNER_MISMATCH', $item['payment_event_error_code'] ?? null);
+            $this->assertFalse($item['future_write_allowed_without_new_approval'] ?? true);
+        }
+
+        $schedulerPolicy = $generated['automatic_scheduler_policy'] ?? [];
+        $this->assertFalse($schedulerPolicy['owner_mismatch_auto_grant_allowed'] ?? true);
+        $this->assertFalse($schedulerPolicy['owner_mismatch_auto_projection_allowed'] ?? true);
+        $this->assertFalse($schedulerPolicy['owner_mismatch_auto_state_sync_allowed'] ?? true);
+
+        $this->assertTrue($generated['no_production_repair'] ?? false);
+        $this->assertTrue($generated['no_manual_compensation'] ?? false);
+        $this->assertTrue($generated['no_raw_log_read'] ?? false);
+        $this->assertTrue($generated['no_cms_mutation'] ?? false);
+        $this->assertTrue($generated['no_deploy'] ?? false);
+        $this->assertTrue($generated['no_search_channel_action'] ?? false);
+        $this->assertTrue($generated['no_url_submission'] ?? false);
+        $this->assertTrue($generated['no_fap_web_change'] ?? false);
+        $this->assertNotEmpty($generated['final_decision'] ?? null);
+        $this->assertNotEmpty($generated['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33515,5 +33515,134 @@
         "notes": "Local verify-bigfive equivalent passed after allowing scoped career warm-cache performance files in the BigFive runtime freeze classifier. Existing PHPUnit warnings remain non-failing."
       }
     ]
+  },
+  "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03": {
+    "id": "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03",
+    "repo": "fap-api",
+    "branch": "codex/payment-alipay-owner-mismatch-review-03",
+    "base": "main",
+    "status": "github_checks_passed",
+    "title": "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 classify Alipay owner mismatch paid orders",
+    "commit_sha": "341d53c0e0a1fffbe3fcba82fe35a29cad5217d4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1777",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 to fap-api pr-train manifest/state."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 is merged as PR #1774 with merge commit 498363c648ff363c106275677a8205472c0631ea, and origin/main contains it."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to owner-mismatch review runbook/report/generated JSON/focused test and pr-train metadata; no production repair, manual compensation, raw log read, deploy, CMS/content mutation, Search Channel action, URL submission, or fap-web change."
+      },
+      "focused_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AlipayOwnerMismatchReview03 --no-ansi",
+        "evidence": "PASS after rebase: 1 test, 43 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS after rebase: route:list rendered successfully."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "PASS after rebase: 3650 files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS after rebase: composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS after rebase: no security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool backend/docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+        "evidence": "PASS after rebase: generated JSON, state JSON, and manifest YAML parsed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check",
+        "evidence": "PASS after rebase: git diff --check and git diff --cached --check passed."
+      },
+      "fap_web_reference_status": {
+        "status": "pass",
+        "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
+        "evidence": "PASS: no fap-web changes reported."
+      },
+      "pr_created": {
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1777",
+        "title": "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 classify Alipay owner mismatch paid orders"
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "PR #1777 GitHub checks passed after rebase: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, and Code Scanning checks reported success."
+      },
+      "rebase_latest_main": {
+        "status": "pass",
+        "evidence": "Rebased onto latest origin/main 85ab91f1eac80ba50b0960a129567d78afeced56 after PR mergeStateStatus showed DIRTY; conflicts resolved by preserving latest ledger/manifest and scoped owner-mismatch entry."
+      },
+      "merge_state": {
+        "status": "pass",
+        "evidence": "PR #1777 mergeStateStatus was CLEAN before this ledger update."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-05-31T12:40:00+08:00",
+        "summary": "User authorized manifest/state update for PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-05-31T12:40:00+08:00",
+        "summary": "Implementing read-only owner-mismatch review artifacts and focused validation."
+      },
+      {
+        "status": "local_checks_passed",
+        "at": "2026-05-31T12:55:00+08:00",
+        "summary": "Read-only owner-mismatch review artifacts, focused test, route list, Pint, Composer validate/audit, JSON/YAML parse, fap-web reference status, and diff checks passed."
+      },
+      {
+        "status": "committed",
+        "at": "2026-05-31T12:58:00+08:00",
+        "summary": "Committed scoped read-only owner-mismatch review at 17604356e7eee000c86b4b7070413ad508fcf1a1."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-05-31T13:02:00+08:00",
+        "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1777 after scoped local validation passed."
+      },
+      {
+        "status": "rebased_local_checks_passed",
+        "at": "2026-05-31T13:10:00+08:00",
+        "summary": "Rebased onto latest origin/main and reran scoped local validation at 404d2cc77747f8c2f70a81f88ac969423f01d5ca."
+      },
+      {
+        "status": "github_checks_passed",
+        "at": "2026-05-31T13:37:00+08:00",
+        "summary": "GitHub checks passed and mergeStateStatus was CLEAN for PR #1777."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "Controlled owner-mismatch repair only after explicit future approval."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16612,6 +16612,54 @@ prs:
     frontend_fallback_authority: false
     next_task: deploy-readiness and production scheduler runner verification required after merge
 
+  - id: PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03
+    repo: fap-api
+    branch: codex/payment-alipay-owner-mismatch-review-03
+    base: main
+    title: "PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03 classify Alipay owner mismatch paid orders"
+    train_scope: payment_alipay_owner_mismatch_review
+    risk_level: p1_payment_fulfillment_reliability
+    depends_on:
+      - PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02
+    allowed_paths:
+      - backend/docs/runbooks/alipay-owner-mismatch-review.md
+      - backend/docs/commerce/alipay-owner-mismatch-review-03.md
+      - backend/docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json
+      - backend/tests/Feature/Commerce/AlipayOwnerMismatchReview03Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Produce a read-only owner-mismatch review packet for the eight current Alipay paid/no-grant orders blocked by ATTEMPT_OWNER_MISMATCH.
+      - Classify one historical state-inconsistency item as safe for future order grant_state sync only after a separate controlled repair approval.
+      - Classify seven items as requiring human ownership review before any controlled repair.
+      - Document that true or unresolved owner mismatch must not be repaired by the automatic pending compensation scheduler.
+      - Do not execute production repair, production compensation, raw log reads, production env changes, deploy, CMS/content mutation, Search Channel action, URL submission, or fap-web changes in this PR.
+    validation:
+      - cd backend && php artisan test --filter=AlipayOwnerMismatchReview03 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: controlled owner-mismatch repair only after explicit future approval
+
+
   - id: ANALYTICS-FUNNEL-EVENT-TAXONOMY-01
     repo: fap-api
     branch: codex/analytics-funnel-event-taxonomy-01


### PR DESCRIPTION
## What changed
- Added a read-only Alipay owner mismatch review report and generated JSON packet for the 8 current `ATTEMPT_OWNER_MISMATCH` paid/no-grant items.
- Added an ops runbook that keeps owner mismatch outside automatic scheduler repair and defines future controlled repair requirements.
- Added focused coverage asserting the review packet, classification counts, and closed write gates.
- Registered `PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03` in the PR train manifest/state.

## Why
The Alipay pending compensation scheduler is running, but 8 paid/no-grant orders remain blocked by owner mismatch semantics. This PR preserves that safety boundary and prepares a separate, explicit future repair decision path.

## Validation commands
- `cd backend && php artisan test --filter=AlipayOwnerMismatchReview03 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/commerce/generated/alipay-owner-mismatch-review-03.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production repair or manual compensation.
- No raw log reads.
- No scheduler bypass for `ATTEMPT_OWNER_MISMATCH`.
- Future controlled repair requires a separate explicit approval.

## Repository rule impact
Payment repair ownership remains backend-authoritative. This PR adds only read-only docs/generated review artifacts and a focused test; it does not change runtime behavior or content authority.
