### PR TITLE
feat(iq): harden 30-item scoring quality and stability

### DIFF
--- a/backend/app/Services/Report/IqReportBuilder.php
+++ b/backend/app/Services/Report/IqReportBuilder.php
@@ -265,16 +265,32 @@ final class IqReportBuilder
     {
         $norms = is_array($score['norms'] ?? null) ? $score['norms'] : [];
         $scored = $status === 'scored';
+        $hasNormAuthority = $this->hasNormAuthority($norms);
 
         return [
             'raw_score' => $scored ? $this->floatOrNull($score['raw_score'] ?? null) : null,
-            'iq_estimate' => $this->floatOrNull($norms['iq_estimate'] ?? null),
-            'percentile' => $this->floatOrNull($norms['percentile'] ?? null),
-            'confidence_interval' => is_array($norms['confidence_interval'] ?? null)
+            'iq_estimate' => $scored && $hasNormAuthority ? $this->floatOrNull($norms['iq_estimate'] ?? null) : null,
+            'percentile' => $scored && $hasNormAuthority ? $this->floatOrNull($norms['percentile'] ?? null) : null,
+            'confidence_interval' => $scored && $hasNormAuthority && is_array($norms['confidence_interval'] ?? null)
                 ? $norms['confidence_interval']
                 : null,
             'norms_status' => $this->stringOrNull($norms['status'] ?? null),
         ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $norms
+     */
+    private function hasNormAuthority(array $norms): bool
+    {
+        $status = strtolower(trim((string) ($norms['status'] ?? '')));
+
+        return in_array($status, [
+            'available',
+            'calibrated',
+            'norm_table_available',
+            'production_normed',
+        ], true);
     }
 
     /**

--- a/backend/tests/Unit/Assessment/IqTestDriverTest.php
+++ b/backend/tests/Unit/Assessment/IqTestDriverTest.php
@@ -90,6 +90,74 @@ final class IqTestDriverTest extends TestCase
         $this->assertSame('blocked_unscored', data_get($result->normedJson, 'status'));
     }
 
+    public function test_beta30_original_bank_scores_raw_dimensions_quality_and_nullable_norms(): void
+    {
+        $driver = new IqTestDriver;
+
+        $result = $driver->score(
+            $this->beta30Answers(18),
+            $this->beta30ScoringSpec(),
+            [
+                'duration_ms' => 20 * 60 * 1000,
+                'pack_id' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+                'content_package_version' => 'v0.3.0-demo',
+                'scoring_spec_version' => 'iq_beta30_original_v1',
+            ]
+        );
+
+        $this->assertSame(18.0, $result->rawScore);
+        $this->assertSame(18.0, $result->finalScore);
+        $this->assertSame('scored', data_get($result->normedJson, 'status'));
+        $this->assertSame('IQ_BETA_30_ORIGINAL', data_get($result->normedJson, 'bank_id'));
+        $this->assertSame(30, data_get($result->normedJson, 'expected_item_count'));
+        $this->assertSame(30, data_get($result->normedJson, 'answer_count'));
+        $this->assertSame('A', data_get($result->normedJson, 'quality.level'));
+        $this->assertSame([], data_get($result->normedJson, 'quality.flags'));
+        $this->assertSame('stable', data_get($result->normedJson, 'result_stability.status'));
+        $this->assertSame('quality_clear', data_get($result->normedJson, 'result_stability.reason'));
+        $this->assertSame('unavailable_without_norm_table', data_get($result->normedJson, 'norms.status'));
+        $this->assertNull(data_get($result->normedJson, 'norms.iq_estimate'));
+        $this->assertNull(data_get($result->normedJson, 'norms.percentile'));
+        $this->assertNull(data_get($result->normedJson, 'norms.confidence_interval'));
+        $this->assertSame(14, data_get($result->normedJson, 'dimension_scores.VSPR.item_count'));
+        $this->assertSame(14, data_get($result->normedJson, 'dimension_scores.VSPR.correct_count'));
+        $this->assertSame(100.0, data_get($result->normedJson, 'dimension_scores.VSPR.percent_correct'));
+        $this->assertSame(10, data_get($result->normedJson, 'dimension_scores.VSI.item_count'));
+        $this->assertSame(4, data_get($result->normedJson, 'dimension_scores.VSI.correct_count'));
+        $this->assertSame(40.0, data_get($result->normedJson, 'dimension_scores.VSI.percent_correct'));
+        $this->assertSame(6, data_get($result->normedJson, 'dimension_scores.NPR.item_count'));
+        $this->assertSame(0, data_get($result->normedJson, 'dimension_scores.NPR.correct_count'));
+        $this->assertSame(0.0, data_get($result->normedJson, 'dimension_scores.NPR.percent_correct'));
+        $this->assertStringNotContainsString('correct_answer', json_encode($result->toArray(), JSON_THROW_ON_ERROR));
+    }
+
+    public function test_beta30_original_bank_marks_partial_speeding_and_straightline_as_caution(): void
+    {
+        $driver = new IqTestDriver;
+
+        $result = $driver->score(
+            $this->beta30Answers(12, 'A'),
+            $this->beta30ScoringSpec(),
+            [
+                'duration_ms' => 10 * 1000,
+                'pack_id' => 'IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO',
+                'content_package_version' => 'v0.3.0-demo',
+                'scoring_spec_version' => 'iq_beta30_original_v1',
+            ]
+        );
+
+        $flags = data_get($result->normedJson, 'quality.flags', []);
+
+        $this->assertSame('C', data_get($result->normedJson, 'quality.level'));
+        $this->assertContains('SPEEDING', $flags);
+        $this->assertContains('STRAIGHTLINING', $flags);
+        $this->assertContains('PARTIAL_COMPLETION', $flags);
+        $this->assertSame('review_with_caution', data_get($result->normedJson, 'result_stability.status'));
+        $this->assertSame('partial_completion', data_get($result->normedJson, 'result_stability.reason'));
+        $this->assertSame(12, data_get($result->normedJson, 'answer_count'));
+        $this->assertSame(30, data_get($result->normedJson, 'expected_item_count'));
+    }
+
     private function completeScoringSpec(): array
     {
         return [
@@ -134,6 +202,85 @@ final class IqTestDriverTest extends TestCase
                 ),
             ],
         ];
+    }
+
+    private function beta30ScoringSpec(): array
+    {
+        $itemsPayload = $this->readBeta30Json('items.json');
+        $answerKey = $this->readBeta30Json('answer_key.json');
+        $items = [];
+
+        foreach (($itemsPayload['items'] ?? []) as $item) {
+            $itemId = (string) ($item['item_id'] ?? '');
+            $items[] = [
+                'item_id' => $itemId,
+                'question_id' => (string) ($item['question_id'] ?? ''),
+                'dimension' => (string) ($item['dimension'] ?? ''),
+                'item_family' => (string) ($item['item_family'] ?? ''),
+                'difficulty_level' => (string) ($item['difficulty_level'] ?? ''),
+                'correct_answer' => (string) data_get($answerKey, "answers.{$itemId}.correct_answer"),
+                'solution_rule' => (string) ($item['solution_rule'] ?? ''),
+                'distractor_logic' => (string) ($item['distractor_logic'] ?? ''),
+                'raw_points' => 1,
+                'assets' => $item['assets'] ?? [],
+                'asset_hashes' => $item['asset_hashes'] ?? [],
+                'generator_metadata' => $item['generator_metadata'] ?? [],
+            ];
+        }
+
+        return [
+            'version' => 'iq_beta30_original_v1',
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scoring_mode' => 'scored',
+            'answer_key_version' => 'iq_beta30_original_answer_key_v1',
+            'norm_table_version' => 'unavailable',
+            'scoring_engine_version' => 'iq_scoring_v2',
+            'item_bank' => [
+                'bank_id' => 'IQ_BETA_30_ORIGINAL',
+                'item_count' => 30,
+            ],
+            'quality_rules' => [
+                'speeding_seconds_lt' => 30,
+                'straightlining_run_len_gte' => 8,
+            ],
+            'items' => $items,
+        ];
+    }
+
+    private function beta30Answers(int $correctCount, ?string $forceCode = null): array
+    {
+        $itemsPayload = $this->readBeta30Json('items.json');
+        $answerKey = $this->readBeta30Json('answer_key.json');
+        $answers = [];
+        $optionCodes = ['A', 'B', 'C', 'D', 'E', 'F'];
+
+        foreach (array_values($itemsPayload['items'] ?? []) as $index => $item) {
+            if ($forceCode !== null && $index >= $correctCount) {
+                break;
+            }
+
+            $itemId = (string) ($item['item_id'] ?? '');
+            $correct = (string) data_get($answerKey, "answers.{$itemId}.correct_answer");
+            $code = $forceCode ?? ($index < $correctCount
+                ? $correct
+                : $optionCodes[(array_search($correct, $optionCodes, true) + 1) % count($optionCodes)]);
+
+            $answers[] = [
+                'question_id' => (string) ($item['question_id'] ?? ''),
+                'code' => $code,
+            ];
+        }
+
+        return $answers;
+    }
+
+    private function readBeta30Json(string $file): array
+    {
+        $path = base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/'.$file);
+        $payload = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
     }
 
     private function itemDefinition(

--- a/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
+++ b/backend/tests/Unit/Services/Report/IqReportBuilderTest.php
@@ -40,9 +40,9 @@ final class IqReportBuilderTest extends TestCase
                     ],
                     'norms' => [
                         'status' => 'unavailable_without_norm_table',
-                        'iq_estimate' => null,
-                        'percentile' => null,
-                        'confidence_interval' => null,
+                        'iq_estimate' => 132.0,
+                        'percentile' => 98.0,
+                        'confidence_interval' => [128.0, 136.0],
                     ],
                     'dimension_scores' => [
                         'VSI' => [
@@ -83,6 +83,10 @@ final class IqReportBuilderTest extends TestCase
         $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', data_get($payload, 'report.scale_code'));
         $this->assertSame('IQ_RAVEN', data_get($payload, 'report.scale_code_legacy'));
         $this->assertSame(18.0, data_get($payload, 'report.summary.raw_score'));
+        $this->assertNull(data_get($payload, 'report.summary.iq_estimate'));
+        $this->assertNull(data_get($payload, 'report.summary.percentile'));
+        $this->assertNull(data_get($payload, 'report.summary.confidence_interval'));
+        $this->assertSame('unavailable_without_norm_table', data_get($payload, 'report.summary.norms_status'));
         $this->assertSame('stable', data_get($payload, 'report.stability.status'));
         $this->assertSame('A', data_get($payload, 'report.quality.level'));
         $this->assertSame(75.0, data_get($payload, 'report.dimensions.visual_spatial_insight.percent_correct'));


### PR DESCRIPTION
## What changed
- Added IQ_BETA_30_ORIGINAL 30-item scoring coverage for raw score, dimension scores, quality flags, and stability status.
- Added partial/speeding/straightline caution coverage for the beta30 bank.
- Hardened IQ report summary so IQ estimate, percentile, and confidence interval stay null unless backend norm authority is explicitly available.
- Added report builder coverage proving unavailable norm status suppresses injected IQ/percentile values.

## Why
This implements IQ-SCORE-30-01 while preserving the no-production-IQ-claim boundary until a backend norm authority exists.

## Validation commands
- php -l backend/app/Services/Report/IqReportBuilder.php && php -l backend/tests/Unit/Assessment/IqTestDriverTest.php && php -l backend/tests/Unit/Services/Report/IqReportBuilderTest.php
- cd backend && php artisan test --filter=IqTestDriverTest
- cd backend && php artisan test --filter=IqReportBuilderTest
- cd backend && php artisan test --filter=IqReportContractTest
- git diff --check -- backend/app/Services/Report/IqReportBuilder.php backend/tests/Unit/Assessment/IqTestDriverTest.php backend/tests/Unit/Services/Report/IqReportBuilderTest.php backend/tests/Feature/V0_3/IqReportContractTest.php

## Intentionally deferred
- Production norm table claims remain out of scope.
- Frontend runtime changes and commerce unlock remain out of scope.
- SEO/CMS claim copy remains deferred to later train items.

## Repository rule impact
IQ scoring remains backend-authoritative. This PR does not add frontend fallback content and does not enable IQ/percentile claims without backend norm authority.