### PR TITLE
AUDIT-SEC-CONTENT-IMPORT-SAFETY-01: harden article baseline import identifiers

### DIFF
--- a/backend/app/Console/Commands/ArticleImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ArticleImportLocalBaseline.php
@@ -23,6 +23,8 @@ final class ArticleImportLocalBaseline extends Command
 {
     private const SUPPORTED_LOCALES = ['en', 'zh-CN'];
 
+    private const TRANSLATION_GROUP_ID_MAX_LENGTH = 64;
+
     protected $signature = 'articles:import-local-baseline
         {--dry-run : Validate and diff without writing to the database}
         {--locale=* : Import only specific locale(s)}
@@ -331,7 +333,7 @@ final class ArticleImportLocalBaseline extends Command
             'related_test_slug' => $this->normalizeNullableSlug($row['related_test_slug'] ?? null),
             'voice' => $this->normalizeNullableString($row['voice'] ?? null),
             'voice_order' => $this->normalizeNullablePositiveInteger($row['voice_order'] ?? null, $file, $slug, 'voice_order'),
-            'translation_group_id' => $this->normalizeNullableString($row['translation_group_id'] ?? null),
+            'translation_group_id' => $this->normalizeTranslationGroupId($row['translation_group_id'] ?? null, $file, $slug),
             'source_locale' => $this->normalizeNullableString($row['source_locale'] ?? null),
             'translation_status' => $this->normalizeNullableString($row['translation_status'] ?? null),
             'category' => $this->normalizeNullableString($row['category'] ?? null),
@@ -351,7 +353,7 @@ final class ArticleImportLocalBaseline extends Command
     {
         /** @var Collection<string, Collection<int, array<string, mixed>>> $groups */
         $groups = collect($rows)->groupBy(
-            static fn (array $row): string => (string) ($row['translation_group_id'] ?: 'article:'.$row['slug'])
+            fn (array $row): string => (string) ($row['translation_group_id'] ?: $this->defaultTranslationGroupId((string) $row['slug']))
         );
 
         $normalized = [];
@@ -1110,6 +1112,39 @@ final class ArticleImportLocalBaseline extends Command
         $normalized = trim((string) ($value ?? ''));
 
         return $normalized !== '' ? $normalized : null;
+    }
+
+    private function normalizeTranslationGroupId(mixed $value, string $file, string $slug): ?string
+    {
+        $normalized = $this->normalizeNullableString($value);
+        if ($normalized === null) {
+            return null;
+        }
+
+        if (mb_strlen($normalized) > self::TRANSLATION_GROUP_ID_MAX_LENGTH) {
+            throw new RuntimeException(sprintf(
+                'Baseline file %s has overlong translation_group_id for slug=%s; max length is %d.',
+                $file,
+                $slug,
+                self::TRANSLATION_GROUP_ID_MAX_LENGTH,
+            ));
+        }
+
+        return $normalized;
+    }
+
+    private function defaultTranslationGroupId(string $slug): string
+    {
+        $candidate = 'article:'.$slug;
+        if (mb_strlen($candidate) <= self::TRANSLATION_GROUP_ID_MAX_LENGTH) {
+            return $candidate;
+        }
+
+        $hash = substr(hash('sha256', $slug), 0, 12);
+        $prefixLength = self::TRANSLATION_GROUP_ID_MAX_LENGTH - mb_strlen('article:') - mb_strlen('-') - mb_strlen($hash);
+        $prefix = mb_substr($slug, 0, max(1, $prefixLength));
+
+        return 'article:'.$prefix.'-'.$hash;
     }
 
     private function normalizeNullableSlug(mixed $value): ?string

--- a/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
@@ -267,6 +267,59 @@ final class ArticleBaselineImportTest extends TestCase
             ->assertJsonPath('jsonld.url', 'https://fermatmind.com/zh/articles/'.$slug);
     }
 
+    public function test_import_rejects_overlong_translation_group_id_before_database_write(): void
+    {
+        $sourceDir = $this->writeBaselineSourceDir([
+            [
+                'slug' => 'overlong-translation-group',
+                'title' => 'Overlong translation group',
+                'excerpt' => 'Importer should reject overlong translation authority identifiers.',
+                'content_md' => "# Overlong translation group\n\nBody.",
+                'translation_group_id' => str_repeat('g', 65),
+            ],
+        ]);
+
+        $this->artisan('articles:import-local-baseline', [
+            '--dry-run' => true,
+            '--source-dir' => $sourceDir,
+            '--locale' => 'zh-CN',
+        ])
+            ->expectsOutputToContain('overlong translation_group_id')
+            ->assertExitCode(1);
+
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_import_keeps_generated_translation_group_id_within_database_limit(): void
+    {
+        $longSlug = 'career-'.str_repeat('translation-', 8).'authority';
+        $sourceDir = $this->writeBaselineSourceDir([
+            [
+                'slug' => $longSlug,
+                'title' => 'Generated translation group',
+                'excerpt' => 'Importer should keep generated translation authority identifiers bounded.',
+                'content_md' => "# Generated translation group\n\nBody.",
+            ],
+        ]);
+
+        $this->artisan('articles:import-local-baseline', [
+            '--source-dir' => $sourceDir,
+            '--locale' => 'zh-CN',
+            '--status' => 'draft',
+        ])
+            ->expectsOutputToContain('articles_found=1')
+            ->assertExitCode(0);
+
+        $article = Article::query()
+            ->withoutGlobalScopes()
+            ->where('slug', $longSlug)
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $this->assertLessThanOrEqual(64, mb_strlen((string) $article->translation_group_id));
+        $this->assertStringStartsWith('article:', (string) $article->translation_group_id);
+    }
+
     private function assertSixEditorialArticlesConvergeThroughSeoAuthority(): void
     {
         config(['app.frontend_url' => 'https://fermatmind.com']);
@@ -371,5 +424,21 @@ final class ArticleBaselineImportTest extends TestCase
         }
 
         $this->fail('Baseline article not found: '.$slug);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $articles
+     */
+    private function writeBaselineSourceDir(array $articles): string
+    {
+        $dir = sys_get_temp_dir().'/article-baseline-import-'.bin2hex(random_bytes(6));
+        mkdir($dir, 0777, true);
+
+        file_put_contents($dir.'/articles.zh-CN.json', json_encode([
+            'meta' => ['locale' => 'zh-CN'],
+            'articles' => $articles,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $dir;
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35509,14 +35509,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-05-31T13:09:40Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -35542,6 +35542,12 @@
         "from": "pr_open_checks_pending",
         "to": "ci_fix_pushed_pending_checks",
         "note": "GitHub verify-bigfive failed on runtime freeze classifier for ContentLoaderService.php; added scoped content runtime cache freshness exception and focused regression test."
+      },
+      {
+        "at": "2026-05-31T21:17:43+08:00",
+        "from": "ci_fix_pushed_pending_checks",
+        "to": "merged_and_cleaned",
+        "note": "GitHub checks passed; PR #1800 squash-merged; origin/main contains merge commit; task worktree/local branch cleaned; remote branch absent."
       }
     ],
     "sidecars": [
@@ -35551,6 +35557,87 @@
         "summary": "bash backend/scripts/ci_verify_mbti.sh failed in PacksPublishBig5Test and PacksRollbackBig5Test because test temp target compiled/manifest.json was absent. The same external failure was observed before this PR; changed files are limited to content runtime cache services/tests and PR-train ledger; no content pack files are staged."
       }
     ],
-    "next_task": "AUDIT-SEC-CONTENT-IMPORT-SAFETY-01"
+    "next_task": "AUDIT-SEC-CONTENT-IMPORT-SAFETY-01",
+    "github": {
+      "status": "merged",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1800"
+    },
+    "merge_commit": "445fc2e91cc1b63e5af95b781b42d7f66c504698"
+  },
+  "AUDIT-SEC-CONTENT-IMPORT-SAFETY-01": {
+    "status": "implementation_in_progress",
+    "branch": "audit/sec-content-import-safety-01",
+    "pr_url": null,
+    "base": "main",
+    "worktree": "/private/tmp/fap-api-audit-sec-content-import-safety-01",
+    "scope": "article_baseline_import_translation_group_bounds",
+    "authorized_by_user": true,
+    "workspace_safety": "using isolated worktree /private/tmp/fap-api-audit-sec-content-import-safety-01; dirty primary worktree untouched",
+    "allowed_paths": [
+      "backend/app/Console/Commands/ArticleImportLocalBaseline.php",
+      "backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php",
+      "docs/codex/pr-train.yaml",
+      "docs/codex/pr-train-state.json"
+    ],
+    "local_validation": {
+      "environment": {
+        "status": "passed_after_autoload_refresh",
+        "commands": [
+          "cd backend && composer dump-autoload --no-ansi"
+        ],
+        "evidence": "Rebuilt Composer autoload in the isolated worktree after vendor autoload pointed at a removed temporary worktree. Existing IQ PSR-4 warnings were emitted but autoload generation completed."
+      },
+      "focused": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi"
+        ],
+        "evidence": "Article baseline import tests passed: 5 tests, 233 assertions."
+      },
+      "acceptance": {
+        "status": "passed_with_external_ci_verify_sidecar",
+        "commands": [
+          "cd backend && php artisan route:list --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-content-import-safety-01.sqlite php artisan migrate --force --no-ansi",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check",
+          "bash backend/scripts/ci_verify_mbti.sh"
+        ],
+        "evidence": "route:list passed with 209 routes; sqlite migrate passed; schema/diff checks passed. ci_verify_mbti.sh passed 824 tests and failed only known Big5 content-pack publish/rollback temp target compiled directory assertions external to this PR scope; generated dirty artifacts were restored."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-05-31T21:17:43+08:00",
+        "from": "authorized",
+        "to": "implementation_in_progress",
+        "note": "Started scoped article baseline import identifier bounds hardening from latest origin/main after AUDIT-SEC-CONTENT-RUNTIME-CACHE-01 post-merge cleanup."
+      },
+      {
+        "at": "2026-05-31T22:23:46+08:00",
+        "from": "implementation_in_progress",
+        "to": "local_scope_validation_passed_with_sidecar",
+        "note": "Focused importer tests, route:list, sqlite migrate, diff/schema checks passed; unrelated ci_verify_mbti Big5 temp-target failures registered as sidecar per train protocol."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "big5_pack_publish_rollback_temp_target_compiled_missing",
+        "status": "registered_non_blocking_external_to_scope",
+        "summary": "bash backend/scripts/ci_verify_mbti.sh failed in PacksPublishBig5Test and PacksRollbackBig5Test because test temp target compiled/manifest.json was absent. This same external failure was observed before this PR; changed files are limited to article baseline importer/tests and PR-train ledger; generated Big5 artifacts were restored."
+      }
+    ],
+    "next_task": null
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35567,7 +35567,7 @@
   "AUDIT-SEC-CONTENT-IMPORT-SAFETY-01": {
     "status": "implementation_in_progress",
     "branch": "audit/sec-content-import-safety-01",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1803",
     "base": "main",
     "worktree": "/private/tmp/fap-api-audit-sec-content-import-safety-01",
     "scope": "article_baseline_import_translation_group_bounds",
@@ -35629,6 +35629,12 @@
         "from": "implementation_in_progress",
         "to": "local_scope_validation_passed_with_sidecar",
         "note": "Focused importer tests, route:list, sqlite migrate, diff/schema checks passed; unrelated ci_verify_mbti Big5 temp-target failures registered as sidecar per train protocol."
+      },
+      {
+        "at": "2026-05-31T22:25:19+08:00",
+        "from": "local_scope_validation_passed_with_sidecar",
+        "to": "pr_open_checks_pending",
+        "note": "Created PR #1803; waiting for GitHub required checks."
       }
     ],
     "sidecars": [
@@ -35638,6 +35644,10 @@
         "summary": "bash backend/scripts/ci_verify_mbti.sh failed in PacksPublishBig5Test and PacksRollbackBig5Test because test temp target compiled/manifest.json was absent. This same external failure was observed before this PR; changed files are limited to article baseline importer/tests and PR-train ledger; generated Big5 artifacts were restored."
       }
     ],
-    "next_task": null
+    "next_task": null,
+    "github": {
+      "status": "checks_pending",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1803"
+    }
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17151,6 +17151,54 @@ prs:
     frontend_fallback_authority: false
     next_task: AUDIT-SEC-CONTENT-IMPORT-SAFETY-01
 
+  - id: AUDIT-SEC-CONTENT-IMPORT-SAFETY-01
+    repo: fap-api
+    branch: audit/sec-content-import-safety-01
+    base: main
+    title: "AUDIT-SEC-CONTENT-IMPORT-SAFETY-01 harden article baseline import identifiers"
+    train_scope: article_baseline_import_translation_group_bounds
+    risk_level: high_security_content_import_integrity
+    depends_on:
+      - AUDIT-SEC-CONTENT-RUNTIME-CACHE-01 merged
+    allowed_paths:
+      - backend/app/Console/Commands/ArticleImportLocalBaseline.php
+      - backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Reject uploaded or committed article baseline rows whose explicit translation_group_id exceeds the articles table 64-character authority field.
+      - Keep generated fallback translation_group_id values within the same database limit when source slugs are long.
+      - Add focused importer regression tests proving overlong explicit identifiers fail before writes and generated identifiers remain bounded.
+    do_not:
+      - Do not deploy, mutate production, run production SSH, or approve production environments.
+      - Do not modify article content payloads, public Article APIs, CMS publish behavior, fap-web, sitemap generation, llms generation, Search Channel, or URL submission files.
+      - Do not add routes, migrations, public endpoints, new import commands, or production import execution.
+    validation:
+      - cd backend && php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-content-import-safety-01.sqlite php artisan migrate --force --no-ansi
+      - bash backend/scripts/ci_verify_mbti.sh
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    public_contract_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: null
+
   - id: PR-POL-01
     repo: fap-api
     branch: content/pr-pol-01-policies-dashboard


### PR DESCRIPTION
## Summary
- Reject explicit article baseline `translation_group_id` values that exceed the 64-character database authority field.
- Keep generated fallback article translation group identifiers within the same database limit for long slugs.
- Add focused importer regression tests and PR-train ledger scope.

## Validation
- `cd backend && composer dump-autoload --no-ansi` passed after isolated worktree autoload refresh; existing IQ PSR-4 warnings emitted.
- `cd backend && php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --no-ansi` passed: 5 tests, 233 assertions.
- `cd backend && php artisan route:list --no-ansi` passed: 209 routes.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-audit-sec-content-import-safety-01.sqlite php artisan migrate --force --no-ansi` passed.
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` passed.
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"` passed.
- `git diff --check` passed.
- `bash backend/scripts/ci_verify_mbti.sh` passed 824 tests and failed only known Big5 publish/rollback temp target compiled-directory assertions external to this PR scope; generated dirty artifacts restored.

## Scope / repository rule impact
- No routes added.
- No migrations added.
- No public API contract change.
- No production deploy, CMS publish, sitemap, llms, Search Channel, URL submission, or fap-web change.
- Sidecar registered for the external Big5 temp target compiled-directory failure.
