### PR TITLE
ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01 allow global org0 funnel scope entry

### DIFF
--- a/backend/app/Filament/Ops/Pages/FunnelConversionPage.php
+++ b/backend/app/Filament/Ops/Pages/FunnelConversionPage.php
@@ -15,6 +15,10 @@ use Illuminate\Support\Facades\DB;
 
 class FunnelConversionPage extends Page
 {
+    private const FUNNEL_SCOPE_CURRENT_ORG = 'current_org';
+
+    private const FUNNEL_SCOPE_GLOBAL_ORG0 = 'global_org0';
+
     protected static ?string $navigationIcon = 'heroicon-o-chart-bar-square';
 
     protected static ?string $navigationGroup = null;
@@ -84,6 +88,8 @@ class FunnelConversionPage extends Page
 
     public string $locale = 'all';
 
+    public string $funnelScope = self::FUNNEL_SCOPE_CURRENT_ORG;
+
     /** @var array<string,string> */
     public array $scaleOptions = [];
 
@@ -117,6 +123,7 @@ class FunnelConversionPage extends Page
     {
         $this->fromDate = now()->subDays(13)->toDateString();
         $this->toDate = now()->toDateString();
+        $this->funnelScope = $this->normalizeFunnelScope(request()->query('scope'));
         $this->refreshPage();
     }
 
@@ -174,6 +181,7 @@ class FunnelConversionPage extends Page
 
     public function applyFilters(): void
     {
+        $this->funnelScope = $this->normalizeFunnelScope($this->funnelScope);
         $this->refreshPage();
     }
 
@@ -312,7 +320,26 @@ class FunnelConversionPage extends Page
 
     private function currentOrgId(): int
     {
+        if ($this->isGlobalOrgZeroScope()) {
+            return 0;
+        }
+
         return max(0, (int) app(OrgContext::class)->orgId());
+    }
+
+    private function isGlobalOrgZeroScope(): bool
+    {
+        return $this->funnelScope === self::FUNNEL_SCOPE_GLOBAL_ORG0;
+    }
+
+    private function normalizeFunnelScope(mixed $scope): string
+    {
+        $normalized = strtolower(trim((string) $scope));
+
+        return match ($normalized) {
+            'global', 'global_org0', 'org0' => self::FUNNEL_SCOPE_GLOBAL_ORG0,
+            default => self::FUNNEL_SCOPE_CURRENT_ORG,
+        };
     }
 
     /**

--- a/backend/docs/seo/analytics-funnel-ops-global-scope-entry-01.md
+++ b/backend/docs/seo/analytics-funnel-ops-global-scope-entry-01.md
@@ -1,0 +1,31 @@
+# ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01
+
+## Summary
+
+This change adds an explicit read-only global scope entry to the Ops funnel conversion page.
+
+The post-deploy smoke found that `analytics_funnel_daily` had valid `org_id=0` rows, but the browser UI was still scoped to the selected tenant organization. The page therefore displayed an empty state even though the global read model was populated.
+
+## Behavior
+
+- `Current organization` keeps the existing behavior and reads `analytics_funnel_daily` for the selected Ops organization.
+- `Global org_id=0` reads only `analytics_funnel_daily.org_id = 0`.
+- `?scope=global`, `?scope=global_org0`, and `?scope=org0` are normalized to the global read-only scope.
+- The global scope does not mutate `ops_org_id` session state or the selected organization cookie.
+
+## Authority Boundary
+
+The page continues to use `analytics_funnel_daily` as the read model source of truth. It does not fall back to raw events, `v_funnel_daily`, frontend state, analytics dashboards, or local files.
+
+## Not Done
+
+- No analytics refresh was run.
+- No production DB write was performed.
+- No CMS mutation was performed.
+- No GA/Baidu setting was changed.
+- No Search Channel or URL submission action was performed.
+- No deployment was performed in this PR.
+
+## Next Task
+
+Deploy the backend change, then rerun a browser read-only smoke on `/ops/funnel-conversion?scope=global_org0`.

--- a/backend/docs/seo/generated/analytics-funnel-ops-global-scope-entry-01.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-ops-global-scope-entry-01.v1.json
@@ -1,0 +1,39 @@
+{
+  "schema_version": "analytics-funnel-ops-global-scope-entry-01.v1",
+  "task": "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01",
+  "final_decision": "analytics_funnel_ops_global_scope_entry_completed_ready_for_deploy",
+  "scope_entry_added": true,
+  "default_scope": "current_org",
+  "global_scope": "global_org0",
+  "accepted_query_aliases": [
+    "global",
+    "global_org0",
+    "org0"
+  ],
+  "source_of_truth": "analytics_funnel_daily",
+  "global_org_id": 0,
+  "current_org_session_mutation": false,
+  "cookie_mutation": false,
+  "analytics_refresh_performed": false,
+  "production_db_write_performed": false,
+  "cms_mutation_performed": false,
+  "ga_baidu_setting_change_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "deploy_performed": false,
+  "expected_browser_smoke_url": "https://ops.fermatmind.com/ops/funnel-conversion?scope=global_org0",
+  "post_deploy_expected_totals": {
+    "row_count": 38,
+    "test_start": 382,
+    "test_submit": 286,
+    "result_view": 277,
+    "order_created": 11,
+    "payment_success": 8,
+    "report_unlock": 2,
+    "report_ready": 0,
+    "pdf_download": 11,
+    "share_generate": 12,
+    "share_click": 5
+  },
+  "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01"
+}

--- a/backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
+++ b/backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
@@ -1,7 +1,7 @@
 <x-filament-panels::page>
     <div class="space-y-6">
         <form wire:submit.prevent="applyFilters" class="rounded-2xl border border-slate-200 bg-white/95 p-5 shadow-sm">
-            <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_220px_220px_auto]">
+            <div class="grid gap-4 xl:grid-cols-[minmax(0,1fr)_minmax(0,1fr)_220px_220px_220px_auto]">
                 <label class="space-y-2">
                     <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">From</span>
                     <input
@@ -18,6 +18,15 @@
                         wire:model.defer="toDate"
                         class="block w-full rounded-xl border-slate-300 text-sm shadow-sm"
                     />
+                </label>
+
+                <label class="space-y-2">
+                    <span class="text-xs font-semibold uppercase tracking-[0.16em] text-slate-500">Scope</span>
+                    <select wire:model.defer="funnelScope" class="block w-full rounded-xl border-slate-300 text-sm shadow-sm">
+                        <option value="current_org">Current organization</option>
+                        <option value="global_org0">Global org_id=0</option>
+                    </select>
+                    <span class="block text-xs text-slate-500">Global scope reads org_id=0 without changing the selected organization.</span>
                 </label>
 
                 <label class="space-y-2">

--- a/backend/tests/Feature/Ops/FunnelConversionPageTest.php
+++ b/backend/tests/Feature/Ops/FunnelConversionPageTest.php
@@ -144,6 +144,80 @@ final class FunnelConversionPageTest extends TestCase
         }
     }
 
+    public function test_funnel_conversion_page_global_scope_reads_org_zero_even_with_selected_org_session(): void
+    {
+        Carbon::setTestNow('2026-05-31 12:00:00');
+
+        try {
+            $admin = $this->createAdminWithPermissions([
+                PermissionNames::ADMIN_MENU_COMMERCE,
+                PermissionNames::ADMIN_OPS_READ,
+            ]);
+            $selectedOrg = $this->createOrganization('Funnel Tenant Org');
+
+            DB::table('analytics_funnel_daily')->insert([
+                [
+                    'day' => '2026-05-31',
+                    'org_id' => 0,
+                    'scale_code' => 'MBTI',
+                    'locale' => 'en',
+                    'started_attempts' => 382,
+                    'submitted_attempts' => 286,
+                    'first_view_attempts' => 277,
+                    'order_created_attempts' => 11,
+                    'paid_attempts' => 8,
+                    'paid_revenue_cents' => 0,
+                    'unlocked_attempts' => 2,
+                    'report_ready_attempts' => 0,
+                    'pdf_download_attempts' => 11,
+                    'share_generated_attempts' => 12,
+                    'share_click_attempts' => 5,
+                    'last_refreshed_at' => now(),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+                [
+                    'day' => '2026-05-31',
+                    'org_id' => (int) $selectedOrg->id,
+                    'scale_code' => 'MBTI',
+                    'locale' => 'en',
+                    'started_attempts' => 1,
+                    'submitted_attempts' => 1,
+                    'first_view_attempts' => 1,
+                    'order_created_attempts' => 0,
+                    'paid_attempts' => 0,
+                    'paid_revenue_cents' => 0,
+                    'unlocked_attempts' => 0,
+                    'report_ready_attempts' => 0,
+                    'pdf_download_attempts' => 0,
+                    'share_generated_attempts' => 0,
+                    'share_click_attempts' => 0,
+                    'last_refreshed_at' => now(),
+                    'created_at' => now(),
+                    'updated_at' => now(),
+                ],
+            ]);
+
+            $response = $this->withSession($this->opsSession($admin, $selectedOrg))
+                ->actingAs($admin, (string) config('admin.guard', 'admin'))
+                ->get('/ops/funnel-conversion?scope=global_org0');
+
+            $response
+                ->assertOk()
+                ->assertSee('Global org_id=0')
+                ->assertSee('Global scope reads org_id=0 without changing the selected organization.')
+                ->assertSee('382')
+                ->assertSee('286')
+                ->assertSee('277')
+                ->assertSee('report_unlock')
+                ->assertDontSee('No analytics_funnel_daily rows match the current scope');
+
+            $this->assertSame((int) $selectedOrg->id, (int) session('ops_org_id'));
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
     private function createOrganization(string $name): Organization
     {
         return Organization::query()->create([

--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -310,7 +310,7 @@ final class IqReportContractTest extends TestCase
         }
     }
 
-    public function test_IqPaidReport_entitlement_unlocks_full_payload_for_matching_anon(): void
+    public function test_iq_paid_report_entitlement_unlocks_full_payload_for_matching_anon(): void
     {
         $this->seedScales();
 
@@ -345,7 +345,7 @@ final class IqReportContractTest extends TestCase
         $this->assertNull(data_get($payload, 'report.correct_answers'));
     }
 
-    public function test_IqPaidReport_entitlement_does_not_unlock_for_wrong_anon(): void
+    public function test_iq_paid_report_entitlement_does_not_unlock_for_wrong_anon(): void
     {
         $this->seedScales();
 
@@ -374,7 +374,7 @@ final class IqReportContractTest extends TestCase
         $this->assertNull(data_get($payload, 'report.summary.raw_score'));
     }
 
-    public function test_IqPaidReport_module_contract_is_iq_specific(): void
+    public function test_iq_paid_report_module_contract_is_iq_specific(): void
     {
         $this->assertSame('iq_core', \App\Services\Report\ReportAccess::freeModuleForScale('IQ_RAVEN'));
         $this->assertSame('iq_full', \App\Services\Report\ReportAccess::fullModuleForScale('IQ_RAVEN'));
@@ -406,5 +406,4 @@ final class IqReportContractTest extends TestCase
             'updated_at' => now(),
         ]);
     }
-
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24912,7 +24912,7 @@
   "BAIDU-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/baidu-live-00-readiness-contract",
-    "status": "local_checks_passed",
+    "status": "pr_open_checks_pending",
     "depends_on": [
       "GSC-LIVE-00"
     ],
@@ -25001,7 +25001,7 @@
   "INDEXNOW-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/indexnow-live-00-readiness-contract",
-    "status": "local_checks_passed",
+    "status": "pr_open_checks_pending",
     "depends_on": [
       "BAIDU-LIVE-00"
     ],
@@ -34810,7 +34810,7 @@
     "depends_on": [
       "OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01 merged"
     ],
-    "commit_sha": null,
+    "commit_sha": "4071ffe255800bf2bca8be239f383245bbd05a5f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1779",
     "checks": {
       "authorization": {
@@ -35240,7 +35240,7 @@
     "status": "in_progress",
     "title": "PAYMENT-ALIPAY-OWNER-MISMATCH-CONTROLLED-REPAIR-04 state-sync owner mismatch candidate",
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1815",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -36090,7 +36090,7 @@
     "merge_commit": "42a8caacb4f4bfa0fb5a83ecd69c25e3b5e83973"
   },
   "AUDIT-SEC-TRAIN-LEDGER-CLOSEOUT-01": {
-    "status": "implementation_in_progress",
+    "status": "local_checks_failed",
     "branch": "audit/sec-train-ledger-closeout-01",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1804",
     "base": "main",
@@ -36160,8 +36160,8 @@
     "depends_on": [
       "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "c1d818f6df20fefb825ba08d1ad3a2f9558ee068",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1815",
     "checks": {
       "authorization": {
         "status": "pass",
@@ -36266,6 +36266,111 @@
       }
     ],
     "next_task": "Wait for GitHub checks on PR #1805, merge if allowed, cleanup, then prepare BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01."
+  },
+  "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01": {
+    "id": "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-ops-global-scope-entry-01",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01 allow global org0 funnel scope entry",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for scoped PR ID ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01."
+      },
+      "dependency_verification": {
+        "status": "pass",
+        "evidence": "GitHub PR #1805 for ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01 is MERGED at 71df37ab3ac873ccbde5325d5285e3176faad9ba, and current HEAD contains that merge commit."
+      },
+      "workspace_safety": {
+        "status": "pass",
+        "evidence": "Implementation is isolated in /private/tmp/fap-api-analytics-funnel-ops-global-scope-entry-01; unrelated primary worktree WIP is untouched."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to FunnelConversionPage, its Blade view, focused Ops test coverage, user-authorized Pint-only formatting for IqReportContractTest, docs/generated report, and PR train ledger. No analytics refresh, production DB mutation, deploy, CMS mutation, GA/Baidu setting change, Search Channel action, URL submission, external search API call, raw log read, or PII access."
+      },
+      "pint_only_authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized including the backend/tests/Feature/V0_3/IqReportContractTest.php Pint-only formatting fix in the current PR after full Pint exposed the style issue."
+      },
+      "local_validation": {
+        "status": "pass",
+        "evidence": [
+          "php artisan test --filter=FunnelConversionPage --no-ansi: pass with PHPUnit warnings (3 tests, 45 assertions).",
+          "php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi: pass with PHPUnit warnings (2 tests, 27 assertions).",
+          "php artisan test --filter=IqReportContractTest --no-ansi: pass with PHPUnit warnings (7 tests, 434 assertions).",
+          "php artisan route:list --no-ansi: pass.",
+          "vendor/bin/pint --test: pass after user-authorized Pint-only IqReportContractTest formatting fix.",
+          "composer validate --strict: pass.",
+          "composer audit --locked --no-interaction --ignore-unreachable: pass.",
+          "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-global-scope-entry-01.v1.json: pass.",
+          "python3 -m json.tool docs/codex/pr-train-state.json: pass.",
+          "python3 -c yaml.safe_load docs/codex/pr-train.yaml: pass.",
+          "git diff --check: pass."
+        ]
+      },
+      "github_pr": {
+        "status": "created",
+        "evidence": "https://github.com/fermatmind/fap-api/pull/1815"
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T00:00:00+08:00",
+        "from": "authorized",
+        "to": "implementation_in_progress",
+        "note": "Started scoped Ops global org_id=0 funnel scope entry PR from latest origin/main in an isolated worktree."
+      },
+      {
+        "at": "2026-06-01T00:00:00+08:00",
+        "from": "implementation_in_progress",
+        "to": "local_checks_failed",
+        "note": "Stopped before commit/PR because required full Pint validation failed on out-of-scope backend/tests/Feature/V0_3/IqReportContractTest.php."
+      },
+      {
+        "at": "2026-06-01T00:00:00+08:00",
+        "from": "local_checks_failed",
+        "to": "local_checks_passed",
+        "note": "User authorized the Pint-only IqReportContractTest formatting fix; required local validation passed after rerun."
+      },
+      {
+        "at": "2026-06-01T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "committed_pending_pr",
+        "note": "Committed scoped implementation at c1d818f6df20fefb825ba08d1ad3a2f9558ee068."
+      },
+      {
+        "at": "2026-06-01T00:00:00+08:00",
+        "from": "committed_pending_pr",
+        "to": "pr_open_checks_pending",
+        "note": "Opened GitHub PR #1815 for the scoped global org0 funnel scope entry."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "out_of_scope_pint_iq_report_contract_test",
+        "status": "resolved_by_user_authorized_pint_only_fix",
+        "summary": "Full vendor/bin/pint --test reported class_attributes_separation in backend/tests/Feature/V0_3/IqReportContractTest.php. User authorized including the Pint-only formatting fix in the current PR; full Pint now passes."
+      }
+    ],
+    "next_task": "Wait for GitHub checks on PR #1815, merge if clean, then prepare BACKEND-DEPLOY-READINESS."
   },
   "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04": {
     "id": "EMAIL-OUTBOX-SCHEDULER-BOOTSTRAP-04",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16624,6 +16624,57 @@ prs:
     frontend_fallback_authority: false
     next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01
 
+  - id: ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01
+    repo: fap-api
+    branch: codex/analytics-funnel-ops-global-scope-entry-01
+    base: main
+    title: "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01 allow global org0 funnel scope entry"
+    train_scope: analytics_funnel_ops_global_scope_entry
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01
+    allowed_paths:
+      - backend/app/Filament/Ops/Pages/FunnelConversionPage.php
+      - backend/resources/views/filament/ops/pages/funnel-conversion-page.blade.php
+      - backend/tests/Feature/Ops/FunnelConversionPageTest.php
+      - backend/tests/Feature/V0_3/IqReportContractTest.php
+      - backend/docs/seo/analytics-funnel-ops-global-scope-entry-01.md
+      - backend/docs/seo/generated/analytics-funnel-ops-global-scope-entry-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Add an explicit read-only global org_id=0 scope entry to the Ops funnel conversion page.
+      - Allow the page to read analytics_funnel_daily org_id=0 rows even when the current Ops session has a selected tenant organization.
+      - Do not mutate ops_org_id session state or selected organization cookies when global scope is selected.
+      - Continue using analytics_funnel_daily as the read model source of truth.
+      - Include the user-authorized Pint-only formatting fix for backend/tests/Feature/V0_3/IqReportContractTest.php required by full Pint validation.
+      - Do not run analytics refresh, mutate production DB, deploy, mutate CMS, change GA/Baidu settings, enqueue Search Channel, submit URLs, call external search APIs, read raw logs, or access production PII.
+    validation:
+      - cd backend && php artisan test --filter=FunnelConversionPage --no-ansi
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-global-scope-entry-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01
+
 
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added an explicit read-only `global_org0` scope to the Ops funnel conversion page.
- Let `/ops/funnel-conversion?scope=global_org0` read `analytics_funnel_daily` rows for `org_id=0` without changing the selected organization session.
- Added focused test coverage and docs/generated closeout artifacts.
- Included the user-authorized Pint-only formatting fix for `backend/tests/Feature/V0_3/IqReportContractTest.php` required by full Pint validation.

## Why
Post-deploy smoke confirmed the 7-day funnel rows exist under global `org_id=0`, but the page stayed scoped to the currently selected tenant org. This PR adds a deliberate global read entry while keeping `analytics_funnel_daily` as the source of truth.

## Validation
- `php artisan test --filter=FunnelConversionPage --no-ansi`
- `php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi`
- `php artisan test --filter=IqReportContractTest --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/analytics-funnel-ops-global-scope-entry-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`

## Deferred
- No production deploy in this PR.
- No analytics refresh or production DB mutation.
- No CMS, GA/Baidu setting, Search Channel, URL submission, raw log, or PII access.

## Repository rule impact
No content authority or publishing ownership change. This is an Ops read-model visibility entry only.