### PR TITLE
CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority

### DIFF
--- a/backend/docs/seo/career-1046-internal-linking-authority-01.md
+++ b/backend/docs/seo/career-1046-internal-linking-authority-01.md
@@ -1,0 +1,85 @@
+# CAREER-1046-INTERNAL-LINKING-AUTHORITY-01
+
+## 1. Executive Summary
+
+This PR records the backend-authoritative internal linking policy for the
+Career 1046 public detail surface.
+
+The current authority is backend Career services, not frontend fallback copy:
+
+- `CareerFirstWaveOccupationCompanionLinksService`
+- `CareerFirstWaveRecommendationCompanionLinksService`
+- `CareerFirstWaveNextStepLinksService`
+
+The policy keeps internal links bounded to public, indexable, release-gated
+Career authority. It does not generate MBTI x Career L3 pages, pSEO pages,
+static cross-matrix pages, Search Channel items, or frontend fallback content.
+
+## 2. Link Families
+
+| Family | Authority service | Runtime status |
+| --- | --- | --- |
+| occupation companion links | `CareerFirstWaveOccupationCompanionLinksService` | backend authority |
+| recommendation companion links | `CareerFirstWaveRecommendationCompanionLinksService` | backend authority |
+| next-step links | `CareerFirstWaveNextStepLinksService` | backend authority |
+
+## 3. Eligibility Rules
+
+Career detail link targets must satisfy all of these before exposure:
+
+- public runtime projection exists
+- `detail_route_enabled=true`
+- `robots_indexable=true`
+- `release_gate_pass=true`
+- target is not private, draft, fallback-only, noindex, 404, or manual-hold
+- target is not one of the excluded slugs
+
+Excluded slugs remain blocked from internal link authority:
+
+- `software-developers`
+- `digital-forensics-analysts`
+- `computer-occupations-all-other`
+
+## 4. Non-Generated L3 Boundary
+
+This PR does not create static MBTI x Career, Big Five x Career, RIASEC x
+Career, or other cross-matrix content. Future L3 work must use a dynamic slot
+architecture with explicit authority and budget controls.
+
+## 5. Claim Boundary
+
+Internal links may support exploration and navigation only. They must not imply:
+
+- best career for the user
+- hiring fit
+- job suitability guarantee
+- salary guarantee
+- career success guarantee
+- diagnosis, treatment, or cure
+- psychometric prediction of job success
+
+## 6. Validation
+
+Focused validation:
+
+- `php artisan test --filter=Career1046InternalLinkingAuthority01 --no-ansi`
+
+The test validates the generated artifact, existing authority service
+versions, excluded slug boundaries, no-generation flags, and report sections.
+
+## 7. What Was Not Done
+
+- No production write.
+- No static L3 generation.
+- No fap-web change.
+- No Search Channel enqueue.
+- No URL submission.
+- No sitemap or llms exposure change.
+
+## 8. Final Decision
+
+`career_1046_internal_linking_authority_completed_ready_for_frontend_discovery_ux`
+
+## 9. Next Task
+
+`CAREER-1046-FRONTEND-DISCOVERY-UX-01`

--- a/backend/docs/seo/generated/career-1046-internal-linking-authority-01.v1.json
+++ b/backend/docs/seo/generated/career-1046-internal-linking-authority-01.v1.json
@@ -1,0 +1,79 @@
+{
+  "schema_version": "career_1046_internal_linking_authority.v1",
+  "task": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01",
+  "final_decision": "career_1046_internal_linking_authority_completed_ready_for_frontend_discovery_ux",
+  "source_of_truth": "backend_career_authority_services",
+  "public_career_detail_expected_count": 1046,
+  "localized_public_career_url_expected_count": 2092,
+  "authority_services": {
+    "occupation_companion_links": {
+      "class": "App\\Domain\\Career\\Publish\\CareerFirstWaveOccupationCompanionLinksService",
+      "summary_version": "career.companion.first_wave.v1",
+      "authority": "backend"
+    },
+    "recommendation_companion_links": {
+      "class": "App\\Domain\\Career\\Publish\\CareerFirstWaveRecommendationCompanionLinksService",
+      "summary_version": "career.companion.recommendation.first_wave.v1",
+      "authority": "backend"
+    },
+    "next_step_links": {
+      "class": "App\\Domain\\Career\\Publish\\CareerFirstWaveNextStepLinksService",
+      "summary_version": "career.next_step.first_wave.v1",
+      "authority": "backend"
+    }
+  },
+  "link_eligibility_rules": [
+    "public_runtime_projection_required",
+    "detail_route_enabled_required",
+    "robots_indexable_required",
+    "release_gate_pass_required",
+    "not_private",
+    "not_draft",
+    "not_fallback_only",
+    "not_noindex",
+    "not_404",
+    "not_manual_hold"
+  ],
+  "excluded_slugs": [
+    "software-developers",
+    "digital-forensics-analysts",
+    "computer-occupations-all-other"
+  ],
+  "excluded_slug_link_exposure_allowed": false,
+  "invalid_link_targets_blocked": [
+    "private",
+    "draft",
+    "fallback_only",
+    "noindex",
+    "hard_404",
+    "soft_404",
+    "manual_hold",
+    "conflict_slug"
+  ],
+  "l3_static_generation_performed": false,
+  "pseo_generation_performed": false,
+  "frontend_fallback_authority_used": false,
+  "sitemap_llms_exposure_changed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "production_write_performed": false,
+  "claim_boundary": {
+    "forbidden_claim_hits": [],
+    "allowed_framing": [
+      "exploration",
+      "navigation",
+      "decision_support",
+      "occupation_information"
+    ],
+    "blocked_claims": [
+      "best_career_for_user",
+      "hiring_fit",
+      "job_suitability_guarantee",
+      "salary_guarantee",
+      "career_success_guarantee",
+      "diagnosis_treatment_cure",
+      "psychometric_job_success_prediction"
+    ]
+  },
+  "next_task": "CAREER-1046-FRONTEND-DISCOVERY-UX-01"
+}

--- a/backend/tests/Feature/SeoIntel/Career1046InternalLinkingAuthority01Test.php
+++ b/backend/tests/Feature/SeoIntel/Career1046InternalLinkingAuthority01Test.php
@@ -1,0 +1,135 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Domain\Career\Publish\CareerFirstWaveNextStepLinksService;
+use App\Domain\Career\Publish\CareerFirstWaveOccupationCompanionLinksService;
+use App\Domain\Career\Publish\CareerFirstWaveRecommendationCompanionLinksService;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class Career1046InternalLinkingAuthority01Test extends TestCase
+{
+    #[Test]
+    public function generated_artifact_records_backend_authority_services(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('career_1046_internal_linking_authority.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('CAREER-1046-INTERNAL-LINKING-AUTHORITY-01', $payload['task'] ?? null);
+        $this->assertSame('backend_career_authority_services', $payload['source_of_truth'] ?? null);
+        $this->assertSame(1046, $payload['public_career_detail_expected_count'] ?? null);
+        $this->assertSame(2092, $payload['localized_public_career_url_expected_count'] ?? null);
+
+        $this->assertSame(
+            CareerFirstWaveOccupationCompanionLinksService::SUMMARY_VERSION,
+            data_get($payload, 'authority_services.occupation_companion_links.summary_version'),
+        );
+        $this->assertSame(
+            CareerFirstWaveRecommendationCompanionLinksService::SUMMARY_VERSION,
+            data_get($payload, 'authority_services.recommendation_companion_links.summary_version'),
+        );
+        $this->assertSame(
+            CareerFirstWaveNextStepLinksService::SUMMARY_VERSION,
+            data_get($payload, 'authority_services.next_step_links.summary_version'),
+        );
+    }
+
+    #[Test]
+    public function link_eligibility_blocks_invalid_and_excluded_targets(): void
+    {
+        $payload = $this->payload();
+
+        foreach ([
+            'public_runtime_projection_required',
+            'detail_route_enabled_required',
+            'robots_indexable_required',
+            'release_gate_pass_required',
+            'not_private',
+            'not_draft',
+            'not_fallback_only',
+            'not_noindex',
+            'not_404',
+            'not_manual_hold',
+        ] as $rule) {
+            $this->assertContains($rule, $payload['link_eligibility_rules'] ?? []);
+        }
+
+        $this->assertEqualsCanonicalizing([
+            'software-developers',
+            'digital-forensics-analysts',
+            'computer-occupations-all-other',
+        ], $payload['excluded_slugs'] ?? []);
+        $this->assertFalse((bool) ($payload['excluded_slug_link_exposure_allowed'] ?? true));
+
+        foreach (['private', 'draft', 'fallback_only', 'noindex', 'hard_404', 'soft_404', 'manual_hold', 'conflict_slug'] as $target) {
+            $this->assertContains($target, $payload['invalid_link_targets_blocked'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function no_l3_generation_or_discoverability_mutation_is_recorded(): void
+    {
+        $payload = $this->payload();
+
+        foreach ([
+            'l3_static_generation_performed',
+            'pseo_generation_performed',
+            'frontend_fallback_authority_used',
+            'sitemap_llms_exposure_changed',
+            'search_channel_action_performed',
+            'url_submission_performed',
+            'production_write_performed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($payload[$flag] ?? true), $flag);
+        }
+
+        $this->assertSame([], data_get($payload, 'claim_boundary.forbidden_claim_hits'));
+        $this->assertContains('exploration', data_get($payload, 'claim_boundary.allowed_framing'));
+        $this->assertContains('best_career_for_user', data_get($payload, 'claim_boundary.blocked_claims'));
+    }
+
+    #[Test]
+    public function report_has_required_sections_and_next_task(): void
+    {
+        $path = base_path('docs/seo/career-1046-internal-linking-authority-01.md');
+
+        $this->assertFileExists($path);
+
+        $report = (string) file_get_contents($path);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. Link Families',
+            '## 3. Eligibility Rules',
+            '## 4. Non-Generated L3 Boundary',
+            '## 5. Claim Boundary',
+            '## 6. Validation',
+            '## 7. What Was Not Done',
+            '## 8. Final Decision',
+            '## 9. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+
+        $this->assertSame(
+            'career_1046_internal_linking_authority_completed_ready_for_frontend_discovery_ux',
+            $this->payload()['final_decision'] ?? null,
+        );
+        $this->assertSame('CAREER-1046-FRONTEND-DISCOVERY-UX-01', $this->payload()['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = base_path('docs/seo/generated/career-1046-internal-linking-authority-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21964,7 +21964,7 @@
       "branch": "codex/pr-hiring-01-content-authority",
       "base": "main",
       "title": "PR-HIRING-01 hiring content authority package",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "CAREER-1046-OBSERVABILITY-SLO-01"
       ],
@@ -22003,19 +22003,28 @@
           "status": "pass",
           "command": "git diff --check && git diff --cached --check",
           "evidence": "Whitespace checks passed before staging; cached check rerun before commit."
+        },
+        "github_checks": {
+          "status": "pass",
+          "evidence": "GitHub checks green on PR #1795: hygiene, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, Semgrep blocking secrets, Semgrep OSS."
+        },
+        "post_merge_revalidate": {
+          "status": "pass",
+          "command": "php artisan test --filter=PrHiring01ContentAuthority --no-ansi",
+          "evidence": "4 tests passed, 67 assertions on origin/main merge commit 6b50e9ab5ed00c2bfc0365d0d4ffc48a8696f58e."
         }
       },
       "failure_reason": null,
       "commit_sha": "0067534e49b55781e88fae0568b58a0204c8e1b6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1795",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T16:47:19+08:00",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
       "transitions": [
         {
@@ -22041,10 +22050,17 @@
           "from": "committed",
           "to": "pr_open",
           "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1795; GitHub checks pending."
+        },
+        {
+          "at": "2026-05-31T16:47:19+08:00",
+          "from": "pr_open",
+          "to": "merged",
+          "note": "PR #1795 checks passed, squash merged at 6b50e9ab5ed00c2bfc0365d0d4ffc48a8696f58e, remote branch deleted, local branch deleted, and post-merge focused test passed."
         }
       ],
       "sidecars": [],
-      "next_task": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01"
+      "next_task": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01",
+      "merge_commit_sha": "6b50e9ab5ed00c2bfc0365d0d4ffc48a8696f58e"
     },
     "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01": {
       "id": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01",
@@ -22052,24 +22068,79 @@
       "branch": "codex/career-1046-internal-linking-authority-01",
       "base": "main",
       "title": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority",
-      "status": "pending",
+      "status": "local_validation_passed",
       "depends_on": [
         "PR-HIRING-01"
       ],
-      "checks": {},
+      "checks": {
+        "focused_phpunit": {
+          "status": "pass",
+          "command": "php artisan test --filter=Career1046InternalLinkingAuthority01 --no-ansi",
+          "evidence": "4 tests passed, 55 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "207 routes listed successfully."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "3663 files passed."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "composer validate --strict",
+          "evidence": "./composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool ... && yaml.safe_load(...)",
+          "evidence": "Generated artifact, train state, and manifest parse successfully."
+        },
+        "scope_validation": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed before staging; cached check rerun before commit."
+        }
+      },
       "failure_reason": null,
-      "commit_sha": null,
+      "commit_sha": "ae1e7c7609888eff5b69ba22a02d37fb88114ff3",
       "pr_url": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [],
+      "transitions": [
+        {
+          "at": "2026-05-31T16:52:00+08:00",
+          "from": "pending",
+          "to": "in_progress",
+          "note": "Started PR4 from origin/main after confirming PR #1795 merge commit is present and post-merge focused revalidate passed."
+        },
+        {
+          "at": "2026-05-31T16:58:00+08:00",
+          "from": "in_progress",
+          "to": "local_validation_passed",
+          "note": "Generated internal linking authority report/artifact/test and passed focused PHPUnit, route:list, Pint, Composer validate/audit, JSON/YAML parse, and diff checks."
+        },
+        {
+          "at": "2026-05-31T16:59:00+08:00",
+          "from": "local_validation_passed",
+          "to": "committed",
+          "note": "Committed scoped PR4 implementation at ae1e7c7609888eff5b69ba22a02d37fb88114ff3."
+        }
+      ],
       "sidecars": [],
       "next_task": "CAREER-1046-FRONTEND-DISCOVERY-UX-01"
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -22068,7 +22068,7 @@
       "branch": "codex/career-1046-internal-linking-authority-01",
       "base": "main",
       "title": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority",
-      "status": "local_validation_passed",
+      "status": "pr_open",
       "depends_on": [
         "PR-HIRING-01"
       ],
@@ -22110,8 +22110,8 @@
         }
       },
       "failure_reason": null,
-      "commit_sha": "ae1e7c7609888eff5b69ba22a02d37fb88114ff3",
-      "pr_url": null,
+      "commit_sha": "c648f3e67147e3aa82d03aef085f8bef0c8a7556",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1798",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
@@ -22139,6 +22139,12 @@
           "from": "local_validation_passed",
           "to": "committed",
           "note": "Committed scoped PR4 implementation at ae1e7c7609888eff5b69ba22a02d37fb88114ff3."
+        },
+        {
+          "at": "2026-05-31T17:00:00+08:00",
+          "from": "committed",
+          "to": "pr_open",
+          "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1798; GitHub checks pending."
         }
       ],
       "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17606,7 +17606,7 @@ prs:
     base: main
     title: "PR-HIRING-01 hiring content authority package"
     train_scope: career_1046_growth_foundation
-    status: in_progress
+    status: merged
     allowed_paths:
       - backend/docs/seo/pr-hiring-01-content-authority.md
       - backend/docs/seo/generated/pr-hiring-01-content-authority.v1.json
@@ -17642,7 +17642,7 @@ prs:
     base: main
     title: "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority"
     train_scope: career_1046_growth_foundation
-    status: pending
+    status: in_progress
     allowed_paths:
       - backend/app/Domain/Career/**
       - backend/app/Services/SeoIntel/**


### PR DESCRIPTION
## What changed
- Added a backend-authoritative Career 1046 internal linking policy report.
- Added a generated artifact documenting companion/next-step authority services, link eligibility gates, excluded slug safety, and no-L3-generation boundaries.
- Added focused SeoIntel test coverage for service summary versions, invalid target blocking, no discoverability mutation, and report sections.

## Why
- Career 1046 internal linking must stay backend-authoritative and must not expose private, draft, noindex, fallback-only, 404, manual-hold, or conflict slugs.

## Validation
- `php artisan test --filter=Career1046InternalLinkingAuthority01 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/career-1046-internal-linking-authority-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `yaml.safe_load` for `docs/codex/pr-train.yaml`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No static MBTI x Career or other L3 page generation.
- No sitemap/llms exposure change.
- No fap-web change.
- No Search Channel, URL submission, production write, or deploy.