### PR TITLE
Deploy hardening: bound career warm cache step

### DIFF
--- a/backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
+++ b/backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
@@ -17,7 +17,11 @@ final class CareerWarmPublicAuthorityCache extends Command
     public function handle(PublicCareerAuthorityResponseCache $cache): int
     {
         try {
-            $summary = $cache->warm();
+            $summary = $cache->warm(function (string $phase, string $state): void {
+                if (! (bool) $this->option('json')) {
+                    $this->line(sprintf('career_warm_phase=%s state=%s', $phase, $state));
+                }
+            });
 
             if ((bool) $this->option('json')) {
                 $this->line((string) json_encode([

--- a/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+++ b/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
@@ -109,11 +109,19 @@ final class PublicCareerAuthorityResponseCache
     /**
      * @return array<string, array{cache_key: string, member_count?: int, status: string}>
      */
-    public function warm(): array
+    public function warm(?callable $reporter = null): array
     {
+        $reporter?->__invoke('dataset_payloads', 'starting');
         [$datasetHub, $datasetMethod] = $this->refreshDatasetPayloads();
+        $reporter?->__invoke('dataset_payloads', 'finished');
+
+        $reporter?->__invoke('job_index_zh_cn', 'starting');
         $jobIndex = $this->refreshJobIndexPayload('zh-CN');
+        $reporter?->__invoke('job_index_zh_cn', 'finished');
+
+        $reporter?->__invoke('launch_governance_closure', 'starting');
         $launchGovernance = $this->refreshLaunchGovernanceClosurePayload();
+        $reporter?->__invoke('launch_governance_closure', 'finished');
 
         return [
             'dataset_hub' => [

--- a/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+++ b/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
@@ -21,6 +21,12 @@ final class CareerWarmPublicAuthorityCacheCommandTest extends TestCase
         Cache::forget(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':zh-CN:public');
 
         $this->artisan('career:warm-public-authority-cache')
+            ->expectsOutputToContain('career_warm_phase=dataset_payloads state=starting')
+            ->expectsOutputToContain('career_warm_phase=dataset_payloads state=finished')
+            ->expectsOutputToContain('career_warm_phase=job_index_zh_cn state=starting')
+            ->expectsOutputToContain('career_warm_phase=job_index_zh_cn state=finished')
+            ->expectsOutputToContain('career_warm_phase=launch_governance_closure state=starting')
+            ->expectsOutputToContain('career_warm_phase=launch_governance_closure state=finished')
             ->expectsOutputToContain('status=warmed')
             ->expectsOutputToContain(PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY)
             ->expectsOutputToContain(PublicCareerAuthorityResponseCache::DATASET_METHOD_CACHE_KEY)

--- a/deploy.php
+++ b/deploy.php
@@ -446,6 +446,8 @@ task('artisan:scales:seed-default', function () {
 task('career:warm-public-authority-cache', function () {
     $timeoutSeconds = (int) (getenv('DEPLOY_CAREER_WARM_CACHE_TIMEOUT') ?: 600);
     $timeoutSeconds = max(180, $timeoutSeconds);
+    $killAfterSeconds = (int) (getenv('DEPLOY_CAREER_WARM_CACHE_KILL_AFTER') ?: 30);
+    $killAfterSeconds = max(5, $killAfterSeconds);
     $strictWarmCache = filter_var((string) (getenv('DEPLOY_CAREER_WARM_CACHE_STRICT') ?: ''), FILTER_VALIDATE_BOOLEAN);
     $skipWarmCache = filter_var((string) (getenv('DEPLOY_SKIP_CAREER_WARM_CACHE') ?: ''), FILTER_VALIDATE_BOOLEAN);
 
@@ -456,7 +458,8 @@ task('career:warm-public-authority-cache', function () {
     }
 
     $command = sprintf(
-        'timeout %d {{bin/php}} %s career:warm-public-authority-cache --no-interaction --ansi',
+        'timeout --kill-after=%ds %d {{bin/php}} %s career:warm-public-authority-cache --no-interaction --ansi',
+        $killAfterSeconds,
         $timeoutSeconds,
         deployPlaceholderPathArg('{{release_path}}', 'backend/artisan'),
     );


### PR DESCRIPTION
## What changed
- Added `timeout --kill-after` around `career:warm-public-authority-cache` in `deploy.php` so a stuck warm process cannot consume the whole production deploy job.
- Kept the existing non-strict deploy behavior: warm failures/timeouts are reported and deploy continues unless `DEPLOY_CAREER_WARM_CACHE_STRICT=true`.
- Added phase-level output for the warm command so future deploy logs show whether it is stuck in dataset payloads, job index, or launch governance closure.
- Added focused assertions for the new phase output.

## Why
Production deploy run `26703000487` reached the approved SHA/release but the GitHub job was cancelled after `Deploy (Deployer)` stayed inside `career:warm-public-authority-cache` until the workflow timeout. SSH preflight and migration had passed; post-deploy checks were skipped. This PR makes that warm step bounded and easier to diagnose without changing public API contracts.

## Validation commands
- `php -l deploy.php`
- `php -l backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php && php -l backend/app/Services/Career/PublicCareerAuthorityResponseCache.php`
- `git diff --check`
- `cd backend && php artisan test --filter=CareerWarmPublicAuthorityCacheCommandTest --no-ansi`
- `cd backend && php artisan route:list --no-ansi | rg 'career|healthz|deploy|seo|sitemap'`
- `backend/vendor/bin/pint --test deploy.php backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php backend/app/Services/Career/PublicCareerAuthorityResponseCache.php backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `cd backend && bash scripts/ci_verify_mbti.sh` passed on rerun. First run hit a transient SQLite `database is locked` in `BigFiveV2EditorialReleaseLinkageTest`; the failing test passed standalone and the full chain passed on rerun.

## Incident check summary
- Current backend release is already on the intended approved SHA/release.
- No deploy/artisan warm orphan process was found in the read-only process check.
- A deploy lock from the cancelled CI run remains and needs a separately approved unlock before another deploy attempt.

## Intentionally deferred
- No deploy rerun in this PR.
- No unlock, process kill, rollback, or server mutation.
- No career cache performance rewrite.
- No public API response contract change.
- No sitemap, CMS, DB, migration, or Search Channel change.

## Post-merge next step
After this PR is merged, perform a read-only lock check. If the stale deploy lock is still present and no deploy-like process is active, request explicit unlock approval, remove only that stale lock, then rerun the approved production deploy.
