### PR TITLE
AUDIT-SEC-RESULT-IDENTITY-01: Harden result recovery identity boundary

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
+++ b/backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
@@ -6,6 +6,7 @@ namespace App\Http\Controllers\API\V0_3;
 
 use App\Http\Controllers\Controller;
 use App\Http\Requests\V0_3\ResultEmailLookupRequest;
+use App\Services\Auth\FmTokenService;
 use App\Services\Results\ResultEmailLookupService;
 use App\Support\OrgContext;
 use Illuminate\Http\JsonResponse;
@@ -14,6 +15,7 @@ final class ResultEmailLookupController extends Controller
 {
     public function __construct(
         private readonly ResultEmailLookupService $lookup,
+        private readonly FmTokenService $fmTokens,
         private readonly OrgContext $orgContext,
     ) {}
 
@@ -24,49 +26,72 @@ final class ResultEmailLookupController extends Controller
     {
         /** @var array{email:string,locale?:string|null} $payload */
         $payload = $request->validated();
+        $identity = $this->resolveAuthenticatedIdentity($request);
 
         return response()->json($this->lookup->lookup(
             (string) $payload['email'],
             (int) $this->orgContext->orgId(),
             $payload['locale'] ?? null,
-            $this->orgContext->userId(),
-            $this->orgContext->anonId(),
-            $this->resolveClientAnonId($request),
+            $identity['user_id'],
+            $identity['anon_id'],
         ));
     }
 
-    private function resolveClientAnonId(ResultEmailLookupRequest $request): ?string
+    /**
+     * @return array{user_id:?int,anon_id:?string}
+     */
+    private function resolveAuthenticatedIdentity(ResultEmailLookupRequest $request): array
     {
-        $candidates = [
-            $request->attributes->get('client_anon_id'),
-            $request->header('X-Anon-Id'),
-            $request->cookie('fap_anonymous_id_v1'),
-        ];
-
-        foreach ($candidates as $candidate) {
-            if (! is_string($candidate) && ! is_numeric($candidate)) {
-                continue;
-            }
-
-            $normalized = trim((string) $candidate);
-            if ($normalized === '' || strlen($normalized) > 128) {
-                continue;
-            }
-
-            $lower = mb_strtolower($normalized, 'UTF-8');
-            $isPlaceholder = false;
-            foreach (['todo', 'placeholder', 'fixme', 'tbd', '填这里'] as $bad) {
-                if (mb_strpos($lower, $bad) !== false) {
-                    $isPlaceholder = true;
-                    break;
-                }
-            }
-
-            if (! $isPlaceholder) {
-                return $normalized;
-            }
+        $token = $this->bearerToken($request);
+        if ($token === '') {
+            return ['user_id' => null, 'anon_id' => null];
         }
 
-        return null;
+        $payload = $this->fmTokens->validateToken($token);
+        if (($payload['ok'] ?? false) !== true) {
+            return ['user_id' => null, 'anon_id' => null];
+        }
+
+        return [
+            'user_id' => $this->normalizeUserId($payload['user_id'] ?? null),
+            'anon_id' => $this->normalizeAnonId($payload['anon_id'] ?? null),
+        ];
+    }
+
+    private function bearerToken(ResultEmailLookupRequest $request): string
+    {
+        $header = (string) $request->header('Authorization', '');
+        if (preg_match('/^\s*Bearer\s+(.+)\s*$/i', $header, $m) !== 1) {
+            return '';
+        }
+
+        return trim((string) ($m[1] ?? ''));
+    }
+
+    private function normalizeUserId(mixed $candidate): ?int
+    {
+        if (! is_string($candidate) && ! is_numeric($candidate)) {
+            return null;
+        }
+
+        $normalized = trim((string) $candidate);
+        if ($normalized === '' || preg_match('/^\d+$/', $normalized) !== 1) {
+            return null;
+        }
+
+        $userId = (int) $normalized;
+
+        return $userId > 0 ? $userId : null;
+    }
+
+    private function normalizeAnonId(mixed $candidate): ?string
+    {
+        if (! is_string($candidate) && ! is_numeric($candidate)) {
+            return null;
+        }
+
+        $normalized = trim((string) $candidate);
+
+        return $normalized !== '' ? $normalized : null;
     }
 }

--- a/backend/app/Services/Email/EmailOutboxService.php
+++ b/backend/app/Services/Email/EmailOutboxService.php
@@ -430,6 +430,23 @@ class EmailOutboxService
 
         $emailHash = $this->piiCipher->emailHash($email);
         $emailEnc = $this->piiCipher->encrypt($email);
+        if (! $this->emailCaptures->allowsReportRecovery($email)) {
+            return [
+                'ok' => true,
+                'queued' => false,
+                'reason' => 'report_recovery_disabled',
+            ];
+        }
+
+        $deliveryPolicy = $this->emailPreferences->deliveryPolicyForEmail($email, self::RESULT_ACCESS_LINK_TEMPLATE);
+        if (! (bool) ($deliveryPolicy['allowed'] ?? false)) {
+            return [
+                'ok' => true,
+                'queued' => false,
+                'reason' => (string) ($deliveryPolicy['reason'] ?? 'delivery_not_allowed'),
+            ];
+        }
+
         $locale = $this->resolveRequestedLocale($attemptId, $preferredLocale);
         $subject = $this->defaultSubjectForTemplate(self::RESULT_ACCESS_LINK_TEMPLATE, $locale);
         $outboxUserId = $this->resultAccessLinkOutboxUserId($binding);

--- a/backend/app/Services/Email/EmailPreferenceService.php
+++ b/backend/app/Services/Email/EmailPreferenceService.php
@@ -457,6 +457,7 @@ class EmailPreferenceService
         return in_array(trim($templateKey), [
             'payment_success',
             'report_claim',
+            'result_access_link',
             'post_purchase_followup',
             'report_reactivation',
         ], true);

--- a/backend/app/Services/Results/ResultEmailLookupService.php
+++ b/backend/app/Services/Results/ResultEmailLookupService.php
@@ -40,12 +40,11 @@ final class ResultEmailLookupService
         int $orgId,
         ?string $locale = null,
         ?int $userId = null,
-        mixed $tokenAnonId = null,
-        mixed $clientAnonId = null
+        mixed $tokenAnonId = null
     ): array {
         $emailHash = $this->emailHash($email);
         $ownerUserId = $userId !== null && $userId > 0 ? (string) $userId : null;
-        $ownerAnonIds = $this->ownerAnonIds($tokenAnonId, $clientAnonId);
+        $ownerAnonIds = $this->ownerAnonIds($tokenAnonId);
 
         if ($emailHash === null || ($ownerUserId === null && $ownerAnonIds === [])) {
             return $this->verificationRequiredResponse();

--- a/backend/tests/Feature/AttemptEmailBindingTest.php
+++ b/backend/tests/Feature/AttemptEmailBindingTest.php
@@ -6,6 +6,9 @@ namespace Tests\Feature;
 
 use App\Models\Attempt;
 use App\Models\Result;
+use App\Models\EmailPreference;
+use App\Services\Email\EmailCaptureService;
+use App\Services\Email\EmailPreferenceService;
 use App\Support\PiiCipher;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -72,6 +75,47 @@ final class AttemptEmailBindingTest extends TestCase
         $this->assertSame('owner@example.test', (string) ($payloadEnc['to_email'] ?? ''));
         $this->assertStringStartsWith("/zh/result/{$attemptId}?access_token=", (string) ($payloadEnc['result_access_url'] ?? ''));
         $this->assertNotEmpty((string) ($payloadEnc['result_access_token'] ?? ''));
+    }
+
+    public function test_report_recovery_opt_out_prevents_result_access_link_email_queue(): void
+    {
+        $anonId = 'anon_email_bind_optout';
+        $attemptId = $this->seedAttemptWithResult($anonId, 'MBTI');
+        $token = $this->seedFmToken($anonId);
+        $email = 'optout@example.test';
+        $capture = app(EmailCaptureService::class)->capture($email, ['surface' => 'preferences']);
+        $preference = EmailPreference::query()
+            ->where('subscriber_id', (string) ($capture['subscriber_id'] ?? ''))
+            ->firstOrFail();
+        $subscriber = $preference->subscriber()->firstOrFail();
+        $preferenceToken = app(EmailPreferenceService::class)->issueTokenForSubscriber($subscriber);
+        app(EmailPreferenceService::class)->updateByToken($preferenceToken, [
+            'marketing_updates' => false,
+            'report_recovery' => false,
+            'product_updates' => false,
+        ]);
+
+        $response = $this->withHeaders([
+            'Authorization' => "Bearer {$token}",
+        ])->postJson("/api/v0.3/attempts/{$attemptId}/email-bind", [
+            'email' => $email,
+            'locale' => 'en',
+            'surface' => 'result_gate',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+        $response->assertJsonPath('result_access_link_email_queued', false);
+        $this->assertDatabaseHas('attempt_email_bindings', [
+            'org_id' => 0,
+            'attempt_id' => $attemptId,
+            'status' => 'active',
+            'source' => 'result_gate',
+        ]);
+        $this->assertSame(0, DB::table('email_outbox')
+            ->where('attempt_id', $attemptId)
+            ->where('template', 'result_access_link')
+            ->count());
     }
 
     public function test_wrong_anon_cannot_bind_someone_else_attempt(): void

--- a/backend/tests/Feature/ResultEmailLookupTest.php
+++ b/backend/tests/Feature/ResultEmailLookupTest.php
@@ -19,6 +19,13 @@ final class ResultEmailLookupTest extends TestCase
 {
     use RefreshDatabase;
 
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config(['fap.rate_limits.bypass_in_test_env' => true]);
+    }
+
     public function test_lookup_by_email_lists_only_results_bound_to_current_anonymous_actor(): void
     {
         $email = 'Owner@Example.Test';
@@ -26,8 +33,11 @@ final class ResultEmailLookupTest extends TestCase
         $secondAttemptId = $this->seedAttemptWithResult('anon_lookup_b', 'BIG5_OCEAN', 'OCEAN-HIGH', now()->subMinute());
         $this->seedBinding($firstAttemptId, $email, 'anon_lookup_a');
         $this->seedBinding($secondAttemptId, $email, 'anon_lookup_b');
+        $token = $this->seedFmToken('anon_lookup_a');
 
-        $response = $this->withHeader('X-Anon-Id', 'anon_lookup_a')
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])
             ->postJson('/api/v0.3/results/lookup-by-email', [
                 'email' => ' owner@example.test ',
                 'locale' => 'zh-CN',
@@ -57,8 +67,11 @@ final class ResultEmailLookupTest extends TestCase
         $secondAttemptId = $this->seedAttemptWithResult('anon_lookup_b', 'BIG5_OCEAN', 'OCEAN-HIGH', now()->subMinute());
         $this->seedBinding($firstAttemptId, $email, 'anon_lookup_a');
         $this->seedBinding($secondAttemptId, $email, 'anon_lookup_b');
+        $token = $this->seedFmToken('anon_lookup_other');
 
-        $response = $this->withHeader('X-Anon-Id', 'anon_lookup_other')
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])
             ->postJson('/api/v0.3/results/lookup-by-email', [
                 'email' => ' owner@example.test ',
                 'locale' => 'zh-CN',
@@ -75,14 +88,18 @@ final class ResultEmailLookupTest extends TestCase
 
     public function test_lookup_by_email_returns_empty_items_for_no_matches(): void
     {
-        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
+        $token = $this->seedFmToken('anon_lookup_missing');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/results/lookup-by-email', [
             'email' => 'missing@example.test',
             'locale' => 'en',
         ]);
 
         $response->assertOk();
         $response->assertJsonPath('ok', true);
-        $response->assertJsonPath('email_verification_required', true);
+        $response->assertJsonPath('email_verification_required', false);
         $response->assertJsonCount(0, 'items');
     }
 
@@ -95,8 +112,11 @@ final class ResultEmailLookupTest extends TestCase
         $this->seedBinding($activeAttemptId, $email, 'anon_lookup_active');
         $this->seedBinding($inactiveAttemptId, $email, 'anon_lookup_inactive', 'pending');
         $this->seedBinding($sensitiveAttemptId, $email, 'anon_lookup_sds');
+        $token = $this->seedFmToken('anon_lookup_active');
 
-        $response = $this->withHeader('X-Anon-Id', 'anon_lookup_active')
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])
             ->postJson('/api/v0.3/results/lookup-by-email', [
                 'email' => $email,
                 'locale' => 'en',
@@ -121,21 +141,63 @@ final class ResultEmailLookupTest extends TestCase
 
         $email = 'ratelimit_'.Str::lower(Str::random(12)).'@example.test';
         $server = ['REMOTE_ADDR' => '198.51.100.77'];
+        $token = $this->seedFmToken('anon_lookup_rate_limited');
         foreach (['127.0.0.1', '198.51.100.77'] as $ip) {
             RateLimiter::clear('ip:'.$ip);
             RateLimiter::clear('api_result_lookup|ip:'.$ip.'|org:0|route:api/v0.3/results/lookup-by-email');
             RateLimiter::clear('api_result_lookup|ip:'.$ip.'|org:0|route:v0.3/results/lookup-by-email');
         }
 
-        $this->withServerVariables($server)->postJson('/api/v0.3/results/lookup-by-email', [
+        $this->withServerVariables($server)->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/results/lookup-by-email', [
             'email' => $email,
         ])->assertOk();
 
-        $this->withServerVariables($server)->postJson('/api/v0.3/results/lookup-by-email', [
+        $this->withServerVariables($server)->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+        ])->postJson('/api/v0.3/results/lookup-by-email', [
             'email' => $email,
         ])
             ->assertStatus(429)
             ->assertJsonPath('error_code', 'RATE_LIMIT_RESULT_LOOKUP');
+    }
+
+    public function test_lookup_by_email_without_server_side_identity_requires_verification(): void
+    {
+        $response = $this->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => 'owner@example.test',
+            'locale' => 'en',
+        ]);
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('email_verification_required', true)
+            ->assertJsonCount(0, 'items');
+    }
+
+    public function test_lookup_by_email_ignores_spoofed_transport_anon_id_when_token_actor_differs(): void
+    {
+        $email = 'Owner@Example.Test';
+        $firstAttemptId = $this->seedAttemptWithResult('anon_lookup_real_actor', 'MBTI', 'INTJ-A', now()->subMinutes(5));
+        $secondAttemptId = $this->seedAttemptWithResult('anon_lookup_spoof_target', 'BIG5_OCEAN', 'OCEAN-HIGH', now()->subMinute());
+        $this->seedBinding($firstAttemptId, $email, 'anon_lookup_real_actor');
+        $this->seedBinding($secondAttemptId, $email, 'anon_lookup_spoof_target');
+        $token = $this->seedFmToken('anon_lookup_real_actor');
+
+        $response = $this->withHeaders([
+            'Authorization' => 'Bearer '.$token,
+            'X-Anon-Id' => 'anon_lookup_spoof_target',
+        ])->postJson('/api/v0.3/results/lookup-by-email', [
+            'email' => ' owner@example.test ',
+            'locale' => 'en',
+        ]);
+
+        $response->assertOk();
+        $response->assertJsonPath('email_verification_required', false);
+        $response->assertJsonCount(1, 'items');
+        $response->assertJsonPath('items.0.attempt_id', $firstAttemptId);
+        $this->assertStringNotContainsString($secondAttemptId, $response->getContent());
     }
 
     private function seedAttemptWithResult(string $anonId, string $scaleCode, string $typeCode, mixed $submittedAt): string
@@ -208,5 +270,24 @@ final class ResultEmailLookupTest extends TestCase
             'created_at' => now()->subMinute(),
             'updated_at' => now()->subMinute(),
         ]);
+    }
+
+    private function seedFmToken(string $anonId): string
+    {
+        $token = 'fm_'.(string) Str::uuid();
+
+        DB::table('fm_tokens')->insert([
+            'token' => $token,
+            'token_hash' => hash('sha256', $token),
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'org_id' => 0,
+            'role' => 'public',
+            'expires_at' => now()->addHour(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ]);
+
+        return $token;
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1443,6 +1443,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_result_email_access_link_delivery_changes(): void
     {
         $changed = [
+            'backend/app/Services/Email/EmailPreferenceService.php',
             'backend/app/Services/Email/EmailOutboxService.php',
         ];
 
@@ -4288,7 +4289,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
 
     private function isResultEmailAccessLinkDeliveryFile(string $file): bool
     {
-        return $file === 'backend/app/Services/Email/EmailOutboxService.php';
+        return in_array($file, [
+            'backend/app/Services/Email/EmailOutboxService.php',
+            'backend/app/Services/Email/EmailPreferenceService.php',
+        ], true);
     }
 
     private function isAnalyticsFunnelEventTaxonomyFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33851,7 +33851,7 @@
     "branch": "audit/sec-result-identity-01",
     "base": "main",
     "title": "AUDIT-SEC-RESULT-IDENTITY-01 harden result recovery identity boundary",
-    "status": "in_progress",
+    "status": "ready_to_merge",
     "depends_on": [
       "AUDIT-SEC-RELEASE-TRAIN-01 merged"
     ],
@@ -33862,7 +33862,8 @@
       "focused_tests": "php artisan test --filter=ResultEmailLookupTest, AttemptEmailBindingTest, ResultEmailGatedReadTest passed; local file cache warnings only",
       "acceptance": "route:list passed; testing sqlite migrate passed; manifest JSON/YAML valid; git diff --check passed; backend/scripts/ci_verify_mbti.sh passed",
       "scope_guard": "BIG5_OCEAN compiled generated files restored; only scoped files remain dirty",
-      "github_ci_first_failure": "PR #1786 verify-bigfive failed on BigFiveResultPageV2CoreBodyPreview runtime-freeze classifier for EmailPreferenceService.php; current-scope guard exception added for result access link delivery preference policy."
+      "github_ci_first_failure": "PR #1786 verify-bigfive failed on BigFiveResultPageV2CoreBodyPreview runtime-freeze classifier for EmailPreferenceService.php; current-scope guard exception added for result access link delivery preference policy.",
+      "github_checks": "PR #1786 second CI run green: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep SARIF upload."
     },
     "failure_reason": null,
     "merged_at": null,
@@ -33871,7 +33872,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": false,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -33892,6 +33893,12 @@
         "from": "pr_checks_pending",
         "to": "ci_scope_fix_in_progress",
         "note": "Fixed current-scope verify-bigfive runtime-freeze classifier failure by covering result access link delivery preference policy changes."
+      },
+      {
+        "at": "2026-05-31T15:44:57+08:00",
+        "from": "ci_scope_fix_in_progress",
+        "to": "github_checks_green",
+        "note": "PR #1786 checks green after current-scope runtime-freeze classifier fix."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33861,7 +33861,8 @@
       "deploy_safety_boundary": "no deploy, no production mutation, no production SSH",
       "focused_tests": "php artisan test --filter=ResultEmailLookupTest, AttemptEmailBindingTest, ResultEmailGatedReadTest passed; local file cache warnings only",
       "acceptance": "route:list passed; testing sqlite migrate passed; manifest JSON/YAML valid; git diff --check passed; backend/scripts/ci_verify_mbti.sh passed",
-      "scope_guard": "BIG5_OCEAN compiled generated files restored; only scoped files remain dirty"
+      "scope_guard": "BIG5_OCEAN compiled generated files restored; only scoped files remain dirty",
+      "github_ci_first_failure": "PR #1786 verify-bigfive failed on BigFiveResultPageV2CoreBodyPreview runtime-freeze classifier for EmailPreferenceService.php; current-scope guard exception added for result access link delivery preference policy."
     },
     "failure_reason": null,
     "merged_at": null,
@@ -33870,7 +33871,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": false,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -33885,6 +33886,12 @@
         "from": "in_progress",
         "to": "local_validation_passed",
         "note": "Focused tests and required local acceptance passed before commit; file cache warnings were non-failing local warnings."
+      },
+      {
+        "at": "2026-05-31T15:38:40+08:00",
+        "from": "pr_checks_pending",
+        "to": "ci_scope_fix_in_progress",
+        "note": "Fixed current-scope verify-bigfive runtime-freeze classifier failure by covering result access link delivery preference policy changes."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33844,5 +33844,50 @@
       }
     ],
     "next_task": "Run local validation, open PR, wait for CI, merge if allowed, cleanup, then continue SECURITY-AUDIT-36-PR-TRAIN."
+  },
+  "AUDIT-SEC-RESULT-IDENTITY-01": {
+    "id": "AUDIT-SEC-RESULT-IDENTITY-01",
+    "repo": "fap-api",
+    "branch": "audit/sec-result-identity-01",
+    "base": "main",
+    "title": "AUDIT-SEC-RESULT-IDENTITY-01 harden result recovery identity boundary",
+    "status": "in_progress",
+    "depends_on": [
+      "AUDIT-SEC-RELEASE-TRAIN-01 merged"
+    ],
+    "checks": {
+      "authorization": "user explicitly authorized adding remaining SECURITY-AUDIT-36 PR train items to manifest/state",
+      "workspace_safety": "using isolated worktree /private/tmp/fap-api-audit-sec-result-identity-01; dirty primary worktree untouched",
+      "deploy_safety_boundary": "no deploy, no production mutation, no production SSH",
+      "focused_tests": "php artisan test --filter=ResultEmailLookupTest, AttemptEmailBindingTest, ResultEmailGatedReadTest passed; local file cache warnings only",
+      "acceptance": "route:list passed; testing sqlite migrate passed; manifest JSON/YAML valid; git diff --check passed; backend/scripts/ci_verify_mbti.sh passed",
+      "scope_guard": "BIG5_OCEAN compiled generated files restored; only scoped files remain dirty"
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-05-31T15:14:47+08:00",
+        "from": "authorized",
+        "to": "in_progress",
+        "note": "Started from latest origin/main after AUDIT-SEC-RELEASE-TRAIN-01 merge cleanup."
+      },
+      {
+        "at": "2026-05-31T15:32:01+08:00",
+        "from": "in_progress",
+        "to": "local_validation_passed",
+        "note": "Focused tests and required local acceptance passed before commit; file cache warnings were non-failing local warnings."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "AUDIT-SEC-PAYMENT-INTEGRITY-01"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16546,6 +16546,7 @@ prs:
       - backend/app/Services/Email/EmailPreferenceService.php
       - backend/tests/Feature/ResultEmailLookupTest.php
       - backend/tests/Feature/AttemptEmailBindingTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     scope:
@@ -16562,6 +16563,7 @@ prs:
       - cd backend && php artisan test --filter=ResultEmailLookupTest --no-ansi
       - cd backend && php artisan test --filter=AttemptEmailBindingTest --no-ansi
       - cd backend && php artisan test --filter=ResultEmailGatedReadTest --no-ansi
+      - cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_result_email_access_link_delivery_changes --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-result-identity-01.sqlite php artisan migrate --force --no-ansi
       - bash backend/scripts/ci_verify_mbti.sh

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16529,6 +16529,61 @@ prs:
     frontend_fallback_authority: false
     next_task: continue SECURITY-AUDIT-36-PR-TRAIN with AUDIT-SEC-RESULT-IDENTITY-01 after post-merge cleanup
 
+  - id: AUDIT-SEC-RESULT-IDENTITY-01
+    repo: fap-api
+    branch: audit/sec-result-identity-01
+    base: main
+    title: "AUDIT-SEC-RESULT-IDENTITY-01 harden result recovery identity boundary"
+    train_scope: result_recovery_identity_boundary
+    risk_level: high_security_identity_recovery
+    depends_on:
+      - AUDIT-SEC-RELEASE-TRAIN-01 merged
+    allowed_paths:
+      - backend/routes/api.php
+      - backend/app/Http/Controllers/API/V0_3/ResultEmailLookupController.php
+      - backend/app/Services/Results/ResultEmailLookupService.php
+      - backend/app/Services/Email/EmailOutboxService.php
+      - backend/app/Services/Email/EmailPreferenceService.php
+      - backend/tests/Feature/ResultEmailLookupTest.php
+      - backend/tests/Feature/AttemptEmailBindingTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Bind email lookup/recovery identity to non-spoofable server-side authority.
+      - Preserve legitimate anonymous result recovery through server-issued FM token identity.
+      - Enforce recovery email opt-out boundary for result access links.
+      - Add focused feature tests.
+    do_not:
+      - Do not deploy, mutate production, run production SSH, or approve production environments.
+      - Do not modify payment, content packs, CMS, fap-web, sitemap, llms, Search Channel, or URL submission files.
+      - Do not broaden result access token privileges or expose sensitive SDS/clinical results.
+      - Do not add migrations or new routes.
+    validation:
+      - cd backend && php artisan test --filter=ResultEmailLookupTest --no-ansi
+      - cd backend && php artisan test --filter=AttemptEmailBindingTest --no-ansi
+      - cd backend && php artisan test --filter=ResultEmailGatedReadTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-result-identity-01.sqlite php artisan migrate --force --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    public_contract_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: AUDIT-SEC-PAYMENT-INTEGRITY-01
+
   - id: PR-POL-01
     repo: fap-api
     branch: content/pr-pol-01-policies-dashboard


### PR DESCRIPTION
## Summary
- hardens result email lookup so listed results are scoped to server-validated FM token identity, not transport-provided anonymous identifiers
- preserves no-token recovery behavior by returning verification-required instead of exposing saved result rows
- applies result access link delivery opt-out to the email outbox path
- records AUDIT-SEC-RESULT-IDENTITY-01 in the PR train manifest/state ledger

## Scope validation
Changed files are limited to result email lookup/recovery services, focused feature tests, and PR train ledger files.

No deploy, no production mutation, no route creation, no fap-web change.

## Local validation
- `php artisan test --filter=ResultEmailLookupTest --no-ansi` passed with local file cache warnings only
- `php artisan test --filter=AttemptEmailBindingTest --no-ansi` passed with local file cache warnings only
- `php artisan test --filter=ResultEmailGatedReadTest --no-ansi` passed with local file cache warnings only
- `php artisan route:list --no-ansi` passed
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-result-identity-01.sqlite php artisan migrate --force --no-ansi` passed
- `python3 -m json.tool docs/codex/pr-train-state.json` passed
- PR train YAML parse passed
- `git diff --check` passed
- `bash backend/scripts/ci_verify_mbti.sh` passed

## Security notes
- Public PR text intentionally avoids operational exploit details.
- Result listing authority is now derived from server-side FM token validation.
- Transport anonymous identifiers remain valid for non-authoritative public flow context but are not used to list email-bound saved results.
