### PR TITLE
test(iq): add original bank provenance and redaction gates

### DIFF
--- a/backend/app/Services/Iq/IqResultPayloadRedactor.php
+++ b/backend/app/Services/Iq/IqResultPayloadRedactor.php
@@ -16,6 +16,14 @@ final class IqResultPayloadRedactor
         'answerKey',
         'correct_answer',
         'correctAnswer',
+        'solution_rule',
+        'solutionRule',
+        'distractor_logic',
+        'distractorLogic',
+        'asset_hashes',
+        'assetHashes',
+        'generator_metadata',
+        'generatorMetadata',
     ];
 
     public static function isIqScale(?string $scaleCode, ?string $scaleCodeV2 = null): bool

--- a/backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
+++ b/backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
@@ -2,6 +2,7 @@
 
 declare(strict_types=1);
 
+use App\Services\Iq\IqResultPayloadRedactor;
 use PHPUnit\Framework\Attributes\Test;
 use Symfony\Component\Process\Process;
 use Tests\TestCase;
@@ -22,5 +23,99 @@ final class IqBeta30OriginalBankImportTest extends TestCase
     {
         $this->runCommand(['php', 'backend/scripts/iq/build_iq_beta30_original_bank.php', '--check']);
         $this->runCommand(['php', 'backend/scripts/iq/verify_iq_beta30_original_bank.php']);
+    }
+
+    #[Test]
+    public function generated_beta30_bank_has_provenance_hash_and_backend_answer_key_gates(): void
+    {
+        $itemsPayload = $this->readJson('items.json');
+        $answerKey = $this->readJson('answer_key.json');
+        $items = $itemsPayload['items'] ?? [];
+
+        $this->assertSame('IQ_BETA_30_ORIGINAL', $itemsPayload['bank_id'] ?? null);
+        $this->assertCount(30, $items);
+        $this->assertFalse((bool) ($answerKey['public_payload'] ?? true));
+        $this->assertSame('backend_only_never_emit_to_public_api', $answerKey['storage_policy'] ?? null);
+
+        foreach ($items as $item) {
+            $itemId = (string) ($item['item_id'] ?? '');
+            $this->assertNotSame('', $itemId);
+            $this->assertSame($item['correct_answer'] ?? null, data_get($answerKey, "answers.{$itemId}.correct_answer"));
+            $this->assertSame('repo_generated_original', data_get($item, 'generator_metadata.source_mode'));
+            $this->assertFalse((bool) data_get($item, 'generator_metadata.copied_from_third_party', true));
+            $this->assertFalse((bool) data_get($item, 'generator_metadata.traced_from_third_party', true));
+            $this->assertMatchesRegularExpression('/^sha256:[a-f0-9]{64}$/', (string) data_get($item, 'generator_metadata.params_hash'));
+            $this->assertSame($this->assetHash($item['assets']['stem'] ?? []), data_get($item, 'asset_hashes.stem'));
+
+            $optionCodes = [];
+            foreach (($item['assets']['options'] ?? []) as $option) {
+                $code = (string) ($option['code'] ?? '');
+                $optionCodes[] = $code;
+                $this->assertSame($this->assetHash($option['asset'] ?? []), data_get($item, "asset_hashes.options.{$code}"));
+            }
+
+            $this->assertSame(['A', 'B', 'C', 'D', 'E', 'F'], $optionCodes);
+        }
+    }
+
+    #[Test]
+    public function iq_public_payload_redactor_removes_beta30_answer_solution_and_provenance_private_fields(): void
+    {
+        $items = $this->readJson('items.json')['items'] ?? [];
+        $this->assertNotEmpty($items);
+
+        $redacted = IqResultPayloadRedactor::redactAnswerKeys([
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'bank_id' => 'IQ_BETA_30_ORIGINAL',
+            'items' => [$items[0]],
+            'answer_key' => $this->readJson('answer_key.json'),
+        ]);
+
+        $this->assertSame('IQ_BETA_30_ORIGINAL', $redacted['bank_id'] ?? null);
+        $this->assertSame('inline_svg_markup', data_get($redacted, 'items.0.assets.stem.kind'));
+        $this->assertPayloadHasNoPrivateIqFields($redacted);
+    }
+
+    private function readJson(string $file): array
+    {
+        $path = base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/'.$file);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+
+    private function assetHash(array $asset): string
+    {
+        return 'sha256:'.hash('sha256', json_encode(
+            $asset,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        )."\n");
+    }
+
+    private function assertPayloadHasNoPrivateIqFields(array $payload): void
+    {
+        $forbidden = [
+            'answer_key',
+            'answerKey',
+            'correct_answer',
+            'correctAnswer',
+            'solution_rule',
+            'solutionRule',
+            'distractor_logic',
+            'distractorLogic',
+            'asset_hashes',
+            'assetHashes',
+            'generator_metadata',
+            'generatorMetadata',
+        ];
+
+        foreach ($payload as $key => $value) {
+            $this->assertNotContains($key, $forbidden);
+
+            if (is_array($value)) {
+                $this->assertPayloadHasNoPrivateIqFields($value);
+            }
+        }
     }
 }


### PR DESCRIPTION
## What changed
- Extended the IQ public payload redactor to remove beta30 private item fields: solution rules, distractor logic, asset hashes, and generator metadata.
- Added IQ_BETA_30_ORIGINAL import gates for provenance flags, backend-only answer key policy, option coverage, and deterministic asset hash matching.
- Added a public payload redaction gate proving item SVG assets can remain while answer, solution, hash, and provenance internals are removed.

## Why
This implements IQ-BANK-30-03 by protecting the original beta30 bank import boundary before runtime/API binding work.

## Validation commands
- php -l backend/app/Services/Iq/IqResultPayloadRedactor.php && php -l backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
- cd backend && php artisan test --filter=IqBeta30OriginalBank
- cd backend && php artisan test --filter=IqReportContractTest
- git diff --check -- backend/app/Services/Iq/IqResultPayloadRedactor.php backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php

## Validation note
Local Composer autoload initially pointed at another temporary worktree. I ran composer dump-autoload --no-scripts locally so PHPUnit would load this branch. No vendor/autoload files are staged or included in this PR.

## Intentionally deferred
- Runtime scoring model changes remain deferred to IQ-SCORE-30-01.
- Frontend runtime rendering, commerce unlock, SEO, and CMS landing work remain out of scope.

## Repository rule impact
IQ_BETA_30_ORIGINAL remains backend/content-package authoritative. This PR only hardens backend public payload redaction and tests; it adds no frontend editorial fallback content.