### PR TITLE
docs(iq): define original 30-item beta bank specification

### DIFF
--- a/backend/docs/iq/iq-beta-30-original-bank-spec.md
+++ b/backend/docs/iq/iq-beta-30-original-bank-spec.md
@@ -1,0 +1,117 @@
+# IQ_BETA_30_ORIGINAL Bank Specification
+
+Date: 2026-05-31
+
+Scope: backend-authoritative planning contract for the first original 30-item FermatMind IQ beta bank. This document defines the item-bank target, metadata contract, copyright boundary, review gates, and launch constraints. It does not import final questions, answer keys, scoring norms, CMS copy, frontend runtime behavior, or commerce unlock.
+
+## 1. Bank identity
+
+| Field | Value |
+| --- | --- |
+| Bank id | `IQ_BETA_30_ORIGINAL` |
+| Scale code | `IQ_INTELLIGENCE_QUOTIENT` |
+| Legacy compatibility | `IQ_RAVEN` remains an input alias only; it is not user-facing copy. |
+| Package family | `IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO` until a production package cutover is explicitly approved. |
+| Item count target | `30` |
+| Option count target | `6` options per item, `A` through `F` |
+| Timing target | `20` minutes beta target; final timing requires pilot evidence. |
+| Runtime status | `planned_spec_only` in this PR |
+| Commerce requirement | None for beta launch; commerce unlock remains deferred. |
+
+## 2. Dimension distribution
+
+| Dimension | Count | Purpose |
+| --- | --- | --- |
+| `VSPR` | `14` | Visual-spatial pattern reasoning, especially matrix and sequence rules. |
+| `VSI` | `10` | Visual-spatial insight, rotation, overlay, symmetry, and visual grouping. |
+| `NPR` | `6` | Numerical pattern reasoning using language-light symbol, count, or recurrence logic. |
+
+## 3. Item-family plan
+
+| Family | Count | Primary dimension | Notes |
+| --- | --- | --- | --- |
+| `matrix_3x3` | `10` | `VSPR` | Missing-tile progressive matrices with original diagrams. |
+| `matrix_2x2` | `4` | `VSPR` | Warm-up transformation and analogy items. |
+| `series` | `4` | `VSPR` | Figure sequence continuation. |
+| `odd_one_out` | `4` | `VSI` | Shared-rule exception detection. |
+| `rotation` | `3` | `VSI` | Pure rotation or mirror-rejection tasks. |
+| `overlay` | `3` | `VSI` | Union, intersection, subtraction, or XOR-style spatial composition. |
+| `numeric_pattern` | `2` | `NPR` | Count-based or symbolic recurrence items. |
+
+The distribution intentionally prioritizes nonverbal reasoning while keeping a small numerical-pattern signal. It must not become a school-math test.
+
+## 4. Required item metadata
+
+Each final item in later implementation PRs must provide:
+
+| Field | Requirement |
+| --- | --- |
+| `item_id` | Stable uppercase id such as `IQB30_ITEM_001`. |
+| `question_id` | Stable public question id; usually same semantic identity as item id. |
+| `scale_code` | `IQ_INTELLIGENCE_QUOTIENT`. |
+| `bank_id` | `IQ_BETA_30_ORIGINAL`. |
+| `dimension` | One of `VSPR`, `VSI`, `NPR`. |
+| `difficulty_level` | One of `L1`, `L2`, `L3`, `L4`, `L5`. |
+| `item_family` | One of the approved item-family values in this specification. |
+| `solution_rule` | Internal-only rule description; must not be exposed in public question payloads. |
+| `distractor_logic` | Internal-only explanation of plausible wrong options. |
+| `correct_answer` | One of `A` through `F`; backend-only. |
+| `raw_points` | Usually `1.0`. |
+| `assets` | Structured SVG stem and option payloads, not raw SVG strings. |
+| `asset_hashes` | Hashes for stem and every option. |
+| `generator_metadata` | Generator version, seed, template key, author/reviewer, and source mode. |
+| `review_status` | `draft`, `technical_reviewed`, `psychometric_reviewed`, or `approved_beta`. |
+
+## 5. Public payload constraints
+
+| Constraint | Rule |
+| --- | --- |
+| Structured SVG only | Public question payloads must use structured SVG objects compatible with the frontend IQ renderer. |
+| No raw SVG HTML | Do not introduce raw SVG string rendering or `innerHTML` payloads. |
+| No answer key leakage | Public payloads must omit `correct_answer`, `answer_key`, `solution_rule`, and equivalent fields. |
+| No frontend scoring | Frontend must submit selected option identifiers only; backend remains scoring authority. |
+| Six options | Final beta bank should use `A` through `F`; renderer support must be verified before runtime enablement. |
+| Language-light prompts | Prompt text should be minimal and not required to solve the item. |
+
+## 6. Copyright and provenance boundary
+
+FermatMind may reproduce item archetypes, not third-party items.
+
+| Source class | Allowed | Forbidden |
+| --- | --- | --- |
+| Mensa / 123test / Cambridge / Creyos | Use high-level public structure such as matrix reasoning, time limits, and disclaimer patterns. | Copy, trace, paraphrase visually, transform, or reorder their questions, diagrams, options, answer keys, reports, or explanations. |
+| SEO-led free IQ sites | Use as market caution examples. | Copy claims, item pools, diagrams, reports, or scoring copy. |
+| Open-source candidates | Import only after a separate license verification gate. | Treat homepage marketing claims as license evidence. |
+
+Every final item must be marked with `source_mode: repo_generated` unless a separate license-verification PR explicitly authorizes a different source mode.
+
+## 7. Review gates
+
+| Gate | Required result before runtime enablement |
+| --- | --- |
+| `copyright_gate` | Reviewer confirms no item is copied, traced, or lightly transformed from third-party tests. |
+| `technical_svg_gate` | Structured SVG renders in existing IQ frontend components. |
+| `answer_key_gate` | Public endpoint redaction proves answer keys and rule explanations are absent. |
+| `ambiguity_gate` | At least two reviewers agree each item has one best answer. |
+| `difficulty_gate` | Internal pilot confirms intended level is plausible. |
+| `claim_gate` | Result and landing copy avoid unsupported claims such as real IQ diagnosis or certified IQ. |
+| `provenance_gate` | `asset_hashes` and `generator_metadata` are complete. |
+| `contract_gate` | Backend import, frontend renderer, and report contracts pass before launch. |
+
+## 8. Norm and report boundary
+
+`IQ_BETA_30_ORIGINAL` may support raw score, dimension scores, quality flags, and stability status. It must not make normed IQ estimate, percentile, or confidence interval production-authoritative until a later backend norm table PR provides evidence and contracts.
+
+## 9. Deferred items
+
+The following are intentionally out of scope for this PR:
+
+| Deferred item | Target phase |
+| --- | --- |
+| Final 30 generated items | `IQ-BANK-30-02` |
+| Import/provenance/redaction runtime gate | `IQ-BANK-30-03` |
+| 30-item scoring hardening | `IQ-SCORE-30-01` |
+| SEO/claim launch guards | `IQ-CLAIM-SEO-01` |
+| CMS landing placement | `IQ-CMS-LANDING-01` |
+| Production-like live smoke | `IQ-LIVE-SMOKE-01` |
+| Commerce unlock | Deferred until backend commerce authority exists |

--- a/backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
+++ b/backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
@@ -1,0 +1,102 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use Tests\TestCase;
+
+final class IqBeta30OriginalBankSpecTest extends TestCase
+{
+    public function test_beta30_original_bank_manifest_is_planned_and_not_runtime_bound(): void
+    {
+        $manifest = $this->readManifest();
+
+        $this->assertSame('fm.iq.item_bank_manifest.v1', $manifest['schema_version'] ?? null);
+        $this->assertSame('IQ_BETA_30_ORIGINAL', $manifest['bank_id'] ?? null);
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', $manifest['scale_code'] ?? null);
+        $this->assertSame('planned_spec_only', $manifest['status'] ?? null);
+        $this->assertFalse((bool) ($manifest['runtime_bound'] ?? true));
+        $this->assertSame(30, $manifest['item_count_target'] ?? null);
+        $this->assertSame(['A', 'B', 'C', 'D', 'E', 'F'], $manifest['option_codes_target'] ?? null);
+        $this->assertSame(20, $manifest['time_limit_minutes_target'] ?? null);
+    }
+
+    public function test_beta30_original_bank_dimension_and_family_plan_matches_launch_spec(): void
+    {
+        $manifest = $this->readManifest();
+
+        $this->assertSame(['VSPR' => 14, 'VSI' => 10, 'NPR' => 6], $manifest['dimension_counts_target'] ?? null);
+        $this->assertSame(30, array_sum($manifest['dimension_counts_target'] ?? []));
+        $this->assertSame([
+            'matrix_3x3' => 10,
+            'matrix_2x2' => 4,
+            'series' => 4,
+            'odd_one_out' => 4,
+            'rotation' => 3,
+            'overlay' => 3,
+            'numeric_pattern' => 2,
+        ], $manifest['item_family_counts_target'] ?? null);
+        $this->assertSame(30, array_sum($manifest['item_family_counts_target'] ?? []));
+    }
+
+    public function test_beta30_original_bank_keeps_copyright_redaction_and_norm_boundaries_explicit(): void
+    {
+        $manifest = $this->readManifest();
+
+        $this->assertSame('repo_generated', data_get($manifest, 'copyright_policy.source_mode_required'));
+        $this->assertFalse((bool) data_get($manifest, 'copyright_policy.third_party_item_copying_allowed', true));
+        $this->assertFalse((bool) data_get($manifest, 'copyright_policy.third_party_visual_tracing_allowed', true));
+        $this->assertTrue((bool) data_get($manifest, 'copyright_policy.license_verification_required_for_external_items'));
+
+        $this->assertTrue((bool) data_get($manifest, 'public_payload_policy.structured_svg_only'));
+        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.raw_svg_html_allowed', true));
+        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.answer_key_public_allowed', true));
+        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.solution_rule_public_allowed', true));
+        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.frontend_scoring_allowed', true));
+
+        $this->assertTrue((bool) data_get($manifest, 'norm_policy.norm_table_required_before_iq_estimate_claims'));
+        $this->assertFalse((bool) data_get($manifest, 'norm_policy.iq_estimate_runtime_authoritative', true));
+        $this->assertFalse((bool) data_get($manifest, 'norm_policy.percentile_runtime_authoritative', true));
+        $this->assertFalse((bool) data_get($manifest, 'norm_policy.confidence_interval_runtime_authoritative', true));
+    }
+
+    public function test_beta30_original_bank_spec_document_records_required_review_gates(): void
+    {
+        $docPath = base_path('docs/iq/iq-beta-30-original-bank-spec.md');
+
+        $this->assertFileExists($docPath);
+        $doc = (string) file_get_contents($docPath);
+
+        foreach ([
+            'copyright_gate',
+            'technical_svg_gate',
+            'answer_key_gate',
+            'ambiguity_gate',
+            'difficulty_gate',
+            'claim_gate',
+            'provenance_gate',
+            'contract_gate',
+        ] as $gate) {
+            $this->assertStringContainsString($gate, $doc);
+        }
+
+        $this->assertStringContainsString('FermatMind may reproduce item archetypes, not third-party items.', $doc);
+        $this->assertStringContainsString('It must not make normed IQ estimate, percentile, or confidence interval production-authoritative', $doc);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readManifest(): array
+    {
+        $path = dirname(base_path()).'/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json';
+
+        $this->assertFileExists($path);
+
+        $manifest = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($manifest);
+
+        return $manifest;
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json
@@ -1,0 +1,70 @@
+{
+    "schema_version": "fm.iq.item_bank_manifest.v1",
+    "bank_id": "IQ_BETA_30_ORIGINAL",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "status": "planned_spec_only",
+    "runtime_bound": false,
+    "content_package_version": "v0.3.0-DEMO",
+    "bank_dir": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL",
+    "item_count_target": 30,
+    "option_codes_target": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+    ],
+    "time_limit_minutes_target": 20,
+    "dimension_counts_target": {
+        "VSPR": 14,
+        "VSI": 10,
+        "NPR": 6
+    },
+    "item_family_counts_target": {
+        "matrix_3x3": 10,
+        "matrix_2x2": 4,
+        "series": 4,
+        "odd_one_out": 4,
+        "rotation": 3,
+        "overlay": 3,
+        "numeric_pattern": 2
+    },
+    "copyright_policy": {
+        "source_mode_required": "repo_generated",
+        "third_party_item_copying_allowed": false,
+        "third_party_visual_tracing_allowed": false,
+        "license_verification_required_for_external_items": true
+    },
+    "review_gates": [
+        "copyright_gate",
+        "technical_svg_gate",
+        "answer_key_gate",
+        "ambiguity_gate",
+        "difficulty_gate",
+        "claim_gate",
+        "provenance_gate",
+        "contract_gate"
+    ],
+    "public_payload_policy": {
+        "structured_svg_only": true,
+        "raw_svg_html_allowed": false,
+        "answer_key_public_allowed": false,
+        "solution_rule_public_allowed": false,
+        "frontend_scoring_allowed": false
+    },
+    "norm_policy": {
+        "norm_table_required_before_iq_estimate_claims": true,
+        "iq_estimate_runtime_authoritative": false,
+        "percentile_runtime_authoritative": false,
+        "confidence_interval_runtime_authoritative": false
+    },
+    "deferred_to": {
+        "final_item_generation": "IQ-BANK-30-02",
+        "import_provenance_redaction_gate": "IQ-BANK-30-03",
+        "scoring_quality_stability": "IQ-SCORE-30-01",
+        "seo_claim_launch_guard": "IQ-CLAIM-SEO-01",
+        "cms_landing_authority": "IQ-CMS-LANDING-01",
+        "production_like_smoke": "IQ-LIVE-SMOKE-01"
+    }
+}


### PR DESCRIPTION
## What changed
- Added the backend IQ_BETA_30_ORIGINAL bank specification document.
- Added a planned, non-runtime-bound manifest for the original 30-item beta bank.
- Added a focused content contract test for bank identity, target distribution, copyright/redaction policy, norm boundaries, and required review gates.

## Why
The IQ train needs a backend-authoritative original 30-item bank specification before generating any final items. This keeps the 123test-level launch work original, reviewable, and explicit about copyright, answer-key, and norm-claim boundaries.

## Validation commands
- python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json >/dev/null
- php -l backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
- cd backend && php artisan test --filter=IqBeta30OriginalBankSpecTest
- git diff --check

## Intentionally deferred items
- No final IQ questions are generated in this PR.
- No answer key, scoring spec, public API wiring, runtime binding, CMS publish, SEO launch change, or commerce unlock is included.
- Final item generation remains for IQ-BANK-30-02.

## Repository rule impact
This PR keeps IQ item-bank authority in backend content packages and docs. It does not add frontend fallback content, does not change CMS publishing authority, does not widen sitemap/llms exposure, and does not make normed IQ estimates production-authoritative.