### PR TITLE
EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04 register email outbox sender in runtime scheduler

### DIFF
--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -39,6 +39,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('storage:inventory --json')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('storage:control-plane-snapshot --json')->dailyAt('04:20')->withoutOverlapping();
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
+        $schedule->command('email:outbox-send --limit=50')->everyMinute()->withoutOverlapping();
         $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --only-stale --limit=10 --older-than-minutes=60')->everyTenMinutes()->withoutOverlapping();
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();

--- a/backend/tests/Feature/Email/EmailOutboxSchedulerBootstrapTest.php
+++ b/backend/tests/Feature/Email/EmailOutboxSchedulerBootstrapTest.php
@@ -1,0 +1,44 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Email;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class EmailOutboxSchedulerBootstrapTest extends TestCase
+{
+    public function test_email_outbox_send_is_registered_in_runtime_schedule(): void
+    {
+        $events = $this->scheduleListEvents();
+        $event = collect($events)->first(
+            fn (array $event): bool => str_contains((string) ($event['command'] ?? ''), 'email:outbox-send')
+        );
+
+        $this->assertNotNull(
+            $event,
+            'schedule:list did not include the email outbox sender command. Commands: '.json_encode(
+                array_values(array_map(fn (array $item): string => (string) ($item['command'] ?? ''), $events))
+            )
+        );
+        $this->assertStringContainsString('email:outbox-send', (string) $event['command']);
+        $this->assertStringContainsString('--limit=50', (string) $event['command']);
+        $this->assertSame('* * * * *', $event['expression']);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function scheduleListEvents(): array
+    {
+        $process = new Process([PHP_BINARY, base_path('artisan'), 'schedule:list', '--json', '--no-ansi'], base_path());
+        $process->mustRun();
+
+        $decoded = json_decode($process->getOutput(), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36063,5 +36063,78 @@
       }
     ],
     "next_task": "Wait for GitHub checks on PR #1805, merge if allowed, cleanup, then prepare BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01."
+  },
+  "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04": {
+    "id": "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04",
+    "repo": "fap-api",
+    "branch": "codex/email-outbox-scheduler-bootstrap-04",
+    "base": "main",
+    "status": "pr_opened_with_sidecar",
+    "title": "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04 register email outbox sender in runtime scheduler",
+    "commit_sha": "e8f34b2870b3567b187939972ab9c74e2872322b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1809",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04 to fap-api pr-train manifest/state."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to backend/bootstrap/app.php, focused email scheduler test, and pr-train metadata; no production env, email send, DNS, credentials, outbox mutation, payment flow, frontend, deploy, Search Channel, or URL submission changes."
+      },
+      "php artisan test --filter=EmailOutboxSchedulerBootstrap --display-warnings --no-ansi": {
+        "status": "pass",
+        "evidence": "Focused test passed: schedule:list --json contains email:outbox-send --limit=50 on every-minute cron."
+      },
+      "php artisan schedule:list --no-ansi": {
+        "status": "pass",
+        "evidence": "Runtime scheduler listing includes email:outbox-send --limit=50."
+      },
+      "php artisan route:list --no-ansi": {
+        "status": "pass",
+        "evidence": "Route listing completed successfully."
+      },
+      "vendor/bin/pint --test bootstrap/app.php tests/Feature/Email/EmailOutboxSchedulerBootstrapTest.php": {
+        "status": "pass",
+        "evidence": "Scoped formatting check passed for files touched by this PR."
+      },
+      "vendor/bin/pint --test": {
+        "status": "sidecar_external_failure",
+        "evidence": "Full Pint fails on pre-existing out-of-scope app/Http/Controllers/API/V0_3/AttemptReadController.php unary_operator_spaces; current scoped files pass Pint."
+      },
+      "composer validate --strict": {
+        "status": "pass",
+        "evidence": "Composer schema validation passed."
+      },
+      "composer audit --locked --no-interaction --ignore-unreachable": {
+        "status": "pass",
+        "evidence": "No locked dependency advisories reported."
+      },
+      "json_yaml_diff_checks": {
+        "status": "pass",
+        "evidence": "pr-train-state JSON parsed, pr-train YAML parsed, git diff --check passed, and git diff --cached --check passed."
+      }
+    },
+    "failure_reason": "Sidecar only: full Pint has a pre-existing out-of-scope AttemptReadController formatting issue; scoped files passed.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "history": [
+      {
+        "at": "2026-05-31T12:41:31Z",
+        "status": "in_progress",
+        "summary": "Initialized after user authorization; using isolated worktree from latest origin/main."
+      },
+      {
+        "at": "2026-05-31T14:47:01Z",
+        "status": "local_checks_passed_with_sidecar",
+        "summary": "Registered email:outbox-send in Laravel bootstrap scheduler and added focused schedule:list coverage. Focused test, schedule:list, route:list, scoped Pint, composer validate, composer audit, JSON/YAML parsing, and diff checks passed. Full Pint remains blocked by a pre-existing out-of-scope AttemptReadController formatting issue."
+      },
+      {
+        "at": "2026-05-31T15:18:00Z",
+        "status": "pr_opened_with_sidecar",
+        "summary": "Opened PR #1809 and rebased onto latest origin/main from implementation commit e8f34b2870b3567b187939972ab9c74e2872322b; GitHub checks must rerun after force-push."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36071,7 +36071,7 @@
     "base": "main",
     "status": "pr_opened_with_sidecar",
     "title": "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04 register email outbox sender in runtime scheduler",
-    "commit_sha": "e8f34b2870b3567b187939972ab9c74e2872322b",
+    "commit_sha": "c240dd9468f99a4c3411dd2d5e669f50694edca4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1809",
     "checks": {
       "manifest_registration": {
@@ -36133,7 +36133,7 @@
       {
         "at": "2026-05-31T15:18:00Z",
         "status": "pr_opened_with_sidecar",
-        "summary": "Opened PR #1809 and rebased onto latest origin/main from implementation commit e8f34b2870b3567b187939972ab9c74e2872322b; GitHub checks must rerun after force-push."
+        "summary": "Opened PR #1809 and rebased onto latest origin/main from implementation commit c240dd9468f99a4c3411dd2d5e669f50694edca4; GitHub checks must rerun after force-push."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18270,3 +18270,37 @@ prs:
       - git diff --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: null
+
+  - id: EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04
+    repo: fap-api
+    depends_on: []
+    branch: codex/email-outbox-scheduler-bootstrap-04
+    base: main
+    title: "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04 register email outbox sender in runtime scheduler"
+    train_scope: email_first_result_access
+    status: pending
+    scope:
+      - Register email:outbox-send in the Laravel 11 bootstrap scheduler so production schedule:run can send pending DirectMail outbox rows.
+      - Add focused schedule:list coverage that verifies the runtime scheduler contains the email outbox command.
+    allowed_paths:
+      - backend/bootstrap/app.php
+      - backend/tests/Feature/Email/EmailOutboxSchedulerBootstrapTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Edit production env, credentials, DNS, DirectMail console settings, or SMTP secrets.
+      - Send real email or mutate production outbox rows.
+      - Change result access token semantics, payment flows, or frontend behavior.
+    validation:
+      - cd backend && php artisan test --filter=EmailOutboxSchedulerBootstrap --no-ansi
+      - cd backend && php artisan schedule:list --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: RESULT-EMAIL-LOOKUP-TOKEN-OPEN-04


### PR DESCRIPTION
## What changed
- Registered `email:outbox-send --limit=50` in the Laravel 11 bootstrap scheduler.
- Added focused `schedule:list --json` coverage to prove the runtime scheduler contains the outbox sender.
- Added the authorized PR-train manifest/state entry.

## Why
Production DirectMail SMTP is configured, but queued outbox rows need the scheduler runner to invoke the sender automatically. This PR wires the existing command into the runtime scheduler without sending mail during validation.

## Validation
- `php artisan test --filter=EmailOutboxSchedulerBootstrap --display-warnings --no-ansi`
- `php artisan schedule:list --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test bootstrap/app.php tests/Feature/Email/EmailOutboxSchedulerBootstrapTest.php`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`

## Sidecar
- Full `vendor/bin/pint --test` currently fails on pre-existing out-of-scope formatting in `app/Http/Controllers/API/V0_3/AttemptReadController.php`; scoped Pint for this PR passed.

## Intentionally deferred
- No production env edits.
- No credentials or DirectMail console changes.
- No real email sends or production outbox mutation.
- No frontend, result token, payment, deploy, Search Channel, or URL submission changes.
