### PR TITLE
ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard

### DIFF
--- a/backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php
@@ -7,15 +7,19 @@ namespace App\Console\Commands;
 use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
 use Carbon\CarbonImmutable;
 use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
 
 class RefreshAnalyticsFunnelDailyCommand extends Command
 {
+    private const MAX_WRITE_RANGE_DAYS = 31;
+
     protected $signature = 'analytics:refresh-funnel-daily
         {--from= : Inclusive start date (Y-m-d)}
         {--to= : Inclusive end date (Y-m-d)}
         {--scale=* : Limit refresh to one or more scale codes}
         {--org=* : Limit refresh to one or more org ids}
-        {--dry-run : Preview the aggregation without writing rows}';
+        {--dry-run : Preview the aggregation without writing rows}
+        {--confirm-write= : Required exact confirmation token for non-dry-run refresh writes}';
 
     protected $description = 'Refresh the analytics_funnel_daily attempt-led commerce funnel read model.';
 
@@ -47,17 +51,42 @@ class RefreshAnalyticsFunnelDailyCommand extends Command
         ), static fn (int $value): bool => $value >= 0));
 
         $dryRun = (bool) $this->option('dry-run');
+        $beforeCount = $this->countExistingRows($from, $to, $orgIds, $scaleCodes);
+
+        if (! $dryRun) {
+            $guard = $this->validateWriteGuard($from, $to, $orgIds, $scaleCodes);
+
+            if ($guard !== null) {
+                $this->line('from='.$from->toDateString());
+                $this->line('to='.$to->toDateString());
+                $this->line('org_scope='.(empty($orgIds) ? '*' : implode(',', $orgIds)));
+                $this->line('scale_scope='.(empty($scaleCodes) ? '*' : implode(',', $scaleCodes)));
+                $this->line('dry_run=0');
+                $this->line('before_count='.$beforeCount);
+                $this->line('after_count='.$beforeCount);
+                $this->line('write_guard=blocked');
+                $this->line('write_guard_reason='.$guard);
+                $this->line('expected_confirm_write='.$this->expectedWriteConfirmationToken($from, $to, $orgIds, $scaleCodes));
+                $this->error('Non-dry-run analytics funnel refresh is blocked by the controlled write guard.');
+
+                return self::FAILURE;
+            }
+        }
 
         $result = $this->builder->refresh($from, $to, $orgIds, $scaleCodes, $dryRun);
+        $afterCount = $this->countExistingRows($from, $to, $orgIds, $scaleCodes);
 
         $this->line('from='.$result['from']);
         $this->line('to='.$result['to']);
         $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
         $this->line('scale_scope='.(empty($result['scale_scope']) ? '*' : implode(',', $result['scale_scope'])));
         $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('before_count='.$beforeCount);
+        $this->line('after_count='.$afterCount);
         $this->line('attempted_rows='.(string) ($result['attempted_rows'] ?? 0));
         $this->line('deleted_rows='.(string) ($result['deleted_rows'] ?? 0));
         $this->line('upserted_rows='.(string) ($result['upserted_rows'] ?? 0));
+        $this->line('write_guard='.($dryRun ? 'dry_run_no_write' : 'passed'));
 
         if (($result['attempted_rows'] ?? 0) === 0) {
             $this->warn('No funnel rows were generated for the selected scope.');
@@ -74,5 +103,81 @@ class RefreshAnalyticsFunnelDailyCommand extends Command
 
         return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
             ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function countExistingRows(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+    ): int {
+        $query = DB::table('analytics_funnel_daily')
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        if ($scaleCodes !== []) {
+            $query->whereIn('scale_code', $scaleCodes);
+        }
+
+        return (int) $query->count();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function validateWriteGuard(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+    ): ?string {
+        if (trim((string) $this->option('from')) === '' || trim((string) $this->option('to')) === '') {
+            return 'explicit_from_to_required';
+        }
+
+        if ($orgIds === []) {
+            return 'explicit_org_scope_required';
+        }
+
+        if ($from->diffInDays($to) + 1 > self::MAX_WRITE_RANGE_DAYS) {
+            return 'date_range_exceeds_'.self::MAX_WRITE_RANGE_DAYS.'_days';
+        }
+
+        $expected = $this->expectedWriteConfirmationToken($from, $to, $orgIds, $scaleCodes);
+        $provided = trim((string) $this->option('confirm-write'));
+
+        if (! hash_equals($expected, $provided)) {
+            return 'confirm_write_token_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function expectedWriteConfirmationToken(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+    ): string {
+        return implode(':', [
+            'analytics_funnel_daily',
+            'write',
+            $from->toDateString(),
+            $to->toDateString(),
+            'org='.($orgIds === [] ? 'all' : implode(',', $orgIds)),
+            'scale='.($scaleCodes === [] ? 'all' : implode(',', $scaleCodes)),
+        ]);
     }
 }

--- a/backend/docs/seo/analytics-funnel-controlled-refresh-write-guard-01.md
+++ b/backend/docs/seo/analytics-funnel-controlled-refresh-write-guard-01.md
@@ -1,0 +1,69 @@
+# ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01
+
+## Purpose
+
+Add a fail-closed write guard around `analytics:refresh-funnel-daily` before any real production refresh is approved.
+
+The prior production R3 dry-run completed successfully for `2026-05-25` through `2026-05-31`, `org=0`, with `attempted_rows=38`, `deleted_rows=0`, and `upserted_rows=0`. This PR does not perform the real refresh. It only makes the command safe enough for a later human-approved controlled write.
+
+## Guard Behavior
+
+Dry-run mode remains the default safe review path:
+
+```bash
+php artisan analytics:refresh-funnel-daily \
+  --from=2026-05-25 \
+  --to=2026-05-31 \
+  --org=0 \
+  --dry-run \
+  --no-ansi
+```
+
+Non-dry-run refresh is blocked unless all write boundaries are explicit:
+
+- `--from` and `--to` must both be supplied.
+- At least one `--org` scope must be supplied.
+- The inclusive date range must be 31 days or less.
+- `--confirm-write` must exactly match the generated confirmation token.
+
+For the R3 production scope, the later write command would require:
+
+```bash
+php artisan analytics:refresh-funnel-daily \
+  --from=2026-05-25 \
+  --to=2026-05-31 \
+  --org=0 \
+  --confirm-write=analytics_funnel_daily:write:2026-05-25:2026-05-31:org=0:scale=all \
+  --no-ansi
+```
+
+## Audit Output
+
+The command now prints:
+
+- `before_count`
+- `after_count`
+- `attempted_rows`
+- `deleted_rows`
+- `upserted_rows`
+- `write_guard`
+- blocked guard reason and expected confirmation token when applicable
+
+This makes the write boundary reviewable before and after a later production refresh.
+
+## Explicit Non-actions
+
+- No production refresh write was run.
+- No production DB mutation was performed.
+- No migration was added.
+- No scheduler was enabled.
+- No GA/Baidu setting was changed.
+- No CMS mutation was performed.
+- No Search Channel enqueue or URL submission was performed.
+- No frontend repository was modified.
+
+## Next Task
+
+`ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-PREFLIGHT-01`
+
+Run one more production dry-run with the deployed write guard, verify the expected confirmation token and counts, then ask for explicit human approval before a real write.

--- a/backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json
@@ -1,0 +1,54 @@
+{
+  "schema_version": "1.0",
+  "task": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01",
+  "final_decision": "analytics_funnel_write_guard_ready_for_deploy_readiness",
+  "command": "analytics:refresh-funnel-daily",
+  "write_guard_enabled": true,
+  "non_dry_run_default_blocked": true,
+  "dry_run_allowed_without_confirm_write": true,
+  "required_write_options": [
+    "--from",
+    "--to",
+    "--org",
+    "--confirm-write"
+  ],
+  "max_write_range_days": 31,
+  "confirmation_token_template": "analytics_funnel_daily:write:{from}:{to}:org={org_scope}:scale={scale_scope}",
+  "r3_production_scope": {
+    "from": "2026-05-25",
+    "to": "2026-05-31",
+    "org_scope": [
+      0
+    ],
+    "scale_scope": "all",
+    "expected_confirm_write": "analytics_funnel_daily:write:2026-05-25:2026-05-31:org=0:scale=all",
+    "last_dry_run_attempted_rows": 38,
+    "last_dry_run_deleted_rows": 0,
+    "last_dry_run_upserted_rows": 0
+  },
+  "audit_output_fields": [
+    "before_count",
+    "after_count",
+    "attempted_rows",
+    "deleted_rows",
+    "upserted_rows",
+    "write_guard",
+    "write_guard_reason",
+    "expected_confirm_write"
+  ],
+  "production_write_performed": false,
+  "production_db_mutation_performed": false,
+  "migration_added": false,
+  "scheduler_enabled": false,
+  "ga_baidu_setting_changed": false,
+  "cms_mutation_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "fap_web_modified": false,
+  "deferred_followups": [
+    "backend deploy readiness for the write guard",
+    "production dry-run with deployed write guard",
+    "human-approved controlled write only after preflight evidence"
+  ],
+  "next_task": "BACKEND-DEPLOY-READINESS｜Deploy analytics funnel controlled refresh write guard"
+}

--- a/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
@@ -34,9 +34,11 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
             '--from' => $scenario['day'],
             '--to' => $scenario['day'],
             '--org' => [91],
+            '--confirm-write' => 'analytics_funnel_daily:write:'.$scenario['day'].':'.$scenario['day'].':org=91:scale=all',
         ])
             ->expectsOutputToContain('dry_run=0')
             ->expectsOutputToContain('upserted_rows=2')
+            ->expectsOutputToContain('write_guard=passed')
             ->assertExitCode(0);
 
         $this->assertSame(2, DB::table('analytics_funnel_daily')->count());
@@ -45,6 +47,7 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
             '--from' => $scenario['day'],
             '--to' => $scenario['day'],
             '--org' => [91],
+            '--confirm-write' => 'analytics_funnel_daily:write:'.$scenario['day'].':'.$scenario['day'].':org=91:scale=all',
         ])->assertExitCode(0);
 
         $this->assertSame(2, DB::table('analytics_funnel_daily')->count());

--- a/backend/tests/Feature/SeoIntel/AnalyticsFunnelControlledRefreshWriteGuard01Test.php
+++ b/backend/tests/Feature/SeoIntel/AnalyticsFunnelControlledRefreshWriteGuard01Test.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Tests\Concerns\SeedsFunnelAnalyticsScenario;
+use Tests\TestCase;
+
+final class AnalyticsFunnelControlledRefreshWriteGuard01Test extends TestCase
+{
+    use RefreshDatabase;
+    use SeedsFunnelAnalyticsScenario;
+
+    public function test_non_dry_run_refresh_is_blocked_without_exact_confirmation_token(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(610);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [610],
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('before_count=0')
+            ->expectsOutputToContain('after_count=0')
+            ->expectsOutputToContain('write_guard=blocked')
+            ->expectsOutputToContain('write_guard_reason=confirm_write_token_mismatch')
+            ->expectsOutputToContain('expected_confirm_write=analytics_funnel_daily:write:'.$scenario['day'].':'.$scenario['day'].':org=610:scale=all')
+            ->assertExitCode(1);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_non_dry_run_refresh_requires_explicit_org_scope(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(611);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--confirm-write' => 'analytics_funnel_daily:write:'.$scenario['day'].':'.$scenario['day'].':org=*:scale=all',
+        ])
+            ->expectsOutputToContain('write_guard=blocked')
+            ->expectsOutputToContain('write_guard_reason=explicit_org_scope_required')
+            ->assertExitCode(1);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_non_dry_run_refresh_requires_explicit_date_range(): void
+    {
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--org' => [612],
+        ])
+            ->expectsOutputToContain('write_guard=blocked')
+            ->expectsOutputToContain('write_guard_reason=explicit_from_to_required')
+            ->assertExitCode(1);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_non_dry_run_refresh_rejects_overwide_date_range(): void
+    {
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => '2026-01-01',
+            '--to' => '2026-02-05',
+            '--org' => [613],
+            '--confirm-write' => 'analytics_funnel_daily:write:2026-01-01:2026-02-05:org=613:scale=all',
+        ])
+            ->expectsOutputToContain('write_guard=blocked')
+            ->expectsOutputToContain('write_guard_reason=date_range_exceeds_31_days')
+            ->assertExitCode(1);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_dry_run_outputs_audit_counts_and_never_writes(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(614);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [614],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('before_count=0')
+            ->expectsOutputToContain('after_count=0')
+            ->expectsOutputToContain('attempted_rows=2')
+            ->expectsOutputToContain('deleted_rows=0')
+            ->expectsOutputToContain('upserted_rows=0')
+            ->expectsOutputToContain('write_guard=dry_run_no_write')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+    }
+
+    public function test_non_dry_run_refresh_writes_only_with_exact_bounded_confirmation_token(): void
+    {
+        $scenario = $this->seedFunnelAnalyticsScenario(615);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $scenario['day'],
+            '--to' => $scenario['day'],
+            '--org' => [615],
+            '--confirm-write' => 'analytics_funnel_daily:write:'.$scenario['day'].':'.$scenario['day'].':org=615:scale=all',
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('before_count=0')
+            ->expectsOutputToContain('after_count=2')
+            ->expectsOutputToContain('attempted_rows=2')
+            ->expectsOutputToContain('upserted_rows=2')
+            ->expectsOutputToContain('write_guard=passed')
+            ->assertExitCode(0);
+
+        $this->assertSame(2, DB::table('analytics_funnel_daily')->where('org_id', 615)->count());
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -267,6 +267,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_analytics_funnel_refresh_command_guard_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_healthz_alias_route_addition(): void
     {
         $changed = [
@@ -2836,6 +2845,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isAnalyticsFunnelRefreshCommandFile($file)) {
+                continue;
+            }
+
             if ($this->isEq60V5ReportAssetLayerChange($file)) {
                 continue;
             }
@@ -4305,6 +4318,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Filament/Ops/Pages/FunnelConversionPage.php',
             'backend/app/Filament/Ops/Widgets/FunnelWidget.php',
         ], true);
+    }
+
+    private function isAnalyticsFunnelRefreshCommandFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php';
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33858,12 +33858,12 @@
     "branch": "codex/analytics-funnel-controlled-refresh-write-guard-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9604f3f5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1783",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -33936,6 +33936,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Scoped implementation and all manifest validations passed locally; no production write or deploy performed."
+      },
+      {
+        "at": "2026-05-31T07:27:35Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened PR #1783 after local validation passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33858,7 +33858,7 @@
     "branch": "codex/analytics-funnel-controlled-refresh-write-guard-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard",
-    "status": "pr_open",
+    "status": "ci_fix_local_checks_passed",
     "depends_on": [
       "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02"
     ],
@@ -33896,7 +33896,7 @@
       "pint": {
         "status": "pass",
         "command": "cd backend && vendor/bin/pint --test",
-        "evidence": "PASS across 3653 files."
+        "evidence": "PASS across 3653 files after CI classifier fix."
       },
       "composer_validate": {
         "status": "pass",
@@ -33911,7 +33911,12 @@
       "json_yaml_diff_validation": {
         "status": "pass",
         "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check && git diff --cached --check",
-        "evidence": "Generated JSON, state JSON, train YAML, unstaged diff check, and cached diff check passed."
+        "evidence": "Generated JSON, state JSON, train YAML, unstaged diff check, and cached diff check passed before PR; state/YAML and diff check passed after CI fix."
+      },
+      "bigfive_runtime_freeze_classifier": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_analytics_funnel_refresh_command_guard_changes --no-ansi",
+        "evidence": "PASS with warning: 1 test, 1 assertion. Classifies analytics funnel refresh command guard changes as non-Big-Five runtime-impacting."
       }
     },
     "failure_reason": null,
@@ -33942,6 +33947,18 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened PR #1783 after local validation passed."
+      },
+      {
+        "at": "2026-05-31T07:33:56Z",
+        "from": "pr_open",
+        "to": "ci_fix_in_progress",
+        "note": "GitHub verify-bigfive failed on runtime freeze classifier for RefreshAnalyticsFunnelDailyCommand.php; adding scoped classifier coverage only."
+      },
+      {
+        "at": "2026-05-31T07:35:39Z",
+        "from": "ci_fix_in_progress",
+        "to": "ci_fix_local_checks_passed",
+        "note": "Added scoped Big Five runtime-freeze classifier coverage and reran focused checks plus Pint."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33328,12 +33328,12 @@
     "branch": "codex/analytics-funnel-refresh-dry-run-sql-fix-02",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02 fix share_click SQL compatibility",
-    "status": "in_progress",
+    "status": "merged_deployed_reconciled",
     "depends_on": [
       "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01"
     ],
-    "commit_sha": "f678306b52eed2572c0815fbd7ad1aaef15cd71b",
-    "pr_url": null,
+    "commit_sha": "2ef86f3bb4885c5cdb1fb13d3e9184a017d5c5a2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1775",
     "checks": [
       {
         "command": "manifest/state authorization",
@@ -33407,9 +33407,9 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-31T04:27:30Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "status": "authorized",
@@ -33438,7 +33438,14 @@
       "git_diff_cached_check": null
     },
     "sidecars": [],
-    "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02"
+    "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02",
+    "reconciliation": [
+      {
+        "at": "2026-05-31T07:18:09Z",
+        "status": "merged_deployed_reconciled",
+        "evidence": "GitHub PR #1775 is MERGED at 2ef86f3bb4885c5cdb1fb13d3e9184a017d5c5a2, origin/main contains it, remote branch is absent, and production dry-run R3 completed after deploy."
+      }
+    ]
   },
   "OPS-CAREER-WARM-CACHE-PERF-01": {
     "id": "OPS-CAREER-WARM-CACHE-PERF-01",
@@ -33844,5 +33851,92 @@
       }
     ],
     "next_task": "Run local validation, open PR, wait for CI, merge if allowed, cleanup, then continue SECURITY-AUDIT-36-PR-TRAIN."
+  },
+  "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01": {
+    "id": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-controlled-refresh-write-guard-01",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to the analytics refresh command write guard, audit docs/generated JSON, focused tests, and PR-train ledger; no production refresh write, migration, scheduler enablement, deploy, CMS mutation, Search Channel action, URL submission, GA/Baidu setting change, or fap-web modification."
+      },
+      "focused_write_guard_test": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AnalyticsFunnelControlledRefreshWriteGuard01 --no-ansi",
+        "evidence": "PASS with warnings: 6 tests, 37 assertions. Covers blocked non-dry-run without token, missing org, missing explicit date range, overwide range, dry-run no write, and exact bounded confirmation token write path."
+      },
+      "refresh_command_regression": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi",
+        "evidence": "PASS with warning: 1 test, 12 assertions. Existing write path now uses exact --confirm-write token."
+      },
+      "analytics_builder_regression": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "evidence": "PASS with warnings: 2 tests, 27 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "Route list rendered successfully with 207 routes."
+      },
+      "pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "PASS across 3653 files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_diff_validation": {
+        "status": "pass",
+        "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check && git diff --cached --check",
+        "evidence": "Generated JSON, state JSON, train YAML, unstaged diff check, and cached diff check passed."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-05-31T07:18:09Z",
+        "from": "authorized",
+        "to": "in_progress",
+        "note": "Started scoped write guard implementation in isolated worktree from latest origin/main."
+      },
+      {
+        "at": "2026-05-31T07:25:50Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Scoped implementation and all manifest validations passed locally; no production write or deploy performed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16192,6 +16192,7 @@ prs:
       - backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json
       - backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
       - backend/tests/Feature/SeoIntel/AnalyticsFunnelControlledRefreshWriteGuard01Test.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -16204,6 +16205,7 @@ prs:
       - cd backend && php artisan test --filter=AnalyticsFunnelControlledRefreshWriteGuard01 --no-ansi
       - cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
       - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_analytics_funnel_refresh_command_guard_changes --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
       - cd backend && composer validate --strict

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16177,6 +16177,57 @@ prs:
     frontend_fallback_authority: false
     next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02
 
+  - id: ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01
+    repo: fap-api
+    branch: codex/analytics-funnel-controlled-refresh-write-guard-01
+    base: main
+    title: "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01 add controlled analytics funnel refresh write guard"
+    train_scope: analytics_funnel_controlled_refresh_write_guard
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02
+    allowed_paths:
+      - backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php
+      - backend/docs/seo/analytics-funnel-controlled-refresh-write-guard-01.md
+      - backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json
+      - backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelControlledRefreshWriteGuard01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add fail-closed non-dry-run write guard to analytics:refresh-funnel-daily.
+      - Require explicit from/to, explicit org scope, bounded date range, and exact --confirm-write token before DB writes.
+      - Emit before_count, after_count, attempted_rows, deleted_rows, upserted_rows, and write_guard audit fields.
+      - Preserve dry-run/no-write production review path.
+      - Document that no production refresh write, migration, scheduler enablement, GA/Baidu setting change, CMS mutation, Search Channel action, URL submission, deploy, or fap-web change is performed in this PR.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelControlledRefreshWriteGuard01 --no-ansi
+      - cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01
+
+
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api
     branch: fix/content-packs-index-artifact-01


### PR DESCRIPTION
## What changed
- Added a fail-closed write guard to `analytics:refresh-funnel-daily`.
- Non-dry-run refresh now requires explicit `--from`, `--to`, `--org`, bounded date range, and exact `--confirm-write` token.
- Added audit output for `before_count`, `after_count`, `attempted_rows`, `deleted_rows`, `upserted_rows`, and `write_guard` state.
- Added docs/generated JSON and focused coverage for blocked and allowed refresh paths.
- Reconciled `ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02` ledger state as merged/deployed, because it is the dependency for this task.

## Why
The production dry-run R3 proved the analytics funnel query can plan rows safely. This PR adds the guardrail needed before any future human-approved real refresh write is considered.

## Validation
- `cd backend && php artisan test --filter=AnalyticsFunnelControlledRefreshWriteGuard01 --no-ansi`
- `cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi`
- `cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/analytics-funnel-controlled-refresh-write-guard-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production refresh write.
- No deploy.
- No migration.
- No scheduler enablement.
- No GA/Baidu settings change.
- No CMS mutation.
- No Search Channel or URL submission.
- No fap-web change.
