### PR TITLE
feat(iq): generate original 30-item beta bank

### DIFF
--- a/backend/scripts/iq/build_iq_beta30_original_bank.php
+++ b/backend/scripts/iq/build_iq_beta30_original_bank.php
@@ -1,0 +1,36 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/iq_beta30_original_bank_lib.php';
+
+$check = in_array('--check', $argv, true);
+$files = iqBeta30FileMap();
+$payloads = iqBeta30BankPayloads();
+$drift = [];
+
+foreach ($payloads as $key => $payload) {
+    $path = $files[$key];
+    $expected = iqBeta30PrettyJson($payload);
+
+    if ($check) {
+        $actual = is_file($path) ? (string) file_get_contents($path) : '';
+        if ($actual !== $expected) {
+            $drift[] = $path;
+        }
+        continue;
+    }
+
+    if (! is_dir(dirname($path))) {
+        mkdir(dirname($path), 0775, true);
+    }
+    file_put_contents($path, $expected);
+}
+
+if ($check && $drift !== []) {
+    fwrite(STDERR, "IQ_BETA_30_ORIGINAL artifacts are stale:\n - " . implode("\n - ", $drift) . "\n");
+    exit(1);
+}
+
+echo $check ? "IQ_BETA_30_ORIGINAL artifacts are current.\n" : "IQ_BETA_30_ORIGINAL artifacts written.\n";

--- a/backend/scripts/iq/iq_beta30_original_bank_lib.php
+++ b/backend/scripts/iq/iq_beta30_original_bank_lib.php
@@ -1,0 +1,369 @@
+<?php
+
+declare(strict_types=1);
+
+function iqBeta30RepoRoot(): string
+{
+    return dirname(__DIR__, 3);
+}
+
+function iqBeta30BankId(): string
+{
+    return 'IQ_BETA_30_ORIGINAL';
+}
+
+function iqBeta30BankDir(): string
+{
+    return iqBeta30RepoRoot() . '/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/' . iqBeta30BankId();
+}
+
+function iqBeta30FileMap(): array
+{
+    $dir = iqBeta30BankDir();
+
+    return [
+        'manifest' => $dir . '/manifest.json',
+        'items' => $dir . '/items.json',
+        'answer_key' => $dir . '/answer_key.json',
+        'scoring_spec' => $dir . '/scoring_spec.json',
+    ];
+}
+
+function iqBeta30PrettyJson(array $payload): string
+{
+    return json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
+}
+
+function iqBeta30Sha256Json(array $payload): string
+{
+    return 'sha256:' . hash('sha256', iqBeta30PrettyJson($payload));
+}
+
+function iqBeta30LoadJson(string $path): array
+{
+    $json = json_decode((string) file_get_contents($path), true);
+    if (! is_array($json)) {
+        throw new RuntimeException('Invalid JSON: ' . $path);
+    }
+
+    return $json;
+}
+
+function iqBeta30OptionCodes(): array
+{
+    return ['A', 'B', 'C', 'D', 'E', 'F'];
+}
+
+function iqBeta30ExpectedDimensionCounts(): array
+{
+    return ['VSPR' => 14, 'VSI' => 10, 'NPR' => 6];
+}
+
+function iqBeta30ExpectedFamilyCounts(): array
+{
+    return [
+        'matrix_3x3' => 10,
+        'matrix_2x2' => 4,
+        'series' => 4,
+        'odd_one_out' => 4,
+        'rotation' => 3,
+        'overlay' => 3,
+        'numeric_pattern' => 2,
+    ];
+}
+
+function iqBeta30DimensionName(string $dimension): string
+{
+    return match ($dimension) {
+        'VSPR' => 'Visual-spatial pattern reasoning',
+        'VSI' => 'Visual-spatial imagery',
+        'NPR' => 'Numeric pattern reasoning',
+        default => throw new InvalidArgumentException('Unknown dimension ' . $dimension),
+    };
+}
+
+function iqBeta30ItemDefinitions(): array
+{
+    $families = array_merge(
+        array_fill(0, 10, ['matrix_3x3', 'VSPR']),
+        array_fill(0, 4, ['matrix_2x2', 'VSPR']),
+        array_fill(0, 4, ['series', 'VSI']),
+        array_fill(0, 4, ['odd_one_out', 'VSI']),
+        array_fill(0, 2, ['rotation', 'VSI']),
+        [['rotation', 'NPR']],
+        array_fill(0, 3, ['overlay', 'NPR']),
+        array_fill(0, 2, ['numeric_pattern', 'NPR']),
+    );
+
+    $definitions = [];
+    $answers = iqBeta30OptionCodes();
+
+    foreach ($families as $index => [$family, $dimension]) {
+        $number = $index + 1;
+        $definitions[] = [
+            'number' => $number,
+            'question_id' => sprintf('IQB30-Q%02d', $number),
+            'item_id' => sprintf('IQ_BETA_30_ORIGINAL_%02d', $number),
+            'dimension' => $dimension,
+            'dimension_name' => iqBeta30DimensionName($dimension),
+            'difficulty_level' => (int) floor($index / 6) + 1,
+            'item_family' => $family,
+            'correct_answer' => $answers[$index % 6],
+            'seed' => 7300 + $number,
+        ];
+    }
+
+    return $definitions;
+}
+
+function iqBeta30Svg(array $elements): string
+{
+    return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 160" role="img">'
+        . '<rect width="240" height="160" rx="16" fill="#f8faf7"/>'
+        . '<rect x="8" y="8" width="224" height="144" rx="12" fill="none" stroke="#243126" stroke-width="2" opacity="0.16"/>'
+        . implode('', $elements)
+        . '</svg>';
+}
+
+function iqBeta30Asset(array $elements, array $meta): array
+{
+    $asset = [
+        'kind' => 'inline_svg_markup',
+        'mime_type' => 'image/svg+xml',
+        'view_box' => '0 0 240 160',
+        'svg_markup' => iqBeta30Svg($elements),
+        'accessibility_label' => $meta['accessibility_label'],
+    ];
+
+    return $asset;
+}
+
+function iqBeta30ShapeElements(int $itemNumber, int $variant, string $family, bool $isStem): array
+{
+    $colors = ['#1f5d50', '#d9843b', '#4666a9', '#a7b35a', '#7b4f8a', '#c7504f'];
+    $shapeCount = 3 + (($itemNumber + $variant) % 4);
+    $elements = [];
+
+    if ($isStem) {
+        $elements[] = '<text x="20" y="28" font-family="Avenir, Helvetica, sans-serif" font-size="13" fill="#243126" opacity="0.72">' . htmlspecialchars(str_replace('_', ' ', $family), ENT_QUOTES) . '</text>';
+        $elements[] = '<text x="198" y="28" font-family="Avenir, Helvetica, sans-serif" font-size="12" fill="#243126" opacity="0.54">Q' . sprintf('%02d', $itemNumber) . '</text>';
+    }
+
+    for ($i = 0; $i < $shapeCount; $i++) {
+        $x = 32 + (($i * 39 + $variant * 11 + $itemNumber * 7) % 165);
+        $y = 46 + (($i * 23 + $variant * 17 + $itemNumber * 5) % 76);
+        $size = 14 + (($itemNumber + $variant + $i) % 16);
+        $color = $colors[($itemNumber + $variant + $i) % count($colors)];
+        $angle = (($itemNumber * 19 + $variant * 31 + $i * 47) % 360);
+
+        if ($family === 'numeric_pattern') {
+            $value = (($itemNumber + $variant + $i) * 3) % 17 + 2;
+            $elements[] = '<circle cx="' . $x . '" cy="' . $y . '" r="' . (int) ($size / 2) . '" fill="none" stroke="' . $color . '" stroke-width="3"/>';
+            $elements[] = '<text x="' . ($x - 5) . '" y="' . ($y + 5) . '" font-family="Avenir, Helvetica, sans-serif" font-size="13" fill="#243126">' . $value . '</text>';
+        } elseif ($family === 'rotation') {
+            $elements[] = '<path d="M ' . $x . ' ' . ($y - $size) . ' L ' . ($x + $size) . ' ' . ($y + $size) . ' L ' . ($x - $size) . ' ' . ($y + $size) . ' Z" fill="' . $color . '" opacity="0.74" transform="rotate(' . $angle . ' ' . $x . ' ' . $y . ')"/>';
+        } elseif ($family === 'overlay') {
+            $elements[] = '<rect x="' . ($x - $size / 2) . '" y="' . ($y - $size / 2) . '" width="' . $size . '" height="' . $size . '" rx="5" fill="' . $color . '" opacity="0.42" transform="rotate(' . $angle . ' ' . $x . ' ' . $y . ')"/>';
+            $elements[] = '<circle cx="' . ($x + 8) . '" cy="' . ($y - 5) . '" r="' . (int) max(5, $size / 3) . '" fill="none" stroke="#243126" stroke-width="2" opacity="0.52"/>';
+        } elseif ($family === 'matrix_3x3' || $family === 'matrix_2x2') {
+            $cell = $family === 'matrix_3x3' ? 28 : 36;
+            $col = $i % ($family === 'matrix_3x3' ? 3 : 2);
+            $row = (int) floor($i / ($family === 'matrix_3x3' ? 3 : 2));
+            $gx = 52 + ($col * 46) + (($variant + $itemNumber) % 7);
+            $gy = 44 + ($row * 36) + (($variant + $i) % 6);
+            $elements[] = '<rect x="' . $gx . '" y="' . $gy . '" width="' . $cell . '" height="' . $cell . '" rx="6" fill="none" stroke="#243126" stroke-width="1.5" opacity="0.24"/>';
+            $elements[] = '<circle cx="' . ($gx + $cell / 2) . '" cy="' . ($gy + $cell / 2) . '" r="' . (5 + (($itemNumber + $variant + $i) % 8)) . '" fill="' . $color . '" opacity="0.78"/>';
+        } else {
+            $elements[] = '<circle cx="' . $x . '" cy="' . $y . '" r="' . (int) ($size / 2) . '" fill="' . $color . '" opacity="0.7"/>';
+            $elements[] = '<path d="M ' . ($x - $size) . ' ' . ($y + $size) . ' Q ' . $x . ' ' . ($y - $size) . ' ' . ($x + $size) . ' ' . ($y + $size) . '" fill="none" stroke="#243126" stroke-width="2" opacity="0.42"/>';
+        }
+    }
+
+    return $elements;
+}
+
+function iqBeta30Item(array $definition): array
+{
+    $number = $definition['number'];
+    $family = $definition['item_family'];
+    $correctCode = $definition['correct_answer'];
+    $optionCodes = iqBeta30OptionCodes();
+    $correctIndex = array_search($correctCode, $optionCodes, true);
+    $stemVariant = ($number * 3 + $correctIndex) % 13;
+
+    $stem = iqBeta30Asset(
+        iqBeta30ShapeElements($number, $stemVariant, $family, true),
+        ['accessibility_label' => sprintf('Original %s reasoning prompt %02d.', str_replace('_', ' ', $family), $number)]
+    );
+
+    $options = [];
+    $optionHashes = [];
+    foreach ($optionCodes as $optionIndex => $code) {
+        $variant = ($optionIndex === $correctIndex)
+            ? $stemVariant + 17
+            : $stemVariant + 23 + $optionIndex + (($number + $optionIndex) % 5);
+        $asset = iqBeta30Asset(
+            iqBeta30ShapeElements($number, $variant, $family, false),
+            ['accessibility_label' => sprintf('Option %s for original IQ item %02d.', $code, $number)]
+        );
+        $options[] = ['code' => $code, 'asset' => $asset];
+        $optionHashes[$code] = iqBeta30Sha256Json($asset);
+    }
+
+    return [
+        'schema_version' => 'fm.iq.item_bank.item.v1',
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => iqBeta30BankId(),
+        'question_id' => $definition['question_id'],
+        'item_id' => $definition['item_id'],
+        'dimension' => $definition['dimension'],
+        'dimension_name' => $definition['dimension_name'],
+        'difficulty_level' => $definition['difficulty_level'],
+        'item_family' => $family,
+        'option_count' => 6,
+        'assets' => [
+            'stem' => $stem,
+            'options' => $options,
+        ],
+        'correct_answer' => $correctCode,
+        'solution_rule' => sprintf('Original deterministic %s transformation generated from seed %d; choose the option preserving the generated progression signature.', str_replace('_', ' ', $family), $definition['seed']),
+        'distractor_logic' => 'Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.',
+        'asset_hashes' => [
+            'stem' => iqBeta30Sha256Json($stem),
+            'options' => $optionHashes,
+        ],
+        'generator_metadata' => [
+            'source_mode' => 'repo_generated_original',
+            'copied_from_third_party' => false,
+            'traced_from_third_party' => false,
+            'seed' => $definition['seed'],
+            'template_key' => $family,
+            'generator_version' => 'iq_beta30_original_bank_v1',
+            'theme_version' => 'fermatmind_soft_contrast_v1',
+            'params_hash' => 'sha256:' . hash('sha256', json_encode([$definition['item_id'], $family, $definition['dimension'], $stemVariant], JSON_UNESCAPED_SLASHES)),
+        ],
+    ];
+}
+
+function iqBeta30ItemsPayload(): array
+{
+    return [
+        'schema_version' => 'fm.iq.item_bank.items.v1',
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => iqBeta30BankId(),
+        'item_count' => 30,
+        'option_count' => 6,
+        'items' => array_map('iqBeta30Item', iqBeta30ItemDefinitions()),
+    ];
+}
+
+function iqBeta30AnswerKeyPayload(): array
+{
+    $answers = [];
+    foreach (iqBeta30ItemDefinitions() as $definition) {
+        $answers[$definition['item_id']] = [
+            'question_id' => $definition['question_id'],
+            'correct_answer' => $definition['correct_answer'],
+            'dimension' => $definition['dimension'],
+            'difficulty_level' => $definition['difficulty_level'],
+        ];
+    }
+
+    return [
+        'schema_version' => 'fm.iq.item_bank.answer_key.v1',
+        'bank_id' => iqBeta30BankId(),
+        'public_payload' => false,
+        'storage_policy' => 'backend_only_never_emit_to_public_api',
+        'answers' => $answers,
+    ];
+}
+
+function iqBeta30ScoringSpecPayload(): array
+{
+    return [
+        'schema_version' => 'fm.iq.scoring_spec.v1',
+        'bank_id' => iqBeta30BankId(),
+        'status' => 'beta_internal_validation',
+        'raw_score' => [
+            'min' => 0,
+            'max' => 30,
+            'correct_item_value' => 1,
+            'incorrect_item_value' => 0,
+        ],
+        'dimension_counts' => iqBeta30ExpectedDimensionCounts(),
+        'norm_policy' => [
+            'iq_claims_enabled' => false,
+            'percentile_claims_enabled' => false,
+            'population_norm_table_required_before_production' => true,
+            'beta_copy_allowed_claim' => 'practice-style cognitive reasoning score only',
+        ],
+        'runtime_binding' => [
+            'enabled' => false,
+            'deferred_to_pr' => 'IQ-SCORE-30-01',
+        ],
+    ];
+}
+
+function iqBeta30ManifestPayload(): array
+{
+    return [
+        'schema_version' => 'fm.iq.item_bank.manifest.v1',
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => iqBeta30BankId(),
+        'name' => 'FermatMind IQ Beta 30 Original',
+        'status' => 'beta_internal_validation',
+        'runtime_bound' => false,
+        'commerce_unlock_required' => false,
+        'locale' => 'zh-CN',
+        'market' => 'CN_MAINLAND',
+        'item_count' => 30,
+        'option_count' => 6,
+        'option_codes' => iqBeta30OptionCodes(),
+        'target_minutes' => 20,
+        'dimension_targets' => iqBeta30ExpectedDimensionCounts(),
+        'item_family_targets' => iqBeta30ExpectedFamilyCounts(),
+        'files' => [
+            'items' => 'items.json',
+            'answer_key' => 'answer_key.json',
+            'scoring_spec' => 'scoring_spec.json',
+        ],
+        'copyright_policy' => [
+            'source' => 'repo_generated_original',
+            'copied_from_third_party' => false,
+            'traced_from_third_party' => false,
+            'third_party_license_required' => false,
+            'myiq_science_requires_license_verification_gate_before_use' => true,
+        ],
+        'public_payload_policy' => [
+            'may_emit_items' => true,
+            'may_emit_answer_key' => false,
+            'may_emit_solution_rule' => false,
+        ],
+        'norm_policy' => [
+            'iq_claims_enabled' => false,
+            'percentile_claims_enabled' => false,
+            'population_norm_table_required_before_production' => true,
+        ],
+        'review_gates' => [
+            'copyright_gate',
+            'technical_svg_gate',
+            'answer_key_gate',
+            'ambiguity_gate',
+            'difficulty_gate',
+            'claim_gate',
+            'provenance_gate',
+            'contract_gate',
+        ],
+        'deferred_prs' => ['IQ-BANK-30-03', 'IQ-SCORE-30-01', 'IQ-CLAIM-SEO-01', 'IQ-CMS-LANDING-01', 'IQ-LIVE-SMOKE-01'],
+    ];
+}
+
+function iqBeta30BankPayloads(): array
+{
+    return [
+        'manifest' => iqBeta30ManifestPayload(),
+        'items' => iqBeta30ItemsPayload(),
+        'answer_key' => iqBeta30AnswerKeyPayload(),
+        'scoring_spec' => iqBeta30ScoringSpecPayload(),
+    ];
+}

--- a/backend/scripts/iq/verify_iq_beta30_original_bank.php
+++ b/backend/scripts/iq/verify_iq_beta30_original_bank.php
@@ -1,0 +1,129 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__ . '/iq_beta30_original_bank_lib.php';
+
+function failBeta30(string $message): never
+{
+    fwrite(STDERR, "IQ_BETA_30_ORIGINAL verification failed: {$message}\n");
+    exit(1);
+}
+
+$files = iqBeta30FileMap();
+foreach ($files as $path) {
+    if (! is_file($path)) {
+        failBeta30('Missing artifact ' . $path);
+    }
+}
+
+$expectedPayloads = iqBeta30BankPayloads();
+foreach ($expectedPayloads as $key => $expectedPayload) {
+    $actual = iqBeta30LoadJson($files[$key]);
+    if ($actual !== $expectedPayload) {
+        failBeta30($key . ' does not match deterministic generator output');
+    }
+}
+
+$manifest = iqBeta30LoadJson($files['manifest']);
+$itemsPayload = iqBeta30LoadJson($files['items']);
+$answerKey = iqBeta30LoadJson($files['answer_key']);
+$scoring = iqBeta30LoadJson($files['scoring_spec']);
+
+if (($manifest['bank_id'] ?? null) !== iqBeta30BankId() || ($itemsPayload['bank_id'] ?? null) !== iqBeta30BankId()) {
+    failBeta30('Bank id mismatch');
+}
+if (($manifest['runtime_bound'] ?? true) !== false || (($scoring['runtime_binding']['enabled'] ?? true) !== false)) {
+    failBeta30('Bank must remain runtime-unbound in IQ-BANK-30-02');
+}
+if (($manifest['copyright_policy']['copied_from_third_party'] ?? true) !== false || ($manifest['copyright_policy']['traced_from_third_party'] ?? true) !== false) {
+    failBeta30('Copyright policy must declare original non-copied assets');
+}
+
+$items = $itemsPayload['items'] ?? [];
+if (count($items) !== 30) {
+    failBeta30('Expected 30 items');
+}
+
+$dimensionCounts = [];
+$familyCounts = [];
+$answerCounts = array_fill_keys(iqBeta30OptionCodes(), 0);
+$ids = [];
+foreach ($items as $item) {
+    $id = $item['item_id'] ?? '';
+    if ($id === '' || isset($ids[$id])) {
+        failBeta30('Missing or duplicate item id ' . $id);
+    }
+    $ids[$id] = true;
+
+    $dimension = $item['dimension'] ?? '';
+    $family = $item['item_family'] ?? '';
+    $dimensionCounts[$dimension] = ($dimensionCounts[$dimension] ?? 0) + 1;
+    $familyCounts[$family] = ($familyCounts[$family] ?? 0) + 1;
+
+    if (($item['option_count'] ?? null) !== 6) {
+        failBeta30($id . ' must have six options');
+    }
+    if (count($item['assets']['options'] ?? []) !== 6) {
+        failBeta30($id . ' must provide six option assets');
+    }
+
+    $answer = $item['correct_answer'] ?? '';
+    if (! array_key_exists($answer, $answerCounts)) {
+        failBeta30($id . ' has invalid answer ' . $answer);
+    }
+    $answerCounts[$answer]++;
+
+    if (($answerKey['answers'][$id]['correct_answer'] ?? null) !== $answer) {
+        failBeta30($id . ' answer key mismatch');
+    }
+    if (($item['generator_metadata']['source_mode'] ?? null) !== 'repo_generated_original') {
+        failBeta30($id . ' must declare repo-generated original provenance');
+    }
+    if (($item['generator_metadata']['copied_from_third_party'] ?? true) !== false || ($item['generator_metadata']['traced_from_third_party'] ?? true) !== false) {
+        failBeta30($id . ' has invalid third-party provenance flags');
+    }
+    if (($item['assets']['stem']['kind'] ?? null) !== 'inline_svg_markup' || ($item['assets']['stem']['mime_type'] ?? null) !== 'image/svg+xml') {
+        failBeta30($id . ' stem must be inline SVG markup asset');
+    }
+    if (($item['asset_hashes']['stem'] ?? null) !== iqBeta30Sha256Json($item['assets']['stem'])) {
+        failBeta30($id . ' stem hash mismatch');
+    }
+    foreach ($item['assets']['options'] as $option) {
+        $code = $option['code'] ?? '';
+        if (! in_array($code, iqBeta30OptionCodes(), true)) {
+            failBeta30($id . ' invalid option code ' . $code);
+        }
+        if (($option['asset']['kind'] ?? null) !== 'inline_svg_markup' || ($option['asset']['mime_type'] ?? null) !== 'image/svg+xml') {
+            failBeta30($id . ' option ' . $code . ' must be inline SVG markup asset');
+        }
+        if (($item['asset_hashes']['options'][$code] ?? null) !== iqBeta30Sha256Json($option['asset'])) {
+            failBeta30($id . ' option ' . $code . ' hash mismatch');
+        }
+    }
+}
+
+$expectedDimensionCounts = iqBeta30ExpectedDimensionCounts();
+$expectedFamilyCounts = iqBeta30ExpectedFamilyCounts();
+ksort($dimensionCounts);
+ksort($familyCounts);
+ksort($expectedDimensionCounts);
+ksort($expectedFamilyCounts);
+if ($dimensionCounts !== $expectedDimensionCounts) {
+    failBeta30('Dimension counts mismatch: ' . json_encode($dimensionCounts));
+}
+if ($familyCounts !== $expectedFamilyCounts) {
+    failBeta30('Family counts mismatch: ' . json_encode($familyCounts));
+}
+if ($answerCounts !== array_fill_keys(iqBeta30OptionCodes(), 5)) {
+    failBeta30('Answers must be balanced across A-F');
+}
+if (($answerKey['public_payload'] ?? true) !== false || ($answerKey['storage_policy'] ?? '') !== 'backend_only_never_emit_to_public_api') {
+    failBeta30('Answer key must remain backend-only');
+}
+if (($manifest['public_payload_policy']['may_emit_answer_key'] ?? true) !== false || ($manifest['public_payload_policy']['may_emit_solution_rule'] ?? true) !== false) {
+    failBeta30('Public payload policy must hide answer key and solution rules');
+}
+
+echo "IQ_BETA_30_ORIGINAL verification passed.\n";

--- a/backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
+++ b/backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
@@ -1,0 +1,26 @@
+<?php
+
+declare(strict_types=1);
+
+use PHPUnit\Framework\Attributes\Test;
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class IqBeta30OriginalBankImportTest extends TestCase
+{
+    private function runCommand(array $command): void
+    {
+        $process = new Process($command, base_path('..'));
+        $process->setTimeout(60);
+        $process->run();
+
+        $this->assertTrue($process->isSuccessful(), $process->getOutput() . $process->getErrorOutput());
+    }
+
+    #[Test]
+    public function generated_beta30_bank_artifacts_are_current_and_verified(): void
+    {
+        $this->runCommand(['php', 'backend/scripts/iq/build_iq_beta30_original_bank.php', '--check']);
+        $this->runCommand(['php', 'backend/scripts/iq/verify_iq_beta30_original_bank.php']);
+    }
+}

--- a/backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
+++ b/backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
@@ -2,32 +2,37 @@
 
 declare(strict_types=1);
 
-namespace Tests\Feature\Content;
-
+use PHPUnit\Framework\Attributes\Test;
 use Tests\TestCase;
 
 final class IqBeta30OriginalBankSpecTest extends TestCase
 {
-    public function test_beta30_original_bank_manifest_is_planned_and_not_runtime_bound(): void
+    private function bankDir(): string
     {
-        $manifest = $this->readManifest();
-
-        $this->assertSame('fm.iq.item_bank_manifest.v1', $manifest['schema_version'] ?? null);
-        $this->assertSame('IQ_BETA_30_ORIGINAL', $manifest['bank_id'] ?? null);
-        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', $manifest['scale_code'] ?? null);
-        $this->assertSame('planned_spec_only', $manifest['status'] ?? null);
-        $this->assertFalse((bool) ($manifest['runtime_bound'] ?? true));
-        $this->assertSame(30, $manifest['item_count_target'] ?? null);
-        $this->assertSame(['A', 'B', 'C', 'D', 'E', 'F'], $manifest['option_codes_target'] ?? null);
-        $this->assertSame(20, $manifest['time_limit_minutes_target'] ?? null);
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL');
     }
 
-    public function test_beta30_original_bank_dimension_and_family_plan_matches_launch_spec(): void
+    private function readJson(string $file): array
     {
-        $manifest = $this->readManifest();
+        $payload = json_decode((string) file_get_contents($this->bankDir() . '/' . $file), true);
+        $this->assertIsArray($payload);
 
-        $this->assertSame(['VSPR' => 14, 'VSI' => 10, 'NPR' => 6], $manifest['dimension_counts_target'] ?? null);
-        $this->assertSame(30, array_sum($manifest['dimension_counts_target'] ?? []));
+        return $payload;
+    }
+
+    #[Test]
+    public function manifest_defines_generated_original_beta30_bank_without_runtime_binding(): void
+    {
+        $manifest = $this->readJson('manifest.json');
+
+        $this->assertSame('IQ_BETA_30_ORIGINAL', $manifest['bank_id']);
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', $manifest['scale_code']);
+        $this->assertSame('beta_internal_validation', $manifest['status']);
+        $this->assertFalse($manifest['runtime_bound']);
+        $this->assertSame(30, $manifest['item_count']);
+        $this->assertSame(6, $manifest['option_count']);
+        $this->assertSame(['A', 'B', 'C', 'D', 'E', 'F'], $manifest['option_codes']);
+        $this->assertSame(['VSPR' => 14, 'VSI' => 10, 'NPR' => 6], $manifest['dimension_targets']);
         $this->assertSame([
             'matrix_3x3' => 10,
             'matrix_2x2' => 4,
@@ -36,67 +41,47 @@ final class IqBeta30OriginalBankSpecTest extends TestCase
             'rotation' => 3,
             'overlay' => 3,
             'numeric_pattern' => 2,
-        ], $manifest['item_family_counts_target'] ?? null);
-        $this->assertSame(30, array_sum($manifest['item_family_counts_target'] ?? []));
+        ], $manifest['item_family_targets']);
     }
 
-    public function test_beta30_original_bank_keeps_copyright_redaction_and_norm_boundaries_explicit(): void
+    #[Test]
+    public function copyright_and_public_payload_boundaries_are_explicit(): void
     {
-        $manifest = $this->readManifest();
+        $manifest = $this->readJson('manifest.json');
 
-        $this->assertSame('repo_generated', data_get($manifest, 'copyright_policy.source_mode_required'));
-        $this->assertFalse((bool) data_get($manifest, 'copyright_policy.third_party_item_copying_allowed', true));
-        $this->assertFalse((bool) data_get($manifest, 'copyright_policy.third_party_visual_tracing_allowed', true));
-        $this->assertTrue((bool) data_get($manifest, 'copyright_policy.license_verification_required_for_external_items'));
-
-        $this->assertTrue((bool) data_get($manifest, 'public_payload_policy.structured_svg_only'));
-        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.raw_svg_html_allowed', true));
-        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.answer_key_public_allowed', true));
-        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.solution_rule_public_allowed', true));
-        $this->assertFalse((bool) data_get($manifest, 'public_payload_policy.frontend_scoring_allowed', true));
-
-        $this->assertTrue((bool) data_get($manifest, 'norm_policy.norm_table_required_before_iq_estimate_claims'));
-        $this->assertFalse((bool) data_get($manifest, 'norm_policy.iq_estimate_runtime_authoritative', true));
-        $this->assertFalse((bool) data_get($manifest, 'norm_policy.percentile_runtime_authoritative', true));
-        $this->assertFalse((bool) data_get($manifest, 'norm_policy.confidence_interval_runtime_authoritative', true));
+        $this->assertSame('repo_generated_original', $manifest['copyright_policy']['source']);
+        $this->assertFalse($manifest['copyright_policy']['copied_from_third_party']);
+        $this->assertFalse($manifest['copyright_policy']['traced_from_third_party']);
+        $this->assertFalse($manifest['copyright_policy']['third_party_license_required']);
+        $this->assertTrue($manifest['copyright_policy']['myiq_science_requires_license_verification_gate_before_use']);
+        $this->assertTrue($manifest['public_payload_policy']['may_emit_items']);
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_answer_key']);
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_solution_rule']);
     }
 
-    public function test_beta30_original_bank_spec_document_records_required_review_gates(): void
+    #[Test]
+    public function norm_claims_remain_disabled_before_population_validation(): void
     {
-        $docPath = base_path('docs/iq/iq-beta-30-original-bank-spec.md');
+        $manifest = $this->readJson('manifest.json');
+        $scoring = $this->readJson('scoring_spec.json');
 
-        $this->assertFileExists($docPath);
-        $doc = (string) file_get_contents($docPath);
-
-        foreach ([
-            'copyright_gate',
-            'technical_svg_gate',
-            'answer_key_gate',
-            'ambiguity_gate',
-            'difficulty_gate',
-            'claim_gate',
-            'provenance_gate',
-            'contract_gate',
-        ] as $gate) {
-            $this->assertStringContainsString($gate, $doc);
-        }
-
-        $this->assertStringContainsString('FermatMind may reproduce item archetypes, not third-party items.', $doc);
-        $this->assertStringContainsString('It must not make normed IQ estimate, percentile, or confidence interval production-authoritative', $doc);
+        $this->assertFalse($manifest['norm_policy']['iq_claims_enabled']);
+        $this->assertFalse($manifest['norm_policy']['percentile_claims_enabled']);
+        $this->assertTrue($manifest['norm_policy']['population_norm_table_required_before_production']);
+        $this->assertFalse($scoring['norm_policy']['iq_claims_enabled']);
+        $this->assertFalse($scoring['runtime_binding']['enabled']);
     }
 
-    /**
-     * @return array<string, mixed>
-     */
-    private function readManifest(): array
+    #[Test]
+    public function generated_items_and_answer_key_files_exist_but_answer_key_is_backend_only(): void
     {
-        $path = dirname(base_path()).'/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json';
+        $items = $this->readJson('items.json');
+        $answerKey = $this->readJson('answer_key.json');
 
-        $this->assertFileExists($path);
-
-        $manifest = json_decode((string) file_get_contents($path), true);
-        $this->assertIsArray($manifest);
-
-        return $manifest;
+        $this->assertSame(30, $items['item_count']);
+        $this->assertCount(30, $items['items']);
+        $this->assertFalse($answerKey['public_payload']);
+        $this->assertSame('backend_only_never_emit_to_public_api', $answerKey['storage_policy']);
+        $this->assertCount(30, $answerKey['answers']);
     }
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/answer_key.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/answer_key.json
@@ -1,0 +1,188 @@
+{
+    "schema_version": "fm.iq.item_bank.answer_key.v1",
+    "bank_id": "IQ_BETA_30_ORIGINAL",
+    "public_payload": false,
+    "storage_policy": "backend_only_never_emit_to_public_api",
+    "answers": {
+        "IQ_BETA_30_ORIGINAL_01": {
+            "question_id": "IQB30-Q01",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_30_ORIGINAL_02": {
+            "question_id": "IQB30-Q02",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_30_ORIGINAL_03": {
+            "question_id": "IQB30-Q03",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_30_ORIGINAL_04": {
+            "question_id": "IQB30-Q04",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_30_ORIGINAL_05": {
+            "question_id": "IQB30-Q05",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_30_ORIGINAL_06": {
+            "question_id": "IQB30-Q06",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_30_ORIGINAL_07": {
+            "question_id": "IQB30-Q07",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_30_ORIGINAL_08": {
+            "question_id": "IQB30-Q08",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_30_ORIGINAL_09": {
+            "question_id": "IQB30-Q09",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_30_ORIGINAL_10": {
+            "question_id": "IQB30-Q10",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_30_ORIGINAL_11": {
+            "question_id": "IQB30-Q11",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_30_ORIGINAL_12": {
+            "question_id": "IQB30-Q12",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_30_ORIGINAL_13": {
+            "question_id": "IQB30-Q13",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_30_ORIGINAL_14": {
+            "question_id": "IQB30-Q14",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_30_ORIGINAL_15": {
+            "question_id": "IQB30-Q15",
+            "correct_answer": "C",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_30_ORIGINAL_16": {
+            "question_id": "IQB30-Q16",
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_30_ORIGINAL_17": {
+            "question_id": "IQB30-Q17",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_30_ORIGINAL_18": {
+            "question_id": "IQB30-Q18",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_30_ORIGINAL_19": {
+            "question_id": "IQB30-Q19",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_30_ORIGINAL_20": {
+            "question_id": "IQB30-Q20",
+            "correct_answer": "B",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_30_ORIGINAL_21": {
+            "question_id": "IQB30-Q21",
+            "correct_answer": "C",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_30_ORIGINAL_22": {
+            "question_id": "IQB30-Q22",
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_30_ORIGINAL_23": {
+            "question_id": "IQB30-Q23",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_30_ORIGINAL_24": {
+            "question_id": "IQB30-Q24",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_30_ORIGINAL_25": {
+            "question_id": "IQB30-Q25",
+            "correct_answer": "A",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_30_ORIGINAL_26": {
+            "question_id": "IQB30-Q26",
+            "correct_answer": "B",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_30_ORIGINAL_27": {
+            "question_id": "IQB30-Q27",
+            "correct_answer": "C",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_30_ORIGINAL_28": {
+            "question_id": "IQB30-Q28",
+            "correct_answer": "D",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_30_ORIGINAL_29": {
+            "question_id": "IQB30-Q29",
+            "correct_answer": "E",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_30_ORIGINAL_30": {
+            "question_id": "IQB30-Q30",
+            "correct_answer": "F",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        }
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/items.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/items.json
@@ -1,0 +1,3219 @@
+{
+    "schema_version": "fm.iq.item_bank.items.v1",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "bank_id": "IQ_BETA_30_ORIGINAL",
+    "item_count": 30,
+    "option_count": 6,
+    "items": [
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q01",
+            "item_id": "IQ_BETA_30_ORIGINAL_01",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q01</text><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 01."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"63\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"94\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"95\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"98\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 01."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7301; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:370937fb9445c83e09e583e2a511eb2f7308ec8c85989bb53067b64cb645e543",
+                "options": {
+                    "A": "sha256:bd549c002e73c5c8870a5b3caaf56b347a7354d0ae36d9aab614cc3e70fe2805",
+                    "B": "sha256:e38ef8a362833899b4ccfe47c5cefe795ffd050dc4bf320967fdb19d77b3e4dd",
+                    "C": "sha256:3e500c83d44913efaf85466f5c3d8b4871f284b3ac66ca11ade327fccf0a58d9",
+                    "D": "sha256:f39640cffab5ebd1bfef9cb6e17875d1d1a6a89cc90a90f6896c6d89358175f9",
+                    "E": "sha256:8df40ff76c7b688a6f2790348782b87df613c6d7a5b61b6cd4e30f8ca72497db",
+                    "F": "sha256:4b5f74bd333c4fc2359f5559c97baa26f02a63a0c6babd3afe97980d3b2ae26b"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7301,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:6d812569d65d9ab04d776360be3d692a56af64146882ca5acd1478d4f2bb99dd"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q02",
+            "item_id": "IQ_BETA_30_ORIGINAL_02",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q02</text><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 02."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"99\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"94\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 02."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7302; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:c6f56c3f0464772d3d97bc7b0f5dee326d82f6e08292153f44db027a4b8fb419",
+                "options": {
+                    "A": "sha256:9e7867876f880475a5ed9d61588c101997aed0a4e96a0c7819c7279f38522421",
+                    "B": "sha256:640a338a82e5c07f7b0111b3c7d7336bb839a2b3911b4d682f8b355cbf6fc827",
+                    "C": "sha256:01885e1a59569a430341266ee351ec5cc1ed99ece196a7fe1e533aefdd51e217",
+                    "D": "sha256:e825df2271ca2a918cae20351cce294aa6b0b4f59e6d7f8421e2505066badea5",
+                    "E": "sha256:f9e7e1314bb48008817596bb5d11d73951f31e49250a438204e5ebd057838f45",
+                    "F": "sha256:e0c9ace5fed6547721316bdb7f85c2ebe3d88341beadfe1b0a77599c04908d13"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7302,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:1103c5162ff3307649beafc828ac1c3b40b232623673469f7631dd9d9c81baf0"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q03",
+            "item_id": "IQ_BETA_30_ORIGINAL_03",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q03</text><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 03."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"95\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"96\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"97\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"96\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"97\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 03."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7303; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:7bf45553bfaad4662a7a67b9529fa93fc8caafbba4522574b92e1d29998ccc8d",
+                "options": {
+                    "A": "sha256:20035f383c4728a21b641933319a1bee1866cf34bfa696db922005fa28adfc36",
+                    "B": "sha256:d89ed6e7da3179d0c7af4c8f857942250e8136f246e5188fbe132df571a95113",
+                    "C": "sha256:0f355da700440c767f2f8084eb112376daa31193aa4d69851410f2495d19c8d7",
+                    "D": "sha256:e9dc84f1965aa9e97976a31f011ded4e6702d2680cba3aa1be5bbff213d90999",
+                    "E": "sha256:d5528674d1028f7baffc9927922504b1e20e441315b1b07ef1c99701ec19beb8",
+                    "F": "sha256:f97739f173e6a74a7231c101a59b13095d796773b93488a885ed24128b73910d"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7303,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:e3104d3af03b3559ec858bfd4139ae5eacc0bffcd79c82d5af03afa6e904cd9c"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q04",
+            "item_id": "IQ_BETA_30_ORIGINAL_04",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q04</text><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 04."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"99\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"94\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"95\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 04."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7304; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:b66cd0dad196935d1927e455ffb580667b0c220f498ab0cdce0db74bf2186ade",
+                "options": {
+                    "A": "sha256:0a991028943ebc0cbc7f4275dbd74f9ba427ecba7a97e0b61acc862a7f85ff44",
+                    "B": "sha256:d976c7eb85b098d60590a2ae9f02f115bbe9399b6d3bfc2528a55c98e677a843",
+                    "C": "sha256:9f8b13aa928c609ffc810c70aa32433ed4e07d8652bfd5b93d67f4dbfd06dd2e",
+                    "D": "sha256:d188999cb0c2c6c7be8a46dedd14d21599e6b9aea5b722d47e2700db54542c6b",
+                    "E": "sha256:d877993aa5abbc109306d4ed6456d85200fd98feee0fa1e152fa6b1cbdecec1b",
+                    "F": "sha256:2c0772bcffb5f4ea8866708bd41ce86124ea6eb669befbbeb54a7654865027ce"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7304,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:ace921ed3a1d7fa95a836ecc5e6a66932c14508bdac1b9dfe947346728521c8c"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q05",
+            "item_id": "IQ_BETA_30_ORIGINAL_05",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q05</text><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"99\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 05."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"58\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"96\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"97\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"61\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"62\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"63\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"94\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"95\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"58\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"59\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"95\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"96\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"97\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 05."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7305; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:9325c540b0c010cc7ba9ce5231ecbe7001320a8b36c71bb054742f2364974c89",
+                "options": {
+                    "A": "sha256:94da768597b27a5077124bf8a564ef98b1206212badb6340eb7ab89726afadc7",
+                    "B": "sha256:7b08d49d0f6e25d3f158060026ef3e367b8bb6626adf48ff68ded1e3cef6215d",
+                    "C": "sha256:18a969c25a2762e8581e510dc2af42e6fbc4d57977fb7d066b7fa2b0f84ec458",
+                    "D": "sha256:4737c47efa1529840f91e49c5b5fb5124782a455dfd2d57bb913769aa486e0d1",
+                    "E": "sha256:af33aa03399b76d239df873ff1b741f169aa13903f1f7566f287142cb69a4d34",
+                    "F": "sha256:0e48ee51d9bcb0e6d8f9d90c24533f925c5b401bfecce9cb52c2af8b011e4e6d"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7305,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:a3bdde3ad5af7d8499da7edac2b75bcabfb16c52708c26cf2c6b9d15a52a77bd"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q06",
+            "item_id": "IQ_BETA_30_ORIGINAL_06",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q06</text><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 06."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"63\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"59\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"97\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"98\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"95\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"96\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"98\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"99\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"94\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"94\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 06."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7306; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:8704992fe93b0eb3086bcf2826796ce6e5b3972bc6856ed464277ea3b95abf0e",
+                "options": {
+                    "A": "sha256:ba08a30c43bb79b22096a71127012f48b4fb0a8501ffc5bfec8924324d2d4242",
+                    "B": "sha256:0c59452928464abcd785a1766783bcc1547ed44eb27db5a91876e47c05790b45",
+                    "C": "sha256:5ec5a5f03a4a2be428168da9074a6b65fe80ece52a9ce9d5de2329864e7a6f2b",
+                    "D": "sha256:87a7fd953079f381130183e06647ff1efa3fde9c1b4fa018cd260ffae0abf763",
+                    "E": "sha256:598910dc79a9dafe8f6778d3f065ed1eed515fbc66b5700332bad485a1cfd9e9",
+                    "F": "sha256:29aea864163f75c712def15fca9692071bb737a1d2c038ab658323928e2bfe2d"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7306,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:71ec61fe492ca42b723d1914281a7dce6fb016a3734b3fb93494357e51acc1dc"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q07",
+            "item_id": "IQ_BETA_30_ORIGINAL_07",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q07</text><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"94\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 07."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 07."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7307; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:776ba2adee04404a80dc2361996cabc03e2b10da0830c59d6c70e3ec1a530278",
+                "options": {
+                    "A": "sha256:56dcd0e15434c0400c40b7327ce3238a21d7068cc8b89b9dcde140025015cb10",
+                    "B": "sha256:58f02a61eaaab5ed8762c3baf269adcee6d13c3f32b23786d7d83dbe6c2c982a",
+                    "C": "sha256:971939b3d78c2201bb0dc2a49891f4b0991fe5412ab4144043d7a61c9b7820cc",
+                    "D": "sha256:4e2a05c6fc724215a71d714c388edc49ebb4dec6d540caab8484ddf37300c706",
+                    "E": "sha256:540b4247a3095849fd954210a6ff7ca1d1ae4b139df6e0758c01868bec3898f1",
+                    "F": "sha256:802f21f8b98f779726ebf0bf5182f4b511927e37c2bd9325fb5097903df5ab67"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7307,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:dee9b7b245f92fdb5da2792f10247f172c1d97cd62298c1b21790db6c71ba506"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q08",
+            "item_id": "IQ_BETA_30_ORIGINAL_08",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q08</text><rect x=\"58\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 08."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"95\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"96\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"94\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 08."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7308; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:d10790064002adb1afd486ffe59a93507aec3b2fb63c7e223361b0313b63ee12",
+                "options": {
+                    "A": "sha256:d0dd5a256e04cf31c35810c6aa61a99cdfa9c0ee10ed79d551d65be1f39bc310",
+                    "B": "sha256:3817bb9d4d8cc5505969624e93856d8546f4b5c5613e97bf2f136f733ce91017",
+                    "C": "sha256:e65a53062e62f6af6823661a1e64ecc52b4df60702191f872235d416c11e4476",
+                    "D": "sha256:e9d807c37f1d6d71b836adcf1738df36ace56bf01fb62fbabc1348f6a245cc05",
+                    "E": "sha256:0f7ec9da4c15f088fadf3355ac1fcbd8ed8424d7548ccbc2d536d86ceb2710a3",
+                    "F": "sha256:9c0cf41992d642c2daae00ac949bfd2b88e78a1c01412713c17a88279f41446d"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7308,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:41a1e8c7f74579ce8537e5429c1140e959368b7b9adcc5d4475fa1b951b9ff27"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q09",
+            "item_id": "IQ_BETA_30_ORIGINAL_09",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q09</text><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 09."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 09."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7309; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:c44393dc408f0f225b7b221b949af3065a232bdbdb83c56317e2f2b6bd98b8c9",
+                "options": {
+                    "A": "sha256:f6e1e07a7b64c19ebd331f3d8d9fe50fbbce8a007083eb029bc14e3e87c9fd63",
+                    "B": "sha256:de55521608ac47b257dc6d6f3ceb090dd4931d801db4d2d2043415436931a257",
+                    "C": "sha256:548032cbfa38ec4bbf1c8eb2c05dc73da1f6b45039dae9b3c441bce2ddff966e",
+                    "D": "sha256:6b306d471cfbcf910eb5f8a325741abf30be025131abe5c4e6895965f26d2306",
+                    "E": "sha256:0d2a98863e1a471c7700d3594c130dc0cc2dca55a49a3ce13c2b7560e97547c5",
+                    "F": "sha256:771a3a43ffbeae22bf0ed40c05e05dea8270c0dead5909a9cdd2324a9e15b25a"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7309,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:3a1b7ea27acb47328c0a8bc7fa992745fbf5da928d21b642db6aa1cfcf6a58b0"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q10",
+            "item_id": "IQ_BETA_30_ORIGINAL_10",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q10</text><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 10."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"94\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"97\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 10."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7310; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:058ee7199f7cdef061e88ec13114e031c93b7015ca6b17f5729e10ff86f46a04",
+                "options": {
+                    "A": "sha256:d26cb10a98e47742630bf9a238a87a237f5416add935418a66598e7cdc9242dd",
+                    "B": "sha256:9619cfaedc1994e286af24a4079fd118e19099a90e6c478be68c6985b4343096",
+                    "C": "sha256:18132c6112cdd578e6e62e69b0cd22a726e89d395f0c1c23b137905260c878ef",
+                    "D": "sha256:efa096ff26626de261ab881d22b95e284e5b9c6e0eb2d7c4738ef4549f5b070e",
+                    "E": "sha256:b1a4941ba00c20364952a52299d574a5140f8a52945bba669d7329384c7265b2",
+                    "F": "sha256:42e035111c558dac8640b9e225a42d8947db95410363e3fe5cb243c3996ce277"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7310,
+                "template_key": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:ed54e74b960582866d87e4ee20ee80aaff6b71887813e7fef47192faa7502294"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q11",
+            "item_id": "IQ_BETA_30_ORIGINAL_11",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q11</text><rect x=\"53\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"67\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"100\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"137\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 11."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"67\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"100\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"137\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"63\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"64\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"101\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"65\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"66\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"103\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"135\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"67\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"62\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"99\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"66\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"67\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"98\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"136\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"137\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"66\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"67\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"54\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"136\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"137\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 11."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7311; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:747a42e4a84f70e1133abdcb45802f50b3a66ef148aae9eef2ccb5311e57261e",
+                "options": {
+                    "A": "sha256:b4353b70422c98d4ad017765c22242b046691543aeca4c54c8ab657737ae1983",
+                    "B": "sha256:9e5a1738f61f1232a0000ea6c5a29078f8cfa2d684e6e070ac0de6c7a2ceb9f8",
+                    "C": "sha256:b8eed0d7bac347d0bc6b5f9d1bec571679bd1d6d7bc5d341c1ce0bd95c7f1b97",
+                    "D": "sha256:e2e6544df5a4651eaaf7e6502f27d7c091e93fbdddbd55d3c09f2fd2c917e006",
+                    "E": "sha256:1d3d49a7f4396a1d0863cf87c0dc40827aba71a544b1570da19ffc5685047187",
+                    "F": "sha256:03499b01319c48f1da525bb391d03a127710eb37889a40b6486dbcf87cf4bcaf"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7311,
+                "template_key": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:456acce7974150fc178f359ee4cc9d53ea5a9b10db78d47c9bb593575137541a"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q12",
+            "item_id": "IQ_BETA_30_ORIGINAL_12",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q12</text><rect x=\"52\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"64\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"65\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"102\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"103\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"134\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 12."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"65\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"66\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"103\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"135\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"136\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"67\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"99\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"100\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"64\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"101\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"102\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"139\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"134\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"66\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"67\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"100\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"101\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"138\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"139\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"134\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 12."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7312; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:b9587716ff0bd3bd55ab8e947d9a2b1f752737270c5511734d0cc517fedf46c5",
+                "options": {
+                    "A": "sha256:ae52dacd002044ae8fd953cffa645c4d4f9681ad54293e094a4eb2b6ef87e70b",
+                    "B": "sha256:3fc5f9fdb79b5f81bf1961f8d17143f608ef11df4d0f04f0c1aa89d02d9e1af6",
+                    "C": "sha256:a79ade4fde38ceda5eb791c92fc03db2497afe685e5bdbbb90e42d5543b44fbc",
+                    "D": "sha256:af10406e85e66b9843d15fd0aabb2efa11b9e2f674e993c68fabeba307eb5473",
+                    "E": "sha256:16de2e5b081df6094e3092a23ad5cca514b64e24449eb9efc4b31fa0a62c011d",
+                    "F": "sha256:95eb0c779168cdfe11ee1e42b37c9440bcf265f664f8aa412e6bdaa2c9e2491b"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7312,
+                "template_key": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:ce9b4be40587ccd960fea303b930631f39708ec1a3f7ebdb56802d22e926ef0e"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q13",
+            "item_id": "IQ_BETA_30_ORIGINAL_13",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 3,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q13</text><rect x=\"58\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"100\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"101\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 13."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"67\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"100\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"137\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"66\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"67\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"98\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"139\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"65\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"66\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"103\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"67\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"100\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"137\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"64\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"101\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 13."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7313; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:688a4d6f78c9962eca09553876dc9a913d970ac5628233bdd74f04912ff32294",
+                "options": {
+                    "A": "sha256:692495581a9e5ca97d127adb57c396bdf2bcfb29bf65be07584a91975e30245e",
+                    "B": "sha256:290c272d368b4a9144a8f27560b4ab296c9601c838658bf87949aafceaa47f4c",
+                    "C": "sha256:1b95e3e5780e552a94b16a4f05c9a94b152caff011c8402637a19c476df5ee72",
+                    "D": "sha256:3b77d9e3705c95c666b24472efbeb46ae2ec5c897992030b1f95758a7e60ef78",
+                    "E": "sha256:0778d11f8337f57d1614e483fb7d87ce5894b727e29760ec1997c5f12c5adb07",
+                    "F": "sha256:f30aebcca26205278dcc0981e5da5e30be3a7c3cb83b384075a40ebae6cc2ff8"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7313,
+                "template_key": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:829eb078a5a6a75f19a3f54f8dd6533b2708450f8fe716dd578d2186e6ed6302"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q14",
+            "item_id": "IQ_BETA_30_ORIGINAL_14",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 3,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q14</text><rect x=\"56\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"66\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"67\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"56\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"136\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 14."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"65\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"66\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"103\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"135\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"136\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"100\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"64\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"65\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"102\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"103\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"134\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"66\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"67\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"98\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"62\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"63\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"100\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"101\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"138\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 14."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7314; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:69ed416fc392ac6bed8fbccd380b8332c2b224db54e69102a45e1d1f85c7b2d3",
+                "options": {
+                    "A": "sha256:d33252a66df1cac1caec11b3a86dd0bd1c65c867d2b4b4ad2e4273ec1dda23ca",
+                    "B": "sha256:6b5eadf4313f88cec70d7d5987f9acddfe9de8f37a2618db3f720cb6a92b9162",
+                    "C": "sha256:2c1f0546ddb27c317d1f3b8678e468917226d6a02910abdc3674ea97eae2d40e",
+                    "D": "sha256:bb1c7332eb0c56f24f424308c28cc3510858d418eafade390b354ab5d91381a2",
+                    "E": "sha256:ae685a14ef0b28ef301beda952f04bb8590bc1e03ec6630848e06791c0f8cb0d",
+                    "F": "sha256:4d081a04aec1e41179c49b2c9a7d9d5dc53d3902005e3e55597ed2612a8640e6"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7314,
+                "template_key": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:caebbc7666134c9ab551d5367e7f5c5b4fc392a6c2e51e4655f2af5d0e61a495"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q15",
+            "item_id": "IQ_BETA_30_ORIGINAL_15",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q15</text><circle cx=\"60\" cy=\"105\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 39 126 Q 60 84 81 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"99\" cy=\"52\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 77 74 Q 99 30 121 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"138\" cy=\"75\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 115 98 Q 138 52 161 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"177\" cy=\"98\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 153 122 Q 177 74 201 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"51\" cy=\"121\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 26 146 Q 51 96 76 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"90\" cy=\"68\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 64 94 Q 90 42 116 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original series reasoning prompt 15."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"148\" cy=\"116\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 120 144 Q 148 88 176 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"187\" cy=\"63\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 158 92 Q 187 34 216 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"61\" cy=\"86\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 47 100 Q 61 72 75 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"100\" cy=\"109\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 85 124 Q 100 94 115 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"56\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 123 72 Q 139 40 155 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"170\" cy=\"74\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 156 88 Q 170 60 184 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"97\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 29 112 Q 44 82 59 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"120\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 67 136 Q 83 104 99 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"82\" cy=\"90\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 60 112 Q 82 68 104 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"113\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 98 136 Q 121 90 144 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"160\" cy=\"60\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 136 84 Q 160 36 184 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"49\" cy=\"66\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 31 84 Q 49 48 67 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"88\" cy=\"89\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 69 108 Q 88 70 107 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"112\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 107 132 Q 127 92 147 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"71\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 120 Q 71 80 91 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"47\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 89 68 Q 110 26 131 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"70\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 127 92 Q 149 48 171 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"93\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 165 116 Q 188 70 211 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"116\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 38 140 Q 62 92 86 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"38\" cy=\"49\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 21 66 Q 38 32 55 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"77\" cy=\"72\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 59 90 Q 77 54 95 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"116\" cy=\"95\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 97 114 Q 116 76 135 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"118\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 135 138 Q 155 98 175 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"194\" cy=\"65\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 173 86 Q 194 44 215 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"68\" cy=\"88\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 46 110 Q 68 66 90 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 15."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Original deterministic series transformation generated from seed 7315; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:8ed3a6a60f4080b4fb573d0e9fc5f89e6b696e774fab03b1b7d74201c24b2ae5",
+                "options": {
+                    "A": "sha256:fb641706cf5c3a03d779ca8f3d2cb254ba19b6430b7e9a9266eda5ea90a6dd5c",
+                    "B": "sha256:f18e50002d0a95dd97f428a3ac9dd3ad782d442b050995a1ea244e27c0e329b1",
+                    "C": "sha256:2f641fb0a6d9337fbf5ac0b635175d3ec26ea415b8bec169a0d54f6a075cdd21",
+                    "D": "sha256:10e899387762c89745230e22911a6a9a8edd7f188f457c3df6f9471fb8f9c549",
+                    "E": "sha256:c083ff1b73924d11c0d013d528360c0381bcc6259ee43301b562096368eaf467",
+                    "F": "sha256:f6f83532d6e1d68bf9af6d644db0a817caf344c4893a836502111f6e926816d7"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7315,
+                "template_key": "series",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:d3bc1b647ef1404c6a37c33475f228bfcaaaff2d1a6acc5af54e79254f30122b"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q16",
+            "item_id": "IQ_BETA_30_ORIGINAL_16",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q16</text><circle cx=\"111\" cy=\"102\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 85 128 Q 111 76 137 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"49\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 123 76 Q 150 22 177 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"72\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 161 100 Q 189 44 217 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original series reasoning prompt 16."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"45\" cy=\"54\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 27 72 Q 45 36 63 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"77\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 65 96 Q 84 58 103 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"123\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 103 120 Q 123 80 143 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"67\" cy=\"88\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 47 108 Q 67 68 87 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"106\" cy=\"111\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 85 132 Q 106 90 127 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 123 80 Q 145 36 167 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"81\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 161 104 Q 184 58 207 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"104\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 34 128 Q 58 80 82 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"89\" cy=\"46\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 67 68 Q 89 24 111 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"128\" cy=\"69\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 105 92 Q 128 46 151 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"92\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 143 116 Q 167 68 191 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"133\" cy=\"87\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 106 114 Q 133 60 160 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"110\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 144 138 Q 172 82 200 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"57\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 17 86 Q 46 28 75 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"85\" cy=\"80\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 71 94 Q 85 66 99 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"78\" cy=\"105\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 57 126 Q 78 84 99 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"117\" cy=\"52\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 95 74 Q 117 30 139 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"156\" cy=\"75\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 133 98 Q 156 52 179 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"195\" cy=\"98\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 171 122 Q 195 74 219 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"69\" cy=\"121\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 44 146 Q 69 96 94 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"108\" cy=\"68\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 82 94 Q 108 42 134 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"100\" cy=\"63\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 77 86 Q 100 40 123 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"86\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 115 110 Q 139 62 163 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"178\" cy=\"109\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 153 134 Q 178 84 203 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"52\" cy=\"56\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 26 82 Q 52 30 78 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 16."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Original deterministic series transformation generated from seed 7316; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:ff292e0449e923efbbeb4da183716f7fad6117edad3cb175e568d240854a75ec",
+                "options": {
+                    "A": "sha256:2d27e74ffbf5d93dd6e7256171d837fb81e0a5145757f985916d81ce00e19f26",
+                    "B": "sha256:05cc449cda375a5a75562ea69984dd26dc318a06e5cd60387e5a5d67387b46c4",
+                    "C": "sha256:89fe574688fd411a090f83ea3d03a8473095bfa3da58c8755dd841c3d67115fe",
+                    "D": "sha256:b02bc241b34cd4470ab31a5cbf0e15fcc599934793b7c3a0efde133489ba9d74",
+                    "E": "sha256:2d2eb334d2f054abc1b7233ef1a0ae3a51c28d7b306b6d66b3d1c3b2d35b177c",
+                    "F": "sha256:054777e8a5bc3785df9110506d204020be0613caab9e8cdf970452b13ecc5c2d"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7316,
+                "template_key": "series",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:fb94c678bb6ec720c67847c073503b3759cc5ff60e4f62ff513e893be0756c0e"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q17",
+            "item_id": "IQ_BETA_30_ORIGINAL_17",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q17</text><circle cx=\"184\" cy=\"106\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 166 124 Q 184 88 202 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"53\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 39 72 Q 58 34 77 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"97\" cy=\"76\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 77 96 Q 97 56 117 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original series reasoning prompt 17."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"129\" cy=\"75\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 102 102 Q 129 48 156 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"168\" cy=\"98\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 140 126 Q 168 70 196 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"42\" cy=\"121\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 13 150 Q 42 92 71 150\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"81\" cy=\"68\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 67 82 Q 81 54 95 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"151\" cy=\"109\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 122 138 Q 151 80 180 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"190\" cy=\"56\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 176 70 Q 190 42 204 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"64\" cy=\"79\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 49 94 Q 64 64 79 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"103\" cy=\"102\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 87 118 Q 103 86 119 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"142\" cy=\"49\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 125 66 Q 142 32 159 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"181\" cy=\"72\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 163 90 Q 181 54 199 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"173\" cy=\"67\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 158 82 Q 173 52 188 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"90\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 31 106 Q 47 74 63 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"113\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 69 130 Q 86 96 103 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 107 78 Q 125 42 143 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"140\" cy=\"92\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 112 120 Q 140 64 168 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"179\" cy=\"115\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 150 144 Q 179 86 208 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 39 76 Q 53 48 67 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"85\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 77 100 Q 92 70 107 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"108\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 115 124 Q 131 92 147 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"41\" cy=\"91\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 22 110 Q 41 72 60 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"114\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 60 134 Q 80 94 100 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 98 82 Q 119 40 140 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"158\" cy=\"84\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 136 106 Q 158 62 180 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"184\" cy=\"84\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 168 100 Q 184 68 200 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"107\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 41 124 Q 58 90 75 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"97\" cy=\"54\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 79 72 Q 97 36 115 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"136\" cy=\"77\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 117 96 Q 136 58 155 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"175\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 155 120 Q 175 80 195 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 17."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Original deterministic series transformation generated from seed 7317; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:c52a9680f883c217eb0151ef9a6d66578e8f65a0752677c4458d60c4dfa35c32",
+                "options": {
+                    "A": "sha256:d2fad7c81f69570707bbeaa6c5f98112bdbda1522d8386285719493e62339da2",
+                    "B": "sha256:72f79f9bb6f56f148447030358624245ba59bbeea2305ce8c59eba623b577d20",
+                    "C": "sha256:67e30c6733f68054fc9b4c7f2d710d872e138df47525d0eda5766f4034fe3040",
+                    "D": "sha256:c7e06bd4494a8116574e511b0a7d01f6802f6cb5c920f914ca8fded3a273f521",
+                    "E": "sha256:dfc2acb210b2f6a3e6b20dd62fa30c661a86fd9e1007cb6b8693980eb973b200",
+                    "F": "sha256:979152c0bc86cc78c16d3968f0f2239b3e4fd51a94300d02a4aa68a69f760238"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7317,
+                "template_key": "series",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:d3eaf38099c13b29e89dd29bc4cb1fa5d2cec7e8a03a8eb21b877d38dc190996"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q18",
+            "item_id": "IQ_BETA_30_ORIGINAL_18",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q18</text><circle cx=\"70\" cy=\"103\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 47 126 Q 70 80 93 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"109\" cy=\"50\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 85 74 Q 109 26 133 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"148\" cy=\"73\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 123 98 Q 148 48 173 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"187\" cy=\"96\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 161 122 Q 187 70 213 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original series reasoning prompt 18."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"191\" cy=\"89\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 174 106 Q 191 72 208 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"112\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 47 130 Q 65 94 83 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"59\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 85 78 Q 104 40 123 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"82\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 123 102 Q 143 62 163 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"105\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 161 126 Q 182 84 203 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"56\" cy=\"52\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 34 74 Q 56 30 78 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"48\" cy=\"47\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 29 66 Q 48 28 67 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"70\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 67 90 Q 87 50 107 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"93\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 105 114 Q 126 72 147 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"116\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 143 138 Q 165 94 187 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"180\" cy=\"72\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 164 88 Q 180 56 196 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"54\" cy=\"95\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 37 112 Q 54 78 71 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"93\" cy=\"118\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 75 136 Q 93 100 111 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"132\" cy=\"65\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 113 84 Q 132 46 151 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"171\" cy=\"88\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 151 108 Q 171 68 191 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"37\" cy=\"106\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 19 124 Q 37 88 55 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"76\" cy=\"53\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 57 72 Q 76 34 95 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"115\" cy=\"76\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 95 96 Q 115 56 135 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"59\" cy=\"64\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 39 84 Q 59 44 79 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"98\" cy=\"87\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 77 108 Q 98 66 119 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"137\" cy=\"110\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 115 132 Q 137 88 159 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"176\" cy=\"57\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 153 80 Q 176 34 199 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"50\" cy=\"80\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 26 104 Q 50 56 74 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"88\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 68 112 Q 92 64 116 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"111\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 106 136 Q 131 86 156 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"58\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 144 84 Q 170 32 196 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"81\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 17 108 Q 44 54 71 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"104\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 55 132 Q 83 76 111 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 18."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Original deterministic series transformation generated from seed 7318; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:485c2f77d4effb9a0f207aee85ef442fc868b4053dfa60050335bf0c7868fb95",
+                "options": {
+                    "A": "sha256:25c3dddbdde06c19841ac6d16a8eab5ebd48ffd11b4803633803010371476563",
+                    "B": "sha256:7ee4a10ebcf55c3e51fb33e3fe91c362e01226f2f60952ef0f2f55a6e3c25fec",
+                    "C": "sha256:b832914423917ef2fca3f9f25540f3f0ee320fb0c4b5229d979b3b0c9bcab1c0",
+                    "D": "sha256:f73fa8b1c812321b879e878a6e58f15447a5cf2f335120424d8fffefb9941ec6",
+                    "E": "sha256:40635cafe7ef90506e10c918ab2f3b9612836eb876a43a4d1b8c4ea32c7f60d9",
+                    "F": "sha256:9c985d494550a1ba8c257bae099e00e68a9c302b7fbc0e5108ae390220749f21"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7318,
+                "template_key": "series",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:0b6a5eaf87d52b17cae445cfba64fa8bb361d43b2432ea1d9783c8ab675b82d6"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q19",
+            "item_id": "IQ_BETA_30_ORIGINAL_19",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q19</text><circle cx=\"55\" cy=\"74\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 33 96 Q 55 52 77 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"94\" cy=\"97\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 71 120 Q 94 74 117 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"120\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 109 144 Q 133 96 157 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 19."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"77\" cy=\"59\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 54 82 Q 77 36 100 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"116\" cy=\"82\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 92 106 Q 116 58 140 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"105\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 130 130 Q 155 80 180 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"194\" cy=\"52\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 168 78 Q 194 26 220 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"154\" cy=\"102\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 140 116 Q 154 88 168 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"193\" cy=\"49\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 178 64 Q 193 34 208 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"67\" cy=\"72\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 51 88 Q 67 56 83 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"176\" cy=\"60\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 160 76 Q 176 44 192 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"50\" cy=\"83\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 33 100 Q 50 66 67 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"89\" cy=\"106\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 71 124 Q 89 88 107 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"128\" cy=\"53\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 109 72 Q 128 34 147 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"76\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 147 96 Q 167 56 187 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"33\" cy=\"94\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 15 112 Q 33 76 51 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"72\" cy=\"117\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 53 136 Q 72 98 91 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"64\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 91 84 Q 111 44 131 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"55\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 35 72 Q 55 32 75 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"94\" cy=\"75\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 73 96 Q 94 54 115 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 111 120 Q 133 76 155 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"121\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 149 144 Q 172 98 195 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"68\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 22 92 Q 46 44 70 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"77\" cy=\"86\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 55 108 Q 77 64 99 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"116\" cy=\"109\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 93 132 Q 116 86 139 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"56\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 131 80 Q 155 32 179 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 19."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Original deterministic odd one out transformation generated from seed 7319; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:0168cec602d900606336c43c4641068eca98cfa10a30e86ed62e6316260029fa",
+                "options": {
+                    "A": "sha256:c291ef4e607449c1442527eda27fbe91804e4f3c33a047bbdc366380e8fa4931",
+                    "B": "sha256:5f150340b198c811e68f26f33836f1395be135666c4c9734dde491d5adfdf0a3",
+                    "C": "sha256:bde23f4e0ab0fa1b66c099599291ba085e7e1c88021e4b108b62a1b8fc746e7a",
+                    "D": "sha256:2b4c152f167bf2383f8c965aac7230e03116b659adf3b2177c09a9bab8c48df1",
+                    "E": "sha256:d53dee82ecf24f60e722b84a50cc854077859058e494884b49245a768b011611",
+                    "F": "sha256:1790ba08d6d48db648d262854dbab1446f9260d73c0b8cffff7a01763bf97014"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7319,
+                "template_key": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:82662df3875a39bb709e2db5599e91eea037dba4956e8d969c6d8006cf04c115"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q20",
+            "item_id": "IQ_BETA_30_ORIGINAL_20",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q20</text><circle cx=\"106\" cy=\"71\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 79 98 Q 106 44 133 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"94\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 117 122 Q 145 66 173 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"117\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 155 146 Q 184 88 213 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"64\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 44 78 Q 58 50 72 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 20."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"194\" cy=\"82\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 176 100 Q 194 64 212 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"68\" cy=\"105\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 49 124 Q 68 86 87 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"107\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 87 72 Q 107 32 127 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"128\" cy=\"56\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 100 84 Q 128 28 156 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"79\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 138 108 Q 167 50 196 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"41\" cy=\"102\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 27 116 Q 41 88 55 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"49\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 65 64 Q 80 34 95 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"72\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 103 88 Q 119 56 135 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"73\" cy=\"74\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 51 96 Q 73 52 95 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"112\" cy=\"97\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 89 120 Q 112 74 135 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"151\" cy=\"120\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 127 144 Q 151 96 175 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"95\" cy=\"108\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 71 132 Q 95 84 119 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"134\" cy=\"55\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 109 80 Q 134 30 159 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"78\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 147 104 Q 173 52 199 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"101\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 20 128 Q 47 74 74 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"48\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 58 76 Q 86 20 114 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"117\" cy=\"66\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 91 92 Q 117 40 143 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"156\" cy=\"89\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 129 116 Q 156 62 183 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"195\" cy=\"112\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 167 140 Q 195 84 223 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"84\" cy=\"91\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 61 114 Q 84 68 107 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"123\" cy=\"114\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 99 138 Q 123 90 147 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"162\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 137 86 Q 162 36 187 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"36\" cy=\"84\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 10 110 Q 36 58 62 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 20."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Original deterministic odd one out transformation generated from seed 7320; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:e1853736f198f2a66e2077e7b3b3fc73113bf93f1b2b17dc5e42a46c6b0605d3",
+                "options": {
+                    "A": "sha256:88e3b04bb8099290bb103435f8aa9d22b6e31bcd624b6961041c32ffdd2b969c",
+                    "B": "sha256:20569201a6a84f97f33e6c40d8f4b14579a1703baca2eec021e7621d4841b24b",
+                    "C": "sha256:b8de5c47f450a6c57dad853a503cf19fafb1b466fdc22ff5752bb5b0a00ef526",
+                    "D": "sha256:7bd76a1f7b8e9b0354a43b1b7379ceab7639a62ff6d9b887b75a3f984e4df8cb",
+                    "E": "sha256:c5a1bb72e0c5d7c2eaa135660e4947c8da8e26192d17a1808b44be54d05a6d0a",
+                    "F": "sha256:4b7f75f330698c8bc3182399109215cd7ae264917866bce1c1acc273ea6db3b3"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7320,
+                "template_key": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:542bee0accfa3c2b2b07e75f158fc7c0e8827d0f2f56e4ff7c8ece7708ae4699"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q21",
+            "item_id": "IQ_BETA_30_ORIGINAL_21",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q21</text><circle cx=\"179\" cy=\"75\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 160 94 Q 179 56 198 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"98\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 33 118 Q 53 78 73 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"121\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 71 142 Q 92 100 113 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"68\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 109 90 Q 131 46 153 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 21."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"113\" cy=\"103\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 86 130 Q 113 76 140 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"152\" cy=\"50\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 124 78 Q 152 22 180 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"191\" cy=\"73\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 162 102 Q 191 44 220 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 110 Q 65 82 79 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"135\" cy=\"61\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 106 90 Q 135 32 164 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"174\" cy=\"84\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 160 98 Q 174 70 188 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"48\" cy=\"107\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 33 122 Q 48 92 63 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"54\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 71 70 Q 87 38 103 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"77\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 109 94 Q 126 60 143 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"100\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 147 118 Q 165 82 183 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"36\" cy=\"60\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 16 80 Q 36 40 56 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"75\" cy=\"83\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 54 104 Q 75 62 96 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"114\" cy=\"106\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 92 128 Q 114 84 136 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"153\" cy=\"53\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 130 76 Q 153 30 176 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"192\" cy=\"76\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 168 100 Q 192 52 216 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"179\" cy=\"53\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 162 70 Q 179 36 196 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"76\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 35 94 Q 53 58 71 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"99\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 73 118 Q 92 80 111 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"46\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 111 66 Q 131 26 151 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"69\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 149 90 Q 170 48 191 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"92\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 22 114 Q 44 70 66 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"146\" cy=\"78\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 132 92 Q 146 64 160 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"185\" cy=\"101\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 170 116 Q 185 86 200 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"59\" cy=\"48\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 43 64 Q 59 32 75 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"168\" cy=\"112\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 152 128 Q 168 96 184 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"42\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 25 76 Q 42 42 59 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"81\" cy=\"82\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 63 100 Q 81 64 99 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"120\" cy=\"105\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 101 124 Q 120 86 139 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"159\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 139 72 Q 159 32 179 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 21."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Original deterministic odd one out transformation generated from seed 7321; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:a51e2f7938948c582fa68fde640074c7764a7b97cea41d5146a701de80e233c3",
+                "options": {
+                    "A": "sha256:92d8ebd8cd763b91401565f183771db830bfe0e1fd7ee4791ceb4916e00f298d",
+                    "B": "sha256:ec7f67760a7a5cb2a91bd0e42dc06ab2dd3b20eb3d0ce5f4cf4cb3915ebf7260",
+                    "C": "sha256:b5fd99e77462552fefb84e57f740193e5a3bef5dd8f687d45b43048c6ddf9b0c",
+                    "D": "sha256:e45f236cf2db75a89d5c807ecebdafe1ba459691c2b3fa06bdc0fb60df1064cc",
+                    "E": "sha256:11e334abeab4d810f7f3b76450a34dc42376308bd378f66b9312a053ea8f149c",
+                    "F": "sha256:a46824664f5dfa7c2abb2af18a5f6d788602c12488c2e6d2215e1655d2ef3b17"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7321,
+                "template_key": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:3df71d9e992de8e96646ad066d3ccbaa611fdf99383181c3a3a694703891a373"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q22",
+            "item_id": "IQ_BETA_30_ORIGINAL_22",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q22</text><circle cx=\"65\" cy=\"72\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 41 96 Q 65 48 89 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"95\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 79 120 Q 104 70 129 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"118\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 117 144 Q 143 92 169 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"65\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 155 92 Q 182 38 209 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"56\" cy=\"88\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 28 116 Q 56 60 84 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 22."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"175\" cy=\"117\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 158 134 Q 175 100 192 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"49\" cy=\"64\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 31 82 Q 49 46 67 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"88\" cy=\"87\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 69 106 Q 88 68 107 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"110\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 107 130 Q 127 90 147 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"166\" cy=\"57\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 145 78 Q 166 36 187 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"40\" cy=\"80\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 18 102 Q 40 58 62 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"32\" cy=\"75\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 13 94 Q 32 56 51 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"98\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 118 Q 71 78 91 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"121\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 89 142 Q 110 100 131 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"68\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 127 90 Q 149 46 171 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"54\" cy=\"109\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 33 130 Q 54 88 75 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"93\" cy=\"56\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 71 78 Q 93 34 115 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"132\" cy=\"79\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 109 102 Q 132 56 155 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"171\" cy=\"102\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 147 126 Q 171 78 195 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"45\" cy=\"49\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 20 74 Q 45 24 70 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"72\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 58 98 Q 84 46 110 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"87\" cy=\"57\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 62 82 Q 87 32 112 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"80\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 100 106 Q 126 54 152 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"103\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 138 130 Q 165 76 192 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"39\" cy=\"50\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 11 78 Q 39 22 67 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"78\" cy=\"73\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 49 102 Q 78 44 107 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"117\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 103 110 Q 117 82 131 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"43\" cy=\"92\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 23 112 Q 43 72 63 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"82\" cy=\"115\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 61 136 Q 82 94 103 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 99 84 Q 121 40 143 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"160\" cy=\"85\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 137 108 Q 160 62 183 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"34\" cy=\"108\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 10 132 Q 34 84 58 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"65\" cy=\"50\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 43 72 Q 65 28 87 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"73\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 81 96 Q 104 50 127 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"96\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 119 120 Q 143 72 167 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 22."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Original deterministic odd one out transformation generated from seed 7322; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:f22e02f9d47b705544f05b949e4673d615bbc481555d7e109929f42d41875685",
+                "options": {
+                    "A": "sha256:0dfb675fb7c4071bdaf804069e88f4d90a1929c6104e92b7b21609b865af6f77",
+                    "B": "sha256:83a93643f0c8b2ab6c43075a7871b336c6adbb4750903f56d4ae5d2a49b9a06a",
+                    "C": "sha256:3dc5f6aa4d8bc230ae7c0a5691da9c64bc2431c3ef571e06dc181e5cca9dd2cc",
+                    "D": "sha256:7cf5b350448e24f69b047c470cfbd1c893060a87d03b8b2ee84fbe1fd625aca8",
+                    "E": "sha256:990a5aea87fa3295b651be5355784daa5861141fbace6beb76c669590e8b3a0a",
+                    "F": "sha256:fc77a0b1bf1c094d6b0ca532736ac24cece829695788ac9d0d7220e44ed4e166"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7322,
+                "template_key": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:5a5556b5d6134875c0d99b7c32e45db97cc77aec2c6609d40507511d8c3a982f"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q23",
+            "item_id": "IQ_BETA_30_ORIGINAL_23",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q23</text><path d=\"M 116 40 L 145 98 L 87 98 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(325 116 69)\"/><path d=\"M 155 78 L 169 106 L 141 106 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(12 155 92)\"/><path d=\"M 194 100 L 209 130 L 179 130 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(59 194 115)\"/><path d=\"M 68 46 L 84 78 L 52 78 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(106 68 62)\"/><path d=\"M 107 68 L 124 102 L 90 102 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(153 107 85)\"/><path d=\"M 146 90 L 164 126 L 128 126 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(200 146 108)\"/></svg>",
+                    "accessibility_label": "Original rotation reasoning prompt 23."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 72 32 L 95 78 L 49 78 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(51 72 55)\"/><path d=\"M 111 54 L 135 102 L 87 102 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(98 111 78)\"/><path d=\"M 150 76 L 175 126 L 125 126 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(145 150 101)\"/><path d=\"M 189 22 L 215 74 L 163 74 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(192 189 48)\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 94 64 L 119 114 L 69 114 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(113 94 89)\"/><path d=\"M 133 86 L 159 138 L 107 138 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(160 133 112)\"/><path d=\"M 172 32 L 199 86 L 145 86 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(207 172 59)\"/><path d=\"M 46 54 L 74 110 L 18 110 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(254 46 82)\"/><path d=\"M 85 76 L 114 134 L 56 134 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(301 85 105)\"/><path d=\"M 124 38 L 138 66 L 110 66 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(348 124 52)\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 61 92 L 83 136 L 39 136 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(20 61 114)\"/><path d=\"M 100 38 L 123 84 L 77 84 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(67 100 61)\"/><path d=\"M 139 60 L 163 108 L 115 108 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(114 139 84)\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 83 48 L 107 96 L 59 96 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(82 83 72)\"/><path d=\"M 122 70 L 147 120 L 97 120 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(129 122 95)\"/><path d=\"M 161 92 L 187 144 L 135 144 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(176 161 118)\"/><path d=\"M 35 38 L 62 92 L 8 92 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(223 35 65)\"/><path d=\"M 74 60 L 102 116 L 46 116 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(270 74 88)\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 138 40 L 152 68 L 124 68 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(132 138 54)\"/><path d=\"M 177 62 L 192 92 L 162 92 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(179 177 77)\"/><path d=\"M 51 84 L 67 116 L 35 116 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(226 51 100)\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 127 36 L 155 92 L 99 92 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(206 127 64)\"/><path d=\"M 166 58 L 195 116 L 137 116 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(253 166 87)\"/><path d=\"M 40 96 L 54 124 L 26 124 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(300 40 110)\"/><path d=\"M 79 42 L 94 72 L 64 72 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(347 79 57)\"/><path d=\"M 118 64 L 134 96 L 102 96 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(34 118 80)\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 23."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Original deterministic rotation transformation generated from seed 7323; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:7ad5dbb787f065e63fd24b6ebd05cfc8ac8c7c22cbb8bd2db7353be5296c8081",
+                "options": {
+                    "A": "sha256:78ff0529a9e368d6b0b0088cca73bc4579d7c80a2e1cc31a379f873968fb3a8a",
+                    "B": "sha256:5ecaeda11423907cf89d7bc691f8cc9ba1bb0a1c60f6c03f1c323e25f99b0f3b",
+                    "C": "sha256:cf8362fec6ccfd4e87159d78a6320d0f02f17b3f90ff8c7a7508c8b08ff88a99",
+                    "D": "sha256:3153bc2fd73a6c31d26540b5229ab069ee7e342d2e7632a0897dc3358fb9d2a6",
+                    "E": "sha256:5c5b91d62905000d38c4c2f8644f92fdf2a72d79bab5b052fe8b771c72b1e954",
+                    "F": "sha256:7c37d773c4cd4cd179a2a3dbf3140b3bdfc8c00ab7420eb137a86d2c7d4f2974"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7323,
+                "template_key": "rotation",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:a3b19778b3b97c102036e259f8c4cf7ebf7419e779456e0008ecdaa81d7aaf7e"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q24",
+            "item_id": "IQ_BETA_30_ORIGINAL_24",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q24</text><path d=\"M 167 48 L 185 84 L 149 84 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(108 167 66)\"/><path d=\"M 41 70 L 60 108 L 22 108 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(155 41 89)\"/><path d=\"M 80 92 L 100 132 L 60 132 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(202 80 112)\"/></svg>",
+                    "accessibility_label": "Original rotation reasoning prompt 24."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 134 40 L 163 98 L 105 98 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(225 134 69)\"/><path d=\"M 173 78 L 187 106 L 159 106 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(272 173 92)\"/><path d=\"M 47 100 L 62 130 L 32 130 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(319 47 115)\"/><path d=\"M 86 46 L 102 78 L 70 78 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(6 86 62)\"/><path d=\"M 125 68 L 142 102 L 108 102 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(53 125 85)\"/><path d=\"M 164 90 L 182 126 L 146 126 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(100 164 108)\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 101 68 L 127 120 L 75 120 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(132 101 94)\"/><path d=\"M 140 90 L 167 144 L 113 144 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(179 140 117)\"/><path d=\"M 179 36 L 207 92 L 151 92 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(226 179 64)\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 123 24 L 151 80 L 95 80 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(194 123 52)\"/><path d=\"M 162 46 L 191 104 L 133 104 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(241 162 75)\"/><path d=\"M 36 84 L 50 112 L 22 112 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(288 36 98)\"/><path d=\"M 75 106 L 90 136 L 60 136 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(335 75 121)\"/><path d=\"M 114 52 L 130 84 L 98 84 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(22 114 68)\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 145 72 L 159 100 L 131 100 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(256 145 86)\"/><path d=\"M 184 94 L 199 124 L 169 124 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(303 184 109)\"/><path d=\"M 58 40 L 74 72 L 42 72 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(350 58 56)\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 167 104 L 183 136 L 151 136 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(318 167 120)\"/><path d=\"M 41 50 L 58 84 L 24 84 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(5 41 67)\"/><path d=\"M 80 72 L 98 108 L 62 108 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(52 80 90)\"/><path d=\"M 119 94 L 138 132 L 100 132 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(99 119 113)\"/><path d=\"M 158 40 L 178 80 L 138 80 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(146 158 60)\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 189 32 L 208 70 L 170 70 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(275 189 51)\"/><path d=\"M 63 54 L 83 94 L 43 94 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(322 63 74)\"/><path d=\"M 102 76 L 123 118 L 81 118 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(9 102 97)\"/><path d=\"M 141 98 L 163 142 L 119 142 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(56 141 120)\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 24."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Original deterministic rotation transformation generated from seed 7324; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:2f746dec717b555e89fffd0aaf5a60a04521148ad1fe8940b099847de99a533f",
+                "options": {
+                    "A": "sha256:11df7775a2545a8137ff6b008dbcdcdea572c78d67cf8faff26c1fc10046ae2a",
+                    "B": "sha256:ff2c455b4fd700944b8aa1b73fbc6f6e5b87fd68714fee86e1e568cf15ce2ce8",
+                    "C": "sha256:8ca53bd3f9eeb292530dc370993a85fa8f3feab100a0534f5720c63ed9fd41dc",
+                    "D": "sha256:7ad49335c1c310cef74c58058e0f15e3e5a44e03a7da9aa3389e8f8773b006b8",
+                    "E": "sha256:7876a44a0daad3de0c5464a33430b0fe5244fa9c24fb4ac2b6e719cdc627f358",
+                    "F": "sha256:305062e34f76af6566c5714b42369b51ce1ea5a1e01ddc3ce27ea512375b25bb"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7324,
+                "template_key": "rotation",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:183f9a63b11badcfee3a6767591e1a3bfac2647664e6a882a3bb7eba3ec5d357"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q25",
+            "item_id": "IQ_BETA_30_ORIGINAL_25",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q25</text><path d=\"M 152 96 L 169 130 L 135 130 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(65 152 113)\"/><path d=\"M 191 42 L 209 78 L 173 78 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(112 191 60)\"/><path d=\"M 65 64 L 84 102 L 46 102 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(159 65 83)\"/><path d=\"M 104 86 L 124 126 L 84 126 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(206 104 106)\"/><path d=\"M 143 32 L 164 74 L 122 74 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(253 143 53)\"/><path d=\"M 182 54 L 204 98 L 160 98 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(300 182 76)\"/></svg>",
+                    "accessibility_label": "Original rotation reasoning prompt 25."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 174 80 L 192 116 L 156 116 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(232 174 98)\"/><path d=\"M 48 102 L 67 140 L 29 140 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(279 48 121)\"/><path d=\"M 87 48 L 107 88 L 67 88 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(326 87 68)\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 97 56 L 123 108 L 71 108 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(120 97 82)\"/><path d=\"M 136 78 L 163 132 L 109 132 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(167 136 105)\"/><path d=\"M 175 24 L 203 80 L 147 80 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(214 175 52)\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 119 88 L 147 144 L 91 144 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(182 119 116)\"/><path d=\"M 158 34 L 187 92 L 129 92 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(229 158 63)\"/><path d=\"M 32 72 L 46 100 L 18 100 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(276 32 86)\"/><path d=\"M 71 94 L 86 124 L 56 124 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(323 71 109)\"/><path d=\"M 110 40 L 126 72 L 94 72 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(10 110 56)\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 141 60 L 155 88 L 127 88 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(244 141 74)\"/><path d=\"M 180 82 L 195 112 L 165 112 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(291 180 97)\"/><path d=\"M 54 104 L 70 136 L 38 136 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(338 54 120)\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 163 92 L 179 124 L 147 124 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(306 163 108)\"/><path d=\"M 37 38 L 54 72 L 20 72 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(353 37 55)\"/><path d=\"M 76 60 L 94 96 L 58 96 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(40 76 78)\"/><path d=\"M 115 82 L 134 120 L 96 120 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(87 115 101)\"/><path d=\"M 154 28 L 174 68 L 134 68 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(134 154 48)\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 130 28 L 159 86 L 101 86 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(213 130 57)\"/><path d=\"M 169 66 L 183 94 L 155 94 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(260 169 80)\"/><path d=\"M 43 88 L 58 118 L 28 118 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(307 43 103)\"/><path d=\"M 82 34 L 98 66 L 66 66 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(354 82 50)\"/><path d=\"M 121 56 L 138 90 L 104 90 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(41 121 73)\"/><path d=\"M 160 78 L 178 114 L 142 114 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(88 160 96)\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 25."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Original deterministic rotation transformation generated from seed 7325; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:668718335be0ea2f933e3d47d76761603c327b00aed535d0c270e4391f7e31ef",
+                "options": {
+                    "A": "sha256:e198a23dcd1fa95a4aefc74e623e9e2ba38850ac8dde2729440e354d53ce64ec",
+                    "B": "sha256:a13b1147d40222da786660021f91c44f5cc892b68e602a2cb3455854e6a76078",
+                    "C": "sha256:7b72165f68af8f792c15e89e2543dfe49d99c77af86f1844a3086b57c59766c7",
+                    "D": "sha256:cc8de962b76d811e12009921a925180e1b98cd8434f9202fcc5a65e9ab44a77a",
+                    "E": "sha256:ad6706d48a95a07f7f3c21cdbbf99832e94715760b249c7f558bae2a2afbcb84",
+                    "F": "sha256:fa13f790cf2d9257513f1caa5d55ddfd3c0946b8c5f32ac13a0fc32252eca60e"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7325,
+                "template_key": "rotation",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:6177a4972b7d6088282798293380ac58cb8119940b8212d600c1a2ec40206348"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q26",
+            "item_id": "IQ_BETA_30_ORIGINAL_26",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q26</text><rect x=\"47.5\" y=\"104.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(165 60 117)\"/><circle cx=\"68\" cy=\"112\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"86\" y=\"51\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(212 99 64)\"/><circle cx=\"107\" cy=\"59\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"124.5\" y=\"73.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(259 138 87)\"/><circle cx=\"146\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"163\" y=\"96\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(306 177 110)\"/><circle cx=\"185\" cy=\"105\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"36.5\" y=\"42.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(353 51 57)\"/><circle cx=\"59\" cy=\"52\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"83\" y=\"73\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(40 90 80)\"/><circle cx=\"98\" cy=\"75\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original overlay reasoning prompt 26."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"150.5\" y=\"60.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(189 159 69)\"/><circle cx=\"167\" cy=\"64\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"24\" y=\"83\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(236 33 92)\"/><circle cx=\"41\" cy=\"87\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"62.5\" y=\"105.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(283 72 115)\"/><circle cx=\"80\" cy=\"110\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"101\" y=\"52\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(330 111 62)\"/><circle cx=\"119\" cy=\"57\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"139.5\" y=\"74.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(17 150 85)\"/><circle cx=\"158\" cy=\"80\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"178\" y=\"97\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(64 189 108)\"/><circle cx=\"197\" cy=\"103\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"69\" y=\"89\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(332 82 102)\"/><circle cx=\"90\" cy=\"97\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"107.5\" y=\"35.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(19 121 49)\"/><circle cx=\"129\" cy=\"44\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"146\" y=\"58\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(66 160 72)\"/><circle cx=\"168\" cy=\"67\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"27.5\" y=\"50.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(313 38 61)\"/><circle cx=\"46\" cy=\"56\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"66\" y=\"73\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(0 77 84)\"/><circle cx=\"85\" cy=\"79\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"104.5\" y=\"95.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(47 116 107)\"/><circle cx=\"124\" cy=\"102\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"143\" y=\"42\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(94 155 54)\"/><circle cx=\"163\" cy=\"49\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181.5\" y=\"64.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(141 194 77)\"/><circle cx=\"202\" cy=\"72\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55\" y=\"87\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(188 68 100)\"/><circle cx=\"76\" cy=\"95\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"48.5\" y=\"83.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(15 60 95)\"/><circle cx=\"68\" cy=\"90\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"87\" y=\"106\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(62 99 118)\"/><circle cx=\"107\" cy=\"113\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"125.5\" y=\"52.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(109 138 65)\"/><circle cx=\"146\" cy=\"60\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"164\" y=\"75\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(156 177 88)\"/><circle cx=\"185\" cy=\"83\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"182\" y=\"110\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(282 192 120)\"/><circle cx=\"200\" cy=\"115\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55.5\" y=\"56.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(329 66 67)\"/><circle cx=\"74\" cy=\"62\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"94\" y=\"79\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(16 105 90)\"/><circle cx=\"113\" cy=\"85\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"132.5\" y=\"101.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(63 144 113)\"/><circle cx=\"152\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"171\" y=\"48\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(110 183 60)\"/><circle cx=\"191\" cy=\"55\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"38\" y=\"67\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(344 49 78)\"/><circle cx=\"57\" cy=\"73\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"76.5\" y=\"89.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(31 88 101)\"/><circle cx=\"96\" cy=\"96\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"115\" y=\"36\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(78 127 48)\"/><circle cx=\"135\" cy=\"43\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 26."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Original deterministic overlay transformation generated from seed 7326; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:dc709c597ed667e732a9ebc8f76ded875c8e429e094074e6d78cf5b505a6a9cc",
+                "options": {
+                    "A": "sha256:950def6a8a3a77c268fb3f3ac575856c37c69349271028da7b4efa811ffb109e",
+                    "B": "sha256:c3c26623968f9a592454886d789f99c3acb8120fd3b5a465c6288e550f936aae",
+                    "C": "sha256:26fd5716d59265a96dc3ad8c3897d24c83a589bbc8b720347147902fd67c2351",
+                    "D": "sha256:c38ea09232c374c0fbedcab64f457a3c1bed68a79e7db471f126fb7638b98313",
+                    "E": "sha256:c6028957f2d23feebd5a3f1b8f840a9f197a3531cf98ccc4ebe3fcf61bb739f0",
+                    "F": "sha256:7d2b7b7e28716ac7fbd3ed558f87d4d88bdf7cb45117023a8f1f0c648b651bad"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7326,
+                "template_key": "overlay",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:50b1a9276ffad59602e1ca72603dafc772118a028fa89a6ba7e7a705e1931a60"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q27",
+            "item_id": "IQ_BETA_30_ORIGINAL_27",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q27</text><rect x=\"104\" y=\"107\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(308 111 114)\"/><circle cx=\"119\" cy=\"109\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"142.5\" y=\"53.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(355 150 61)\"/><circle cx=\"158\" cy=\"56\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181\" y=\"76\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(42 189 84)\"/><circle cx=\"197\" cy=\"79\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original overlay reasoning prompt 27."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"44.5\" y=\"71.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(3 56 83)\"/><circle cx=\"64\" cy=\"78\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"83\" y=\"94\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(50 95 106)\"/><circle cx=\"103\" cy=\"101\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"121.5\" y=\"40.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(97 134 53)\"/><circle cx=\"142\" cy=\"48\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"160\" y=\"63\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(144 173 76)\"/><circle cx=\"181\" cy=\"71\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"65.5\" y=\"104.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(65 78 117)\"/><circle cx=\"86\" cy=\"112\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"104\" y=\"51\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(112 117 64)\"/><circle cx=\"125\" cy=\"59\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"142.5\" y=\"73.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(159 156 87)\"/><circle cx=\"164\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181\" y=\"96\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(206 195 110)\"/><circle cx=\"203\" cy=\"105\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"54.5\" y=\"42.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(253 69 57)\"/><circle cx=\"77\" cy=\"52\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"101\" y=\"73\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(300 108 80)\"/><circle cx=\"116\" cy=\"75\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"125.5\" y=\"91.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(115 133 99)\"/><circle cx=\"141\" cy=\"94\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"164\" y=\"38\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(162 172 46)\"/><circle cx=\"180\" cy=\"41\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"37.5\" y=\"60.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(209 46 69)\"/><circle cx=\"54\" cy=\"64\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"76\" y=\"83\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(256 85 92)\"/><circle cx=\"93\" cy=\"87\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"88\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(34 67 100)\"/><circle cx=\"75\" cy=\"95\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"93.5\" y=\"34.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(81 106 47)\"/><circle cx=\"114\" cy=\"42\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"132\" y=\"57\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(128 145 70)\"/><circle cx=\"153\" cy=\"65\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"170.5\" y=\"79.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(175 184 93)\"/><circle cx=\"192\" cy=\"88\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"44\" y=\"102\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(222 58 116)\"/><circle cx=\"66\" cy=\"111\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"76\" y=\"45\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(96 89 58)\"/><circle cx=\"97\" cy=\"53\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"114.5\" y=\"67.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(143 128 81)\"/><circle cx=\"136\" cy=\"76\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"153\" y=\"90\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(190 167 104)\"/><circle cx=\"175\" cy=\"99\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"97\" y=\"78\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(158 111 92)\"/><circle cx=\"119\" cy=\"87\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"135.5\" y=\"100.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(205 150 115)\"/><circle cx=\"158\" cy=\"110\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"182\" y=\"55\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(252 189 62)\"/><circle cx=\"197\" cy=\"57\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55.5\" y=\"77.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(299 63 85)\"/><circle cx=\"71\" cy=\"80\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"94\" y=\"100\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(346 102 108)\"/><circle cx=\"110\" cy=\"103\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 27."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Original deterministic overlay transformation generated from seed 7327; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:0f83ec621c0a5aebac17b9d13156bd908d1f615a589eb06f1fd090e8585d2021",
+                "options": {
+                    "A": "sha256:c2922b532a7455e83064ec9f260d6cee0eda771f84af254bf5f87f86ab3e9054",
+                    "B": "sha256:0822e7d3834ac263640c3a7fe6c32ec8c538b09626b53ad23b4222e8ef9b5b0e",
+                    "C": "sha256:0f57184d0fd71b8667c5be3a79fa68a7062074bc59b74234076da85263054cb1",
+                    "D": "sha256:93e331b6e4e85b946db2201ed14c4772460ea6c56baeb5bbd7ee18e58f24c37c",
+                    "E": "sha256:2d3e49a056c6310dcc3b6fef4e8a124f37e72e30c1081a8712415f69dad492d6",
+                    "F": "sha256:492bc52040e82ab52777aaef25dd6be6cdfe9a1733b229cbca58b44cf98d2122"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7327,
+                "template_key": "overlay",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:4f957980dc2757cd58199ab138b057cc8f526b4c15bfa47b141ca39aac594113"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q28",
+            "item_id": "IQ_BETA_30_ORIGINAL_28",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q28</text><rect x=\"152.5\" y=\"101.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(91 162 111)\"/><circle cx=\"170\" cy=\"106\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"26\" y=\"48\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(138 36 58)\"/><circle cx=\"44\" cy=\"53\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"64.5\" y=\"70.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(185 75 81)\"/><circle cx=\"83\" cy=\"76\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"103\" y=\"93\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(232 114 104)\"/><circle cx=\"122\" cy=\"99\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original overlay reasoning prompt 28."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"103.5\" y=\"82.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(177 118 97)\"/><circle cx=\"126\" cy=\"92\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"150\" y=\"113\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(224 157 120)\"/><circle cx=\"165\" cy=\"115\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"188.5\" y=\"59.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(271 196 67)\"/><circle cx=\"204\" cy=\"62\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"62\" y=\"82\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(318 70 90)\"/><circle cx=\"78\" cy=\"85\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"100.5\" y=\"104.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(5 109 113)\"/><circle cx=\"117\" cy=\"108\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"139\" y=\"51\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(52 148 60)\"/><circle cx=\"156\" cy=\"55\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"132.5\" y=\"47.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(239 140 55)\"/><circle cx=\"148\" cy=\"50\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"171\" y=\"70\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(286 179 78)\"/><circle cx=\"187\" cy=\"73\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"44.5\" y=\"92.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(333 53 101)\"/><circle cx=\"61\" cy=\"96\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"83\" y=\"39\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(20 92 48)\"/><circle cx=\"100\" cy=\"43\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"93\" y=\"66\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(146 107 80)\"/><circle cx=\"115\" cy=\"75\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"131.5\" y=\"88.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(193 146 103)\"/><circle cx=\"154\" cy=\"98\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"178\" y=\"43\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(240 185 50)\"/><circle cx=\"193\" cy=\"45\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"51.5\" y=\"65.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(287 59 73)\"/><circle cx=\"67\" cy=\"68\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"90\" y=\"88\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(334 98 96)\"/><circle cx=\"106\" cy=\"91\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"174\" y=\"86\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(258 184 96)\"/><circle cx=\"192\" cy=\"91\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"47.5\" y=\"108.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(305 58 119)\"/><circle cx=\"66\" cy=\"114\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"86\" y=\"55\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(352 97 66)\"/><circle cx=\"105\" cy=\"61\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"124.5\" y=\"77.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(39 136 89)\"/><circle cx=\"144\" cy=\"84\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"163\" y=\"100\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(86 175 112)\"/><circle cx=\"183\" cy=\"107\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"143\" y=\"64\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(270 151 72)\"/><circle cx=\"159\" cy=\"67\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181.5\" y=\"86.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(317 190 95)\"/><circle cx=\"198\" cy=\"90\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55\" y=\"109\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(4 64 118)\"/><circle cx=\"72\" cy=\"113\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"93.5\" y=\"55.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(51 103 65)\"/><circle cx=\"111\" cy=\"60\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"132\" y=\"78\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(98 142 88)\"/><circle cx=\"150\" cy=\"83\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"164\" y=\"97\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(332 173 106)\"/><circle cx=\"181\" cy=\"101\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"37.5\" y=\"43.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(19 47 53)\"/><circle cx=\"55\" cy=\"48\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"76\" y=\"66\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(66 86 76)\"/><circle cx=\"94\" cy=\"71\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original IQ item 28."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Original deterministic overlay transformation generated from seed 7328; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:4b91e7a6cefd88838c9e914d3f98a86e2ec4f416fa98a55046b9b7e70e0625f0",
+                "options": {
+                    "A": "sha256:25dd2f31809da9d3e7080f3987e92a4c17e5969332a54771fecb8d6303115fad",
+                    "B": "sha256:8ed991869fc7c837bdb90af2688cc0290d2ee8d9f6dd7687e008d211cd855eb1",
+                    "C": "sha256:21d5db92c5fb6d31f5bff64bfa6b373a02448887e0cab05cbeec2615f4419fbc",
+                    "D": "sha256:ee7a00fdbcf49d3f643e124b202cbf9778621786cc9ca49b9050197b3f4ec426",
+                    "E": "sha256:f2d78feb4e36b5722ffab98fd1804127c6fc461e1d05236ac8b267bd4fcad3d4",
+                    "F": "sha256:03da9b2bcfe5de0ff3d7a14e84291385b037032acd82d2ee2dcabe010a170b3f"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7328,
+                "template_key": "overlay",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:1547caaf07a8bc13ddd762890435e96dd02edbda07126ef12138f5618d135fac"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q29",
+            "item_id": "IQ_BETA_30_ORIGINAL_29",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "numeric_pattern",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q29</text><circle cx=\"70\" cy=\"115\" r=\"13\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"65\" y=\"120\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"109\" cy=\"62\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"104\" y=\"67\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"148\" cy=\"85\" r=\"14\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"143\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"187\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"182\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text></svg>",
+                    "accessibility_label": "Original numeric pattern reasoning prompt 29."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"37\" cy=\"118\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"32\" y=\"123\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"76\" cy=\"65\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"71\" y=\"70\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"115\" cy=\"88\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"110\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text></svg>",
+                            "accessibility_label": "Option A for original IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"169\" cy=\"67\" r=\"9\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"164\" y=\"72\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"43\" cy=\"90\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"38\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"82\" cy=\"113\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"77\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"121\" cy=\"60\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"116\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text></svg>",
+                            "accessibility_label": "Option B for original IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"191\" cy=\"101\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"186\" y=\"106\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"65\" cy=\"48\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"60\" y=\"53\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"104\" cy=\"71\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"99\" y=\"76\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"143\" cy=\"94\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"138\" y=\"99\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"182\" cy=\"117\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"177\" y=\"122\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"56\" cy=\"64\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"51\" y=\"69\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "accessibility_label": "Option C for original IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"48\" cy=\"59\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"43\" y=\"64\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"87\" cy=\"82\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"82\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"126\" cy=\"105\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"121\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"165\" cy=\"52\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"160\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "accessibility_label": "Option D for original IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"100\" r=\"14\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"87\" y=\"105\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"131\" cy=\"47\" r=\"14\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"126\" y=\"52\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"170\" cy=\"70\" r=\"7\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"165\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"44\" cy=\"93\" r=\"7\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"39\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"83\" cy=\"116\" r=\"8\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"78\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text></svg>",
+                            "accessibility_label": "Option E for original IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"51\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"87\" y=\"56\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"131\" cy=\"74\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"126\" y=\"79\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"170\" cy=\"97\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"165\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"44\" cy=\"120\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"39\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text></svg>",
+                            "accessibility_label": "Option F for original IQ item 29."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Original deterministic numeric pattern transformation generated from seed 7329; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:66aa91aad2367b80265e6bfbf4b2e5ee9495550c344af66a7fb6f498bd7b5eee",
+                "options": {
+                    "A": "sha256:54ead778100bfb815655eecf41cccf823921a1b678447b05bc836048714b8063",
+                    "B": "sha256:bb0de362a5b0e0cbedaac2d25db1e0a5fb49f3d9c4caaa2d2bbaf59a3a82add4",
+                    "C": "sha256:868e49b5717cf5b9ff17f85b06ae44ebe11afa734692c6c089e9a6e03ae507f5",
+                    "D": "sha256:240deaf0a3ae50f5a88a97afcd9442e5a8f2d21ef41a9bc3f0c0b44776d2219e",
+                    "E": "sha256:1866082abef847ebd2473f60a7ac1bf696cc4f1cd4774d371d19c18e8fcd72ba",
+                    "F": "sha256:52078504ec24a4a2b8c948d9b4d7da8ad8ac017c1ff1e403cc8cfbce12c17328"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7329,
+                "template_key": "numeric_pattern",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:4387f241faa2f6848dce78a72b6d1daa420db72767551cf651a6b9db30730770"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_30_ORIGINAL",
+            "question_id": "IQB30-Q30",
+            "item_id": "IQ_BETA_30_ORIGINAL_30",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "numeric_pattern",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q30</text><circle cx=\"121\" cy=\"112\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"116\" y=\"117\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"160\" cy=\"59\" r=\"8\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"155\" y=\"64\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"34\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"29\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"73\" cy=\"105\" r=\"9\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"68\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"112\" cy=\"52\" r=\"10\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"107\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text></svg>",
+                    "accessibility_label": "Original numeric pattern reasoning prompt 30."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"44\" cy=\"47\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"39\" y=\"52\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"83\" cy=\"70\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"78\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"122\" cy=\"93\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"117\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"161\" cy=\"116\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"156\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "accessibility_label": "Option A for original IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"66\" cy=\"81\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"61\" y=\"86\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"105\" cy=\"104\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"100\" y=\"109\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"144\" cy=\"51\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"139\" y=\"56\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"183\" cy=\"74\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"178\" y=\"79\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"57\" cy=\"97\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"52\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"96\" cy=\"120\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"91\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text></svg>",
+                            "accessibility_label": "Option B for original IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"88\" cy=\"115\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"83\" y=\"120\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"127\" cy=\"62\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"122\" y=\"67\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"166\" cy=\"85\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"161\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"40\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"35\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text></svg>",
+                            "accessibility_label": "Option C for original IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"110\" cy=\"73\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"105\" y=\"78\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"149\" cy=\"96\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"144\" y=\"101\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"188\" cy=\"119\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"183\" y=\"124\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"62\" cy=\"66\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"57\" y=\"71\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"101\" cy=\"89\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"96\" y=\"94\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"140\" cy=\"112\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"135\" y=\"117\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text></svg>",
+                            "accessibility_label": "Option D for original IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"132\" cy=\"107\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"127\" y=\"112\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"171\" cy=\"54\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"166\" y=\"59\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"45\" cy=\"77\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"40\" y=\"82\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"84\" cy=\"100\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"79\" y=\"105\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text></svg>",
+                            "accessibility_label": "Option E for original IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"143\" cy=\"97\" r=\"8\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"138\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"182\" cy=\"120\" r=\"9\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"177\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"56\" cy=\"67\" r=\"9\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"51\" y=\"72\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"95\" cy=\"90\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"90\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"134\" cy=\"113\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"129\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"173\" cy=\"60\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"168\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text></svg>",
+                            "accessibility_label": "Option F for original IQ item 30."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Original deterministic numeric pattern transformation generated from seed 7330; choose the option preserving the generated progression signature.",
+            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "asset_hashes": {
+                "stem": "sha256:f6861884016af3bf8ffb612183ecabd5adc170f1224fd0c43d793f02ecfc10ba",
+                "options": {
+                    "A": "sha256:af3f9cb4ee6c198f766ab7c7725570527603b5a0a2b9362edcb0e05e0cd8728c",
+                    "B": "sha256:dcbb2f934e42d92ca9a14cab0908d3ebd197308ecb0d667c657d09959bd3f5e6",
+                    "C": "sha256:6e3f38abce966a54e5c828545c3ee733fc7b14bfd15225b07fe8004eb0eb902a",
+                    "D": "sha256:e03fa25fe5f6212ff6eb2411a0bd3d4a525312c80c0eaf10ec365a17e622c03c",
+                    "E": "sha256:517cd7e63ee1d83d3ef33b38455c5b6912df1ad6ca8d664defb584746e414f7f",
+                    "F": "sha256:17734fa59224ab74848d71e42f182a90397abeaefe0e503b8aad542908740f28"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 7330,
+                "template_key": "numeric_pattern",
+                "generator_version": "iq_beta30_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:42487a5c9b845e9ead70ae58c5e01d5d730dcd78c8d94ddb5ed4ddc3a2347d1c"
+            }
+        }
+    ]
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json
@@ -1,13 +1,16 @@
 {
-    "schema_version": "fm.iq.item_bank_manifest.v1",
-    "bank_id": "IQ_BETA_30_ORIGINAL",
+    "schema_version": "fm.iq.item_bank.manifest.v1",
     "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
-    "status": "planned_spec_only",
+    "bank_id": "IQ_BETA_30_ORIGINAL",
+    "name": "FermatMind IQ Beta 30 Original",
+    "status": "beta_internal_validation",
     "runtime_bound": false,
-    "content_package_version": "v0.3.0-DEMO",
-    "bank_dir": "content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL",
-    "item_count_target": 30,
-    "option_codes_target": [
+    "commerce_unlock_required": false,
+    "locale": "zh-CN",
+    "market": "CN_MAINLAND",
+    "item_count": 30,
+    "option_count": 6,
+    "option_codes": [
         "A",
         "B",
         "C",
@@ -15,13 +18,13 @@
         "E",
         "F"
     ],
-    "time_limit_minutes_target": 20,
-    "dimension_counts_target": {
+    "target_minutes": 20,
+    "dimension_targets": {
         "VSPR": 14,
         "VSI": 10,
         "NPR": 6
     },
-    "item_family_counts_target": {
+    "item_family_targets": {
         "matrix_3x3": 10,
         "matrix_2x2": 4,
         "series": 4,
@@ -30,11 +33,27 @@
         "overlay": 3,
         "numeric_pattern": 2
     },
+    "files": {
+        "items": "items.json",
+        "answer_key": "answer_key.json",
+        "scoring_spec": "scoring_spec.json"
+    },
     "copyright_policy": {
-        "source_mode_required": "repo_generated",
-        "third_party_item_copying_allowed": false,
-        "third_party_visual_tracing_allowed": false,
-        "license_verification_required_for_external_items": true
+        "source": "repo_generated_original",
+        "copied_from_third_party": false,
+        "traced_from_third_party": false,
+        "third_party_license_required": false,
+        "myiq_science_requires_license_verification_gate_before_use": true
+    },
+    "public_payload_policy": {
+        "may_emit_items": true,
+        "may_emit_answer_key": false,
+        "may_emit_solution_rule": false
+    },
+    "norm_policy": {
+        "iq_claims_enabled": false,
+        "percentile_claims_enabled": false,
+        "population_norm_table_required_before_production": true
     },
     "review_gates": [
         "copyright_gate",
@@ -46,25 +65,11 @@
         "provenance_gate",
         "contract_gate"
     ],
-    "public_payload_policy": {
-        "structured_svg_only": true,
-        "raw_svg_html_allowed": false,
-        "answer_key_public_allowed": false,
-        "solution_rule_public_allowed": false,
-        "frontend_scoring_allowed": false
-    },
-    "norm_policy": {
-        "norm_table_required_before_iq_estimate_claims": true,
-        "iq_estimate_runtime_authoritative": false,
-        "percentile_runtime_authoritative": false,
-        "confidence_interval_runtime_authoritative": false
-    },
-    "deferred_to": {
-        "final_item_generation": "IQ-BANK-30-02",
-        "import_provenance_redaction_gate": "IQ-BANK-30-03",
-        "scoring_quality_stability": "IQ-SCORE-30-01",
-        "seo_claim_launch_guard": "IQ-CLAIM-SEO-01",
-        "cms_landing_authority": "IQ-CMS-LANDING-01",
-        "production_like_smoke": "IQ-LIVE-SMOKE-01"
-    }
+    "deferred_prs": [
+        "IQ-BANK-30-03",
+        "IQ-SCORE-30-01",
+        "IQ-CLAIM-SEO-01",
+        "IQ-CMS-LANDING-01",
+        "IQ-LIVE-SMOKE-01"
+    ]
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/scoring_spec.json
@@ -1,0 +1,26 @@
+{
+    "schema_version": "fm.iq.scoring_spec.v1",
+    "bank_id": "IQ_BETA_30_ORIGINAL",
+    "status": "beta_internal_validation",
+    "raw_score": {
+        "min": 0,
+        "max": 30,
+        "correct_item_value": 1,
+        "incorrect_item_value": 0
+    },
+    "dimension_counts": {
+        "VSPR": 14,
+        "VSI": 10,
+        "NPR": 6
+    },
+    "norm_policy": {
+        "iq_claims_enabled": false,
+        "percentile_claims_enabled": false,
+        "population_norm_table_required_before_production": true,
+        "beta_copy_allowed_claim": "practice-style cognitive reasoning score only"
+    },
+    "runtime_binding": {
+        "enabled": false,
+        "deferred_to_pr": "IQ-SCORE-30-01"
+    }
+}


### PR DESCRIPTION
## What changed
- Added deterministic IQ_BETA_30_ORIGINAL generator and verifier scripts.
- Generated 30 original repo-authored SVG IQ items with six options each.
- Added backend-only answer_key.json and beta scoring_spec.json.
- Updated IQ beta30 tests to assert generated, runtime-unbound, non-copied bank boundaries.

## Why
This implements IQ-BANK-30-02 by converting the planned beta30 specification into a concrete original item bank while keeping runtime scoring and IQ/percentile claims disabled for later PRs.

## Validation commands
- php -l backend/scripts/iq/iq_beta30_original_bank_lib.php && php -l backend/scripts/iq/build_iq_beta30_original_bank.php && php -l backend/scripts/iq/verify_iq_beta30_original_bank.php
- php -l backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php && php -l backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
- python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json >/dev/null
- python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/items.json >/dev/null
- python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/answer_key.json >/dev/null
- python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/scoring_spec.json >/dev/null
- php backend/scripts/iq/build_iq_beta30_original_bank.php --check && php backend/scripts/iq/verify_iq_beta30_original_bank.php
- cd backend && php artisan test --filter=IqBeta30OriginalBank
- git diff --check -- <scoped IQ files>

## Intentionally deferred
- Runtime/public API binding remains deferred to IQ-BANK-30-03 / IQ-SCORE-30-01.
- IQ and percentile claims remain disabled until norm validation.
- CMS landing and SEO claim copy remain deferred to later train items.

## Repository rule impact
IQ_BETA_30_ORIGINAL is backend/content-package authoritative. This PR does not add frontend editorial content or runtime fallback content. Answer keys and solution rules remain backend-only.

## Scope note
The train manifest originated from fap-web and names backend content paths; in fap-api the actual package root is content_packages/..., which is the path used here.