### PR TITLE
IQ/AttemptEmail Pint cleanup

### DIFF
--- a/backend/scripts/iq/build_iq_beta30_original_bank.php
+++ b/backend/scripts/iq/build_iq_beta30_original_bank.php
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/iq_beta30_original_bank_lib.php';
+require_once __DIR__.'/iq_beta30_original_bank_lib.php';
 
 $check = in_array('--check', $argv, true);
 $files = iqBeta30FileMap();
@@ -19,6 +19,7 @@ foreach ($payloads as $key => $payload) {
         if ($actual !== $expected) {
             $drift[] = $path;
         }
+
         continue;
     }
 
@@ -29,7 +30,7 @@ foreach ($payloads as $key => $payload) {
 }
 
 if ($check && $drift !== []) {
-    fwrite(STDERR, "IQ_BETA_30_ORIGINAL artifacts are stale:\n - " . implode("\n - ", $drift) . "\n");
+    fwrite(STDERR, "IQ_BETA_30_ORIGINAL artifacts are stale:\n - ".implode("\n - ", $drift)."\n");
     exit(1);
 }
 

--- a/backend/scripts/iq/iq_beta30_original_bank_lib.php
+++ b/backend/scripts/iq/iq_beta30_original_bank_lib.php
@@ -14,7 +14,7 @@ function iqBeta30BankId(): string
 
 function iqBeta30BankDir(): string
 {
-    return iqBeta30RepoRoot() . '/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/' . iqBeta30BankId();
+    return iqBeta30RepoRoot().'/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/'.iqBeta30BankId();
 }
 
 function iqBeta30FileMap(): array
@@ -22,28 +22,28 @@ function iqBeta30FileMap(): array
     $dir = iqBeta30BankDir();
 
     return [
-        'manifest' => $dir . '/manifest.json',
-        'items' => $dir . '/items.json',
-        'answer_key' => $dir . '/answer_key.json',
-        'scoring_spec' => $dir . '/scoring_spec.json',
+        'manifest' => $dir.'/manifest.json',
+        'items' => $dir.'/items.json',
+        'answer_key' => $dir.'/answer_key.json',
+        'scoring_spec' => $dir.'/scoring_spec.json',
     ];
 }
 
 function iqBeta30PrettyJson(array $payload): string
 {
-    return json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) . "\n";
+    return json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n";
 }
 
 function iqBeta30Sha256Json(array $payload): string
 {
-    return 'sha256:' . hash('sha256', iqBeta30PrettyJson($payload));
+    return 'sha256:'.hash('sha256', iqBeta30PrettyJson($payload));
 }
 
 function iqBeta30LoadJson(string $path): array
 {
     $json = json_decode((string) file_get_contents($path), true);
     if (! is_array($json)) {
-        throw new RuntimeException('Invalid JSON: ' . $path);
+        throw new RuntimeException('Invalid JSON: '.$path);
     }
 
     return $json;
@@ -78,7 +78,7 @@ function iqBeta30DimensionName(string $dimension): string
         'VSPR' => 'Visual-spatial pattern reasoning',
         'VSI' => 'Visual-spatial imagery',
         'NPR' => 'Numeric pattern reasoning',
-        default => throw new InvalidArgumentException('Unknown dimension ' . $dimension),
+        default => throw new InvalidArgumentException('Unknown dimension '.$dimension),
     };
 }
 
@@ -119,10 +119,10 @@ function iqBeta30ItemDefinitions(): array
 function iqBeta30Svg(array $elements): string
 {
     return '<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 240 160" role="img">'
-        . '<rect width="240" height="160" rx="16" fill="#f8faf7"/>'
-        . '<rect x="8" y="8" width="224" height="144" rx="12" fill="none" stroke="#243126" stroke-width="2" opacity="0.16"/>'
-        . implode('', $elements)
-        . '</svg>';
+        .'<rect width="240" height="160" rx="16" fill="#f8faf7"/>'
+        .'<rect x="8" y="8" width="224" height="144" rx="12" fill="none" stroke="#243126" stroke-width="2" opacity="0.16"/>'
+        .implode('', $elements)
+        .'</svg>';
 }
 
 function iqBeta30Asset(array $elements, array $meta): array
@@ -145,8 +145,8 @@ function iqBeta30ShapeElements(int $itemNumber, int $variant, string $family, bo
     $elements = [];
 
     if ($isStem) {
-        $elements[] = '<text x="20" y="28" font-family="Avenir, Helvetica, sans-serif" font-size="13" fill="#243126" opacity="0.72">' . htmlspecialchars(str_replace('_', ' ', $family), ENT_QUOTES) . '</text>';
-        $elements[] = '<text x="198" y="28" font-family="Avenir, Helvetica, sans-serif" font-size="12" fill="#243126" opacity="0.54">Q' . sprintf('%02d', $itemNumber) . '</text>';
+        $elements[] = '<text x="20" y="28" font-family="Avenir, Helvetica, sans-serif" font-size="13" fill="#243126" opacity="0.72">'.htmlspecialchars(str_replace('_', ' ', $family), ENT_QUOTES).'</text>';
+        $elements[] = '<text x="198" y="28" font-family="Avenir, Helvetica, sans-serif" font-size="12" fill="#243126" opacity="0.54">Q'.sprintf('%02d', $itemNumber).'</text>';
     }
 
     for ($i = 0; $i < $shapeCount; $i++) {
@@ -158,24 +158,24 @@ function iqBeta30ShapeElements(int $itemNumber, int $variant, string $family, bo
 
         if ($family === 'numeric_pattern') {
             $value = (($itemNumber + $variant + $i) * 3) % 17 + 2;
-            $elements[] = '<circle cx="' . $x . '" cy="' . $y . '" r="' . (int) ($size / 2) . '" fill="none" stroke="' . $color . '" stroke-width="3"/>';
-            $elements[] = '<text x="' . ($x - 5) . '" y="' . ($y + 5) . '" font-family="Avenir, Helvetica, sans-serif" font-size="13" fill="#243126">' . $value . '</text>';
+            $elements[] = '<circle cx="'.$x.'" cy="'.$y.'" r="'.(int) ($size / 2).'" fill="none" stroke="'.$color.'" stroke-width="3"/>';
+            $elements[] = '<text x="'.($x - 5).'" y="'.($y + 5).'" font-family="Avenir, Helvetica, sans-serif" font-size="13" fill="#243126">'.$value.'</text>';
         } elseif ($family === 'rotation') {
-            $elements[] = '<path d="M ' . $x . ' ' . ($y - $size) . ' L ' . ($x + $size) . ' ' . ($y + $size) . ' L ' . ($x - $size) . ' ' . ($y + $size) . ' Z" fill="' . $color . '" opacity="0.74" transform="rotate(' . $angle . ' ' . $x . ' ' . $y . ')"/>';
+            $elements[] = '<path d="M '.$x.' '.($y - $size).' L '.($x + $size).' '.($y + $size).' L '.($x - $size).' '.($y + $size).' Z" fill="'.$color.'" opacity="0.74" transform="rotate('.$angle.' '.$x.' '.$y.')"/>';
         } elseif ($family === 'overlay') {
-            $elements[] = '<rect x="' . ($x - $size / 2) . '" y="' . ($y - $size / 2) . '" width="' . $size . '" height="' . $size . '" rx="5" fill="' . $color . '" opacity="0.42" transform="rotate(' . $angle . ' ' . $x . ' ' . $y . ')"/>';
-            $elements[] = '<circle cx="' . ($x + 8) . '" cy="' . ($y - 5) . '" r="' . (int) max(5, $size / 3) . '" fill="none" stroke="#243126" stroke-width="2" opacity="0.52"/>';
+            $elements[] = '<rect x="'.($x - $size / 2).'" y="'.($y - $size / 2).'" width="'.$size.'" height="'.$size.'" rx="5" fill="'.$color.'" opacity="0.42" transform="rotate('.$angle.' '.$x.' '.$y.')"/>';
+            $elements[] = '<circle cx="'.($x + 8).'" cy="'.($y - 5).'" r="'.(int) max(5, $size / 3).'" fill="none" stroke="#243126" stroke-width="2" opacity="0.52"/>';
         } elseif ($family === 'matrix_3x3' || $family === 'matrix_2x2') {
             $cell = $family === 'matrix_3x3' ? 28 : 36;
             $col = $i % ($family === 'matrix_3x3' ? 3 : 2);
             $row = (int) floor($i / ($family === 'matrix_3x3' ? 3 : 2));
             $gx = 52 + ($col * 46) + (($variant + $itemNumber) % 7);
             $gy = 44 + ($row * 36) + (($variant + $i) % 6);
-            $elements[] = '<rect x="' . $gx . '" y="' . $gy . '" width="' . $cell . '" height="' . $cell . '" rx="6" fill="none" stroke="#243126" stroke-width="1.5" opacity="0.24"/>';
-            $elements[] = '<circle cx="' . ($gx + $cell / 2) . '" cy="' . ($gy + $cell / 2) . '" r="' . (5 + (($itemNumber + $variant + $i) % 8)) . '" fill="' . $color . '" opacity="0.78"/>';
+            $elements[] = '<rect x="'.$gx.'" y="'.$gy.'" width="'.$cell.'" height="'.$cell.'" rx="6" fill="none" stroke="#243126" stroke-width="1.5" opacity="0.24"/>';
+            $elements[] = '<circle cx="'.($gx + $cell / 2).'" cy="'.($gy + $cell / 2).'" r="'.(5 + (($itemNumber + $variant + $i) % 8)).'" fill="'.$color.'" opacity="0.78"/>';
         } else {
-            $elements[] = '<circle cx="' . $x . '" cy="' . $y . '" r="' . (int) ($size / 2) . '" fill="' . $color . '" opacity="0.7"/>';
-            $elements[] = '<path d="M ' . ($x - $size) . ' ' . ($y + $size) . ' Q ' . $x . ' ' . ($y - $size) . ' ' . ($x + $size) . ' ' . ($y + $size) . '" fill="none" stroke="#243126" stroke-width="2" opacity="0.42"/>';
+            $elements[] = '<circle cx="'.$x.'" cy="'.$y.'" r="'.(int) ($size / 2).'" fill="'.$color.'" opacity="0.7"/>';
+            $elements[] = '<path d="M '.($x - $size).' '.($y + $size).' Q '.$x.' '.($y - $size).' '.($x + $size).' '.($y + $size).'" fill="none" stroke="#243126" stroke-width="2" opacity="0.42"/>';
         }
     }
 
@@ -240,7 +240,7 @@ function iqBeta30Item(array $definition): array
             'template_key' => $family,
             'generator_version' => 'iq_beta30_original_bank_v1',
             'theme_version' => 'fermatmind_soft_contrast_v1',
-            'params_hash' => 'sha256:' . hash('sha256', json_encode([$definition['item_id'], $family, $definition['dimension'], $stemVariant], JSON_UNESCAPED_SLASHES)),
+            'params_hash' => 'sha256:'.hash('sha256', json_encode([$definition['item_id'], $family, $definition['dimension'], $stemVariant], JSON_UNESCAPED_SLASHES)),
         ],
     ];
 }

--- a/backend/scripts/iq/verify_iq_beta30_original_bank.php
+++ b/backend/scripts/iq/verify_iq_beta30_original_bank.php
@@ -3,7 +3,7 @@
 
 declare(strict_types=1);
 
-require_once __DIR__ . '/iq_beta30_original_bank_lib.php';
+require_once __DIR__.'/iq_beta30_original_bank_lib.php';
 
 function failBeta30(string $message): never
 {
@@ -14,7 +14,7 @@ function failBeta30(string $message): never
 $files = iqBeta30FileMap();
 foreach ($files as $path) {
     if (! is_file($path)) {
-        failBeta30('Missing artifact ' . $path);
+        failBeta30('Missing artifact '.$path);
     }
 }
 
@@ -22,7 +22,7 @@ $expectedPayloads = iqBeta30BankPayloads();
 foreach ($expectedPayloads as $key => $expectedPayload) {
     $actual = iqBeta30LoadJson($files[$key]);
     if ($actual !== $expectedPayload) {
-        failBeta30($key . ' does not match deterministic generator output');
+        failBeta30($key.' does not match deterministic generator output');
     }
 }
 
@@ -53,7 +53,7 @@ $ids = [];
 foreach ($items as $item) {
     $id = $item['item_id'] ?? '';
     if ($id === '' || isset($ids[$id])) {
-        failBeta30('Missing or duplicate item id ' . $id);
+        failBeta30('Missing or duplicate item id '.$id);
     }
     $ids[$id] = true;
 
@@ -63,43 +63,43 @@ foreach ($items as $item) {
     $familyCounts[$family] = ($familyCounts[$family] ?? 0) + 1;
 
     if (($item['option_count'] ?? null) !== 6) {
-        failBeta30($id . ' must have six options');
+        failBeta30($id.' must have six options');
     }
     if (count($item['assets']['options'] ?? []) !== 6) {
-        failBeta30($id . ' must provide six option assets');
+        failBeta30($id.' must provide six option assets');
     }
 
     $answer = $item['correct_answer'] ?? '';
     if (! array_key_exists($answer, $answerCounts)) {
-        failBeta30($id . ' has invalid answer ' . $answer);
+        failBeta30($id.' has invalid answer '.$answer);
     }
     $answerCounts[$answer]++;
 
     if (($answerKey['answers'][$id]['correct_answer'] ?? null) !== $answer) {
-        failBeta30($id . ' answer key mismatch');
+        failBeta30($id.' answer key mismatch');
     }
     if (($item['generator_metadata']['source_mode'] ?? null) !== 'repo_generated_original') {
-        failBeta30($id . ' must declare repo-generated original provenance');
+        failBeta30($id.' must declare repo-generated original provenance');
     }
     if (($item['generator_metadata']['copied_from_third_party'] ?? true) !== false || ($item['generator_metadata']['traced_from_third_party'] ?? true) !== false) {
-        failBeta30($id . ' has invalid third-party provenance flags');
+        failBeta30($id.' has invalid third-party provenance flags');
     }
     if (($item['assets']['stem']['kind'] ?? null) !== 'inline_svg_markup' || ($item['assets']['stem']['mime_type'] ?? null) !== 'image/svg+xml') {
-        failBeta30($id . ' stem must be inline SVG markup asset');
+        failBeta30($id.' stem must be inline SVG markup asset');
     }
     if (($item['asset_hashes']['stem'] ?? null) !== iqBeta30Sha256Json($item['assets']['stem'])) {
-        failBeta30($id . ' stem hash mismatch');
+        failBeta30($id.' stem hash mismatch');
     }
     foreach ($item['assets']['options'] as $option) {
         $code = $option['code'] ?? '';
         if (! in_array($code, iqBeta30OptionCodes(), true)) {
-            failBeta30($id . ' invalid option code ' . $code);
+            failBeta30($id.' invalid option code '.$code);
         }
         if (($option['asset']['kind'] ?? null) !== 'inline_svg_markup' || ($option['asset']['mime_type'] ?? null) !== 'image/svg+xml') {
-            failBeta30($id . ' option ' . $code . ' must be inline SVG markup asset');
+            failBeta30($id.' option '.$code.' must be inline SVG markup asset');
         }
         if (($item['asset_hashes']['options'][$code] ?? null) !== iqBeta30Sha256Json($option['asset'])) {
-            failBeta30($id . ' option ' . $code . ' hash mismatch');
+            failBeta30($id.' option '.$code.' hash mismatch');
         }
     }
 }
@@ -111,10 +111,10 @@ ksort($familyCounts);
 ksort($expectedDimensionCounts);
 ksort($expectedFamilyCounts);
 if ($dimensionCounts !== $expectedDimensionCounts) {
-    failBeta30('Dimension counts mismatch: ' . json_encode($dimensionCounts));
+    failBeta30('Dimension counts mismatch: '.json_encode($dimensionCounts));
 }
 if ($familyCounts !== $expectedFamilyCounts) {
-    failBeta30('Family counts mismatch: ' . json_encode($familyCounts));
+    failBeta30('Family counts mismatch: '.json_encode($familyCounts));
 }
 if ($answerCounts !== array_fill_keys(iqBeta30OptionCodes(), 5)) {
     failBeta30('Answers must be balanced across A-F');

--- a/backend/tests/Feature/AttemptEmailBindingTest.php
+++ b/backend/tests/Feature/AttemptEmailBindingTest.php
@@ -5,8 +5,8 @@ declare(strict_types=1);
 namespace Tests\Feature;
 
 use App\Models\Attempt;
-use App\Models\Result;
 use App\Models\EmailPreference;
+use App\Models\Result;
 use App\Services\Email\EmailCaptureService;
 use App\Services\Email\EmailPreferenceService;
 use App\Support\PiiCipher;

--- a/backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
+++ b/backend/tests/Feature/Content/IqBeta30OriginalBankImportTest.php
@@ -15,7 +15,7 @@ final class IqBeta30OriginalBankImportTest extends TestCase
         $process->setTimeout(60);
         $process->run();
 
-        $this->assertTrue($process->isSuccessful(), $process->getOutput() . $process->getErrorOutput());
+        $this->assertTrue($process->isSuccessful(), $process->getOutput().$process->getErrorOutput());
     }
 
     #[Test]

--- a/backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
+++ b/backend/tests/Feature/Content/IqBeta30OriginalBankSpecTest.php
@@ -14,7 +14,7 @@ final class IqBeta30OriginalBankSpecTest extends TestCase
 
     private function readJson(string $file): array
     {
-        $payload = json_decode((string) file_get_contents($this->bankDir() . '/' . $file), true);
+        $payload = json_decode((string) file_get_contents($this->bankDir().'/'.$file), true);
         $this->assertIsArray($payload);
 
         return $payload;


### PR DESCRIPTION
## What changed
- Applied Pint formatting to IQ beta30 scripts and related IQ/AttemptEmail tests.
- Kept this as a standalone mechanical cleanup so the Career 1046 train can keep its own manifest/state scope isolated.

## Why
- Repo-wide `vendor/bin/pint --test` was failing on these pre-existing files outside the current Career PR scope.
- This PR does not modify `docs/codex/pr-train.yaml` or `docs/codex/pr-train-state.json` to avoid affecting other active PR trains.

## Validation
- `/private/tmp/fap-api-career-1046-growth-foundation-train/backend/vendor/bin/pint --test`
- `php artisan test --filter=AttemptEmailBindingTest --no-ansi`
- `php artisan test --filter=IqBeta30OriginalBank --no-ansi`
- `php artisan route:list --no-ansi`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `git diff --check`
- `git diff --cached --check`

## Deferred
- No production deploy.
- No CMS, DB, Search Channel, URL submission, or runtime behavior changes.
- No Career 1046 manifest/state edits in this cleanup PR.