### PR TITLE
PR-HIRING-01 hiring content authority package

### DIFF
--- a/backend/docs/seo/generated/pr-hiring-01-content-authority.v1.json
+++ b/backend/docs/seo/generated/pr-hiring-01-content-authority.v1.json
@@ -1,0 +1,90 @@
+{
+  "schema_version": "pr_hiring_01_content_authority.v1",
+  "task": "PR-HIRING-01",
+  "final_decision": "pr_hiring_content_authority_package_ready_for_human_review",
+  "source_of_truth": "backend_content_pages_and_operator_reviewed_import_package",
+  "careers_content_page_topology": {
+    "en_baseline_contains_careers": true,
+    "zh_baseline_contains_careers": true,
+    "runtime_publish_changed_by_this_pr": false
+  },
+  "roles_count": 3,
+  "role_keys": [
+    "technical-partner-engineering-lead",
+    "product-design-brand-systems-lead",
+    "growth-seo-content-operations-lead"
+  ],
+  "roles": [
+    {
+      "role_key": "technical-partner-engineering-lead",
+      "locale": "en",
+      "status": "draft_review_only",
+      "title": "Technical Partner / Engineering Lead",
+      "summary": "Lead backend, frontend, release, and observability work for the Career 1046 operating system while preserving content authority and claim boundaries.",
+      "review_required": [
+        "founder_review",
+        "technical_scope_review",
+        "legal_terms_review"
+      ],
+      "runtime_exposure_allowed": false,
+      "sitemap_llms_exposure_allowed": false,
+      "footer_exposure_allowed": false
+    },
+    {
+      "role_key": "product-design-brand-systems-lead",
+      "locale": "en",
+      "status": "draft_review_only",
+      "title": "Product Design & Brand Systems Lead",
+      "summary": "Shape the Career and assessment experience through product UI, design systems, content hierarchy, and bilingual brand consistency.",
+      "review_required": [
+        "founder_review",
+        "brand_review",
+        "legal_terms_review"
+      ],
+      "runtime_exposure_allowed": false,
+      "sitemap_llms_exposure_allowed": false,
+      "footer_exposure_allowed": false
+    },
+    {
+      "role_key": "growth-seo-content-operations-lead",
+      "locale": "en",
+      "status": "draft_review_only",
+      "title": "Growth SEO & Content Operations Lead",
+      "summary": "Operate topic, article, career, and discoverability workflows with backend authority, Search Channel discipline, and bounded claim language.",
+      "review_required": [
+        "founder_review",
+        "seo_claim_review",
+        "legal_terms_review"
+      ],
+      "runtime_exposure_allowed": false,
+      "sitemap_llms_exposure_allowed": false,
+      "footer_exposure_allowed": false
+    }
+  ],
+  "claim_boundary_status": {
+    "forbidden_claim_hits": [],
+    "requires_human_review_before_publish": true,
+    "notes": [
+      "Compensation, title, location, contract terms, and legal hiring language require separate approval.",
+      "The package avoids promises about pay, partnership grants, selection suitability, career outcomes, clinical outcomes, or psychometric prediction."
+    ]
+  },
+  "exposure_guard": {
+    "draft_import_must_not_enter_sitemap": true,
+    "draft_import_must_not_enter_llms": true,
+    "draft_import_must_not_enter_footer": true,
+    "frontend_fallback_must_not_be_authority": true,
+    "search_channel_must_remain_closed": true
+  },
+  "future_human_review_required": true,
+  "future_cms_import_required": true,
+  "future_publish_required": true,
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_frontend_fallback_authority": true,
+  "draft_import_not_exposed": true,
+  "next_task": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01"
+}

--- a/backend/docs/seo/import-packages/pr-hiring-01.import.v1.json
+++ b/backend/docs/seo/import-packages/pr-hiring-01.import.v1.json
@@ -1,0 +1,78 @@
+{
+  "schema_version": "pr_hiring_01_import.v1",
+  "task": "PR-HIRING-01",
+  "package_type": "backend_content_pages_hiring_draft_import",
+  "non_runtime": true,
+  "publish_state": "draft_review_only",
+  "cms_mutation_performed": false,
+  "runtime_exposure_allowed": false,
+  "sitemap_llms_exposure_allowed": false,
+  "footer_exposure_allowed": false,
+  "search_channel_action_allowed": false,
+  "page_key": "careers",
+  "locale": "en",
+  "roles": [
+    {
+      "role_key": "technical-partner-engineering-lead",
+      "title": "Technical Partner / Engineering Lead",
+      "status": "draft_review_only",
+      "intro": "FermatMind needs a senior engineering partner to make the Career 1046 runtime easier to operate, observe, and extend without weakening backend authority boundaries.",
+      "responsibilities": [
+        "Own Laravel and Next.js integration boundaries for career, result, and discoverability surfaces.",
+        "Improve release train observability, read models, and operator-facing diagnostics.",
+        "Keep frontend rendering separate from CMS and backend content authority.",
+        "Design technical paths for dynamic career explanation slots without static build explosion."
+      ],
+      "review_notes": [
+        "Confirm title, contract structure, location, and legal terms before import.",
+        "Do not imply partnership grant, employment terms, compensation, or current opening availability until approved."
+      ]
+    },
+    {
+      "role_key": "product-design-brand-systems-lead",
+      "title": "Product Design & Brand Systems Lead",
+      "status": "draft_review_only",
+      "intro": "FermatMind needs a design lead to turn assessment, report, and career surfaces into a consistent bilingual product system.",
+      "responsibilities": [
+        "Improve career page hierarchy, result page readability, and bilingual UX consistency.",
+        "Define reusable visual patterns for assessment, report, article, and career modules.",
+        "Partner with content and engineering on media, alt text, and layout quality.",
+        "Preserve a calm, trustworthy product experience rather than a marketing-only page style."
+      ],
+      "review_notes": [
+        "Confirm portfolio requirements and collaboration model before import.",
+        "Do not imply employment terms, compensation, or hiring process commitments until approved."
+      ]
+    },
+    {
+      "role_key": "growth-seo-content-operations-lead",
+      "title": "Growth SEO & Content Operations Lead",
+      "status": "draft_review_only",
+      "intro": "FermatMind needs an operator who can grow articles, career content, and GEO surfaces while keeping backend authority, Search Channel gates, and claim boundaries intact.",
+      "responsibilities": [
+        "Run content inventory, internal linking, sitemap, llms, and observation workflows.",
+        "Coordinate human review for article, career, content page, and media batches.",
+        "Maintain claim-safe wording for psychology, career, and assessment topics.",
+        "Turn data from scans and smoke tests into prioritized PR trains."
+      ],
+      "review_notes": [
+        "Confirm decision rights, review workflow, and publication authority before import.",
+        "Do not imply guaranteed traffic, ranking, compensation, or career outcomes until approved."
+      ]
+    }
+  ],
+  "claim_boundary": {
+    "forbidden_claim_hits": [],
+    "blocked_claims": [
+      "guaranteed_compensation",
+      "equity_transfer",
+      "hiring_suitability_guarantee",
+      "career_success_guarantee",
+      "diagnosis_claim",
+      "treatment_claim",
+      "cure_claim",
+      "salary_prediction",
+      "psychometric_job_success_prediction"
+    ]
+  }
+}

--- a/backend/docs/seo/pr-hiring-01-content-authority.md
+++ b/backend/docs/seo/pr-hiring-01-content-authority.md
@@ -1,0 +1,83 @@
+# PR-HIRING-01
+
+## 1. Executive Summary
+
+This PR prepares a backend-owned, non-runtime hiring content authority package
+for three first-wave roles connected to the Career 1046 growth foundation:
+
+- technical partner / engineering lead
+- product design and brand systems lead
+- growth SEO and content operations lead
+
+The package is draft/import-only. It does not publish pages, mutate production
+CMS, expose footer links, enqueue Search Channel, submit URLs, or use fap-web
+fallback content as authority.
+
+## 2. Authority Boundary
+
+The intended authority layer is backend `content_pages` plus an operator
+reviewed import package. The frontend may render approved CMS content later,
+but it must not become the source of hiring copy.
+
+The existing English content-page baseline already contains a `careers` node,
+so this PR does not add runtime content-page schema keys.
+
+## 3. Draft Roles
+
+| Role key | Status | Runtime exposure |
+| --- | --- | --- |
+| `technical-partner-engineering-lead` | `draft_review_only` | false |
+| `product-design-brand-systems-lead` | `draft_review_only` | false |
+| `growth-seo-content-operations-lead` | `draft_review_only` | false |
+
+Each draft contains role intent, responsibilities, review notes, and claim
+boundaries. Compensation, title, location, contract terms, and legal hiring
+language require human approval before any CMS import or publish task.
+
+## 4. Discoverability Boundary
+
+The draft package must remain absent from:
+
+- sitemap
+- `llms.txt`
+- `llms-full.txt`
+- footer/nav links
+- Search Channel queue
+- public runtime pages
+
+## 5. Claim Boundary
+
+The package avoids unsupported claims about:
+
+- guaranteed compensation or employment terms
+- equity transfer or partnership grants
+- hiring suitability guarantees
+- career success guarantees
+- clinical, diagnosis, treatment, or cure outcomes
+- salary prediction or psychometric job success prediction
+
+## 6. Validation
+
+Focused validation:
+
+- `php artisan test --filter=PrHiring01ContentAuthority --no-ansi`
+
+The test validates the generated artifact, import package, no-exposure flags,
+role count, claim boundary markers, and report sections.
+
+## 7. What Was Not Done
+
+- No production CMS mutation.
+- No runtime publish.
+- No deployment.
+- No fap-web footer/nav change.
+- No Search Channel enqueue.
+- No URL submission.
+
+## 8. Final Decision
+
+`pr_hiring_content_authority_package_ready_for_human_review`
+
+## 9. Next Task
+
+`CAREER-1046-INTERNAL-LINKING-AUTHORITY-01`

--- a/backend/tests/Feature/SeoIntel/PrHiring01ContentAuthorityTest.php
+++ b/backend/tests/Feature/SeoIntel/PrHiring01ContentAuthorityTest.php
@@ -1,0 +1,153 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PrHiring01ContentAuthorityTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_records_non_runtime_boundaries(): void
+    {
+        $payload = $this->artifact();
+
+        $this->assertSame('pr_hiring_01_content_authority.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('PR-HIRING-01', $payload['task'] ?? null);
+        $this->assertSame('backend_content_pages_and_operator_reviewed_import_package', $payload['source_of_truth'] ?? null);
+        $this->assertSame(3, $payload['roles_count'] ?? null);
+        $this->assertTrue((bool) data_get($payload, 'careers_content_page_topology.en_baseline_contains_careers'));
+        $this->assertTrue((bool) data_get($payload, 'careers_content_page_topology.zh_baseline_contains_careers'));
+        $this->assertFalse((bool) data_get($payload, 'careers_content_page_topology.runtime_publish_changed_by_this_pr'));
+
+        foreach ([
+            'no_cms_mutation',
+            'no_publish',
+            'no_deploy',
+            'no_search_channel_action',
+            'no_url_submission',
+            'no_frontend_fallback_authority',
+            'draft_import_not_exposed',
+        ] as $flag) {
+            $this->assertTrue((bool) ($payload[$flag] ?? false), $flag);
+        }
+    }
+
+    #[Test]
+    public function import_package_contains_three_draft_roles_and_no_exposure(): void
+    {
+        $payload = $this->importPackage();
+
+        $this->assertSame('pr_hiring_01_import.v1', $payload['schema_version'] ?? null);
+        $this->assertTrue((bool) ($payload['non_runtime'] ?? false));
+        $this->assertSame('draft_review_only', $payload['publish_state'] ?? null);
+        $this->assertFalse((bool) ($payload['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($payload['runtime_exposure_allowed'] ?? true));
+        $this->assertFalse((bool) ($payload['sitemap_llms_exposure_allowed'] ?? true));
+        $this->assertFalse((bool) ($payload['footer_exposure_allowed'] ?? true));
+        $this->assertFalse((bool) ($payload['search_channel_action_allowed'] ?? true));
+        $this->assertSame('careers', $payload['page_key'] ?? null);
+        $this->assertSame('en', $payload['locale'] ?? null);
+
+        $roles = collect($payload['roles'] ?? [])->keyBy('role_key');
+
+        $this->assertEqualsCanonicalizing([
+            'technical-partner-engineering-lead',
+            'product-design-brand-systems-lead',
+            'growth-seo-content-operations-lead',
+        ], $roles->keys()->all());
+
+        foreach ($roles as $role) {
+            $this->assertSame('draft_review_only', $role['status'] ?? null);
+            $this->assertNotEmpty($role['intro'] ?? null);
+            $this->assertNotEmpty($role['responsibilities'] ?? null);
+            $this->assertNotEmpty($role['review_notes'] ?? null);
+        }
+    }
+
+    #[Test]
+    public function hiring_package_remains_claim_safe(): void
+    {
+        $artifact = $this->artifact();
+        $importPackage = $this->importPackage();
+
+        $this->assertSame([], data_get($artifact, 'claim_boundary_status.forbidden_claim_hits'));
+        $this->assertSame([], data_get($importPackage, 'claim_boundary.forbidden_claim_hits'));
+
+        $text = strtolower(json_encode([$artifact, $importPackage], JSON_THROW_ON_ERROR));
+
+        foreach ([
+            'salary guarantee',
+            'career success guarantee',
+            'hiring suitability guarantee',
+            'best career for you',
+            'diagnosis product',
+            'treatment product',
+            'cure outcome',
+            'equity transfer',
+            'guaranteed compensation',
+            'psychometric job success prediction',
+        ] as $forbiddenPhrase) {
+            $this->assertStringNotContainsString($forbiddenPhrase, $text, $forbiddenPhrase);
+        }
+    }
+
+    #[Test]
+    public function report_has_required_sections_and_next_task(): void
+    {
+        $reportPath = base_path('docs/seo/pr-hiring-01-content-authority.md');
+
+        $this->assertFileExists($reportPath);
+
+        $report = (string) file_get_contents($reportPath);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. Authority Boundary',
+            '## 3. Draft Roles',
+            '## 4. Discoverability Boundary',
+            '## 5. Claim Boundary',
+            '## 6. Validation',
+            '## 7. What Was Not Done',
+            '## 8. Final Decision',
+            '## 9. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+
+        $this->assertSame(
+            'pr_hiring_content_authority_package_ready_for_human_review',
+            $this->artifact()['final_decision'] ?? null,
+        );
+        $this->assertSame(
+            'CAREER-1046-INTERNAL-LINKING-AUTHORITY-01',
+            $this->artifact()['next_task'] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/pr-hiring-01-content-authority.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function importPackage(): array
+    {
+        $path = base_path('docs/seo/import-packages/pr-hiring-01.import.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21860,7 +21860,7 @@
       "branch": "codex/career-1046-observability-slo-01",
       "base": "main",
       "title": "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "CAREER-1046-OPS-READ-MODEL-REPAIR-01"
       ],
@@ -21899,19 +21899,28 @@
           "status": "pass",
           "command": "git diff --check && git diff --cached --check",
           "evidence": "Whitespace checks passed before staging; cached check rerun before commit."
+        },
+        "github_checks": {
+          "status": "pass",
+          "evidence": "GitHub checks green on PR #1794: hygiene, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, Semgrep blocking secrets, Semgrep OSS."
+        },
+        "post_merge_revalidate": {
+          "status": "pass",
+          "command": "php artisan test --filter=Career1046ObservabilitySlo01 --no-ansi",
+          "evidence": "3 tests passed, 37 assertions on origin/main merge commit 1f6694b12db6a4f35c65f2fe5e753243bce01eae."
         }
       },
       "failure_reason": null,
       "commit_sha": "9b60bea48210d31334b9939d9bf3eb14fc3e41c8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1794",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T16:29:35+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
       "transitions": [
         {
@@ -21937,10 +21946,17 @@
           "from": "committed",
           "to": "pr_open",
           "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1794; GitHub checks pending."
+        },
+        {
+          "at": "2026-05-31T16:29:35+08:00",
+          "from": "pr_open",
+          "to": "merged",
+          "note": "PR #1794 checks passed, squash merged at 1f6694b12db6a4f35c65f2fe5e753243bce01eae, remote branch deleted, local branch deleted, and post-merge focused test passed."
         }
       ],
       "sidecars": [],
-      "next_task": "PR-HIRING-01"
+      "next_task": "PR-HIRING-01",
+      "merge_commit_sha": "1f6694b12db6a4f35c65f2fe5e753243bce01eae"
     },
     "PR-HIRING-01": {
       "id": "PR-HIRING-01",
@@ -21948,24 +21964,79 @@
       "branch": "codex/pr-hiring-01-content-authority",
       "base": "main",
       "title": "PR-HIRING-01 hiring content authority package",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "CAREER-1046-OBSERVABILITY-SLO-01"
       ],
-      "checks": {},
+      "checks": {
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=PrHiring01ContentAuthority --no-ansi",
+          "evidence": "4 tests passed, 67 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "207 routes listed successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3662 files passed."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "composer validate --strict",
+          "evidence": "./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool ... && yaml.safe_load(...)",
+          "evidence": "Generated artifact, import package, train state, and manifest parse successfully."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed before staging; cached check rerun before commit."
+        }
+      },
       "failure_reason": null,
-      "commit_sha": null,
+      "commit_sha": "06516fa0000be81e680337a7937c7e773ac73870",
       "pr_url": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [],
+      "transitions": [
+        {
+          "at": "2026-05-31T16:34:00+08:00",
+          "from": "pending",
+          "to": "in_progress",
+          "note": "Started PR-HIRING-01 from origin/main after confirming PR #1794 merge commit is present and post-merge focused revalidate passed."
+        },
+        {
+          "at": "2026-05-31T16:39:00+08:00",
+          "from": "in_progress",
+          "to": "local_validation_passed",
+          "note": "Generated hiring draft/import package, report, artifact, and focused test; passed focused PHPUnit, route:list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks."
+        },
+        {
+          "at": "2026-05-31T16:43:00+08:00",
+          "from": "local_validation_passed",
+          "to": "committed",
+          "note": "Committed scoped PR-HIRING-01 implementation at 06516fa0000be81e680337a7937c7e773ac73870."
+        }
+      ],
       "sidecars": [],
       "next_task": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01"
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21964,7 +21964,7 @@
       "branch": "codex/pr-hiring-01-content-authority",
       "base": "main",
       "title": "PR-HIRING-01 hiring content authority package",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "CAREER-1046-OBSERVABILITY-SLO-01"
       ],
@@ -22006,8 +22006,8 @@
         }
       },
       "failure_reason": null,
-      "commit_sha": "06516fa0000be81e680337a7937c7e773ac73870",
-      "pr_url": null,
+      "commit_sha": "0067534e49b55781e88fae0568b58a0204c8e1b6",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1795",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -22035,6 +22035,12 @@
           "from": "local_validation_passed",
           "to": "committed",
           "note": "Committed scoped PR-HIRING-01 implementation at 06516fa0000be81e680337a7937c7e773ac73870."
+        },
+        {
+          "at": "2026-05-31T16:46:00+08:00",
+          "from": "committed",
+          "to": "pr_open",
+          "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1795; GitHub checks pending."
         }
       ],
       "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17571,7 +17571,7 @@ prs:
     base: main
     title: "CAREER-1046-OBSERVABILITY-SLO-01 career runtime observability SLO"
     train_scope: career_1046_growth_foundation
-    status: in_progress
+    status: merged
     allowed_paths:
       - backend/docs/seo/career-1046-observability-slo-01.md
       - backend/docs/seo/generated/career-1046-observability-slo-01.v1.json
@@ -17606,7 +17606,7 @@ prs:
     base: main
     title: "PR-HIRING-01 hiring content authority package"
     train_scope: career_1046_growth_foundation
-    status: pending
+    status: in_progress
     allowed_paths:
       - backend/docs/seo/pr-hiring-01-content-authority.md
       - backend/docs/seo/generated/pr-hiring-01-content-authority.v1.json


### PR DESCRIPTION
## What changed
- Added a backend-owned, non-runtime hiring content authority report.
- Added a generated JSON artifact and import package for three draft-review-only roles.
- Added a focused SeoIntel test for no-publish/no-exposure flags, role count, claim boundaries, and report sections.
- Reconciled the train ledger after CAREER-1046-OBSERVABILITY-SLO-01 merged.

## Why
- The Career 1046 growth foundation needs hiring/careers copy prepared as backend authority, not frontend fallback, before any future human-reviewed CMS import or publish task.

## Validation
- `php artisan test --filter=PrHiring01ContentAuthority --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/pr-hiring-01-content-authority.v1.json >/dev/null`
- `python3 -m json.tool backend/docs/seo/import-packages/pr-hiring-01.import.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `yaml.safe_load` for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation or runtime publish.
- No fap-web/footer/nav changes.
- No sitemap, llms, Search Channel, URL submission, deploy, or production action.
- Compensation, location, legal terms, and publication require future explicit human approval.