### PR TITLE
AUDIT-SEC-CONTENT-PUBLISH-GATES-01: harden content publication gates

### DIFF
--- a/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
+++ b/backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
@@ -35,6 +35,7 @@ final class CareerFullVisiblePublicationGate
             'found_published_locale_rows' => $this->foundPublishedLocaleRows($liveAcceptance),
             'release_gate_pass_count' => $this->releaseGatePassCount($liveAcceptance),
             'forbidden_exposure_counts' => $this->forbiddenExposureCounts($liveAcceptance),
+            'forbidden_exposure_evidence_present' => $this->forbiddenExposureEvidencePresent($liveAcceptance),
             'product_claim' => $this->productClaim($liveAcceptance, $targetPublicTotal, $expectedLocaleRows),
         ];
     }
@@ -102,6 +103,14 @@ final class CareerFullVisiblePublicationGate
             if ($count > 0) {
                 $blockers[] = $this->blocker('product_forbidden_'.$key.'_present', [
                     'actual' => $count,
+                ]);
+            }
+        }
+
+        foreach ($summary['forbidden_exposure_evidence_present'] as $surface => $present) {
+            if (! $present) {
+                $blockers[] = $this->blocker('product_forbidden_'.$surface.'_evidence_missing', [
+                    'message' => 'Full visible publication claims require explicit forbidden URL evidence for sitemap, llms, and llms_full surfaces.',
                 ]);
             }
         }
@@ -243,6 +252,8 @@ final class CareerFullVisiblePublicationGate
         $publicDetailIndexableCount = $this->publicDetailIndexableCount($payload);
         $foundPublishedLocaleRows = $this->foundPublishedLocaleRows($payload);
         $releaseGatePassCount = $this->releaseGatePassCount($payload);
+        $forbiddenExposureCounts = $this->forbiddenExposureCounts($payload);
+        $forbiddenExposureEvidencePresent = $this->forbiddenExposureEvidencePresent($payload);
         $partitionAccountingTotal = $this->intAtAny($payload, [
             'partition_accounting.final_public_accounted_total',
             'final_public_accounted_total',
@@ -253,7 +264,9 @@ final class CareerFullVisiblePublicationGate
             && $detailReadyCount === $targetPublicTotal
             && $publicDetailIndexableCount === $targetPublicTotal
             && $foundPublishedLocaleRows === $expectedLocaleRows
-            && $releaseGatePassCount === $expectedLocaleRows;
+            && $releaseGatePassCount === $expectedLocaleRows
+            && ! in_array(false, $forbiddenExposureEvidencePresent, true)
+            && array_sum($forbiddenExposureCounts) === 0;
 
         return [
             'claim_policy_version' => 'career_product_visible_claim.v1',
@@ -274,6 +287,8 @@ final class CareerFullVisiblePublicationGate
                 'found_published_locale_rows' => $foundPublishedLocaleRows,
                 'release_gate_pass_count' => $releaseGatePassCount,
                 'partition_accounting_total' => $partitionAccountingTotal,
+                'forbidden_exposure_counts' => $forbiddenExposureCounts,
+                'forbidden_exposure_evidence_present' => $forbiddenExposureEvidencePresent,
             ],
             'blocked_claims' => $visibleDetailClaimAllowed ? [] : [
                 $targetPublicTotal.'_visible_directory_members',
@@ -290,7 +305,7 @@ final class CareerFullVisiblePublicationGate
     private function forbiddenExposureCounts(array $payload): array
     {
         return [
-            'sitemap_noindex_urls' => $this->intAtAny($payload, [
+            'sitemap_noindex_urls' => $this->countAtAny($payload, [
                 'product_surface.sitemap_noindex_url_count',
                 'product_surface.sitemap_noindex_urls',
                 'sitemap.noindex_url_count',
@@ -298,7 +313,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.sitemap_noindex_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_noindex_urls',
             ]) ?? 0,
-            'sitemap_404_urls' => $this->intAtAny($payload, [
+            'sitemap_404_urls' => $this->countAtAny($payload, [
                 'product_surface.sitemap_404_url_count',
                 'product_surface.sitemap_404_urls',
                 'sitemap.not_found_url_count',
@@ -306,7 +321,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.sitemap_404_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_404_urls',
             ]) ?? 0,
-            'sitemap_redirect_source_urls' => $this->intAtAny($payload, [
+            'sitemap_redirect_source_urls' => $this->countAtAny($payload, [
                 'product_surface.sitemap_redirect_source_url_count',
                 'product_surface.sitemap_redirect_source_urls',
                 'sitemap.redirect_source_url_count',
@@ -314,7 +329,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.sitemap_redirect_source_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_redirect_source_urls',
             ]) ?? 0,
-            'llms_noindex_urls' => $this->intAtAny($payload, [
+            'llms_noindex_urls' => $this->countAtAny($payload, [
                 'product_surface.llms_noindex_url_count',
                 'product_surface.llms_noindex_urls',
                 'llms.noindex_url_count',
@@ -322,7 +337,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.llms_noindex_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_noindex_urls',
             ]) ?? 0,
-            'llms_404_urls' => $this->intAtAny($payload, [
+            'llms_404_urls' => $this->countAtAny($payload, [
                 'product_surface.llms_404_url_count',
                 'product_surface.llms_404_urls',
                 'llms.not_found_url_count',
@@ -330,7 +345,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.llms_404_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_404_urls',
             ]) ?? 0,
-            'llms_redirect_source_urls' => $this->intAtAny($payload, [
+            'llms_redirect_source_urls' => $this->countAtAny($payload, [
                 'product_surface.llms_redirect_source_url_count',
                 'product_surface.llms_redirect_source_urls',
                 'llms.redirect_source_url_count',
@@ -338,7 +353,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.llms_redirect_source_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_redirect_source_urls',
             ]) ?? 0,
-            'llms_full_noindex_urls' => $this->intAtAny($payload, [
+            'llms_full_noindex_urls' => $this->countAtAny($payload, [
                 'product_surface.llms_full_noindex_url_count',
                 'product_surface.llms_full_noindex_urls',
                 'llms_full.noindex_url_count',
@@ -346,7 +361,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.llms_full_noindex_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_noindex_urls',
             ]) ?? 0,
-            'llms_full_404_urls' => $this->intAtAny($payload, [
+            'llms_full_404_urls' => $this->countAtAny($payload, [
                 'product_surface.llms_full_404_url_count',
                 'product_surface.llms_full_404_urls',
                 'llms_full.not_found_url_count',
@@ -354,7 +369,7 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.llms_full_404_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_404_urls',
             ]) ?? 0,
-            'llms_full_redirect_source_urls' => $this->intAtAny($payload, [
+            'llms_full_redirect_source_urls' => $this->countAtAny($payload, [
                 'product_surface.llms_full_redirect_source_url_count',
                 'product_surface.llms_full_redirect_source_urls',
                 'llms_full.redirect_source_url_count',
@@ -362,6 +377,76 @@ final class CareerFullVisiblePublicationGate
                 'forbidden_exposure.llms_full_redirect_source_urls',
                 'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_redirect_source_urls',
             ]) ?? 0,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return array{sitemap: bool, llms: bool, llms_full: bool}
+     */
+    private function forbiddenExposureEvidencePresent(array $payload): array
+    {
+        return [
+            'sitemap' => $this->hasAny($payload, [
+                'product_surface.sitemap_noindex_url_count',
+                'product_surface.sitemap_noindex_urls',
+                'product_surface.sitemap_404_url_count',
+                'product_surface.sitemap_404_urls',
+                'product_surface.sitemap_redirect_source_url_count',
+                'product_surface.sitemap_redirect_source_urls',
+                'sitemap.noindex_url_count',
+                'sitemap.noindex_urls',
+                'sitemap.not_found_url_count',
+                'sitemap.404_urls',
+                'sitemap.redirect_source_url_count',
+                'sitemap.redirect_source_urls',
+                'forbidden_exposure.sitemap_noindex_urls',
+                'forbidden_exposure.sitemap_404_urls',
+                'forbidden_exposure.sitemap_redirect_source_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_noindex_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_404_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.sitemap_redirect_source_urls',
+            ]),
+            'llms' => $this->hasAny($payload, [
+                'product_surface.llms_noindex_url_count',
+                'product_surface.llms_noindex_urls',
+                'product_surface.llms_404_url_count',
+                'product_surface.llms_404_urls',
+                'product_surface.llms_redirect_source_url_count',
+                'product_surface.llms_redirect_source_urls',
+                'llms.noindex_url_count',
+                'llms.noindex_urls',
+                'llms.not_found_url_count',
+                'llms.404_urls',
+                'llms.redirect_source_url_count',
+                'llms.redirect_source_urls',
+                'forbidden_exposure.llms_noindex_urls',
+                'forbidden_exposure.llms_404_urls',
+                'forbidden_exposure.llms_redirect_source_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_noindex_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_404_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_redirect_source_urls',
+            ]),
+            'llms_full' => $this->hasAny($payload, [
+                'product_surface.llms_full_noindex_url_count',
+                'product_surface.llms_full_noindex_urls',
+                'product_surface.llms_full_404_url_count',
+                'product_surface.llms_full_404_urls',
+                'product_surface.llms_full_redirect_source_url_count',
+                'product_surface.llms_full_redirect_source_urls',
+                'llms_full.noindex_url_count',
+                'llms_full.noindex_urls',
+                'llms_full.not_found_url_count',
+                'llms_full.404_urls',
+                'llms_full.redirect_source_url_count',
+                'llms_full.redirect_source_urls',
+                'forbidden_exposure.llms_full_noindex_urls',
+                'forbidden_exposure.llms_full_404_urls',
+                'forbidden_exposure.llms_full_redirect_source_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_noindex_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_404_urls',
+                'validation.full_visible_publication_gate.forbidden_exposure_counts.llms_full_redirect_source_urls',
+            ]),
         ];
     }
 
@@ -379,6 +464,40 @@ final class CareerFullVisiblePublicationGate
         }
 
         return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $paths
+     */
+    private function countAtAny(array $payload, array $paths): ?int
+    {
+        foreach ($paths as $path) {
+            $value = data_get($payload, $path);
+            if (is_numeric($value)) {
+                return (int) $value;
+            }
+            if (is_array($value) && array_is_list($value)) {
+                return count($value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $paths
+     */
+    private function hasAny(array $payload, array $paths): bool
+    {
+        foreach ($paths as $path) {
+            if (data_get($payload, $path) !== null) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
+++ b/backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
@@ -544,13 +544,18 @@ final class CareerRuntimeCandidatePrepPlanner
      */
     private function slugSetAtAny(array $payload, array $paths): array
     {
+        $slugs = [];
+
         foreach ($paths as $path) {
             $value = data_get($payload, $path);
             if (is_array($value) && array_is_list($value)) {
-                return $this->normalizedUniqueStrings($value, str_replace('.', '_', $path), allowEmpty: true);
+                $slugs = [
+                    ...$slugs,
+                    ...$this->normalizedUniqueStrings($value, str_replace('.', '_', $path), allowEmpty: true),
+                ];
             }
         }
 
-        return [];
+        return $this->normalizedUniqueStrings($slugs, 'gated_slug_set', allowEmpty: true);
     }
 }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php
@@ -18,6 +18,9 @@ final class CareerFullVisiblePublicationGateTest extends TestCase
                 'career_jobs_item_count' => 2786,
                 'detail_ready_count' => 2786,
                 'canonical_public_slug_count' => 2786,
+                'sitemap_noindex_url_count' => 0,
+                'llms_noindex_url_count' => 0,
+                'llms_full_noindex_url_count' => 0,
             ],
             'found_published' => 5572,
             'release_gate' => [
@@ -43,6 +46,9 @@ final class CareerFullVisiblePublicationGateTest extends TestCase
                 'detail_ready_count' => 2786,
                 'public_detail_indexable_count' => 2786,
                 'canonical_public_slug_count' => 2786,
+                'sitemap_noindex_url_count' => 0,
+                'llms_noindex_url_count' => 0,
+                'llms_full_noindex_url_count' => 0,
             ],
             'found_published' => 5572,
             'release_gate' => [
@@ -67,6 +73,9 @@ final class CareerFullVisiblePublicationGateTest extends TestCase
                 'detail_ready_count' => 1048,
                 'public_detail_indexable_count' => 1048,
                 'canonical_public_slug_count' => 1048,
+                'sitemap_noindex_url_count' => 0,
+                'llms_noindex_url_count' => 0,
+                'llms_full_noindex_url_count' => 0,
             ],
             'found_published' => 2096,
             'release_gate' => [
@@ -110,5 +119,37 @@ final class CareerFullVisiblePublicationGateTest extends TestCase
         $this->assertContains('product_forbidden_sitemap_noindex_urls_present', $reasons);
         $this->assertContains('product_forbidden_llms_404_urls_present', $reasons);
         $this->assertContains('product_forbidden_llms_full_redirect_source_urls_present', $reasons);
+    }
+
+    public function test_1048_gate_counts_forbidden_url_lists_and_requires_evidence(): void
+    {
+        $gate = new CareerFullVisiblePublicationGate;
+        $liveAcceptance = [
+            'product_surface' => [
+                'directory_member_count' => 1048,
+                'career_jobs_item_count' => 1048,
+                'detail_ready_count' => 1048,
+                'public_detail_indexable_count' => 1048,
+                'canonical_public_slug_count' => 1048,
+                'sitemap_noindex_urls' => [
+                    'https://example.test/noindex',
+                    'https://example.test/noindex-2',
+                ],
+            ],
+            'found_published' => 2096,
+            'release_gate' => [
+                'pass_count' => 2096,
+            ],
+        ];
+
+        $summary = $gate->summary($liveAcceptance, 1048, 2);
+        $reasons = array_column($gate->blockers($liveAcceptance, 1048, 2), 'reason');
+
+        $this->assertSame(2, $summary['forbidden_exposure_counts']['sitemap_noindex_urls']);
+        $this->assertContains('product_forbidden_sitemap_noindex_urls_present', $reasons);
+        $this->assertContains('product_forbidden_llms_evidence_missing', $reasons);
+        $this->assertContains('product_forbidden_llms_full_evidence_missing', $reasons);
+        $this->assertFalse($summary['forbidden_exposure_evidence_present']['llms']);
+        $this->assertFalse($summary['product_claim']['visible_detail_claim_allowed']);
     }
 }

--- a/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
+++ b/backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
@@ -154,6 +154,48 @@ final class CareerRuntimeCandidatePrepPlannerTest extends TestCase
         $this->assertContains('delta_contains_cn_proxy_slugs', $reasons);
     }
 
+    public function test_detail_ready_1048_blocks_fallback_gated_slug_lists(): void
+    {
+        $slugs = $this->slugs('ready', 1018);
+
+        $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(
+            targetDeltaPlan: [
+                'schema_version' => 'career_detail_ready_publication_candidates.v1',
+                'status' => 'pass',
+                'target_key' => 'detail_ready_1048',
+                'current_public_total' => 30,
+                'target_public_total' => 1048,
+                'ready_not_public_1018' => [
+                    'count' => 1018,
+                    'slugs' => $slugs,
+                ],
+                'manual_hold' => [
+                    'ready_slugs' => [],
+                    'slugs' => ['ready-001'],
+                ],
+                'blocked' => [
+                    'ready_slugs' => [],
+                    'slugs' => ['ready-002'],
+                ],
+                'cn_proxy' => [
+                    'ready_slugs' => [],
+                    'slugs' => [],
+                ],
+                'cn_proxy_policy_asset' => [
+                    'slugs' => ['ready-003'],
+                ],
+            ],
+            targetPublicTotal: 1048,
+            cohort: 'detail_ready_1048',
+        )->toArray();
+
+        $this->assertSame('blocked', $payload['status']);
+        $reasons = array_column($payload['blockers'], 'reason');
+        $this->assertContains('delta_contains_manual_hold_slugs', $reasons);
+        $this->assertContains('delta_contains_blocked_slugs', $reasons);
+        $this->assertContains('delta_contains_cn_proxy_slugs', $reasons);
+    }
+
     public function test_blocks_target_delta_plan_that_did_not_pass(): void
     {
         $payload = (new CareerRuntimeCandidatePrepPlanner)->plan(

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:41:36+08:00",
+  "updated_at": "2026-05-31T16:43:04+08:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -34821,7 +34821,7 @@
     "branch": "audit/sec-content-publish-gates-01",
     "base": "main",
     "title": "AUDIT-SEC-CONTENT-PUBLISH-GATES-01 harden content publication gates",
-    "status": "local_scope_validation_passed_with_sidecar",
+    "status": "pr_open_checks_pending",
     "depends_on": [
       "AUDIT-SEC-PAYMENT-INTEGRITY-01 merged"
     ],
@@ -34853,6 +34853,10 @@
           "bash backend/scripts/ci_verify_mbti.sh"
         ],
         "evidence": "route:list passed; sqlite migrate passed; diff/schema checks passed. ci_verify_mbti.sh failed only in existing Big5 content-pack publish/rollback temp target compiled directory assertions outside this PR scope; generated dirty artifacts were restored."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1796"
       }
     },
     "failure_reason": null,
@@ -34877,6 +34881,12 @@
         "from": "implementation_in_progress",
         "to": "local_scope_validation_passed_with_sidecar",
         "note": "Focused tests, route:list, sqlite migrate, diff check, and manifest/state parse passed; unrelated ci_verify_mbti Big5 content-pack temp-target failures registered as sidecar per train protocol."
+      },
+      {
+        "at": "2026-05-31T16:43:04+08:00",
+        "from": "local_scope_validation_passed_with_sidecar",
+        "to": "pr_open_checks_pending",
+        "note": "Created PR #1796; waiting for GitHub required checks."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:21:06+08:00",
+  "updated_at": "2026-05-31T16:41:36+08:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -34679,7 +34679,7 @@
     "branch": "audit/sec-payment-integrity-01",
     "base": "main",
     "title": "AUDIT-SEC-PAYMENT-INTEGRITY-01 harden payment integrity boundaries",
-    "status": "ci_fix_pushed_checks_pending",
+    "status": "merged",
     "depends_on": [
       "AUDIT-SEC-RESULT-IDENTITY-01 merged"
     ],
@@ -34733,14 +34733,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-31T08:31:32Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -34772,6 +34772,12 @@
         "from": "pr_open_checks_pending",
         "to": "ci_fix_pushed_checks_pending",
         "note": "Fixed verify-bigfive runtime-freeze allowlist for ReprocessPaymentEventJob.php and pushed retry commit."
+      },
+      {
+        "at": "2026-05-31T16:37:25+08:00",
+        "from": "ci_fix_pushed_checks_pending",
+        "to": "merged",
+        "note": "PR #1793 checks passed after rebase; squash merged; origin/main contains merge commit; local and remote task branches cleaned."
       }
     ],
     "sidecars": [
@@ -34806,6 +34812,80 @@
     ],
     "commit_sha": "1b4663df4c0fe6d17d48b0fc78555e09188ee7c4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1793",
-    "pr_number": 1793
+    "pr_number": 1793,
+    "merge_commit": "14c30683909759a4607607c9056c7bad2ed64341"
+  },
+  "AUDIT-SEC-CONTENT-PUBLISH-GATES-01": {
+    "id": "AUDIT-SEC-CONTENT-PUBLISH-GATES-01",
+    "repo": "fap-api",
+    "branch": "audit/sec-content-publish-gates-01",
+    "base": "main",
+    "title": "AUDIT-SEC-CONTENT-PUBLISH-GATES-01 harden content publication gates",
+    "status": "local_scope_validation_passed_with_sidecar",
+    "depends_on": [
+      "AUDIT-SEC-PAYMENT-INTEGRITY-01 merged"
+    ],
+    "checks": {
+      "authorization": "user explicitly authorized adding remaining SECURITY-AUDIT-36 PR train items to manifest/state",
+      "workspace_safety": "using isolated worktree /private/tmp/fap-api-audit-sec-content-publish-gates-01; dirty primary worktree untouched",
+      "deploy_safety_boundary": "no deploy, no production mutation, no production SSH",
+      "source_findings": [
+        "Forbidden URL lists are ignored by publication gate",
+        "Fallback gated slug lists are ignored",
+        "Missing sitemap evidence allows false 1048 claim"
+      ],
+      "focused_local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && composer dump-autoload --no-ansi",
+          "cd backend && php artisan test --filter='CareerRuntimeCandidatePrepPlannerTest|CareerFullVisiblePublicationGateTest' --no-ansi"
+        ],
+        "evidence": "Focused content publication gate tests passed: 16 tests, 83 assertions. Composer emitted existing PSR-4 warnings for IQ tests."
+      },
+      "acceptance": {
+        "status": "passed_with_external_ci_verify_sidecar",
+        "commands": [
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-content-publish-gates-01.sqlite php artisan migrate --force --no-ansi",
+          "git diff --check",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 - <<PY\nimport yaml\nfrom pathlib import Path\nyaml.safe_load(Path(\"docs/codex/pr-train.yaml\").read_text())\nPY",
+          "bash backend/scripts/ci_verify_mbti.sh"
+        ],
+        "evidence": "route:list passed; sqlite migrate passed; diff/schema checks passed. ci_verify_mbti.sh failed only in existing Big5 content-pack publish/rollback temp target compiled directory assertions outside this PR scope; generated dirty artifacts were restored."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-05-31T16:37:25+08:00",
+        "from": "authorized",
+        "to": "implementation_in_progress",
+        "note": "Started scoped content publication gate hardening from latest origin/main after AUDIT-SEC-PAYMENT-INTEGRITY-01 post-merge cleanup."
+      },
+      {
+        "at": "2026-05-31T16:41:36+08:00",
+        "from": "implementation_in_progress",
+        "to": "local_scope_validation_passed_with_sidecar",
+        "note": "Focused tests, route:list, sqlite migrate, diff check, and manifest/state parse passed; unrelated ci_verify_mbti Big5 content-pack temp-target failures registered as sidecar per train protocol."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "big5_pack_publish_rollback_temp_target_compiled_missing",
+        "status": "registered_non_blocking_external_to_scope",
+        "summary": "bash backend/scripts/ci_verify_mbti.sh failed in PacksPublishBig5Test and PacksRollbackBig5Test because test temp target compiled/manifest.json was absent. Changed files are limited to career audit publication gates and PR-train ledger; no content pack files are staged."
+      }
+    ],
+    "next_task": "AUDIT-SEC-CONTENT-RUNTIME-CACHE-01"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17040,6 +17040,58 @@ prs:
     frontend_fallback_authority: false
     next_task: AUDIT-SEC-CONTENT-PUBLISH-GATES-01
 
+
+  - id: AUDIT-SEC-CONTENT-PUBLISH-GATES-01
+    repo: fap-api
+    branch: audit/sec-content-publish-gates-01
+    base: main
+    title: "AUDIT-SEC-CONTENT-PUBLISH-GATES-01 harden content publication gates"
+    train_scope: content_publication_gate_integrity
+    risk_level: high_security_public_content_indexing
+    depends_on:
+      - AUDIT-SEC-PAYMENT-INTEGRITY-01 merged
+    allowed_paths:
+      - backend/app/Domain/Career/Audit/CareerRuntimeCandidatePrepPlanner.php
+      - backend/app/Domain/Career/Audit/CareerFullVisiblePublicationGate.php
+      - backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php
+      - backend/tests/Unit/Domain/Career/Audit/CareerFullVisiblePublicationGateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Ensure fallback gated slug lists participate in career runtime candidate prep planning.
+      - Require explicit forbidden exposure evidence before detail-ready publication claims can pass.
+      - Count forbidden URL/list evidence from sitemap, llms, and llms-full scan artifacts.
+      - Add focused unit tests for fallback slug list and forbidden exposure evidence handling.
+    do_not:
+      - Do not deploy, mutate production, run production SSH, or approve production environments.
+      - Do not modify content packs, CMS content, fap-web, sitemap generation policy, llms generation policy, Search Channel, or URL submission files.
+      - Do not add routes, migrations, schemas, public endpoints, or cache invalidation/runtime cache changes.
+    validation:
+      - cd backend && php artisan test --filter='CareerRuntimeCandidatePrepPlannerTest|CareerFullVisiblePublicationGateTest' --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-content-publish-gates-01.sqlite php artisan migrate --force --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: AUDIT-SEC-CONTENT-RUNTIME-CACHE-01
+
   - id: PR-POL-01
     repo: fap-api
     branch: content/pr-pol-01-policies-dashboard


### PR DESCRIPTION
## Summary
- Harden detail-ready candidate prep so fallback gated slug lists are unioned instead of hidden by an empty first source.
- Harden full-visible publication gates so forbidden URL lists count as exposure and sitemap/llms/llms_full forbidden evidence must be explicit before visible-publication claims pass.
- Add focused unit coverage and register the PR-train manifest/state entry.

## Validation
- PASS: cd backend && composer dump-autoload --no-ansi
- PASS: cd backend && php artisan test --filter='CareerRuntimeCandidatePrepPlannerTest|CareerFullVisiblePublicationGateTest' --no-ansi
- PASS: cd backend && php artisan route:list --no-ansi
- PASS: cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-content-publish-gates-01.sqlite php artisan migrate --force --no-ansi
- PASS: git diff --check
- PASS: manifest/state parse
- SIDEcar: bash backend/scripts/ci_verify_mbti.sh failed in existing Big5 content-pack publish/rollback temp target compiled directory assertions outside this PR scope; no content pack files are included.

## Scope
- No fap-web change.
- No sitemap generation or llms cache implementation change.
- No routes, migrations, deploy, production mutation, CMS publish, or content pack changes.

## Security notes
- Public wording is intentionally non-operational.
- The PR only strengthens read-only publication gate semantics.
