### PR TITLE
IQ-NORM-01 add IQ norm calibration authority

### DIFF
--- a/backend/app/Services/Iq/IqNormAuthorityContract.php
+++ b/backend/app/Services/Iq/IqNormAuthorityContract.php
@@ -1,0 +1,133 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Iq;
+
+final class IqNormAuthorityContract
+{
+    public const SCALE_CODE = 'IQ_INTELLIGENCE_QUOTIENT';
+
+    public const DEFAULT_POPULATION_KEY = 'general_adult_online';
+
+    /**
+     * Minimum production calibration sample for unlocking public IQ estimate claims.
+     */
+    public const MIN_PRODUCTION_SAMPLE_SIZE = 500;
+
+    /**
+     * @return list<string>
+     */
+    public static function claimEligibleStatuses(): array
+    {
+        return [
+            'calibrated',
+            'norm_table_available',
+            'production_normed',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public static function allowedStatuses(): array
+    {
+        return [
+            'draft',
+            'dry_run_validated',
+            'calibrated',
+            'norm_table_available',
+            'production_normed',
+            'retired',
+        ];
+    }
+
+    public static function statusAllowsPublicClaims(?string $status): bool
+    {
+        return in_array(strtolower(trim((string) $status)), self::claimEligibleStatuses(), true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $record
+     * @return list<string>
+     */
+    public static function validationErrors(array $record): array
+    {
+        $errors = [];
+
+        $scaleCode = strtoupper(trim((string) ($record['scale_code'] ?? '')));
+        if ($scaleCode !== self::SCALE_CODE) {
+            $errors[] = 'scale_code_must_be_iq_intelligence_quotient';
+        }
+
+        foreach (['bank_id', 'norm_table_version', 'population_key', 'locale'] as $field) {
+            if (trim((string) ($record[$field] ?? '')) === '') {
+                $errors[] = $field.'_required';
+            }
+        }
+
+        $status = strtolower(trim((string) ($record['status'] ?? '')));
+        if (! in_array($status, self::allowedStatuses(), true)) {
+            $errors[] = 'status_not_allowed';
+        }
+
+        $sampleSize = (int) ($record['sample_size'] ?? 0);
+        if ($sampleSize < self::MIN_PRODUCTION_SAMPLE_SIZE) {
+            $errors[] = 'sample_size_below_public_claim_minimum';
+        }
+
+        foreach (['mean', 'standard_deviation', 'min_raw_score', 'max_raw_score'] as $field) {
+            if (! is_int($record[$field] ?? null) && ! is_float($record[$field] ?? null) && ! is_numeric((string) ($record[$field] ?? ''))) {
+                $errors[] = $field.'_numeric_required';
+            }
+        }
+
+        if ((float) ($record['standard_deviation'] ?? 0.0) <= 0.0) {
+            $errors[] = 'standard_deviation_must_be_positive';
+        }
+
+        if (! (bool) ($record['license_verified'] ?? false)) {
+            $errors[] = 'license_verification_required';
+        }
+
+        if (! (bool) ($record['locked'] ?? false)) {
+            $errors[] = 'locked_authority_required';
+        }
+
+        if (trim((string) ($record['source_kind'] ?? '')) === '') {
+            $errors[] = 'source_kind_required';
+        }
+
+        if (trim((string) ($record['source_ref'] ?? '')) === '') {
+            $errors[] = 'source_ref_required';
+        }
+
+        return array_values(array_unique($errors));
+    }
+
+    /**
+     * @param  array<string,mixed>  $record
+     * @return array{claim_eligible:bool,reason_code:?string,errors:list<string>}
+     */
+    public static function publicClaimGate(array $record): array
+    {
+        $errors = self::validationErrors($record);
+        $status = strtolower(trim((string) ($record['status'] ?? '')));
+
+        if (! self::statusAllowsPublicClaims($status)) {
+            $errors[] = 'status_not_public_claim_eligible';
+        }
+
+        if (trim((string) ($record['retired_at'] ?? '')) !== '') {
+            $errors[] = 'retired_authority_cannot_claim';
+        }
+
+        $errors = array_values(array_unique($errors));
+
+        return [
+            'claim_eligible' => $errors === [],
+            'reason_code' => $errors[0] ?? null,
+            'errors' => $errors,
+        ];
+    }
+}

--- a/backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php
+++ b/backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php
@@ -1,0 +1,91 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'iq_norm_authorities';
+
+    private const UNIQUE_VERSION = 'iq_norm_authorities_version_unique';
+
+    private const IDX_STATUS = 'iq_norm_authorities_status_idx';
+
+    private const IDX_BANK = 'iq_norm_authorities_bank_idx';
+
+    public function up(): void
+    {
+        $isSqlite = Schema::getConnection()->getDriverName() === 'sqlite';
+
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table) use ($isSqlite): void {
+                $table->uuid('id')->primary();
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('scale_code', 64)->default('IQ_INTELLIGENCE_QUOTIENT');
+                $table->string('bank_id', 128);
+                $table->string('norm_table_version', 128);
+                $table->string('status', 32)->default('draft');
+                $table->string('population_key', 128)->default('general_adult_online');
+                $table->string('locale', 16)->default('zh-CN');
+                $table->unsignedInteger('sample_size')->nullable();
+                $table->decimal('mean', 8, 3)->nullable();
+                $table->decimal('standard_deviation', 8, 3)->nullable();
+                $table->decimal('min_raw_score', 8, 3)->nullable();
+                $table->decimal('max_raw_score', 8, 3)->nullable();
+                $table->string('source_kind', 32)->default('internal_calibration');
+                $table->string('source_ref', 255)->nullable();
+                $table->boolean('license_verified')->default(false);
+                $table->boolean('locked')->default(false);
+                $table->timestamp('effective_at')->nullable();
+                $table->timestamp('retired_at')->nullable();
+                if ($isSqlite) {
+                    $table->text('metadata')->nullable();
+                } else {
+                    $table->json('metadata')->nullable();
+                }
+                $table->timestamp('created_at')->nullable();
+                $table->timestamp('updated_at')->nullable();
+            });
+        }
+
+        $this->addIndexes();
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to protect norm authority audit state.
+        // Irreversible operation: schema/data rollback must use a forward fix migration.
+    }
+
+    private function addIndexes(): void
+    {
+        if (! SchemaIndex::indexExists(self::TABLE, self::UNIQUE_VERSION)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->unique([
+                    'org_id',
+                    'scale_code',
+                    'bank_id',
+                    'norm_table_version',
+                    'population_key',
+                    'locale',
+                ], self::UNIQUE_VERSION);
+            });
+        }
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::IDX_STATUS)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->index(['scale_code', 'status', 'effective_at'], self::IDX_STATUS);
+            });
+        }
+
+        if (! SchemaIndex::indexExists(self::TABLE, self::IDX_BANK)) {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                $table->index(['scale_code', 'bank_id', 'norm_table_version'], self::IDX_BANK);
+            });
+        }
+    }
+};

--- a/backend/docs/iq/iq-production-norm-authority.md
+++ b/backend/docs/iq/iq-production-norm-authority.md
@@ -1,0 +1,37 @@
+# IQ production norm authority v1
+
+## Purpose
+
+`IQ-NORM-01` establishes the backend-only authority boundary for future IQ norm and calibration work. It does not import real norm data, does not unlock IQ estimate claims, and does not change the current beta scoring/report runtime behavior.
+
+## Authority boundary
+
+- Backend `iq_norm_authorities` records are the only source allowed to unlock public IQ estimate, percentile, or confidence interval claims.
+- Frontend, CMS, SEO metadata, and paid-report rendering must not infer norm availability from local content, copy, payment state, or item-bank metadata.
+- A norm authority is claim-eligible only when it is locked, license-verified, not retired, sample-size gated, and in a claim-eligible status.
+- Future importers must run schema validation and dry-run checks before any authority record can be locked.
+
+## Claim-eligible statuses
+
+- `calibrated`
+- `norm_table_available`
+- `production_normed`
+
+Draft and dry-run states must keep public IQ claims disabled.
+
+## Required gates before SEO/report unlock
+
+- `scale_code` is exactly `IQ_INTELLIGENCE_QUOTIENT`.
+- `bank_id`, `norm_table_version`, `population_key`, and `locale` are explicit.
+- `sample_size` is at least `500` for public claims.
+- `mean`, `standard_deviation`, `min_raw_score`, and `max_raw_score` are numeric, with positive standard deviation.
+- `license_verified` is true.
+- `locked` is true.
+- `source_kind` and `source_ref` are present.
+- `retired_at` is empty.
+
+## Deferred to later train items
+
+- `IQ-NORM-02`: dry-run norm table importer and fixture validation.
+- `IQ-NORM-03`: scoring/report unlock through backend norm authority.
+- `IQ-SEO-RAMP-02`: frontend discoverability expansion gated by backend authority.

--- a/backend/tests/Feature/Content/IqNormAuthorityTest.php
+++ b/backend/tests/Feature/Content/IqNormAuthorityTest.php
@@ -1,0 +1,143 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use App\Services\Iq\IqNormAuthorityContract;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class IqNormAuthorityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $migration = require base_path('database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php');
+        $migration->up();
+    }
+
+    public function test_iq_norm_authority_schema_exists_without_seeded_production_norms(): void
+    {
+        $this->assertTrue(Schema::hasTable('iq_norm_authorities'));
+
+        foreach ([
+            'id',
+            'org_id',
+            'scale_code',
+            'bank_id',
+            'norm_table_version',
+            'status',
+            'population_key',
+            'locale',
+            'sample_size',
+            'mean',
+            'standard_deviation',
+            'min_raw_score',
+            'max_raw_score',
+            'source_kind',
+            'source_ref',
+            'license_verified',
+            'locked',
+            'effective_at',
+            'retired_at',
+            'metadata',
+        ] as $column) {
+            $this->assertTrue(Schema::hasColumn('iq_norm_authorities', $column), $column.' column missing');
+        }
+
+        $this->assertSame(0, DB::table('iq_norm_authorities')->count());
+    }
+
+    public function test_iq_norm_authority_contract_blocks_claims_until_license_lock_and_sample_gate_pass(): void
+    {
+        $gate = IqNormAuthorityContract::publicClaimGate([
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'bank_id' => 'IQ_BETA_30_ORIGINAL',
+            'norm_table_version' => 'iq_norm_prod_v1',
+            'status' => 'production_normed',
+            'population_key' => 'general_adult_online',
+            'locale' => 'zh-CN',
+            'sample_size' => 120,
+            'mean' => 15.2,
+            'standard_deviation' => 4.1,
+            'min_raw_score' => 0,
+            'max_raw_score' => 30,
+            'source_kind' => 'internal_calibration',
+            'source_ref' => 'calibration-run-placeholder',
+            'license_verified' => false,
+            'locked' => false,
+        ]);
+
+        $this->assertFalse($gate['claim_eligible']);
+        $this->assertContains('sample_size_below_public_claim_minimum', $gate['errors']);
+        $this->assertContains('license_verification_required', $gate['errors']);
+        $this->assertContains('locked_authority_required', $gate['errors']);
+    }
+
+    public function test_iq_norm_authority_contract_allows_claims_only_for_locked_verified_iq_authority(): void
+    {
+        $record = [
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'bank_id' => 'IQ_BETA_30_ORIGINAL',
+            'norm_table_version' => 'iq_norm_prod_v1',
+            'status' => 'production_normed',
+            'population_key' => 'general_adult_online',
+            'locale' => 'zh-CN',
+            'sample_size' => 1200,
+            'mean' => 15.2,
+            'standard_deviation' => 4.1,
+            'min_raw_score' => 0,
+            'max_raw_score' => 30,
+            'source_kind' => 'internal_calibration',
+            'source_ref' => 'calibration-run-placeholder',
+            'license_verified' => true,
+            'locked' => true,
+            'effective_at' => now(),
+            'created_at' => now(),
+            'updated_at' => now(),
+        ];
+
+        DB::table('iq_norm_authorities')->insert($record);
+
+        $gate = IqNormAuthorityContract::publicClaimGate($record);
+
+        $this->assertTrue($gate['claim_eligible']);
+        $this->assertNull($gate['reason_code']);
+        $this->assertSame(1, DB::table('iq_norm_authorities')->where('scale_code', 'IQ_INTELLIGENCE_QUOTIENT')->count());
+    }
+
+    public function test_iq_norm_authority_contract_rejects_non_iq_or_retired_authority(): void
+    {
+        $gate = IqNormAuthorityContract::publicClaimGate([
+            'scale_code' => 'BIG5_OCEAN',
+            'bank_id' => 'IQ_BETA_30_ORIGINAL',
+            'norm_table_version' => 'iq_norm_prod_v1',
+            'status' => 'production_normed',
+            'population_key' => 'general_adult_online',
+            'locale' => 'zh-CN',
+            'sample_size' => 1200,
+            'mean' => 15.2,
+            'standard_deviation' => 4.1,
+            'min_raw_score' => 0,
+            'max_raw_score' => 30,
+            'source_kind' => 'internal_calibration',
+            'source_ref' => 'calibration-run-placeholder',
+            'license_verified' => true,
+            'locked' => true,
+            'retired_at' => now()->toISOString(),
+        ]);
+
+        $this->assertFalse($gate['claim_eligible']);
+        $this->assertContains('scale_code_must_be_iq_intelligence_quotient', $gate['errors']);
+        $this->assertContains('retired_authority_cannot_claim', $gate['errors']);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1583,6 +1583,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_norm_authority_foundation_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Iq/IqNormAuthorityContract.php',
+            'backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_iq_result_secrecy_redaction_only(): void
     {
         $changed = [
@@ -2942,6 +2952,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isIqNormAuthorityFoundationFile($file)) {
+                continue;
+            }
+
             if ($this->isRiasecMeasurementContractComparePolicyFile($file)) {
                 continue;
             }
@@ -3648,6 +3662,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqScoringContractFoundationFile(string $file): bool
     {
         return $file === 'backend/app/Services/Assessment/Drivers/IqTestDriver.php';
+    }
+
+    private function isIqNormAuthorityFoundationFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Iq/IqNormAuthorityContract.php',
+            'backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php',
+        ], true);
     }
 
     private function isIqResultSecrecyRedactionFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T09:09:20Z",
+  "updated_at": "2026-05-31T12:41:29+00:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -96,7 +96,13 @@
         "github": {
           "status": "passed",
           "repository": "fap-web",
-          "required_checks": ["build", "contracts", "verify-big5-contract-freeze", "verify-enneagram-contract-freeze", "CodeQL"]
+          "required_checks": [
+            "build",
+            "contracts",
+            "verify-big5-contract-freeze",
+            "verify-enneagram-contract-freeze",
+            "CodeQL"
+          ]
         }
       },
       "failure_reason": null,
@@ -22264,6 +22270,394 @@
       "transitions": [],
       "sidecars": [],
       "next_task": "DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes"
+    },
+    "IQ-NORM-01": {
+      "id": "IQ-NORM-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-norm-01-calibration-authority",
+      "base": "main",
+      "title": "IQ-NORM-01 add IQ norm calibration authority",
+      "status": "local_scope_validation_passed",
+      "depends_on": [],
+      "checks": {
+        "local": {
+          "status": "passed",
+          "commands": [
+            "php -l backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php backend/app/Services/Iq/IqNormAuthorityContract.php backend/tests/Feature/Content/IqNormAuthorityTest.php",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqNormAuthorityTest --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "git diff --check"
+          ],
+          "notes": "Targeted PHPUnit suites exited 0 with warnings only; IqNormAuthorityTest had 4 tests/32 assertions and IqReportContractTest had 4 tests/404 assertions."
+        },
+        "github": {
+          "status": null
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "planned",
+          "to": "implementation_in_progress",
+          "note": "Started backend-only IQ norm authority schema, contract, docs, and tests from latest origin/main."
+        },
+        {
+          "at": "2026-05-31T12:41:29+00:00",
+          "from": "implementation_in_progress",
+          "to": "local_scope_validation_passed",
+          "note": "PHP syntax, targeted IQ norm authority/report contract tests, manifest/state parse, and diff check passed in isolated worktree."
+        }
+      ]
+    },
+    "IQ-NORM-02": {
+      "id": "IQ-NORM-02",
+      "repo": "fap-api",
+      "branch": "codex/iq-norm-02-importer-dry-run",
+      "base": "main",
+      "title": "IQ-NORM-02 add IQ norm table importer dry-run",
+      "status": "planned",
+      "depends_on": [
+        "IQ-NORM-01"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-NORM-03": {
+      "id": "IQ-NORM-03",
+      "repo": "fap-api",
+      "branch": "codex/iq-norm-03-score-claim-unlock",
+      "base": "main",
+      "title": "IQ-NORM-03 unlock IQ score claims through norm authority",
+      "status": "planned",
+      "depends_on": [
+        "IQ-NORM-02"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-PAID-REPORT-01": {
+      "id": "IQ-PAID-REPORT-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-paid-report-01-entitlement-contract",
+      "base": "main",
+      "title": "IQ-PAID-REPORT-01 define paid report entitlement contract",
+      "status": "planned",
+      "depends_on": [
+        "IQ-NORM-03"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-PAID-REPORT-02": {
+      "id": "IQ-PAID-REPORT-02",
+      "repo": "fap-web",
+      "branch": "codex/iq-paid-report-02-render-entitlement-states",
+      "base": "main",
+      "title": "IQ-PAID-REPORT-02 render paid report entitlement states",
+      "status": "planned",
+      "depends_on": [
+        "IQ-PAID-REPORT-01"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-CMS-MEDIA-01": {
+      "id": "IQ-CMS-MEDIA-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-cms-media-01-authority-metadata",
+      "base": "main",
+      "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
+      "status": "planned",
+      "depends_on": [
+        "IQ-PAID-REPORT-02"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-CMS-MEDIA-02": {
+      "id": "IQ-CMS-MEDIA-02",
+      "repo": "fap-web",
+      "branch": "codex/iq-cms-media-02-rendering-guard",
+      "base": "main",
+      "title": "IQ-CMS-MEDIA-02 render CMS media without frontend fallbacks",
+      "status": "planned",
+      "depends_on": [
+        "IQ-CMS-MEDIA-01"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-SEO-RAMP-01": {
+      "id": "IQ-SEO-RAMP-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-seo-ramp-01-cms-authority",
+      "base": "main",
+      "title": "IQ-SEO-RAMP-01 publish CMS SEO ramp authority",
+      "status": "planned",
+      "depends_on": [
+        "IQ-CMS-MEDIA-02",
+        "IQ-NORM-03"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-SEO-RAMP-02": {
+      "id": "IQ-SEO-RAMP-02",
+      "repo": "fap-web",
+      "branch": "codex/iq-seo-ramp-02-indexation-gate",
+      "base": "main",
+      "title": "IQ-SEO-RAMP-02 gate SEO indexation through backend authority",
+      "status": "planned",
+      "depends_on": [
+        "IQ-SEO-RAMP-01"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-LIVE-RAMP-01": {
+      "id": "IQ-LIVE-RAMP-01",
+      "repo": "fap-web",
+      "branch": "codex/iq-live-ramp-01-authenticated-smoke",
+      "base": "main",
+      "title": "IQ-LIVE-RAMP-01 add authenticated production smoke fixture gate",
+      "status": "planned",
+      "depends_on": [
+        "IQ-SEO-RAMP-02",
+        "IQ-PAID-REPORT-02"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-OBS-01": {
+      "id": "IQ-OBS-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-obs-01-production-guards",
+      "base": "main",
+      "title": "IQ-OBS-01 add production observability guards",
+      "status": "planned",
+      "depends_on": [
+        "IQ-LIVE-RAMP-01"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
+    },
+    "IQ-RELEASE-01": {
+      "id": "IQ-RELEASE-01",
+      "repo": "fap-web",
+      "branch": "codex/iq-release-01-launch-readiness-ledger",
+      "base": "main",
+      "title": "IQ-RELEASE-01 finalize production launch readiness ledger",
+      "status": "planned",
+      "depends_on": [
+        "IQ-OBS-01"
+      ],
+      "checks": {},
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": null,
+        "local_validation_passed": null,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        }
+      ]
     }
   },
   "SEO-DASH-PROD-03D-FIX": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T12:49:18+00:00",
+  "updated_at": "2026-05-31T12:54:52+00:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22277,7 +22277,7 @@
       "branch": "codex/iq-norm-01-calibration-authority",
       "base": "main",
       "title": "IQ-NORM-01 add IQ norm calibration authority",
-      "status": "ci_fix_pushed_checks_pending",
+      "status": "github_checks_green",
       "depends_on": [],
       "checks": {
         "local": {
@@ -22293,11 +22293,18 @@
           "notes": "Targeted PHPUnit suites exited 0 with warnings only; IqNormAuthorityTest had 4 tests/32 assertions and IqReportContractTest had 4 tests/404 assertions."
         },
         "github": {
-          "status": "failed_then_fix_pushed",
-          "failed_check": "verify-bigfive",
-          "failure_summary": "BigFive runtime freeze classifier flagged IQ norm authority service and migration as runtime diff.",
-          "fix_summary": "Added explicit IQ norm authority foundation classifier exception and regression test; no BigFive runtime behavior changed.",
-          "pr_url": "https://github.com/fermatmind/fap-api/pull/1799"
+          "status": "passed",
+          "required_checks": [
+            "hygiene",
+            "supply-chain",
+            "content-pack-build-validate",
+            "verify-mbti-legacy",
+            "verify-mbti-v2",
+            "verify-bigfive",
+            "Semgrep blocking secrets"
+          ],
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1799",
+          "note": "All required GitHub checks passed after scoped verify-bigfive classifier fix."
         },
         "local_fix": {
           "status": "passed",
@@ -22319,7 +22326,7 @@
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
+        "github_checks_green": true,
         "post_merge_revalidated": null
       },
       "transitions": [
@@ -22352,9 +22359,15 @@
           "from": "pr_open_checks_pending",
           "to": "ci_fix_pushed_checks_pending",
           "note": "Inspected verify-bigfive failure and pushed scoped classifier fix for IQ norm authority foundation files."
+        },
+        {
+          "at": "2026-05-31T12:54:52+00:00",
+          "from": "ci_fix_pushed_checks_pending",
+          "to": "github_checks_green",
+          "note": "All GitHub required checks passed on PR #1799 after CI fix."
         }
       ],
-      "commit_sha": "aec55ff3",
+      "commit_sha": "054cdec9",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1799",
       "pr_number": 1799
     },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T12:42:08+00:00",
+  "updated_at": "2026-05-31T12:49:18+00:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22277,7 +22277,7 @@
       "branch": "codex/iq-norm-01-calibration-authority",
       "base": "main",
       "title": "IQ-NORM-01 add IQ norm calibration authority",
-      "status": "pr_open_checks_pending",
+      "status": "ci_fix_pushed_checks_pending",
       "depends_on": [],
       "checks": {
         "local": {
@@ -22293,8 +22293,23 @@
           "notes": "Targeted PHPUnit suites exited 0 with warnings only; IqNormAuthorityTest had 4 tests/32 assertions and IqReportContractTest had 4 tests/404 assertions."
         },
         "github": {
-          "status": "pending",
+          "status": "failed_then_fix_pushed",
+          "failed_check": "verify-bigfive",
+          "failure_summary": "BigFive runtime freeze classifier flagged IQ norm authority service and migration as runtime diff.",
+          "fix_summary": "Added explicit IQ norm authority foundation classifier exception and regression test; no BigFive runtime behavior changed.",
           "pr_url": "https://github.com/fermatmind/fap-api/pull/1799"
+        },
+        "local_fix": {
+          "status": "passed",
+          "commands": [
+            "php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqNormAuthorityTest --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi",
+            "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "python3 yaml manifest parse",
+            "git diff --check"
+          ]
         }
       },
       "failure_reason": null,
@@ -22331,6 +22346,12 @@
           "from": "local_scope_validation_passed",
           "to": "pr_open_checks_pending",
           "note": "Created PR #1799 and started waiting for GitHub required checks."
+        },
+        {
+          "at": "2026-05-31T12:49:18+00:00",
+          "from": "pr_open_checks_pending",
+          "to": "ci_fix_pushed_checks_pending",
+          "note": "Inspected verify-bigfive failure and pushed scoped classifier fix for IQ norm authority foundation files."
         }
       ],
       "commit_sha": "aec55ff3",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T12:41:29+00:00",
+  "updated_at": "2026-05-31T12:42:08+00:00",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22277,7 +22277,7 @@
       "branch": "codex/iq-norm-01-calibration-authority",
       "base": "main",
       "title": "IQ-NORM-01 add IQ norm calibration authority",
-      "status": "local_scope_validation_passed",
+      "status": "pr_open_checks_pending",
       "depends_on": [],
       "checks": {
         "local": {
@@ -22293,7 +22293,8 @@
           "notes": "Targeted PHPUnit suites exited 0 with warnings only; IqNormAuthorityTest had 4 tests/32 assertions and IqReportContractTest had 4 tests/404 assertions."
         },
         "github": {
-          "status": null
+          "status": "pending",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1799"
         }
       },
       "failure_reason": null,
@@ -22324,8 +22325,17 @@
           "from": "implementation_in_progress",
           "to": "local_scope_validation_passed",
           "note": "PHP syntax, targeted IQ norm authority/report contract tests, manifest/state parse, and diff check passed in isolated worktree."
+        },
+        {
+          "at": "2026-05-31T12:42:08+00:00",
+          "from": "local_scope_validation_passed",
+          "to": "pr_open_checks_pending",
+          "note": "Created PR #1799 and started waiting for GitHub required checks."
         }
-      ]
+      ],
+      "commit_sha": "aec55ff3",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1799",
+      "pr_number": 1799
     },
     "IQ-NORM-02": {
       "id": "IQ-NORM-02",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17821,6 +17821,7 @@ prs:
       - backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php
       - backend/app/Services/Iq/IqNormAuthorityContract.php
       - backend/tests/Feature/Content/IqNormAuthorityTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - backend/docs/iq/iq-production-norm-authority.md
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17805,3 +17805,247 @@ prs:
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes
+
+  - id: IQ-NORM-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/iq-norm-01-calibration-authority
+    base: main
+    title: "IQ-NORM-01 add IQ norm calibration authority"
+    train_scope: iq_production_launch
+    status: in_progress
+    scope:
+      - Add backend-only IQ norm authority schema, contract service, governance documentation, and regression tests.
+      - Keep current beta scoring/report runtime behavior unchanged and keep IQ public claims locked until later norm unlock work.
+    allowed_paths:
+      - backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php
+      - backend/app/Services/Iq/IqNormAuthorityContract.php
+      - backend/tests/Feature/Content/IqNormAuthorityTest.php
+      - backend/docs/iq/iq-production-norm-authority.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Import real norm tables or third-party IQ data.
+      - Unlock iq_estimate, percentile, confidence_interval, SEO indexation, or paid-report claims.
+      - Move norm authority to frontend or CMS.
+    validation:
+      - php -l backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php backend/app/Services/Iq/IqNormAuthorityContract.php backend/tests/Feature/Content/IqNormAuthorityTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqNormAuthorityTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-NORM-02
+
+  - id: IQ-NORM-02
+    repo: fap-api
+    depends_on: [IQ-NORM-01]
+    branch: codex/iq-norm-02-importer-dry-run
+    base: main
+    title: "IQ-NORM-02 add IQ norm table importer dry-run"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Add dry-run IQ norm table importer, schema validation, version lock checks, and invalid fixture rejection.
+    do_not:
+      - Change runtime scoring/report behavior or publish real norm data.
+    validation:
+      - php -l changed PHP files
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqNorm --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-NORM-03
+
+  - id: IQ-NORM-03
+    repo: fap-api
+    depends_on: [IQ-NORM-02]
+    branch: codex/iq-norm-03-score-claim-unlock
+    base: main
+    title: "IQ-NORM-03 unlock IQ score claims through norm authority"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Wire IQ scoring/report claim fields to backend norm authority only.
+    do_not:
+      - Let frontend, CMS, payment state, or SEO copy unlock IQ claims.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqTestDriverTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportBuilderTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-PAID-REPORT-01
+
+  - id: IQ-PAID-REPORT-01
+    repo: fap-api
+    depends_on: [IQ-NORM-03]
+    branch: codex/iq-paid-report-01-entitlement-contract
+    base: main
+    title: "IQ-PAID-REPORT-01 define paid report entitlement contract"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Define backend free/paid IQ report field contract, entitlement redaction, and order permission tests.
+    do_not:
+      - Expose private report fields without backend entitlement.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqPaidReport --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-PAID-REPORT-02
+
+  - id: IQ-PAID-REPORT-02
+    repo: fap-web
+    depends_on: [IQ-PAID-REPORT-01]
+    branch: codex/iq-paid-report-02-render-entitlement-states
+    base: main
+    title: "IQ-PAID-REPORT-02 render paid report entitlement states"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Render IQ paid-report free, paid, unauthorized, and error states from backend contract only.
+    do_not:
+      - Add local report conclusions, local IQ claims, or frontend entitlement inference.
+    validation:
+      - ./node_modules/.bin/vitest run targeted IQ paid report contracts
+      - ./node_modules/.bin/tsc --noEmit --pretty false
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-CMS-MEDIA-01
+
+  - id: IQ-CMS-MEDIA-01
+    repo: fap-api
+    depends_on: [IQ-PAID-REPORT-02]
+    branch: codex/iq-cms-media-01-authority-metadata
+    base: main
+    title: "IQ-CMS-MEDIA-01 register CMS media authority metadata"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Register IQ landing, OG, and report media metadata through backend CMS/Media Library authority.
+    do_not:
+      - Add frontend public static media fallback assets.
+    validation:
+      - python3 JSON parse changed baselines
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-CMS-MEDIA-02
+
+  - id: IQ-CMS-MEDIA-02
+    repo: fap-web
+    depends_on: [IQ-CMS-MEDIA-01]
+    branch: codex/iq-cms-media-02-rendering-guard
+    base: main
+    title: "IQ-CMS-MEDIA-02 render CMS media without frontend fallbacks"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Render IQ CMS media metadata with minimal shell behavior when media authority is missing.
+    do_not:
+      - Add local public assets or editorial media fallbacks.
+    validation:
+      - ./node_modules/.bin/vitest run targeted IQ media contracts
+      - ./node_modules/.bin/tsc --noEmit --pretty false
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-SEO-RAMP-01
+
+  - id: IQ-SEO-RAMP-01
+    repo: fap-api
+    depends_on: [IQ-CMS-MEDIA-02, IQ-NORM-03]
+    branch: codex/iq-seo-ramp-01-cms-authority
+    base: main
+    title: "IQ-SEO-RAMP-01 publish CMS SEO ramp authority"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Publish backend CMS SEO metadata, canonical, and claim policy needed for IQ SEO ramp.
+    do_not:
+      - Expand frontend sitemap, llms, or JSON-LD directly.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Seo --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-SEO-RAMP-02
+
+  - id: IQ-SEO-RAMP-02
+    repo: fap-web
+    depends_on: [IQ-SEO-RAMP-01]
+    branch: codex/iq-seo-ramp-02-indexation-gate
+    base: main
+    title: "IQ-SEO-RAMP-02 gate SEO indexation through backend authority"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Gate IQ sitemap, llms, canonical, and JSON-LD expansion on backend SEO, norm authority, and claim policy.
+    do_not:
+      - Bypass backend claim_policy or norm_authority gates.
+    validation:
+      - ./node_modules/.bin/vitest run targeted sitemap llms IQ SEO contracts
+      - ./node_modules/.bin/tsc --noEmit --pretty false
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-LIVE-RAMP-01
+
+  - id: IQ-LIVE-RAMP-01
+    repo: fap-web
+    depends_on: [IQ-SEO-RAMP-02, IQ-PAID-REPORT-02]
+    branch: codex/iq-live-ramp-01-authenticated-smoke
+    base: main
+    title: "IQ-LIVE-RAMP-01 add authenticated production smoke fixture gate"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Extend IQ live smoke for operator fixture validation of submit, result, paid report, canonical, and leakage checks.
+    do_not:
+      - Commit real tokens, user data, answer keys, or private report payloads.
+    validation:
+      - node scripts/iq/iq-launch-readiness-smoke.mjs
+      - ./node_modules/.bin/vitest run targeted IQ smoke contracts
+      - ./node_modules/.bin/tsc --noEmit --pretty false
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-OBS-01
+
+  - id: IQ-OBS-01
+    repo: fap-api
+    depends_on: [IQ-LIVE-RAMP-01]
+    branch: codex/iq-obs-01-production-guards
+    base: main
+    title: "IQ-OBS-01 add production observability guards"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Add IQ production observability for completion, norm miss, entitlement miss, scoring anomalies, and version drift.
+    do_not:
+      - Log answer keys, answer text, private paid report fields, or personal sensitive data.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: IQ-RELEASE-01
+
+  - id: IQ-RELEASE-01
+    repo: fap-web
+    depends_on: [IQ-OBS-01]
+    branch: codex/iq-release-01-launch-readiness-ledger
+    base: main
+    title: "IQ-RELEASE-01 finalize production launch readiness ledger"
+    train_scope: iq_production_launch
+    status: pending
+    scope:
+      - Finalize IQ production launch readiness ledger, gate evidence, deferred risks, and release checklist.
+    do_not:
+      - Change runtime behavior or deploy production.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 YAML/manifest validation
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: null


### PR DESCRIPTION
## What changed
- Added backend `iq_norm_authorities` schema for IQ norm/calibration authority records.
- Added `IqNormAuthorityContract` to define claim-eligible statuses and hard gates for public IQ estimate claims.
- Added IQ norm authority contract tests and governance documentation.
- Registered the authorized IQ production PR train entries in manifest/state and marked IQ-NORM-01 through local validation.

## Why
- IQ estimate, percentile, confidence interval, paid-report claims, and SEO ramp need a backend-only norm authority before any public claim unlock.
- This PR creates the authority boundary without importing real norm data or changing current beta runtime behavior.

## Validation
- `php -l backend/database/migrations/2026_05_31_090000_create_iq_norm_authorities_table.php backend/app/Services/Iq/IqNormAuthorityContract.php backend/tests/Feature/Content/IqNormAuthorityTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqNormAuthorityTest --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No real norm table import.
- No scoring/report claim unlock.
- No paid report entitlement changes.
- No CMS media or SEO indexation expansion.

## Repository rule impact
- Adds backend-authoritative IQ norm/calibration infrastructure.
- Confirms frontend/CMS/SEO/payment surfaces must not unlock IQ claims without backend norm authority.