### PR TITLE
AUDIT-SEC-PAYMENT-INTEGRITY-01: harden payment integrity boundaries

### DIFF
--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -338,7 +338,7 @@ class Kernel extends ConsoleKernel
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->exec(PHP_BINARY.' '.base_path('artisan').' storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
-        $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15')->everyFiveMinutes()->withoutOverlapping();
+        $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --only-stale --limit=10 --older-than-minutes=60')->everyTenMinutes()->withoutOverlapping();
         $schedule->command('commerce:repair-paid-orders --limit=50')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('commerce:repair-post-commit-failed --limit=50')->everyFiveMinutes()->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();

--- a/backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php
+++ b/backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php
@@ -57,7 +57,17 @@ class ReprocessPaymentEventJob implements ShouldQueue
 
         $signatureOk = (bool) ($event->signature_ok ?? false);
         $originalStatus = strtolower(trim((string) ($event->status ?? '')));
-        $result = $processor->process($provider, $payload, $signatureOk);
+        $result = $processor->handle(
+            $provider,
+            $payload,
+            $effectiveOrgId,
+            null,
+            null,
+            $signatureOk,
+            $this->payloadMeta($event),
+            trim((string) ($event->payload_sha256 ?? '')),
+            is_numeric($event->payload_size_bytes ?? null) ? (int) $event->payload_size_bytes : -1
+        );
 
         if (($result['ok'] ?? false) === true) {
             $repair = $this->repairOrderIfNeeded($event, $orderRepair, $effectiveOrgId);
@@ -159,6 +169,18 @@ class ReprocessPaymentEventJob implements ShouldQueue
                 'error_message' => mb_substr($message, 0, 255),
             ],
         );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function payloadMeta(object $event): array
+    {
+        return [
+            'sha256' => trim((string) ($event->payload_sha256 ?? '')),
+            'size_bytes' => is_numeric($event->payload_size_bytes ?? null) ? (int) $event->payload_size_bytes : null,
+            's3_key' => trim((string) ($event->payload_s3_key ?? '')) ?: null,
+        ];
     }
 
     private function writeAudit(int $orgId, string $action, string $targetType, string $targetId, string $orderNo, array $meta): void

--- a/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
+++ b/backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php
@@ -123,7 +123,7 @@ class WebhookEntitlementService
                         'order_id' => (string) Str::uuid(),
                         'event_type' => $eventType,
                         'order_no' => $orderNo,
-                        'payload_json' => $payloadSummaryJson,
+                        'payload_json' => $this->untrustedPayloadSummaryJson($payloadSummaryJson),
                         'signature_ok' => $signatureOk,
                         'status' => 'received',
                         'attempts' => 0,
@@ -133,10 +133,10 @@ class WebhookEntitlementService
                         'processed_at' => null,
                         'handled_at' => null,
                         'handle_status' => null,
-                        'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
-                        'payload_sha256' => $resolvedPayloadMeta['sha256'],
-                        'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
-                        'payload_excerpt' => $payloadExcerpt,
+                        'payload_size_bytes' => null,
+                        'payload_sha256' => null,
+                        'payload_s3_key' => null,
+                        'payload_excerpt' => null,
                         'request_id' => $requestId,
                         'received_at' => $receivedAt,
                         'created_at' => $receivedAt,
@@ -152,6 +152,22 @@ class WebhookEntitlementService
                         ->first();
                     if (! $eventRow) {
                         return $this->core->serverError('EVENT_INIT_FAILED', 'payment event init failed.');
+                    }
+
+                    if ($signatureOk !== true) {
+                        if ($inserted === 1) {
+                            $this->core->markEventError($provider, $providerEventId, 'rejected', 'INVALID_SIGNATURE', 'signature invalid.');
+                        } else {
+                            Log::warning('PAYMENT_EVENT_INVALID_SIGNATURE_DUPLICATE_IGNORED', [
+                                'provider' => $provider,
+                                'provider_event_id' => $providerEventId,
+                                'order_id' => $eventRow->order_id ?? null,
+                                'order_no' => $eventRow->order_no ?? null,
+                                'incoming_order_no' => $orderNo,
+                            ]);
+                        }
+
+                        return $this->core->badRequest('INVALID_SIGNATURE', 'invalid signature.');
                     }
 
                     $existingPayloadSha256 = trim((string) ($eventRow->payload_sha256 ?? ''));
@@ -211,25 +227,14 @@ class WebhookEntitlementService
                         'processed_at' => null,
                         'handled_at' => null,
                         'handle_status' => null,
-                        'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
-                        'payload_sha256' => $resolvedPayloadMeta['sha256'],
-                        'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
-                        'payload_excerpt' => $payloadExcerpt,
+                        'payload_size_bytes' => null,
+                        'payload_sha256' => null,
+                        'payload_s3_key' => null,
+                        'payload_excerpt' => null,
                         'request_id' => $requestId,
                         'received_at' => $receivedAt,
                         'updated_at' => $receivedAt,
                     ];
-
-                    DB::table('payment_events')
-                        ->where('provider', $provider)
-                        ->where('provider_event_id', $providerEventId)
-                        ->update($baseRow);
-
-                    if ($signatureOk !== true) {
-                        $this->core->markEventError($provider, $providerEventId, 'rejected', 'INVALID_SIGNATURE', 'signature invalid.');
-
-                        return $this->core->badRequest('INVALID_SIGNATURE', 'invalid signature.');
-                    }
 
                     $orderQuery = DB::table('orders')
                         ->where('order_no', $orderNo)
@@ -265,6 +270,17 @@ class WebhookEntitlementService
 
                         return $this->core->semanticReject('PROVIDER_MISMATCH', 'provider mismatch');
                     }
+
+                    DB::table('payment_events')
+                        ->where('provider', $provider)
+                        ->where('provider_event_id', $providerEventId)
+                        ->update(array_merge($baseRow, [
+                            'payload_json' => $payloadSummaryJson,
+                            'payload_size_bytes' => $resolvedPayloadMeta['size_bytes'],
+                            'payload_sha256' => $resolvedPayloadMeta['sha256'],
+                            'payload_s3_key' => $resolvedPayloadMeta['s3_key'],
+                            'payload_excerpt' => $payloadExcerpt,
+                        ]));
 
                     $isRefundEvent = $this->core->isRefundEvent($eventType, $normalized);
                     $orderStatus = strtolower((string) ($order->status ?? ''));
@@ -711,6 +727,17 @@ class WebhookEntitlementService
         $ctx['post_commit_ctx'] = $postCommitCtx;
 
         return $ctx;
+    }
+
+    private function untrustedPayloadSummaryJson(string $payloadSummaryJson): string
+    {
+        $decoded = json_decode($payloadSummaryJson, true);
+        $summary = is_array($decoded) ? $decoded : [];
+        $summary['trusted_forensics'] = false;
+
+        $encoded = json_encode($summary, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+
+        return is_string($encoded) && $encoded !== '' ? $encoded : '{}';
     }
 
     private function normalizeRequestId(mixed $value): ?string

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -39,7 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
-        $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15')->everyFiveMinutes()->withoutOverlapping();
+        $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --only-stale --limit=10 --older-than-minutes=60')->everyTenMinutes()->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('eq60:psychometrics --window=last_90_days')->weeklyOn(1, '04:20')->withoutOverlapping();

--- a/backend/docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json
+++ b/backend/docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json
@@ -1,8 +1,8 @@
 {
   "schema_version": "commerce.order_grant_projection_readonly.v1",
-  "task": "ORDER-GRANT-PROJECTION-READONLY-ORD-1093B7E6",
+  "task": "ORDER-GRANT-PROJECTION-READONLY-REDACTED-1093B7E6",
   "final_decision": "order_grant_projection_readonly_completed_payment_pending_no_grant",
-  "order_no": "ord_1093b7e6-073a-4d93-b26d-4a68a819fa23",
+  "order_ref": "redacted_production_order_ref_1093b7e6",
   "production_readonly_verification": true,
   "no_write_performed": true,
   "no_env_edit": true,

--- a/backend/docs/commerce/order-grant-projection-readonly-ord-1093b7e6.md
+++ b/backend/docs/commerce/order-grant-projection-readonly-ord-1093b7e6.md
@@ -1,10 +1,10 @@
 # Order Grant / Projection Read-only Check
 
-Task: `ORDER-GRANT-PROJECTION-READONLY-ORD-1093B7E6`
+Task: `ORDER-GRANT-PROJECTION-READONLY-REDACTED-1093B7E6`
 
 Order checked:
 
-- `ord_1093b7e6-073a-4d93-b26d-4a68a819fa23`
+- `redacted_production_order_ref_1093b7e6`
 
 ## Summary
 
@@ -23,6 +23,7 @@ The order wait page behavior is consistent with the backend state: payment has n
 ## Read-only Evidence
 
 The production checks used SELECT-only Laravel query builder reads through the production application context. No public order endpoint was called because that endpoint can invoke projection repair when a result exists.
+The committed packet stores only a redacted production order reference; the raw production order number is intentionally not retained in repository artifacts.
 
 Observed order state:
 

--- a/backend/docs/runbooks/alipay-pending-compensation.md
+++ b/backend/docs/runbooks/alipay-pending-compensation.md
@@ -13,19 +13,20 @@ order when Alipay confirms a terminal paid state.
 ## Scheduled Command
 
 ```bash
-php artisan commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15
+php artisan commerce:compensate-pending-orders --provider=alipay --include-created --only-stale --limit=10 --older-than-minutes=60
 ```
 
 Runtime policy:
 
-- Runs every five minutes through Laravel scheduler.
+- Runs every ten minutes through Laravel scheduler.
 - Must be registered in `bootstrap/app.php` via `withSchedule`; this is the
   runtime scheduler source used by the production Laravel 11 bootstrap.
 - Uses `withoutOverlapping`.
 - Includes stale `created` and `pending` Alipay orders.
 - Does not pass `--close-expired`, so it does not automatically close or expire
   unpaid historical orders.
-- Keeps the query window conservative with `--limit=50`.
+- Keeps the provider query window conservative with `--limit=10`,
+  `--older-than-minutes=60`, and `--only-stale`.
 
 ## Scheduler Runner Verification
 

--- a/backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
+++ b/backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php
@@ -19,10 +19,11 @@ final class AlipayPendingCompensationSchedulerTest extends TestCase
         $this->assertNotNull($event, 'schedule:list did not include the Alipay pending compensation command.');
         $this->assertStringContainsString('--provider=alipay', (string) $event['command']);
         $this->assertStringContainsString('--include-created', (string) $event['command']);
-        $this->assertStringContainsString('--limit=50', (string) $event['command']);
-        $this->assertStringContainsString('--older-than-minutes=15', (string) $event['command']);
+        $this->assertStringContainsString('--only-stale', (string) $event['command']);
+        $this->assertStringContainsString('--limit=10', (string) $event['command']);
+        $this->assertStringContainsString('--older-than-minutes=60', (string) $event['command']);
         $this->assertStringNotContainsString('--close-expired', (string) $event['command']);
-        $this->assertSame('*/5 * * * *', $event['expression']);
+        $this->assertSame('*/10 * * * *', $event['expression']);
     }
 
     /**

--- a/backend/tests/Feature/Commerce/OrderGrantProjectionReadonlyOrd1093b7e6Test.php
+++ b/backend/tests/Feature/Commerce/OrderGrantProjectionReadonlyOrd1093b7e6Test.php
@@ -16,7 +16,8 @@ final class OrderGrantProjectionReadonlyOrd1093b7e6Test extends TestCase
 
         $payload = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
 
-        $this->assertSame('ord_1093b7e6-073a-4d93-b26d-4a68a819fa23', $payload['order_no']);
+        $this->assertSame('redacted_production_order_ref_1093b7e6', $payload['order_ref']);
+        $this->assertArrayNotHasKey('order_no', $payload);
         $this->assertTrue($payload['production_readonly_verification']);
         $this->assertTrue($payload['no_write_performed']);
         $this->assertTrue($payload['no_env_edit']);

--- a/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php
@@ -340,5 +340,9 @@ class PaymentWebhookIdempotencyTest extends TestCase
             ->where('provider', 'stripe')
             ->where('provider_event_id', 'evt_sig_1')
             ->value('last_error_code'));
+        $this->assertNull(DB::table('payment_events')
+            ->where('provider', 'stripe')
+            ->where('provider_event_id', 'evt_sig_1')
+            ->value('payload_sha256'));
     }
 }

--- a/backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
+++ b/backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php
@@ -72,6 +72,14 @@ class PaymentWebhookTrustBoundaryTest extends TestCase
             ->where('provider', 'billing')
             ->where('provider_event_id', 'evt_trust_sig_1')
             ->value('last_error_code'));
+        $this->assertNull(DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_sig_1')
+            ->value('payload_sha256'));
+        $this->assertNull(DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_sig_1')
+            ->value('payload_excerpt'));
         $this->assertSame(0, DB::table('benefit_wallet_ledgers')->count());
     }
 
@@ -131,5 +139,48 @@ class PaymentWebhookTrustBoundaryTest extends TestCase
             ->where('provider_event_id', 'evt_trust_evt_1')
             ->value('reason'));
         $this->assertSame('created', (string) DB::table('orders')->where('order_no', $orderNo)->value('status'));
+    }
+
+    public function test_invalid_duplicate_does_not_overwrite_trusted_processed_event(): void
+    {
+        (new Pr19CommerceSeeder)->run();
+        $orderNo = 'ord_trust_dup_sig_1';
+        $this->seedOrder($orderNo);
+
+        $processor = app(PaymentWebhookProcessor::class);
+        $paid = $processor->handle('billing', [
+            'provider_event_id' => 'evt_trust_dup_sig_1',
+            'order_no' => $orderNo,
+            'amount_cents' => 4990,
+            'currency' => 'USD',
+            'event_type' => 'payment_succeeded',
+        ], 0, null, null, true);
+
+        $this->assertTrue((bool) ($paid['ok'] ?? false));
+
+        $trustedDigest = (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_dup_sig_1')
+            ->value('payload_sha256');
+        $this->assertNotSame('', $trustedDigest);
+
+        $invalid = $processor->handle('billing', [
+            'provider_event_id' => 'evt_trust_dup_sig_1',
+            'order_no' => $orderNo,
+            'amount_cents' => 1,
+            'currency' => 'USD',
+            'event_type' => 'payment_succeeded',
+        ], 0, null, null, false);
+
+        $this->assertFalse((bool) ($invalid['ok'] ?? true));
+        $this->assertSame('INVALID_SIGNATURE', (string) ($invalid['error_code'] ?? ''));
+        $this->assertSame('processed', (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_dup_sig_1')
+            ->value('status'));
+        $this->assertSame($trustedDigest, (string) DB::table('payment_events')
+            ->where('provider', 'billing')
+            ->where('provider_event_id', 'evt_trust_dup_sig_1')
+            ->value('payload_sha256'));
     }
 }

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1190,6 +1190,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_payment_webhook_digest_idempotency_changes(): void
     {
         $changed = [
+            'backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php',
             'backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php',
         ];
 
@@ -3135,6 +3136,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/Commerce/Checkout/AlipayCheckoutService.php',
             'backend/app/Services/Commerce/OrderManager.php',
             'backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php',
+            'backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php',
         ], true);
     }
 

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1380,7 +1380,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Console/Kernel.php',
         ];
         $kernelChangedLines = [
-            "+        \$schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --limit=50 --older-than-minutes=15')->everyFiveMinutes()->withoutOverlapping();",
+            "+        \$schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --only-stale --limit=10 --older-than-minutes=60')->everyTenMinutes()->withoutOverlapping();",
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
@@ -3000,6 +3000,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (
+                $file === 'backend/bootstrap/app.php'
+                && $repoRoot !== ''
+                && $baseRef !== ''
+                && $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly(
+                    $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                )
+            ) {
+                continue;
+            }
+
+            if (
                 $file === 'backend/database/seeders/ScaleRegistrySeeder.php'
                 && $this->scaleRegistrySeederDiffIsIqIdentityMetadataOnly(
                     $scaleRegistrySeederChangedLines ?? $this->scaleRegistrySeederChangedLines($repoRoot, $baseRef)
@@ -4583,7 +4594,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 return false;
             }
 
-            if (preg_match('/commerce:compensate-pending-orders|--provider=alipay|--include-created|--limit=50|--older-than-minutes=15|everyFiveMinutes|withoutOverlapping/u', $line) !== 1) {
+            if (preg_match('/commerce:compensate-pending-orders|--provider=alipay|--include-created|--only-stale|--limit=10|--older-than-minutes=60|everyTenMinutes|withoutOverlapping/u', $line) !== 1) {
                 return false;
             }
         }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:15:33+08:00",
+  "updated_at": "2026-05-31T16:21:06+08:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -34525,7 +34525,7 @@
     "branch": "audit/sec-payment-integrity-01",
     "base": "main",
     "title": "AUDIT-SEC-PAYMENT-INTEGRITY-01 harden payment integrity boundaries",
-    "status": "pr_open_checks_pending",
+    "status": "ci_fix_pushed_checks_pending",
     "depends_on": [
       "AUDIT-SEC-RESULT-IDENTITY-01 merged"
     ],
@@ -34564,8 +34564,18 @@
         "evidence": "route:list passed; sqlite migrate passed; ci_verify_mbti.sh passed; diff check passed; manifest/state parse passed; raw production order id scan passed."
       },
       "github": {
-        "status": "pending",
+        "status": "retry_pending",
+        "previous_failure": "verify-bigfive runtime freeze classifier flagged backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php",
+        "fix": "Added ReprocessPaymentEventJob.php to the payment webhook digest/reprocess runtime-freeze exception and targeted test fixture.",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1793"
+      },
+      "ci_fix_local": {
+        "status": "passed_with_existing_file_cache_warnings",
+        "commands": [
+          "cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_payment_webhook_digest_idempotency_changes' --no-ansi",
+          "git diff --check"
+        ],
+        "evidence": "Exit code 0; 2 warnings from existing file cache warnings."
       }
     },
     "failure_reason": null,
@@ -34602,6 +34612,12 @@
         "from": "local_scope_validation_passed",
         "to": "pr_open_checks_pending",
         "note": "Created PR #1793 from audit/sec-payment-integrity-01; waiting for GitHub required checks."
+      },
+      {
+        "at": "2026-05-31T16:21:06+08:00",
+        "from": "pr_open_checks_pending",
+        "to": "ci_fix_pushed_checks_pending",
+        "note": "Fixed verify-bigfive runtime-freeze allowlist for ReprocessPaymentEventJob.php and pushed retry commit."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:11:00+08:00",
+  "updated_at": "2026-05-31T16:14:44+08:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -34459,7 +34459,7 @@
     "branch": "audit/sec-result-identity-01",
     "base": "main",
     "title": "AUDIT-SEC-RESULT-IDENTITY-01 harden result recovery identity boundary",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [
       "AUDIT-SEC-RELEASE-TRAIN-01 merged"
     ],
@@ -34474,14 +34474,14 @@
       "github_checks": "PR #1786 second CI run green: hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, verify-mbti-v2, Semgrep blocking secrets, Semgrep SARIF upload."
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-31T07:57:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -34507,9 +34507,122 @@
         "from": "ci_scope_fix_in_progress",
         "to": "github_checks_green",
         "note": "PR #1786 checks green after current-scope runtime-freeze classifier fix."
+      },
+      {
+        "at": "2026-05-31T16:00:28+08:00",
+        "from": "github_checks_green",
+        "to": "merged_and_cleaned",
+        "note": "PR #1786 squash merged; origin/main contains merge commit; local main synced; local and remote task branches cleaned."
       }
     ],
     "sidecars": [],
-    "next_task": "AUDIT-SEC-PAYMENT-INTEGRITY-01"
+    "next_task": "AUDIT-SEC-PAYMENT-INTEGRITY-01",
+    "merge_commit": "9e59c976a71811e76f9a70c64eb6380cf0a25878"
+  },
+  "AUDIT-SEC-PAYMENT-INTEGRITY-01": {
+    "id": "AUDIT-SEC-PAYMENT-INTEGRITY-01",
+    "repo": "fap-api",
+    "branch": "audit/sec-payment-integrity-01",
+    "base": "main",
+    "title": "AUDIT-SEC-PAYMENT-INTEGRITY-01 harden payment integrity boundaries",
+    "status": "local_scope_validation_passed",
+    "depends_on": [
+      "AUDIT-SEC-RESULT-IDENTITY-01 merged"
+    ],
+    "checks": {
+      "authorization": "user explicitly authorized adding remaining SECURITY-AUDIT-36 PR train items to manifest/state",
+      "workspace_safety": "using isolated worktree /private/tmp/fap-api-audit-sec-payment-integrity-01; dirty primary worktree untouched",
+      "deploy_safety_boundary": "no deploy, no production mutation, no production SSH",
+      "focused_local": {
+        "status": "passed_with_existing_file_cache_warnings",
+        "commands": [
+          "cd backend && composer dump-autoload --no-ansi",
+          "cd backend && php artisan test --filter='AlipayPendingCompensationScheduler|PaymentWebhookTrustBoundary|PaymentWebhookIdempotency|OrderGrantProjectionReadonlyOrd1093b7e6' --no-ansi",
+          "cd backend && php artisan test --filter='PaymentRepairEngine|PaymentWebhookTrustBoundary|PaymentWebhookIdempotency' --no-ansi"
+        ],
+        "evidence": "Exit code 0; payment boundary, idempotency, repair, scheduler, and redaction tests passed; warnings were existing file cache warnings."
+      },
+      "manifest_local": {
+        "status": "passed_with_sidecar_for_broad_payment_filter",
+        "commands": [
+          "cd backend && php artisan test --filter=Payment --no-ansi",
+          "cd backend && php artisan test --filter=Alipay --no-ansi"
+        ],
+        "evidence": "Alipay filter passed. Broad Payment filter had two external failures outside changed paths: EmailOutboxLifecycleContextTest checkout fixture 404 and PaymentWebhookCnCallbackTest WeChat signature fixture 400; scoped payment-boundary tests passed."
+      },
+      "acceptance": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-payment-integrity-01.sqlite php artisan migrate --force --no-ansi",
+          "bash backend/scripts/ci_verify_mbti.sh",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<PY\nimport yaml\nfrom pathlib import Path\nyaml.safe_load(Path(\"docs/codex/pr-train.yaml\").read_text())\nPY",
+          "rg raw production order id scan on backend/docs backend/tests docs/codex"
+        ],
+        "evidence": "route:list passed; sqlite migrate passed; ci_verify_mbti.sh passed; diff check passed; manifest/state parse passed; raw production order id scan passed."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-05-31T16:00:28+08:00",
+        "from": "authorized",
+        "to": "in_progress",
+        "note": "Started from latest origin/main after AUDIT-SEC-RESULT-IDENTITY-01 post-merge cleanup."
+      },
+      {
+        "at": "2026-05-31T16:07:16+08:00",
+        "from": "in_progress",
+        "to": "local_scope_validation_in_progress",
+        "note": "Scoped payment integrity implementation completed; focused tests passed; running full acceptance next."
+      },
+      {
+        "at": "2026-05-31T16:14:44+08:00",
+        "from": "local_scope_validation_in_progress",
+        "to": "local_scope_validation_passed",
+        "note": "Focused payment integrity tests, Alipay filter, route list, sqlite migrate, ci_verify_mbti, diff check, manifest parse, and redaction scan passed; broad Payment filter external fixture failures registered as sidecar."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "broad_payment_filter_external_fixture_failures",
+        "status": "registered_non_blocking",
+        "summary": "php artisan test --filter=Payment has two failures outside this PR scope: EmailOutboxLifecycleContextTest checkout fixture returns 404, and PaymentWebhookCnCallbackTest valid WeChat callback fixture returns 400 because signature is empty. Scoped payment-boundary tests and required ci_verify_mbti.sh pass."
+      }
+    ],
+    "next_task": "AUDIT-SEC-CONTENT-PUBLISH-GATES-01",
+    "implementation_summary": [
+      "Bound Alipay pending compensation scheduler to every ten minutes, only stale orders, limit 10, older-than-minutes 60.",
+      "Deferred trusted payment payload digest/forensics promotion until provider signature and order/provider binding validation pass.",
+      "Ignored invalid duplicate webhook payloads without overwriting an existing trusted processed payment event.",
+      "Redacted committed production order number from order grant/projection read-only artifacts."
+    ],
+    "changed_files": [
+      "backend/app/Console/Kernel.php",
+      "backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php",
+      "backend/bootstrap/app.php",
+      "backend/app/Services/Commerce/Webhook/WebhookEntitlementService.php",
+      "backend/docs/commerce/generated/order-grant-projection-readonly-ord-1093b7e6.v1.json",
+      "backend/docs/commerce/order-grant-projection-readonly-ord-1093b7e6.md",
+      "backend/docs/runbooks/alipay-pending-compensation.md",
+      "backend/tests/Feature/Commerce/AlipayPendingCompensationSchedulerTest.php",
+      "backend/tests/Feature/Commerce/OrderGrantProjectionReadonlyOrd1093b7e6Test.php",
+      "backend/tests/Feature/Commerce/PaymentWebhookIdempotencyTest.php",
+      "backend/tests/Feature/Commerce/PaymentWebhookTrustBoundaryTest.php",
+      "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+      "docs/codex/pr-train.yaml",
+      "docs/codex/pr-train-state.json"
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:14:44+08:00",
+  "updated_at": "2026-05-31T16:15:33+08:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -34525,7 +34525,7 @@
     "branch": "audit/sec-payment-integrity-01",
     "base": "main",
     "title": "AUDIT-SEC-PAYMENT-INTEGRITY-01 harden payment integrity boundaries",
-    "status": "local_scope_validation_passed",
+    "status": "pr_open_checks_pending",
     "depends_on": [
       "AUDIT-SEC-RESULT-IDENTITY-01 merged"
     ],
@@ -34562,6 +34562,10 @@
           "rg raw production order id scan on backend/docs backend/tests docs/codex"
         ],
         "evidence": "route:list passed; sqlite migrate passed; ci_verify_mbti.sh passed; diff check passed; manifest/state parse passed; raw production order id scan passed."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1793"
       }
     },
     "failure_reason": null,
@@ -34592,6 +34596,12 @@
         "from": "local_scope_validation_in_progress",
         "to": "local_scope_validation_passed",
         "note": "Focused payment integrity tests, Alipay filter, route list, sqlite migrate, ci_verify_mbti, diff check, manifest parse, and redaction scan passed; broad Payment filter external fixture failures registered as sidecar."
+      },
+      {
+        "at": "2026-05-31T16:15:33+08:00",
+        "from": "local_scope_validation_passed",
+        "to": "pr_open_checks_pending",
+        "note": "Created PR #1793 from audit/sec-payment-integrity-01; waiting for GitHub required checks."
       }
     ],
     "sidecars": [
@@ -34623,6 +34633,9 @@
       "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
       "docs/codex/pr-train.yaml",
       "docs/codex/pr-train-state.json"
-    ]
+    ],
+    "commit_sha": "1b4663df4c0fe6d17d48b0fc78555e09188ee7c4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1793",
+    "pr_number": 1793
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16977,6 +16977,69 @@ prs:
     frontend_fallback_authority: false
     next_task: AUDIT-SEC-PAYMENT-INTEGRITY-01
 
+  - id: AUDIT-SEC-PAYMENT-INTEGRITY-01
+    repo: fap-api
+    branch: audit/sec-payment-integrity-01
+    base: main
+    title: "AUDIT-SEC-PAYMENT-INTEGRITY-01 harden payment integrity boundaries"
+    train_scope: payment_integrity_boundary
+    risk_level: high_security_payment_integrity
+    depends_on:
+      - AUDIT-SEC-RESULT-IDENTITY-01 merged
+    allowed_paths:
+      - backend/app/Console/Commands/*Alipay*
+      - backend/app/Console/Commands/*Payment*
+      - backend/app/Console/Commands/*Commerce*
+      - backend/app/Jobs/Commerce/ReprocessPaymentEventJob.php
+      - backend/app/Services/Commerce/**
+      - backend/app/Services/Payment/**
+      - backend/app/Models/Order.php
+      - backend/app/Models/PaymentEvent.php
+      - backend/app/Models/BenefitGrant.php
+      - backend/config/fap.php
+      - backend/routes/api.php
+      - backend/tests/Feature/Commerce/**
+      - backend/tests/Unit/Commerce/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/commerce/**
+      - backend/docs/runbooks/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Bound Alipay compensation scheduler against provider-polling abuse.
+      - Ensure payment event digest/audit rows are trusted only after provider signature/binding validation.
+      - Remove or redact committed production order details from repo artifacts/docs.
+      - Add focused payment integrity tests.
+    do_not:
+      - Do not deploy, mutate production, run production SSH, or approve production environments.
+      - Do not execute payment compensation against production or mutate production orders.
+      - Do not add new payment providers, routes, migrations, checkout flows, or entitlement products.
+      - Do not modify content packs, CMS content, fap-web, sitemap, llms, Search Channel, or URL submission files.
+    validation:
+      - cd backend && php artisan test --filter=Payment --no-ansi
+      - cd backend && php artisan test --filter=Alipay --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-payment-integrity-01.sqlite php artisan migrate --force --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: AUDIT-SEC-CONTENT-PUBLISH-GATES-01
+
   - id: PR-POL-01
     repo: fap-api
     branch: content/pr-pol-01-policies-dashboard


### PR DESCRIPTION
## Summary
- Bound automatic Alipay pending compensation to a lower provider polling budget: every 10 minutes, stale-only, limit 10, 60 minute age window.
- Deferred trusted payment payload digest/forensics promotion until provider signature and order/provider binding validation pass.
- Preserved repair/reprocess behavior by carrying trusted payload metadata during payment event reprocess.
- Redacted committed production order details from the order grant/projection read-only packet.
- Added focused regression coverage for invalid signature forensics, invalid duplicate preservation, scheduler bounds, and redacted order artifacts.

## Scope validation
- fap-api only.
- No production deploy, production mutation, production SSH, CMS mutation, fap-web change, sitemap/llms/Search Channel/URL submission change.
- BIG5 compiled artifacts generated by local CI were restored and are not included.

## Local validation
- `cd backend && composer dump-autoload --no-ansi`
- `cd backend && php artisan test --filter='AlipayPendingCompensationScheduler|PaymentWebhookTrustBoundary|PaymentWebhookIdempotency|OrderGrantProjectionReadonlyOrd1093b7e6' --no-ansi`
- `cd backend && php artisan test --filter='PaymentRepairEngine|PaymentWebhookTrustBoundary|PaymentWebhookIdempotency' --no-ansi`
- `cd backend && php artisan test --filter=Alipay --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-payment-integrity-01.sqlite php artisan migrate --force --no-ansi`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY'
import yaml
from pathlib import Path
yaml.safe_load(Path('docs/codex/pr-train.yaml').read_text())
PY`
- raw production order id scan: no matches

## Sidecar / non-blocking external failures
`php artisan test --filter=Payment --no-ansi` has two failures outside this PR scope:
- `EmailOutboxLifecycleContextTest`: checkout fixture returns 404.
- `PaymentWebhookCnCallbackTest`: WeChat valid callback fixture returns 400 because test signature fixture is empty.

Current PR-scoped payment-boundary tests, `Alipay` filter, and required MBTI CI chain pass.

## Security wording
Public PR text intentionally avoids exploit-ready reproduction details.
