### PR TITLE
feat(iq): publish CMS-authoritative IQ landing placement

### DIFF
--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -219,6 +219,59 @@ final class LandingSurfacePublicApiTest extends TestCase
         $this->assertSame(10, LandingSurface::query()->withoutGlobalScopes()->count());
     }
 
+    public function test_iq_landing_baseline_is_cms_authoritative_and_claim_safe(): void
+    {
+        $this->artisan('landing-surfaces:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/landing_surfaces',
+        ])->assertExitCode(0);
+
+        $home = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('surface_key', 'home')
+            ->where('locale', 'en')
+            ->firstOrFail();
+        $homeIqCard = collect(data_get($home->payload_json, 'quickStart.items'))
+            ->firstWhere('key', 'iq-test-intelligence-quotient-assessment');
+
+        $this->assertIsArray($homeIqCard);
+        $this->assertSame('IQ Reasoning Practice', (string) data_get($homeIqCard, 'title'));
+        $this->assertSame('30 questions', (string) data_get($homeIqCard, 'questionsLabel'));
+        $this->assertSame('IQ_BETA_30_ORIGINAL', (string) data_get($homeIqCard, 'primaryActions.0.form_code'));
+        $this->assertSame('media_library_required', (string) data_get($homeIqCard, 'media.source'));
+        $this->assertSame('metadata_only_no_frontend_asset', (string) data_get($homeIqCard, 'media.status'));
+        $this->assertTrue((bool) data_get($homeIqCard, 'claim_policy.norm_authority_required'));
+        $this->assertFalse((bool) data_get($homeIqCard, 'claim_policy.iq_estimate_claims_enabled'));
+        $this->assertFalse((bool) data_get($homeIqCard, 'claim_policy.percentile_claims_enabled'));
+        $this->assertStringNotContainsString('official IQ', json_encode($homeIqCard, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('percentile ranking', json_encode($homeIqCard, JSON_THROW_ON_ERROR));
+
+        $tests = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('surface_key', 'tests')
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+        $cognitiveFamily = collect(data_get($tests->payload_json, 'families.items'))
+            ->firstWhere('id', 'family-cognitive-ability');
+        $iqCard = collect(data_get($cognitiveFamily, 'tests'))
+            ->firstWhere('key', 'iq-test-intelligence-quotient-assessment');
+
+        $this->assertIsArray($iqCard);
+        $this->assertSame('IQ 推理练习', (string) data_get($iqCard, 'title'));
+        $this->assertSame('30 题', (string) data_get($iqCard, 'questionsLabel'));
+        $this->assertSame('约 20 分钟', (string) data_get($iqCard, 'durationLabel'));
+        $this->assertSame('/zh/tests/iq-test-intelligence-quotient-assessment/take', (string) data_get($iqCard, 'href'));
+        $this->assertSame('IQ_BETA_30_ORIGINAL', (string) data_get($iqCard, 'primaryActions.0.form_code'));
+        $this->assertSame('media_library_required', (string) data_get($iqCard, 'media.source'));
+        $this->assertTrue((bool) data_get($iqCard, 'claim_policy.norm_authority_required'));
+        $this->assertFalse((bool) data_get($iqCard, 'claim_policy.iq_estimate_claims_enabled'));
+        $this->assertFalse((bool) data_get($iqCard, 'claim_policy.percentile_claims_enabled'));
+        $this->assertStringContainsString('不输出正式 IQ 或百分位', (string) data_get($iqCard, 'outputLabel'));
+        $this->assertStringNotContainsString('官方智商', json_encode($iqCard, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('人群百分位', json_encode($iqCard, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+    }
+
     public function test_public_and_internal_api_return_surface_payloads(): void
     {
         $this->artisan('landing-surfaces:import-local-baseline', [

--- a/content_baselines/landing_surfaces/home.en.json
+++ b/content_baselines/landing_surfaces/home.en.json
@@ -76,11 +76,35 @@
           ]
         },
         {
-          "title": "IQ Test",
-          "description": "Get a quick baseline for cognitive ability.",
+          "title": "IQ Reasoning Practice",
+          "description": "Practice 30 original visual and numeric reasoning items. Raw score only until norm authority is available.",
           "href": "/tests/iq-test-intelligence-quotient-assessment",
-          "label": "Start test",
-          "meta": "Ability assessment"
+          "label": "Start practice",
+          "meta": "Cognition practice",
+          "key": "iq-test-intelligence-quotient-assessment",
+          "questionsLabel": "30 questions",
+          "durationLabel": "20 min",
+          "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+          "claim_policy": {
+            "norm_authority_required": true,
+            "iq_estimate_claims_enabled": false,
+            "percentile_claims_enabled": false,
+            "copy_boundary": "raw score and original reasoning practice only",
+            "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+          },
+          "media": {
+            "asset_key": "iq-beta30-original-card",
+            "source": "media_library_required",
+            "status": "metadata_only_no_frontend_asset",
+            "alt": "Original IQ reasoning practice card"
+          },
+          "primaryActions": [
+            {
+              "label": "30-item beta",
+              "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+              "form_code": "IQ_BETA_30_ORIGINAL"
+            }
+          ]
         },
         {
           "title": "Depression and Anxiety Assessment",

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -76,11 +76,35 @@
           ]
         },
         {
-          "title": "IQ 智商测试",
-          "description": "快速了解你的认知能力基线",
+          "title": "IQ 推理练习",
+          "description": "练习 30 道原创视觉与数字推理题。在常模权威上线前，仅提供原始分参考。",
           "href": "/tests/iq-test-intelligence-quotient-assessment",
-          "label": "开始测试",
-          "meta": "能力测评"
+          "label": "开始练习",
+          "meta": "认知练习",
+          "key": "iq-test-intelligence-quotient-assessment",
+          "questionsLabel": "30 题",
+          "durationLabel": "约 20 分钟",
+          "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+          "claim_policy": {
+            "norm_authority_required": true,
+            "iq_estimate_claims_enabled": false,
+            "percentile_claims_enabled": false,
+            "copy_boundary": "仅限原创推理练习和原始分参考",
+            "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+          },
+          "media": {
+            "asset_key": "iq-beta30-original-card",
+            "source": "media_library_required",
+            "status": "metadata_only_no_frontend_asset",
+            "alt": "原创 IQ 推理练习卡片"
+          },
+          "primaryActions": [
+            {
+              "label": "30 题 Beta 版",
+              "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+              "form_code": "IQ_BETA_30_ORIGINAL"
+            }
+          ]
         },
         {
           "title": "抑郁焦虑综合症测试",

--- a/content_baselines/landing_surfaces/tests.en.json
+++ b/content_baselines/landing_surfaces/tests.en.json
@@ -355,16 +355,36 @@
           "tests": [
             {
               "key": "iq-test-intelligence-quotient-assessment",
-              "title": "IQ Test",
-              "description": "When you want a read on reasoning performance, pattern recognition, and cognitive strengths.",
-              "questionsLabel": "40 questions",
+              "title": "IQ Reasoning Practice",
+              "description": "Use 30 original visual-spatial, pattern, and numeric reasoning items. Current output is raw score and dimension reference only.",
+              "questionsLabel": "30 questions",
               "durationLabel": "20 min",
-              "outputLabel": "Ability baseline, reasoning profile, and reference notes",
+              "outputLabel": "Raw score, dimension performance, and stability notes; no formal IQ or percentile claim",
               "detailsHref": "/en/tests/iq-test-intelligence-quotient-assessment",
-              "secondaryLabel": "View details",
+              "secondaryLabel": "View boundaries",
               "previewVariant": "matrix",
               "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
-              "primaryLabel": "Start test"
+              "primaryLabel": "Start 30-item practice",
+              "claim_policy": {
+                "norm_authority_required": true,
+                "iq_estimate_claims_enabled": false,
+                "percentile_claims_enabled": false,
+                "copy_boundary": "raw score and original reasoning practice only",
+                "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+              },
+              "media": {
+                "asset_key": "iq-beta30-original-card",
+                "source": "media_library_required",
+                "status": "metadata_only_no_frontend_asset",
+                "alt": "Original IQ reasoning practice card"
+              },
+              "primaryActions": [
+                {
+                  "label": "30-item beta",
+                  "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+                  "form_code": "IQ_BETA_30_ORIGINAL"
+                }
+              ]
             }
           ]
         },

--- a/content_baselines/landing_surfaces/tests.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests.zh-CN.json
@@ -355,16 +355,36 @@
           "tests": [
             {
               "key": "iq-test-intelligence-quotient-assessment",
-              "title": "智商测试",
-              "description": "当你想看推理表现、问题处理速度与认知优势线索时。",
-              "questionsLabel": "40 题",
+              "title": "IQ 推理练习",
+              "description": "适合先练习原创视觉空间、图形规律与数字规律题，当前只给出原始分和维度参考。",
+              "questionsLabel": "30 题",
               "durationLabel": "约 20 分钟",
-              "outputLabel": "能力基线、推理表现与后续参考",
+              "outputLabel": "原始分、维度表现与稳定性提示；不输出正式 IQ 或百分位",
               "detailsHref": "/zh/tests/iq-test-intelligence-quotient-assessment",
-              "secondaryLabel": "查看详情",
+              "secondaryLabel": "查看边界说明",
               "previewVariant": "matrix",
               "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
-              "primaryLabel": "开始测试"
+              "primaryLabel": "开始 30 题练习",
+              "claim_policy": {
+                "norm_authority_required": true,
+                "iq_estimate_claims_enabled": false,
+                "percentile_claims_enabled": false,
+                "copy_boundary": "仅限原创推理练习和原始分参考",
+                "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+              },
+              "media": {
+                "asset_key": "iq-beta30-original-card",
+                "source": "media_library_required",
+                "status": "metadata_only_no_frontend_asset",
+                "alt": "原创 IQ 推理练习卡片"
+              },
+              "primaryActions": [
+                {
+                  "label": "30 题 Beta 版",
+                  "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+                  "form_code": "IQ_BETA_30_ORIGINAL"
+                }
+              ]
             }
           ]
         },


### PR DESCRIPTION
## What changed
- Updated CMS landing baseline placement for IQ on homepage quickStart and tests hub cognitive family.
- Reframed IQ as 30-item original reasoning practice with raw-score-only claim boundaries.
- Added CMS payload claim_policy and media metadata for IQ cards without adding frontend fallback assets.
- Added LandingSurfacePublicApiTest coverage for IQ claim safety, media metadata, and IQ_BETA_30_ORIGINAL placement.

## Why
This implements IQ-CMS-LANDING-01 by making IQ landing placement CMS/baseline authoritative while keeping formal IQ and percentile claims disabled until backend norm authority exists.

## Validation commands
- python3 -m json.tool content_baselines/landing_surfaces/home.zh-CN.json >/dev/null
- python3 -m json.tool content_baselines/landing_surfaces/home.en.json >/dev/null
- python3 -m json.tool content_baselines/landing_surfaces/tests.zh-CN.json >/dev/null
- python3 -m json.tool content_baselines/landing_surfaces/tests.en.json >/dev/null
- php -l backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
- cd backend && php artisan test --filter=LandingSurfacePublicApiTest
- git diff --check -- content_baselines/landing_surfaces/home.zh-CN.json content_baselines/landing_surfaces/home.en.json content_baselines/landing_surfaces/tests.zh-CN.json content_baselines/landing_surfaces/tests.en.json backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php

## Intentionally deferred
- Frontend fallback content remains out of scope.
- Scoring and commerce unlock remain out of scope.
- Live smoke validation remains deferred to IQ-LIVE-SMOKE-01.

## Repository rule impact
IQ landing placement is CMS/content-baseline authoritative. This PR does not add frontend editorial copy, frontend static media, or runtime fallback content.

## Scope note
The fap-web train manifest names backend/content_baselines, but fap-api stores baseline files at the repo root content_baselines/ path used here.