### PR TITLE
CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01 dynamic slot architecture guardrails

### DIFF
--- a/backend/docs/seo/career-l3-dynamic-slot-architecture-01.md
+++ b/backend/docs/seo/career-l3-dynamic-slot-architecture-01.md
@@ -1,0 +1,67 @@
+# CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01
+
+## 1. Executive Summary
+
+This PR records the architecture boundary for future MBTI, Big Five, and RIASEC x Career personalization.
+
+The approved model is dynamic-slot-only. Public career detail pages remain the 1046 backend-authoritative occupation pages. Personalized cross-assessment explanations may be rendered only as bounded runtime slots after a user context exists, not as static public pages.
+
+## 2. Dynamic Slot Model
+
+Dynamic slots are request-time or session-aware overlays that combine:
+
+- backend career runtime authority;
+- assessment result vectors or user-held result context;
+- bounded explanation templates approved by backend/CMS authority;
+- explicit claim and discoverability gates.
+
+They must not create static URL families such as `/career/jobs/{slug}/mbti/{type}`, `/mbti/{type}/careers/{slug}`, or equivalent cross-matrix pSEO pages.
+
+## 3. Static pSEO Block
+
+The L3 combinatorial matrix is intentionally not generated:
+
+- 1046 careers x 16 MBTI types is 16,736 combinations before Big Five and RIASEC are considered.
+- Static SSG/ISR page generation would create build, sitemap, llms, and claim-boundary risk.
+- Search surfaces must not expose personalized or cross-matrix slot content as public URL Truth.
+
+## 4. Discoverability Boundary
+
+Sitemap, `llms.txt`, `llms-full.txt`, Search Channel, and footer/nav exposure are limited to canonical backend-authoritative public pages.
+
+Dynamic L3 slots are not independently sitemap-eligible, llms-eligible, Search Channel-eligible, or canonical URL entities until a future explicitly approved authority model exists.
+
+## 5. Claim Boundary
+
+L3 copy may frame outputs as exploratory decision support. It must not claim:
+
+- best career for the user;
+- hiring fit or job suitability guarantee;
+- salary, turnover, or career success prediction;
+- diagnosis, treatment, or cure;
+- MBTI, Big Five, or RIASEC determines a career outcome.
+
+## 6. Validation
+
+Focused validation:
+
+- `php artisan test --filter=CareerL3DynamicSlotArchitecture01 --no-ansi`
+
+The test validates the generated artifact, non-generation flags, discoverability gates, blocked URL patterns, claim boundary, and report sections.
+
+## 7. What Was Not Done
+
+- No runtime L3 product was implemented.
+- No static L3 pages were generated.
+- No CMS mutation or content generation occurred.
+- No sitemap, llms, footer/nav, or Search Channel exposure changed.
+- No fap-web change was made.
+- No deploy or production operation was performed.
+
+## 8. Final Decision
+
+`career_l3_dynamic_slot_architecture_completed_ready_for_release_train_sidecar_soft_alert`
+
+## 9. Next Task
+
+`RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01`

--- a/backend/docs/seo/generated/career-l3-dynamic-slot-architecture-01.v1.json
+++ b/backend/docs/seo/generated/career-l3-dynamic-slot-architecture-01.v1.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "career_l3_dynamic_slot_architecture.v1",
+  "task": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01",
+  "final_decision": "career_l3_dynamic_slot_architecture_completed_ready_for_release_train_sidecar_soft_alert",
+  "architecture_mode": "dynamic_slot_only",
+  "source_of_truth": "backend_career_runtime_authority_plus_backend_approved_assessment_context",
+  "public_career_detail_expected_count": 1046,
+  "localized_public_career_url_expected_count": 2092,
+  "supported_signal_families": [
+    "mbti",
+    "big_five",
+    "riasec"
+  ],
+  "dynamic_slot_requirements": [
+    "user_or_session_assessment_context_required",
+    "backend_authority_required",
+    "claim_boundary_required",
+    "budgeted_runtime_fetch_required",
+    "fail_closed_when_authority_missing",
+    "no_frontend_fallback_authority"
+  ],
+  "blocked_static_url_patterns": [
+    "/career/jobs/{slug}/mbti/{type}",
+    "/career/jobs/{slug}/big-five/{profile}",
+    "/career/jobs/{slug}/riasec/{code}",
+    "/mbti/{type}/careers/{slug}",
+    "/big-five/{profile}/careers/{slug}",
+    "/riasec/{code}/careers/{slug}"
+  ],
+  "static_combinatorial_pages_allowed": false,
+  "static_cross_matrix_url_count": 0,
+  "estimated_mbti_career_static_matrix_count": 16736,
+  "pseo_generation_performed": false,
+  "static_l3_generation_performed": false,
+  "sitemap_llms_exposure_changed": false,
+  "sitemap_llms_exposure_allowed_for_slots": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "cms_mutation_performed": false,
+  "production_write_performed": false,
+  "deploy_performed": false,
+  "frontend_fallback_authority_used": false,
+  "fap_web_change_performed": false,
+  "claim_boundary": {
+    "forbidden_claim_hits": [],
+    "allowed_framing": [
+      "exploratory_guidance",
+      "decision_support",
+      "workstyle_tendency",
+      "interest_signal",
+      "occupation_information"
+    ],
+    "blocked_claims": [
+      "best_career_for_user",
+      "hiring_fit",
+      "job_suitability_guarantee",
+      "salary_prediction_or_guarantee",
+      "turnover_prediction",
+      "career_success_guarantee",
+      "diagnosis_treatment_cure",
+      "psychometric_determines_career"
+    ]
+  },
+  "next_task": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01"
+}

--- a/backend/tests/Feature/SeoIntel/CareerL3DynamicSlotArchitecture01Test.php
+++ b/backend/tests/Feature/SeoIntel/CareerL3DynamicSlotArchitecture01Test.php
@@ -1,0 +1,141 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerL3DynamicSlotArchitecture01Test extends TestCase
+{
+    #[Test]
+    public function generated_artifact_records_dynamic_slot_only_architecture(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('career_l3_dynamic_slot_architecture.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01', $payload['task'] ?? null);
+        $this->assertSame('dynamic_slot_only', $payload['architecture_mode'] ?? null);
+        $this->assertSame('backend_career_runtime_authority_plus_backend_approved_assessment_context', $payload['source_of_truth'] ?? null);
+        $this->assertSame(1046, $payload['public_career_detail_expected_count'] ?? null);
+        $this->assertSame(2092, $payload['localized_public_career_url_expected_count'] ?? null);
+
+        $this->assertEqualsCanonicalizing(['mbti', 'big_five', 'riasec'], $payload['supported_signal_families'] ?? []);
+
+        foreach ([
+            'user_or_session_assessment_context_required',
+            'backend_authority_required',
+            'claim_boundary_required',
+            'budgeted_runtime_fetch_required',
+            'fail_closed_when_authority_missing',
+            'no_frontend_fallback_authority',
+        ] as $requirement) {
+            $this->assertContains($requirement, $payload['dynamic_slot_requirements'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function static_combinatorial_pseo_and_discoverability_are_blocked(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertFalse((bool) ($payload['static_combinatorial_pages_allowed'] ?? true));
+        $this->assertSame(0, $payload['static_cross_matrix_url_count'] ?? null);
+        $this->assertSame(16736, $payload['estimated_mbti_career_static_matrix_count'] ?? null);
+
+        foreach ([
+            'pseo_generation_performed',
+            'static_l3_generation_performed',
+            'sitemap_llms_exposure_changed',
+            'sitemap_llms_exposure_allowed_for_slots',
+            'search_channel_action_performed',
+            'url_submission_performed',
+            'cms_mutation_performed',
+            'production_write_performed',
+            'deploy_performed',
+            'frontend_fallback_authority_used',
+            'fap_web_change_performed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($payload[$flag] ?? true), $flag);
+        }
+
+        foreach ([
+            '/career/jobs/{slug}/mbti/{type}',
+            '/career/jobs/{slug}/big-five/{profile}',
+            '/career/jobs/{slug}/riasec/{code}',
+            '/mbti/{type}/careers/{slug}',
+            '/big-five/{profile}/careers/{slug}',
+            '/riasec/{code}/careers/{slug}',
+        ] as $pattern) {
+            $this->assertContains($pattern, $payload['blocked_static_url_patterns'] ?? []);
+        }
+    }
+
+    #[Test]
+    public function claim_boundary_stays_bounded_for_l3_slots(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame([], data_get($payload, 'claim_boundary.forbidden_claim_hits'));
+
+        foreach (['exploratory_guidance', 'decision_support', 'workstyle_tendency', 'interest_signal'] as $framing) {
+            $this->assertContains($framing, data_get($payload, 'claim_boundary.allowed_framing', []));
+        }
+
+        foreach ([
+            'best_career_for_user',
+            'hiring_fit',
+            'job_suitability_guarantee',
+            'salary_prediction_or_guarantee',
+            'turnover_prediction',
+            'career_success_guarantee',
+            'diagnosis_treatment_cure',
+            'psychometric_determines_career',
+        ] as $claim) {
+            $this->assertContains($claim, data_get($payload, 'claim_boundary.blocked_claims', []));
+        }
+    }
+
+    #[Test]
+    public function report_has_required_sections_and_next_task(): void
+    {
+        $path = base_path('docs/seo/career-l3-dynamic-slot-architecture-01.md');
+
+        $this->assertFileExists($path);
+
+        $report = (string) file_get_contents($path);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. Dynamic Slot Model',
+            '## 3. Static pSEO Block',
+            '## 4. Discoverability Boundary',
+            '## 5. Claim Boundary',
+            '## 6. Validation',
+            '## 7. What Was Not Done',
+            '## 8. Final Decision',
+            '## 9. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+
+        $this->assertSame(
+            'career_l3_dynamic_slot_architecture_completed_ready_for_release_train_sidecar_soft_alert',
+            $this->payload()['final_decision'] ?? null,
+        );
+        $this->assertSame('RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01', $this->payload()['next_task'] ?? null);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = base_path('docs/seo/generated/career-l3-dynamic-slot-architecture-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T22:58:00+08:00",
+  "updated_at": "2026-05-31T15:45:22Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22170,7 +22170,7 @@
       "branch": "codex/career-1046-internal-linking-authority-01",
       "base": "main",
       "title": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 career internal linking authority",
-      "status": "pr_open",
+      "status": "merged",
       "depends_on": [
         "PR-HIRING-01"
       ],
@@ -22209,14 +22209,18 @@
           "status": "pass",
           "command": "git diff --check && git diff --cached --check",
           "evidence": "Whitespace checks passed before staging; cached check rerun before commit."
+        },
+        "reconciliation": {
+          "status": "pass",
+          "evidence": "GitHub PR #1798 is MERGED, origin/main contains 38d0c8a7646d9e8264c62694c60a8445d3623096, remote branch is absent, and local branch cleanup was performed in the isolated train worktree."
         }
       },
       "failure_reason": null,
       "commit_sha": "c648f3e67147e3aa82d03aef085f8bef0c8a7556",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1798",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T09:02:34Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
@@ -22247,10 +22251,17 @@
           "from": "committed",
           "to": "pr_open",
           "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1798; GitHub checks pending."
+        },
+        {
+          "at": "2026-05-31T14:40:00Z",
+          "from": "pr_open",
+          "to": "merged",
+          "note": "Reconciled already-merged fap-api PR #1798 before resuming CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01."
         }
       ],
       "sidecars": [],
-      "next_task": "CAREER-1046-FRONTEND-DISCOVERY-UX-01"
+      "next_task": "CAREER-1046-FRONTEND-DISCOVERY-UX-01",
+      "merge_sha": "38d0c8a7646d9e8264c62694c60a8445d3623096"
     },
     "CAREER-1046-FRONTEND-DISCOVERY-UX-01": {
       "id": "CAREER-1046-FRONTEND-DISCOVERY-UX-01",
@@ -22258,26 +22269,39 @@
       "branch": "codex/career-1046-frontend-discovery-ux-01",
       "base": "main",
       "title": "CAREER-1046-FRONTEND-DISCOVERY-UX-01 career discovery UX",
-      "status": "pending",
+      "status": "merged",
       "depends_on": [
         "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01"
       ],
-      "checks": {},
-      "failure_reason": null,
-      "commit_sha": null,
-      "pr_url": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
-      "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+      "checks": {
+        "reconciliation": {
+          "status": "pass",
+          "evidence": "GitHub PR #939 is MERGED, fap-web origin/main contains 7626b901d77a5191a1b9211fd0b9a91c854a6c4f, remote branch is absent, isolated worktree was removed, and post-merge focused contract passed."
+        }
       },
-      "transitions": [],
+      "failure_reason": null,
+      "commit_sha": "60fab8cfa0624122edc231b7b67f39cc65ce658b",
+      "pr_url": "https://github.com/fermatmind/fap-web/pull/939",
+      "merged_at": "2026-05-31T12:54:10Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": true,
+        "post_merge_revalidated": true
+      },
+      "transitions": [
+        {
+          "at": "2026-05-31T14:40:00Z",
+          "from": "pending",
+          "to": "merged",
+          "note": "Reconciled fap-web PR #939 as merged before resuming dependent fap-api PR6."
+        }
+      ],
       "sidecars": [],
-      "next_task": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01"
+      "next_task": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01",
+      "merge_sha": "7626b901d77a5191a1b9211fd0b9a91c854a6c4f"
     },
     "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01": {
       "id": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01",
@@ -22285,26 +22309,122 @@
       "branch": "codex/career-l3-dynamic-slot-architecture-01",
       "base": "main",
       "title": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01 dynamic slot architecture guardrails",
-      "status": "pending",
+      "status": "pr_open",
       "depends_on": [
         "CAREER-1046-FRONTEND-DISCOVERY-UX-01"
       ],
-      "checks": {},
+      "checks": {
+        "dependency_preflight": {
+          "status": "pass",
+          "evidence": "Dependencies CAREER-1046-FRONTEND-DISCOVERY-UX-01 and CAREER-1046-INTERNAL-LINKING-AUTHORITY-01 are reconciled as merged; branch was rebased/reset to latest origin/main before validation."
+        },
+        "focused_test": {
+          "status": "pass",
+          "command": "php artisan test --filter=CareerL3DynamicSlotArchitecture01 --no-ansi",
+          "evidence": "4 tests passed, 63 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully, 209 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Passed after scoped Pint cleanup PR #1811 merged Eq60ReportComposer.php formatting fix; 3677 files checked."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "composer validate --strict",
+          "evidence": "composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool backend/docs/seo/generated/career-l3-dynamic-slot-architecture-01.v1.json >/dev/null; python3 -m json.tool docs/codex/pr-train-state.json >/dev/null; yaml.safe_load(docs/codex/pr-train.yaml)",
+          "evidence": "Generated JSON, state JSON, and train YAML parse successfully."
+        },
+        "scope_diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "Whitespace checks passed before and after path-limited staging."
+        }
+      },
       "failure_reason": null,
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "944797b6b32b8a1e1f2fc74cc28dca81e5e18087",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1814",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [],
-      "sidecars": [],
-      "next_task": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01"
+      "transitions": [
+        {
+          "at": "2026-05-31T14:40:00Z",
+          "from": "pending",
+          "to": "in_progress",
+          "note": "Resumed PR6 after upstream main advanced and reapplied scoped docs/generated/test changes on latest origin/main."
+        },
+        {
+          "at": "2026-05-31T14:45:00Z",
+          "from": "in_progress",
+          "to": "blocked_local_check_failed_external",
+          "note": "After rebasing/resetting to latest origin/main, required full Pint still fails on out-of-scope Eq60ReportComposer formatting issue; PR not opened per repo rules."
+        },
+        {
+          "at": "2026-05-31T15:40:15Z",
+          "from": "blocked_local_check_failed_external",
+          "to": "local_validation_passed",
+          "note": "Resumed after scoped Pint cleanup PR #1811 merged; full local validation now passes for CAREER-L3 dynamic slot architecture scope."
+        },
+        {
+          "at": "2026-05-31T15:43:00Z",
+          "from": "local_validation_passed",
+          "to": "committed",
+          "note": "Created scoped PR6 commit 6b9b2d3bc9a8394dbecf598f91d5cf2a0b7f6c96 after local validation passed."
+        },
+        {
+          "at": "2026-05-31T15:45:22Z",
+          "from": "committed",
+          "to": "pr_open",
+          "note": "Pushed branch and opened PR https://github.com/fermatmind/fap-api/pull/1814; GitHub checks pending."
+        }
+      ],
+      "sidecars": [
+        {
+          "source_pr": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01",
+          "repo": "fap-api",
+          "branch": "codex/career-l3-dynamic-slot-architecture-01",
+          "command_or_check": "vendor/bin/pint --test",
+          "evidence": "Pint reports backend/app/Services/Report/Eq60ReportComposer.php unary_operator_spaces/braces while git diff shows the file is unmodified by this branch.",
+          "failure_summary": "Latest origin/main still has an out-of-scope Pint formatting issue after the previous AttemptReadController blocker was resolved upstream.",
+          "why_external_to_current_pr": "Current PR changes only CAREER-L3 dynamic-slot docs/generated/test/ledger; Eq60ReportComposer.php is outside scope and untouched.",
+          "impact_on_current_pr": "Cannot open/merge PR under repository local validation rules until the out-of-scope Pint issue is fixed or user authorizes a separate scoped cleanup path.",
+          "owner": "backend/EQ upstream",
+          "follow_up_recommendation": "Wait for upstream EQ/Pint cleanup or run a separately authorized scoped Pint cleanup PR for Eq60ReportComposer.php, then resume CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01 validation.",
+          "required_checks_status": "not_run_no_pr_opened",
+          "scope_validation_status": "current_diff_allowed_paths_only_but_local_validation_blocked",
+          "continue_train_decision": "resume_current_pr_after_resolution",
+          "status": "resolved",
+          "resolved_by_pr": "https://github.com/fermatmind/fap-api/pull/1811",
+          "resolved_by_merge_commit": "ac069d5998d5389cdb3f7c0d799ea54fe47909c4"
+        }
+      ],
+      "next_task": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01",
+      "external_blocker_resolution": {
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1811",
+        "merge_commit": "ac069d5998d5389cdb3f7c0d799ea54fe47909c4",
+        "resolved_check": "vendor/bin/pint --test",
+        "resolution_summary": "Scoped Eq60ReportComposer.php Pint formatting cleanup merged before PR6 validation resumed."
+      }
     },
     "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01": {
       "id": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01",


### PR DESCRIPTION
## What changed
- Added the CAREER-L3 dynamic slot architecture report and generated JSON artifact.
- Added a focused SeoIntel test proving L3 career personalization remains dynamic-slot-only, with no static combinatorial pSEO pages or sitemap/llms exposure.
- Reconciled dependent train ledger state and recorded the resolved out-of-scope Pint sidecar via PR #1811.

## Why
- Defines the safe architecture boundary for future MBTI/Big Five/RIASEC x career personalization without creating 16,736+ static pages or expanding career claims.
- Keeps backend authority and bounded runtime slot loading as the required source of truth.

## Validation
- `php artisan test --filter=CareerL3DynamicSlotArchitecture01 --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/career-l3-dynamic-slot-architecture-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No fap-web implementation.
- No CMS/DB mutation.
- No runtime promotion, deploy, Search Channel action, or URL submission.
- No static L3 pSEO generation or discoverability exposure.

## Repository rule impact
- This PR adds planning/test guardrails only. It does not change content ownership, runtime publishing, sitemap/llms generation, or frontend fallback behavior.