### PR TITLE
SIDECAR-CI-BIGFIVE-MEMORY raise Big Five verify memory limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -368,6 +368,6 @@ jobs:
         working-directory: backend
         run: |
           bash scripts/ci/verify_big5_norms.sh
-          php artisan content:lint --pack=BIG5_OCEAN --pack-version=v1
-          php artisan content:compile --pack=BIG5_OCEAN --pack-version=v1
-          php artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi
+          php -d memory_limit=1024M artisan content:lint --pack=BIG5_OCEAN --pack-version=v1
+          php -d memory_limit=1024M artisan content:compile --pack=BIG5_OCEAN --pack-version=v1
+          php -d memory_limit=1024M artisan test --filter '(BigFive|Big5|NonMbtiReportContractRegressionTest)' --no-ansi


### PR DESCRIPTION
## What changed
- Raises PHP memory_limit to 1024M for the Big Five verify lint, compile, and regression test commands in CI.

## Why
- IQ-NORM-02 exposed an external CI resource blocker where verify-bigfive exhausted the default 512M during BigFiveContentCompileService.
- This sidecar keeps the CI resource fix separate from the IQ norm importer PR so IQ-NORM-02 scope remains clean.

## Validation
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No product, backend runtime, CMS, scoring, or IQ changes.
