### PR TITLE
AUDIT-SEC-RELEASE-TRAIN-01: Harden release train deploy boundary

### DIFF
--- a/.github/workflows/release-train.yml
+++ b/.github/workflows/release-train.yml
@@ -59,15 +59,32 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Validate manifest
+        env:
+          RELEASE_TRAIN_MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
-          python3 -m json.tool "${{ github.event.inputs.manifest_path }}"
+          python3 - <<'PY'
+          import os
+          import pathlib
+
+          raw = os.environ.get("RELEASE_TRAIN_MANIFEST_PATH", "")
+          path = pathlib.PurePosixPath(raw)
+          if (
+              raw == ""
+              or path.is_absolute()
+              or ".." in path.parts
+              or path.suffix != ".json"
+              or not pathlib.Path(raw).is_file()
+          ):
+              raise SystemExit("invalid release train manifest path")
+          PY
+          python3 -m json.tool "${RELEASE_TRAIN_MANIFEST_PATH}"
           python3 ops/release-train/release_train.py validate-manifest \
-            --manifest "${{ github.event.inputs.manifest_path }}" \
+            --manifest "${RELEASE_TRAIN_MANIFEST_PATH}" \
             --output artifacts/validation.json
           python3 ops/release-train/release_train.py plan \
-            --manifest "${{ github.event.inputs.manifest_path }}" \
+            --manifest "${RELEASE_TRAIN_MANIFEST_PATH}" \
             --output artifacts/plan.json
       - uses: actions/upload-artifact@v4
         if: always()
@@ -85,11 +102,28 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Dry-run execution
+        env:
+          RELEASE_TRAIN_MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          python3 - <<'PY'
+          import os
+          import pathlib
+
+          raw = os.environ.get("RELEASE_TRAIN_MANIFEST_PATH", "")
+          path = pathlib.PurePosixPath(raw)
+          if (
+              raw == ""
+              or path.is_absolute()
+              or ".." in path.parts
+              or path.suffix != ".json"
+              or not pathlib.Path(raw).is_file()
+          ):
+              raise SystemExit("invalid release train manifest path")
+          PY
           python3 ops/release-train/release_train.py dry-run \
-            --manifest "${{ github.event.inputs.manifest_path }}" \
+            --manifest "${RELEASE_TRAIN_MANIFEST_PATH}" \
             --output artifacts/dry-run.json
       - uses: actions/upload-artifact@v4
         if: always()
@@ -100,22 +134,39 @@ jobs:
   run-train:
     name: Run release train
     needs: validate
-    if: ${{ github.event.inputs.mode == 'run' && github.event.inputs.allow_deploy == 'true' && github.event.inputs.dry_run != 'true' }}
+    if: ${{ github.ref == 'refs/heads/main' && github.event.inputs.mode == 'run' && github.event.inputs.allow_deploy == 'true' && github.event.inputs.dry_run != 'true' }}
     runs-on: ubuntu-latest
     environment: production
     steps:
       - uses: actions/checkout@v4
       - name: Execute train
         env:
+          RELEASE_TRAIN_MANIFEST_PATH: ${{ github.event.inputs.manifest_path }}
+          RELEASE_TRAIN_TRAIN_ID: ${{ github.event.inputs.train_id }}
           RELEASE_TRAIN_ALLOW_MERGE: ${{ github.event.inputs.allow_merge }}
           RELEASE_TRAIN_ALLOW_DEPLOY: ${{ github.event.inputs.allow_deploy }}
           RELEASE_TRAIN_ALLOW_ROLLBACK: ${{ github.event.inputs.allow_rollback }}
         run: |
           set -euo pipefail
           mkdir -p artifacts
+          python3 - <<'PY'
+          import os
+          import pathlib
+
+          raw = os.environ.get("RELEASE_TRAIN_MANIFEST_PATH", "")
+          path = pathlib.PurePosixPath(raw)
+          if (
+              raw == ""
+              or path.is_absolute()
+              or ".." in path.parts
+              or path.suffix != ".json"
+              or not pathlib.Path(raw).is_file()
+          ):
+              raise SystemExit("invalid release train manifest path")
+          PY
           python3 ops/release-train/release_train.py run \
-            --manifest "${{ github.event.inputs.manifest_path }}" \
-            --train-id "${{ github.event.inputs.train_id }}" \
+            --manifest "${RELEASE_TRAIN_MANIFEST_PATH}" \
+            --train-id "${RELEASE_TRAIN_TRAIN_ID}" \
             --allow-merge "${RELEASE_TRAIN_ALLOW_MERGE}" \
             --allow-deploy "${RELEASE_TRAIN_ALLOW_DEPLOY}" \
             --allow-rollback "${RELEASE_TRAIN_ALLOW_ROLLBACK}" \

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33644,5 +33644,55 @@
     ],
     "sidecars": [],
     "next_task": "Controlled owner-mismatch repair only after explicit future approval."
+  },
+  "AUDIT-SEC-RELEASE-TRAIN-01": {
+    "id": "AUDIT-SEC-RELEASE-TRAIN-01",
+    "repo": "fap-api",
+    "branch": "audit/sec-release-train-01",
+    "base": "main",
+    "title": "AUDIT-SEC-RELEASE-TRAIN-01 harden release train deploy boundary",
+    "status": "in_progress",
+    "depends_on": [
+      "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01 merged"
+    ],
+    "checks": {
+      "authorization": "user explicitly authorized continuing AUDIT-SEC-RELEASE-TRAIN-01",
+      "workspace_safety": "using isolated worktree /private/tmp/fap-api-audit-sec-release-train-01; primary worktree untouched",
+      "deploy_safety_boundary": "no deploy, no production mutation, no secret read/write"
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": false,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-05-31T14:36:40+08:00",
+        "from": "authorized",
+        "to": "in_progress",
+        "note": "Audit PR started from latest origin/main in isolated worktree."
+      },
+      {
+        "at": "2026-05-31T14:39:58+08:00",
+        "from": "in_progress",
+        "to": "local_validation_external_blocker_recorded",
+        "note": "Scoped release-train validation passed; unrelated ci_verify_mbti failure registered as sidecar per train protocol."
+      }
+    ],
+    "sidecars": [
+      {
+        "at": "2026-05-31T14:39:58+08:00",
+        "type": "external_validation_failure",
+        "scope": "backend/scripts/ci_verify_mbti.sh",
+        "summary": "Local MBTI master chain failed in BigFive norm/registry SQLite schema-lock tests outside release-train scope; generated BIG5 compiled files were reverted and not included.",
+        "current_pr_introduced": false
+      }
+    ],
+    "next_task": "Run local validation, open PR, wait for CI, merge if allowed, cleanup, then continue SECURITY-AUDIT-36-PR-TRAIN."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16467,6 +16467,68 @@ prs:
     frontend_fallback_authority: false
     next_task: after merge restrict GitHub production environment branch policy to main and rerun dry-run/readiness
 
+  - id: AUDIT-SEC-RELEASE-TRAIN-01
+    repo: fap-api
+    branch: audit/sec-release-train-01
+    base: main
+    title: "AUDIT-SEC-RELEASE-TRAIN-01 harden release train deploy boundary"
+    train_scope: release_train_deploy_boundary_hardening
+    risk_level: p0_security_deploy_boundary
+    depends_on:
+      - OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01 merged
+    allowed_paths:
+      - .github/workflows/release-train.yml
+      - ops/release-train/release_train.py
+      - ops/release-train/schema/release-train.schema.json
+      - ops/release-train/examples/release-train.example.json
+      - tests/ops/test_release_train_workflow.py
+      - tests/ops/test_backend_deploy_adapter.py
+      - docs/ops/release-train.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Fix release-train production deploy branch/ref guard.
+      - Prevent manifest-controlled deployer binary/path override.
+      - Harden workflow/release-train input handling against command injection.
+      - Keep dry-run/validate behavior working.
+    do_not:
+      - Do not deploy, run mode=run, approve production, mutate production, or run SSH.
+      - Do not modify .github/workflows/deploy.yml or .github/workflows/ci.yml.
+      - Do not modify deploy.php, backend app/business code, migrations, content baselines, CMS, DB, production env, fap-web, sitemap, llms, Search Channel, or URL submission files.
+      - Do not enable rollback, frontend deploy, auto merge, or production approval bypass.
+      - Do not print, read, create, update, or delete secret values.
+    validation:
+      - python3 -m json.tool ops/release-train/schema/release-train.schema.json >/dev/null
+      - python3 -m json.tool ops/release-train/examples/release-train.example.json >/dev/null
+      - python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json
+      - python3 ops/release-train/release_train.py plan --manifest ops/release-train/examples/release-train.example.json
+      - python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json
+      - python3 -m unittest discover tests/ops
+      - bash -n backend/scripts/deploy/deploy_backend.sh
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-release-train-01.sqlite php artisan migrate --force --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release-train.yml').read_text()); yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - bash backend/scripts/ci_verify_mbti.sh
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: continue SECURITY-AUDIT-36-PR-TRAIN with AUDIT-SEC-RESULT-IDENTITY-01 after post-merge cleanup
+
   - id: PR-POL-01
     repo: fap-api
     branch: content/pr-pol-01-policies-dashboard

--- a/docs/ops/release-train.md
+++ b/docs/ops/release-train.md
@@ -56,6 +56,7 @@ environment-scoped secrets apply to the same job that can invoke
 
 `run-train` is guarded by all of the following workflow inputs:
 
+- workflow ref is `refs/heads/main`
 - `mode == run`
 - `allow_deploy == true`
 - `dry_run != true`
@@ -63,6 +64,16 @@ environment-scoped secrets apply to the same job that can invoke
 This keeps dry-run validation outside production approval while making the
 future real backend run path wait for the production environment reviewer before
 the job can access production environment secrets.
+
+The main-branch guard is enforced in the repository workflow, not only by
+external GitHub Environment settings. A manual dispatch against any non-main ref
+must not enter the deploy-capable `run-train` job even if the dispatcher supplies
+deployment-oriented inputs.
+
+The workflow passes operator inputs to shell steps through environment variables
+and validates the manifest path before use. The manifest path must be a relative
+JSON file that exists in the checked-out repository, must not be absolute, and
+must not contain `..` path components.
 
 ## Manifest
 Top-level fields:
@@ -93,6 +104,12 @@ Each item includes:
 - `smoke_checks`
 - `rollback`
 - `sidecar_policy`
+
+Manifest items must not provide deployer override fields. The release train does
+not accept `deployer_bin`, `deployer_file`, `DEPLOYER_BIN`, or `DEPLOYER_FILE`
+from a manifest, and the run path blocks any item that contains those fields.
+The deploy wrapper is responsible for resolving the approved Deployer binary and
+deploy file from repository-controlled configuration.
 
 ## Smoke checks
 `smoke.py` supports:

--- a/ops/release-train/release_train.py
+++ b/ops/release-train/release_train.py
@@ -43,6 +43,12 @@ ALLOWED_COMPONENTS = {"backend", "frontend", "both", "docs", "ops"}
 ALLOWED_RISK = {"low", "medium", "high"}
 ALLOWED_DEPLOY_ORDER = {"backend_first", "frontend_first", "none"}
 ALLOWED_CHECK_POLICIES = {"required_only", "all_checks"}
+FORBIDDEN_DEPLOY_OVERRIDE_FIELDS = {
+    "deployer_bin",
+    "deployer_file",
+    "DEPLOYER_BIN",
+    "DEPLOYER_FILE",
+}
 
 
 def _load_json(path: str) -> dict:
@@ -106,6 +112,9 @@ def validate_schema(manifest: dict) -> tuple[bool, list[str]]:
         for key in sorted(required_item_fields):
             if key not in item:
                 errors.append(f"item[{index}] missing field {key}")
+        for key in sorted(FORBIDDEN_DEPLOY_OVERRIDE_FIELDS):
+            if key in item:
+                errors.append(f"item[{index}] forbidden deploy override field {key}")
         if item.get("repo") not in ALLOWED_REPOS:
             errors.append(f"item[{index}] has unsupported repo {item.get('repo')}")
         if item.get("component") not in ALLOWED_COMPONENTS:
@@ -206,6 +215,13 @@ def evaluate_item(
         "failures": [],
         "sidecars": [],
     }
+
+    override_fields = sorted(key for key in FORBIDDEN_DEPLOY_OVERRIDE_FIELDS if key in item)
+    if override_fields:
+        result["status"] = "blocked"
+        result["failures"].append("deployer_override_forbidden")
+        result["checks"]["deployer_override_forbidden"] = override_fields
+        return result
 
     pr_data = github.get_pull_request(f"fermatmind/{repo}", pr_number)
     if pr_data is None:
@@ -313,12 +329,6 @@ def evaluate_item(
             "ALLOW_PRODUCTION_DEPLOY": "true" if _bool_from_str(os.environ.get("RELEASE_TRAIN_ALLOW_DEPLOY", "false")) else "false",
             "ALLOW_REAL_DEPLOY": "true" if allow_deploy else "false",
         })
-        deployer_bin = item.get("deployer_bin") or item.get("DEPLOYER_BIN")
-        deployer_file = item.get("deployer_file") or item.get("DEPLOYER_FILE")
-        if deployer_bin:
-            cmd_env["DEPLOYER_BIN"] = str(deployer_bin)
-        if deployer_file:
-            cmd_env["DEPLOYER_FILE"] = str(deployer_file)
         deployment = _run_command(
             ["bash", str(CURRENT_DIR.parent.parent / "backend/scripts/deploy/deploy_backend.sh")],
             env=cmd_env,

--- a/ops/release-train/schema/release-train.schema.json
+++ b/ops/release-train/schema/release-train.schema.json
@@ -86,8 +86,6 @@
         "risk_level": { "type": "string", "enum": ["low", "medium", "high"] },
         "deploy_required": { "type": "boolean" },
         "deploy_target": { "type": "string", "enum": ["production", "staging"] },
-        "deployer_bin": { "type": "string" },
-        "deployer_file": { "type": "string" },
         "deploy_order": { "type": "string", "enum": ["backend_first", "frontend_first", "none"] },
         "required_checks_policy": { "type": "string", "enum": ["required_only", "all_checks"] },
         "allowed_files": { "type": "array", "items": { "type": "string" } },
@@ -96,6 +94,14 @@
         "smoke_checks": { "type": "array", "items": { "$ref": "#/$defs/smoke" } },
         "rollback": { "$ref": "#/$defs/rollback" },
         "sidecar_policy": { "$ref": "#/$defs/sidecar" }
+      },
+      "not": {
+        "anyOf": [
+          { "required": ["deployer_bin"] },
+          { "required": ["deployer_file"] },
+          { "required": ["DEPLOYER_BIN"] },
+          { "required": ["DEPLOYER_FILE"] }
+        ]
       },
       "additionalProperties": true
     }

--- a/tests/ops/test_backend_deploy_adapter.py
+++ b/tests/ops/test_backend_deploy_adapter.py
@@ -240,6 +240,84 @@ class ReleaseTrainDeployAdapterIntegrationTest(unittest.TestCase):
         self.assertEqual(env["BACKEND_DEPLOY_SHA"], _head_sha())
         self.assertEqual(env["RELEASE_NAME"], "adapter-release-name")
         self.assertNotIn("ROLLBACK_COMMAND", env)
+        self.assertNotIn("DEPLOYER_BIN", env)
+        self.assertNotIn("DEPLOYER_FILE", env)
+
+    def test_release_train_blocks_manifest_controlled_deployer_override(self):
+        module = _load_release_train_module()
+
+        result = module.evaluate_item(
+            {
+                "id": "adapter-run",
+                "release_name": "adapter-release-name",
+                "repo": "fap-api",
+                "pr_number": 1,
+                "expected_head_sha": _head_sha(),
+                "component": "backend",
+                "risk_level": "medium",
+                "deploy_required": True,
+                "deploy_target": "production",
+                "deployer_bin": "/tmp/dep",
+                "deploy_order": "backend_first",
+                "required_checks_policy": "required_only",
+                "allowed_files": ["backend/scripts/deploy/deploy_backend.sh"],
+                "allowed_generated_paths": [],
+                "scope_validation": "required_scope_only",
+                "smoke_checks": [],
+                "rollback": {"enabled": False, "wrapper": "backend/scripts/deploy/rollback_backend.sh"},
+                "sidecar_policy": {"allow_nonblocking_sidecars": False},
+            },
+            manifest={"train_id": "adapter-test"},
+            github=_FakeGitHub(),
+            execute_smoke=False,
+            allow_deploy=True,
+            mode="run",
+        )
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertIn("deployer_override_forbidden", result["failures"])
+        self.assertEqual(result["checks"]["deployer_override_forbidden"], ["deployer_bin"])
+
+    def test_release_train_schema_rejects_deployer_override_fields(self):
+        module = _load_release_train_module()
+
+        manifest = {
+            "schema_version": "1.0",
+            "train_id": "adapter-test",
+            "environment": "production",
+            "mode": "dry_run",
+            "stop_on_failure": True,
+            "rollback_on_failed_smoke": True,
+            "allow_merge": False,
+            "allow_deploy": False,
+            "allow_rollback": False,
+            "items": [
+                {
+                    "id": "adapter-run",
+                    "repo": "fap-api",
+                    "pr_number": 1,
+                    "expected_head_sha": _head_sha(),
+                    "component": "backend",
+                    "risk_level": "medium",
+                    "deploy_required": True,
+                    "deploy_target": "production",
+                    "DEPLOYER_FILE": "/tmp/deploy.php",
+                    "deploy_order": "backend_first",
+                    "required_checks_policy": "required_only",
+                    "allowed_files": ["backend/scripts/deploy/deploy_backend.sh"],
+                    "allowed_generated_paths": [],
+                    "scope_validation": "required_scope_only",
+                    "smoke_checks": [],
+                    "rollback": {"enabled": False, "wrapper": "backend/scripts/deploy/rollback_backend.sh"},
+                    "sidecar_policy": {"allow_nonblocking_sidecars": False},
+                }
+            ],
+        }
+
+        ok, errors = module.validate_schema(manifest)
+
+        self.assertFalse(ok)
+        self.assertIn("item[1] forbidden deploy override field DEPLOYER_FILE", errors)
 
 
 class DeployPhpCareerWarmCachePolicyTest(unittest.TestCase):

--- a/tests/ops/test_release_train_workflow.py
+++ b/tests/ops/test_release_train_workflow.py
@@ -25,9 +25,29 @@ class ReleaseTrainWorkflowTest(unittest.TestCase):
 
         self.assertEqual(run_train["needs"], "validate")
         self.assertEqual(run_train["environment"], "production")
+        self.assertIn("github.ref == 'refs/heads/main'", run_train["if"])
         self.assertIn("mode == 'run'", run_train["if"])
         self.assertIn("allow_deploy == 'true'", run_train["if"])
         self.assertIn("dry_run != 'true'", run_train["if"])
+
+    def test_workflow_does_not_interpolate_manifest_path_inside_shell_commands(self):
+        for job_name in ["validate", "dry-run", "run-train"]:
+            with self.subTest(job_name=job_name):
+                steps = self.jobs[job_name]["steps"]
+                run_steps = [step for step in steps if "run" in step]
+                joined = "\n".join(step["run"] for step in run_steps)
+
+                self.assertIn("RELEASE_TRAIN_MANIFEST_PATH", joined)
+                self.assertIn("invalid release train manifest path", joined)
+                self.assertNotIn("${{ github.event.inputs.manifest_path }}", joined)
+
+    def test_run_train_passes_input_values_via_environment(self):
+        run_step = next(step for step in self.jobs["run-train"]["steps"] if step.get("name") == "Execute train")
+
+        self.assertEqual(run_step["env"]["RELEASE_TRAIN_MANIFEST_PATH"], "${{ github.event.inputs.manifest_path }}")
+        self.assertEqual(run_step["env"]["RELEASE_TRAIN_TRAIN_ID"], "${{ github.event.inputs.train_id }}")
+        self.assertIn('--manifest "${RELEASE_TRAIN_MANIFEST_PATH}"', run_step["run"])
+        self.assertIn('--train-id "${RELEASE_TRAIN_TRAIN_ID}"', run_step["run"])
 
     def test_no_separate_approval_only_production_gate_remains(self):
         self.assertNotIn("production-gate", self.jobs)


### PR DESCRIPTION
## Summary
- Harden release-train workflow dispatch handling for manifest input validation and deploy job branch guard.
- Block manifest-controlled deployer override fields in release-train schema and runtime evaluation.
- Add ops tests covering workflow input handling, main-branch deploy guard, schema rejection, and fail-closed deploy override handling.
- Update release-train docs and PR-train ledger for AUDIT-SEC-RELEASE-TRAIN-01.

## Scope
- Release-train deploy boundary only.
- No production deploy.
- No production mutation.
- No secret read/write.
- No backend runtime/API behavior change.

## Local validation
Passed:
- `python3 -m json.tool ops/release-train/schema/release-train.schema.json >/dev/null`
- `python3 -m json.tool ops/release-train/examples/release-train.example.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('.github/workflows/release-train.yml').read_text()); yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json`
- `python3 ops/release-train/release_train.py plan --manifest ops/release-train/examples/release-train.example.json`
- `python3 ops/release-train/release_train.py dry-run --manifest ops/release-train/examples/release-train.example.json`
- `python3 -m unittest discover tests/ops`
- `bash -n backend/scripts/deploy/deploy_backend.sh`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-release-train-01.sqlite php artisan migrate --force --no-ansi`
- `git diff --check`

External sidecar failure, not introduced by this PR:
- `bash backend/scripts/ci_verify_mbti.sh` failed in BigFive norm/registry SQLite schema-lock tests outside release-train scope.
- Observed examples include missing `big_five_norm_observations`, missing `scales_registry.assessment_driver`, and SQLite database lock failures.
- BIG5 compiled/generated dirty files from the run were reverted and are not included.

## Merge note
Draft while the external local MBTI chain failure remains unresolved. Required GitHub checks must be green and scope validation must remain clean before this PR can be considered mergeable.
