### PR TITLE
style(eq): format Eq60 report composer

### DIFF
--- a/backend/app/Services/Report/Eq60ReportComposer.php
+++ b/backend/app/Services/Report/Eq60ReportComposer.php
@@ -662,8 +662,7 @@ final class Eq60ReportComposer
         array $interpretation,
         array $quality,
         array $crossAssessmentContext
-    ): array
-    {
+    ): array {
         $docs = is_array($assets['assets'] ?? null) ? $assets['assets'] : [];
         $scientificAssets = (array) data_get($docs, 'scientific_contract.assets', []);
         $sjtAssets = (array) data_get($docs, 'sjt_bridge.assets', []);


### PR DESCRIPTION
## What changed
- Applied Pint formatting to `backend/app/Services/Report/Eq60ReportComposer.php` only.

## Why
- Unblocks required full-repo `vendor/bin/pint --test` validation for the waiting `CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01` PR.
- No behavior, runtime, CMS, deploy, Search Channel, or content changes.

## Validation
- `php artisan route:list --no-ansi` passed.
- `vendor/bin/pint --test` passed: 3674 files.
- `composer validate --strict` passed.
- `composer audit --locked --no-interaction --ignore-unreachable` passed.
- `git diff --check` passed.

## Intentionally deferred
- No EQ behavior or report logic changes.
- No train manifest/state changes.
- No production operation or deploy.
