### PR TITLE
style(iq): format report contract test

### DIFF
--- a/backend/tests/Feature/V0_3/IqReportContractTest.php
+++ b/backend/tests/Feature/V0_3/IqReportContractTest.php
@@ -310,7 +310,7 @@ final class IqReportContractTest extends TestCase
         }
     }
 
-    public function test_IqPaidReport_entitlement_unlocks_full_payload_for_matching_anon(): void
+    public function test_iq_paid_report_entitlement_unlocks_full_payload_for_matching_anon(): void
     {
         $this->seedScales();
 
@@ -345,7 +345,7 @@ final class IqReportContractTest extends TestCase
         $this->assertNull(data_get($payload, 'report.correct_answers'));
     }
 
-    public function test_IqPaidReport_entitlement_does_not_unlock_for_wrong_anon(): void
+    public function test_iq_paid_report_entitlement_does_not_unlock_for_wrong_anon(): void
     {
         $this->seedScales();
 
@@ -374,7 +374,7 @@ final class IqReportContractTest extends TestCase
         $this->assertNull(data_get($payload, 'report.summary.raw_score'));
     }
 
-    public function test_IqPaidReport_module_contract_is_iq_specific(): void
+    public function test_iq_paid_report_module_contract_is_iq_specific(): void
     {
         $this->assertSame('iq_core', \App\Services\Report\ReportAccess::freeModuleForScale('IQ_RAVEN'));
         $this->assertSame('iq_full', \App\Services\Report\ReportAccess::fullModuleForScale('IQ_RAVEN'));
@@ -406,5 +406,4 @@ final class IqReportContractTest extends TestCase
             'updated_at' => now(),
         ]);
     }
-
 }


### PR DESCRIPTION
## What changed
- Renamed the IQ paid-report contract test methods to Pint-compliant snake case.
- Removed the extra trailing blank line at the end of the IQ report contract test.

## Why
- Unblocks the full repository Pint check required by the release-train sidecar soft-alert PR.
- This is a scoped formatting-only cleanup; it does not change IQ behavior or runtime logic.

## Validation
- php artisan test --filter=IqReportContractTest --no-ansi
- php artisan route:list --no-ansi
- vendor/bin/pint --test
- composer validate --strict
- composer audit --locked --no-interaction --ignore-unreachable
- git diff --check
- git diff --cached --check

## Deferred
- No runtime, CMS, DB, deploy, Search Channel, or content changes.