### PR TITLE
CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO

### DIFF
--- a/backend/docs/seo/career-1046-observability-slo-01.md
+++ b/backend/docs/seo/career-1046-observability-slo-01.md
@@ -1,0 +1,107 @@
+# CAREER-1046-OBSERVABILITY-SLO-01
+
+## 1. Executive Summary
+
+This PR records the read-only observability/SLO baseline for the production
+Career runtime after the 1046-detail rollout.
+
+The long-term operating baseline is:
+
+- EN Career jobs API: `1046`
+- ZH Career jobs API: `1046`
+- runtime public Career slugs: `1046`
+- localized EN/ZH Career detail URLs: `2092`
+- sitemap Career detail URLs: `2092`
+- `llms.txt` Career detail URLs: `2092`
+- complete `llms-full.txt` Career detail URLs: `2092`
+
+This is an observability artifact only. It does not deploy, mutate production
+data, warm or rewrite caches, enqueue Search Channel, or submit URLs.
+
+## 2. SLO Baselines
+
+| Surface | Expected value |
+| --- | ---: |
+| EN Career API jobs | 1046 |
+| ZH Career API jobs | 1046 |
+| Runtime public Career slugs | 1046 |
+| Localized Career detail URLs | 2092 |
+| Sitemap Career URLs | 2092 |
+| `llms.txt` Career URLs | 2092 |
+| Complete `llms-full.txt` Career URLs | 2092 |
+
+Excluded slugs must remain absent from API, sitemap, `llms.txt`, and
+`llms-full.txt`:
+
+- `software-developers`
+- `digital-forensics-analysts`
+- `computer-occupations-all-other`
+
+## 3. Priority Conditions
+
+P0 conditions:
+
+- public Career API count regression
+- excluded slug leakage
+- sitemap or `llms.txt` missing Career URLs
+- private/noindex URL exposure
+- Career detail runtime 404 for a public slug
+
+P1 conditions:
+
+- `llms-full.txt` degraded response rate above budget
+- slow Career API response budget breach
+- stale public authority cache
+- metadata/indexability drift
+
+P2 conditions:
+
+- minor metadata copy drift
+- non-core visual mismatch
+- non-blocking internal link gap
+
+## 4. Observation Cadence
+
+Recommended operating cadence:
+
+- Day 0: post-deploy smoke
+- Day 1: Career API, sitemap, `llms.txt`, `llms-full.txt`, and sample detail check
+- Day 3: trend and degraded artifact review
+- Day 7: Search Channel GO/HOLD review
+
+Search Channel remains closed unless a future explicitly approved task opens it.
+
+## 5. Safety Boundaries
+
+Not performed:
+
+- production write
+- cache mutation
+- database mutation
+- CMS mutation
+- deployment
+- Search Channel enqueue
+- URL submission
+- external search API call
+- fap-web change
+
+Career language remains bounded to occupation information, workstyle context,
+exploratory guidance, interest signals, and decision support.
+
+## 6. Validation
+
+Focused validation:
+
+- `php artisan test --filter=Career1046ObservabilitySlo01 --no-ansi`
+
+The test validates the generated artifact, required no-write flags, expected
+counts, excluded slug boundaries, and consistency with the
+`CareerRuntimeReadModelService`.
+
+## 7. Final Decision
+
+`career_1046_observability_slo_completed_ready_for_hiring_content_authority`
+
+## 8. Next Task
+
+`PR-HIRING-01`

--- a/backend/docs/seo/generated/career-1046-observability-slo-01.v1.json
+++ b/backend/docs/seo/generated/career-1046-observability-slo-01.v1.json
@@ -1,0 +1,63 @@
+{
+  "schema_version": "career_1046_observability_slo.v1",
+  "task": "CAREER-1046-OBSERVABILITY-SLO-01",
+  "final_decision": "career_1046_observability_slo_completed_ready_for_hiring_content_authority",
+  "source_read_model": "career.runtime_projection.ops_read_model.v1",
+  "source_of_truth": "career_runtime_publish_projection",
+  "api_en_expected_count": 1046,
+  "api_zh_expected_count": 1046,
+  "runtime_public_slug_expected_count": 1046,
+  "localized_public_url_expected_count": 2092,
+  "sitemap_expected_career_url_count": 2092,
+  "llms_expected_career_url_count": 2092,
+  "llms_full_expected_career_url_count": 2092,
+  "public_locales": [
+    "en",
+    "zh"
+  ],
+  "excluded_slugs": [
+    "software-developers",
+    "digital-forensics-analysts",
+    "computer-occupations-all-other"
+  ],
+  "excluded_slug_expected_state": "absent_from_api_sitemap_llms_llms_full",
+  "slo_baselines": {
+    "career_api_en_jobs_count": 1046,
+    "career_api_zh_jobs_count": 1046,
+    "runtime_public_career_slugs": 1046,
+    "localized_public_career_urls": 2092,
+    "sitemap_career_urls": 2092,
+    "llms_career_urls": 2092,
+    "llms_full_complete_artifact_career_urls": 2092
+  },
+  "p0_conditions": [
+    "career_api_public_count_regression",
+    "excluded_slug_leakage",
+    "sitemap_or_llms_missing_career_urls",
+    "private_or_noindex_url_exposure",
+    "career_detail_runtime_404_for_public_slug"
+  ],
+  "p1_conditions": [
+    "llms_full_degraded_response_rate_above_budget",
+    "career_api_slow_response_budget_breach",
+    "stale_public_authority_cache",
+    "metadata_indexability_drift"
+  ],
+  "p2_conditions": [
+    "minor_metadata_copy_drift",
+    "non_core_visual_mismatch",
+    "non_blocking_internal_link_gap"
+  ],
+  "observation_cadence": {
+    "day_0": "post_deploy_smoke",
+    "day_1": "career_api_sitemap_llms_llms_full_sample",
+    "day_3": "trend_and_degraded_artifact_review",
+    "day_7": "search_channel_go_hold_review"
+  },
+  "no_production_write": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_cache_mutation": true,
+  "no_deploy": true,
+  "next_task": "PR-HIRING-01"
+}

--- a/backend/tests/Feature/SeoIntel/Career1046ObservabilitySlo01Test.php
+++ b/backend/tests/Feature/SeoIntel/Career1046ObservabilitySlo01Test.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Services\SeoIntel\OpsDashboard\CareerRuntimeReadModelService;
+use Tests\TestCase;
+
+final class Career1046ObservabilitySlo01Test extends TestCase
+{
+    public function test_generated_slo_artifact_records_required_baselines_and_boundaries(): void
+    {
+        $artifactPath = base_path('docs/seo/generated/career-1046-observability-slo-01.v1.json');
+
+        $this->assertFileExists($artifactPath);
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('career_1046_observability_slo.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('CAREER-1046-OBSERVABILITY-SLO-01', $artifact['task'] ?? null);
+        $this->assertSame('career_1046_observability_slo_completed_ready_for_hiring_content_authority', $artifact['final_decision'] ?? null);
+        $this->assertSame(1046, $artifact['api_en_expected_count'] ?? null);
+        $this->assertSame(1046, $artifact['api_zh_expected_count'] ?? null);
+        $this->assertSame(1046, $artifact['runtime_public_slug_expected_count'] ?? null);
+        $this->assertSame(2092, $artifact['localized_public_url_expected_count'] ?? null);
+        $this->assertSame(2092, $artifact['sitemap_expected_career_url_count'] ?? null);
+        $this->assertSame(2092, $artifact['llms_expected_career_url_count'] ?? null);
+        $this->assertSame(2092, $artifact['llms_full_expected_career_url_count'] ?? null);
+
+        $this->assertSame(CareerRuntimeReadModelService::EXCLUDED_SLUGS, $artifact['excluded_slugs'] ?? null);
+        $this->assertContains('career_api_public_count_regression', $artifact['p0_conditions'] ?? []);
+        $this->assertContains('llms_full_degraded_response_rate_above_budget', $artifact['p1_conditions'] ?? []);
+        $this->assertContains('minor_metadata_copy_drift', $artifact['p2_conditions'] ?? []);
+
+        $this->assertTrue((bool) ($artifact['no_production_write'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_search_channel_action'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_url_submission'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_cache_mutation'] ?? false));
+        $this->assertTrue((bool) ($artifact['no_deploy'] ?? false));
+        $this->assertSame('PR-HIRING-01', $artifact['next_task'] ?? null);
+    }
+
+    public function test_slo_baseline_matches_runtime_read_model_fixture(): void
+    {
+        $service = new CareerRuntimeReadModelService(
+            $this->fakeProjection(1046),
+            static fn (): int => 378,
+        );
+
+        $readModel = $service->read();
+        $artifact = json_decode(
+            (string) file_get_contents(base_path('docs/seo/generated/career-1046-observability-slo-01.v1.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR,
+        );
+
+        $this->assertSame($readModel['runtime_public_career_slug_count'], $artifact['runtime_public_slug_expected_count']);
+        $this->assertSame($readModel['localized_public_career_url_count'], $artifact['localized_public_url_expected_count']);
+        $this->assertSame($readModel['sitemap_career_url_count_expected'], $artifact['sitemap_expected_career_url_count']);
+        $this->assertSame($readModel['llms_career_url_count_expected'], $artifact['llms_expected_career_url_count']);
+
+        foreach (CareerRuntimeReadModelService::EXCLUDED_SLUGS as $slug) {
+            $this->assertTrue((bool) data_get($readModel, "excluded_slugs_absent.{$slug}"), $slug);
+        }
+    }
+
+    public function test_generated_report_has_required_sections(): void
+    {
+        $reportPath = base_path('docs/seo/career-1046-observability-slo-01.md');
+
+        $this->assertFileExists($reportPath);
+
+        $report = (string) file_get_contents($reportPath);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. SLO Baselines',
+            '## 3. Priority Conditions',
+            '## 4. Observation Cadence',
+            '## 5. Safety Boundaries',
+            '## 6. Validation',
+            '## 7. Final Decision',
+            '## 8. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+    }
+
+    private function fakeProjection(int $count): CareerRuntimePublishProjectionVisibility
+    {
+        return new class($count) implements CareerRuntimePublishProjectionVisibility
+        {
+            public function __construct(private readonly int $count) {}
+
+            public function itemForSlug(string $slug, string $locale = 'en'): ?array
+            {
+                return null;
+            }
+
+            public function publicDatasetItems(): array
+            {
+                return $this->publicDetailItems();
+            }
+
+            public function publicDetailItems(): array
+            {
+                $items = [];
+
+                for ($i = 1; $i <= $this->count; $i++) {
+                    $items[] = ['slug' => 'career-slug-'.$i];
+                }
+
+                return $items;
+            }
+
+            public function datasetVisible(string $slug): bool
+            {
+                return false;
+            }
+
+            public function searchVisible(string $slug): bool
+            {
+                return false;
+            }
+
+            public function detailRouteEnabled(string $slug): bool
+            {
+                return false;
+            }
+
+            public function robotsIndexable(string $slug): bool
+            {
+                return false;
+            }
+
+            public function releaseGatePass(string $slug): bool
+            {
+                return false;
+            }
+
+            public function familyHubLive(string $slug): bool
+            {
+                return false;
+            }
+        };
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21731,7 +21731,7 @@
       "branch": "codex/career-1046-ops-read-model-repair-01",
       "base": "main",
       "title": "CAREER-1046-OPS-READ-MODEL-REPAIR-01 career runtime read model repair",
-      "status": "open",
+      "status": "merged",
       "depends_on": [],
       "checks": {
         "focused_phpunit": {
@@ -21789,19 +21789,28 @@
           "status": "pass",
           "command": "vendor/bin/pint --test",
           "evidence": "3654 files passed."
+        },
+        "github_checks": {
+          "status": "pass",
+          "evidence": "GitHub checks green on PR #1784: hygiene, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, Semgrep blocking secrets, Semgrep OSS."
+        },
+        "post_merge_revalidate": {
+          "status": "pass",
+          "command": "php artisan test --filter=Career1046OpsReadModelRepair01 --no-ansi --display-warnings",
+          "evidence": "2 tests passed, 37 assertions on origin/main merge commit 530f412f8996b8223a2c6a36dd93fee5d3135584."
         }
       },
       "failure_reason": null,
-      "commit_sha": "2f8d17ec990796f774db3215db94719acd363a08",
+      "commit_sha": "b2713e384d5a6d0b650df56222eac19831df21b8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1784",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T15:48:04+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": false,
-        "post_merge_revalidated": null
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
       "transitions": [
         {
@@ -21833,10 +21842,17 @@
           "from": "pr_open",
           "to": "ci_fix_local_validation_passed",
           "note": "Fixed verify-bigfive freeze classifier false positive for the Career SeoIntel OpsDashboard read model and reran focused PR, BigFive freeze, Pint, JSON/YAML, and diff checks locally."
+        },
+        {
+          "at": "2026-05-31T15:48:04+08:00",
+          "from": "ci_fix_local_validation_passed",
+          "to": "merged",
+          "note": "PR #1784 checks passed, squash merged at 530f412f8996b8223a2c6a36dd93fee5d3135584, remote branch deleted, local branch deleted, and post-merge focused test passed."
         }
       ],
       "sidecars": [],
-      "next_task": "CAREER-1046-OBSERVABILITY-SLO-01"
+      "next_task": "CAREER-1046-OBSERVABILITY-SLO-01",
+      "merge_commit_sha": "530f412f8996b8223a2c6a36dd93fee5d3135584"
     },
     "CAREER-1046-OBSERVABILITY-SLO-01": {
       "id": "CAREER-1046-OBSERVABILITY-SLO-01",
@@ -21844,24 +21860,79 @@
       "branch": "codex/career-1046-observability-slo-01",
       "base": "main",
       "title": "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "CAREER-1046-OPS-READ-MODEL-REPAIR-01"
       ],
-      "checks": {},
+      "checks": {
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=Career1046ObservabilitySlo01 --no-ansi",
+          "evidence": "3 tests passed, 37 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "207 routes listed successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3661 files passed after separate IQ/AttemptEmail Pint cleanup PR #1792 merged."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "composer validate --strict",
+          "evidence": "./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool ... && yaml.safe_load(...)",
+          "evidence": "Generated artifact, train state, and manifest parse successfully."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed before staging; cached check rerun before commit."
+        }
+      },
       "failure_reason": null,
-      "commit_sha": null,
+      "commit_sha": "c56c1f7dd25a5d254facf56b24dc0c9f008f382a",
       "pr_url": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [],
+      "transitions": [
+        {
+          "at": "2026-05-31T15:52:00+08:00",
+          "from": "pending",
+          "to": "in_progress",
+          "note": "Started PR2 from latest origin/main after confirming PR1 merge commit is present."
+        },
+        {
+          "at": "2026-05-31T16:18:00+08:00",
+          "from": "in_progress",
+          "to": "local_validation_passed",
+          "note": "Generated SLO report/artifact/test, rebased after IQ/AttemptEmail Pint cleanup PR #1792, and passed focused PHPUnit, route:list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks."
+        },
+        {
+          "at": "2026-05-31T16:22:00+08:00",
+          "from": "local_validation_passed",
+          "to": "committed",
+          "note": "Committed scoped PR2 implementation at c56c1f7dd25a5d254facf56b24dc0c9f008f382a."
+        }
+      ],
       "sidecars": [],
       "next_task": "PR-HIRING-01"
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21860,7 +21860,7 @@
       "branch": "codex/career-1046-observability-slo-01",
       "base": "main",
       "title": "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "CAREER-1046-OPS-READ-MODEL-REPAIR-01"
       ],
@@ -21902,8 +21902,8 @@
         }
       },
       "failure_reason": null,
-      "commit_sha": "c56c1f7dd25a5d254facf56b24dc0c9f008f382a",
-      "pr_url": null,
+      "commit_sha": "9b60bea48210d31334b9939d9bf3eb14fc3e41c8",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1794",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -21931,6 +21931,12 @@
           "from": "local_validation_passed",
           "to": "committed",
           "note": "Committed scoped PR2 implementation at c56c1f7dd25a5d254facf56b24dc0c9f008f382a."
+        },
+        {
+          "at": "2026-05-31T16:25:00+08:00",
+          "from": "committed",
+          "to": "pr_open",
+          "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1794; GitHub checks pending."
         }
       ],
       "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17458,7 +17458,7 @@ prs:
     base: main
     title: "CAREER-1046-OPS-READ-MODEL-REPAIR-01 career runtime read model repair"
     train_scope: career_1046_growth_foundation
-    status: in_progress
+    status: merged
     allowed_paths:
       - backend/app/Services/SeoIntel/OpsDashboard/CareerRuntimeReadModelService.php
       - backend/docs/seo/career-1046-ops-read-model-repair-01.md
@@ -17508,7 +17508,7 @@ prs:
     base: main
     title: "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO"
     train_scope: career_1046_growth_foundation
-    status: pending
+    status: in_progress
     allowed_paths:
       - backend/docs/seo/career-1046-observability-slo-01.md
       - backend/docs/seo/generated/career-1046-observability-slo-01.v1.json


### PR DESCRIPTION
## What changed
- Added a read-only Career 1046 observability/SLO report and generated JSON artifact.
- Added a focused SeoIntel test that validates expected public counts, excluded slug boundaries, no-write flags, and consistency with the Career runtime read model.
- Reconciled PR train state from PR1 and moved the current task through local validation.

## Why
- The Career 1046 rollout needs a stable operating baseline for API counts, localized URL counts, sitemap/llms surfaces, excluded slug leakage, and Day 0/1/3/7 observation cadence before the hiring/content and growth foundation PRs proceed.

## Validation
- `php artisan test --filter=Career1046ObservabilitySlo01 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/career-1046-observability-slo-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `yaml.safe_load` for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production read/write, deploy, cache mutation, Search Channel action, or URL submission.
- No fap-web changes.
- Search Channel GO/HOLD remains a future explicitly approved SEO Ops task.

## Sidecar
- Repo-wide Pint was unblocked by separate mechanical cleanup PR #1792 before this PR was finalized.