### PR TITLE
IQ-CMS-MEDIA-01 register CMS media authority metadata

### DIFF
--- a/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+++ b/backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
@@ -239,8 +239,12 @@ final class LandingSurfacePublicApiTest extends TestCase
         $this->assertSame('IQ Reasoning Practice', (string) data_get($homeIqCard, 'title'));
         $this->assertSame('30 questions', (string) data_get($homeIqCard, 'questionsLabel'));
         $this->assertSame('IQ_BETA_30_ORIGINAL', (string) data_get($homeIqCard, 'primaryActions.0.form_code'));
+        $this->assertSame('iq-beta30-original-card', (string) data_get($homeIqCard, 'media.asset_key'));
         $this->assertSame('media_library_required', (string) data_get($homeIqCard, 'media.source'));
+        $this->assertSame('backend_cms_media_library', (string) data_get($homeIqCard, 'media.authority'));
         $this->assertSame('metadata_only_no_frontend_asset', (string) data_get($homeIqCard, 'media.status'));
+        $this->assertFalse((bool) data_get($homeIqCard, 'media.fallback_allowed', true));
+        $this->assertSame('iq-beta30-original-og', (string) data_get($homeIqCard, 'media.variants.og_asset_key'));
         $this->assertTrue((bool) data_get($homeIqCard, 'claim_policy.norm_authority_required'));
         $this->assertFalse((bool) data_get($homeIqCard, 'claim_policy.iq_estimate_claims_enabled'));
         $this->assertFalse((bool) data_get($homeIqCard, 'claim_policy.percentile_claims_enabled'));
@@ -263,13 +267,37 @@ final class LandingSurfacePublicApiTest extends TestCase
         $this->assertSame('约 20 分钟', (string) data_get($iqCard, 'durationLabel'));
         $this->assertSame('/zh/tests/iq-test-intelligence-quotient-assessment/take', (string) data_get($iqCard, 'href'));
         $this->assertSame('IQ_BETA_30_ORIGINAL', (string) data_get($iqCard, 'primaryActions.0.form_code'));
+        $this->assertSame('iq-beta30-original-card', (string) data_get($iqCard, 'media.asset_key'));
         $this->assertSame('media_library_required', (string) data_get($iqCard, 'media.source'));
+        $this->assertSame('backend_cms_media_library', (string) data_get($iqCard, 'media.authority'));
+        $this->assertFalse((bool) data_get($iqCard, 'media.fallback_allowed', true));
         $this->assertTrue((bool) data_get($iqCard, 'claim_policy.norm_authority_required'));
         $this->assertFalse((bool) data_get($iqCard, 'claim_policy.iq_estimate_claims_enabled'));
         $this->assertFalse((bool) data_get($iqCard, 'claim_policy.percentile_claims_enabled'));
         $this->assertStringContainsString('不输出正式 IQ 或百分位', (string) data_get($iqCard, 'outputLabel'));
         $this->assertStringNotContainsString('官方智商', json_encode($iqCard, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
         $this->assertStringNotContainsString('人群百分位', json_encode($iqCard, JSON_UNESCAPED_UNICODE | JSON_THROW_ON_ERROR));
+
+        $mediaRows = collect(json_decode(
+            (string) file_get_contents(base_path('../content_baselines/media_assets/default_media_assets.json')),
+            true,
+            512,
+            JSON_THROW_ON_ERROR
+        ))->keyBy(fn (array $row): string => (string) ($row['asset_key'] ?? ''));
+
+        foreach (['iq-beta30-original-card', 'iq-beta30-original-og', 'iq-full-report-cover'] as $assetKey) {
+            $asset = $mediaRows->get($assetKey);
+            $this->assertIsArray($asset, $assetKey.' media asset baseline is missing');
+            $this->assertSame('media_library', (string) data_get($asset, 'disk'));
+            $this->assertSame('backend_cms_media_library', (string) data_get($asset, 'payload_json.authority'));
+            $this->assertFalse((bool) data_get($asset, 'payload_json.frontend_fallback_allowed', true));
+            $this->assertSame('IQ_BETA_30_ORIGINAL', (string) data_get($asset, 'payload_json.applies_to.scale_code.0'));
+            $this->assertStringNotContainsString('/public/', json_encode($asset, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+            $this->assertStringNotContainsString('fap-web', json_encode($asset, JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR));
+        }
+
+        $this->assertContains('seo_og', data_get($mediaRows->get('iq-beta30-original-og'), 'payload_json.render_surface'));
+        $this->assertContains('paid_report', data_get($mediaRows->get('iq-full-report-cover'), 'payload_json.render_surface'));
     }
 
     public function test_public_and_internal_api_return_surface_payloads(): void

--- a/content_baselines/landing_surfaces/home.en.json
+++ b/content_baselines/landing_surfaces/home.en.json
@@ -95,8 +95,15 @@
           "media": {
             "asset_key": "iq-beta30-original-card",
             "source": "media_library_required",
+            "authority": "backend_cms_media_library",
             "status": "metadata_only_no_frontend_asset",
-            "alt": "Original IQ reasoning practice card"
+            "fallback_allowed": false,
+            "alt": "Original IQ reasoning practice card",
+            "variants": {
+              "card_asset_key": "iq-beta30-original-card",
+              "og_asset_key": "iq-beta30-original-og",
+              "report_cover_asset_key": "iq-full-report-cover"
+            }
           },
           "primaryActions": [
             {
@@ -279,8 +286,44 @@
               "href": "/tests/big-five-personality-test-ocean-model"
             },
             {
-              "title": "IQ",
-              "href": "/tests/iq-test-intelligence-quotient-assessment"
+              "title": "IQ Reasoning Practice",
+              "description": "Use 30 original visual-spatial, pattern, and numeric reasoning items. Current output is raw score and dimension reference only.",
+              "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+              "key": "iq-test-intelligence-quotient-assessment",
+              "questionsLabel": "30 questions",
+              "durationLabel": "20 min",
+              "detailsHref": "/en/tests/iq-test-intelligence-quotient-assessment",
+              "secondaryLabel": "View boundaries",
+              "previewVariant": "matrix",
+              "primaryLabel": "Start 30-item practice",
+              "outputLabel": "Raw score, dimension performance, and stability notes; no formal IQ or percentile claim",
+              "claim_policy": {
+                "norm_authority_required": true,
+                "iq_estimate_claims_enabled": false,
+                "percentile_claims_enabled": false,
+                "copy_boundary": "raw score and original reasoning practice only",
+                "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+              },
+              "media": {
+                "asset_key": "iq-beta30-original-card",
+                "source": "media_library_required",
+                "authority": "backend_cms_media_library",
+                "status": "metadata_only_no_frontend_asset",
+                "fallback_allowed": false,
+                "alt": "Original IQ reasoning practice card",
+                "variants": {
+                  "card_asset_key": "iq-beta30-original-card",
+                  "og_asset_key": "iq-beta30-original-og",
+                  "report_cover_asset_key": "iq-full-report-cover"
+                }
+              },
+              "primaryActions": [
+                {
+                  "label": "30-item beta",
+                  "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+                  "form_code": "IQ_BETA_30_ORIGINAL"
+                }
+              ]
             },
             {
               "title": "EQ",
@@ -304,8 +347,42 @@
               "href": "/tests/big-five-personality-test-ocean-model"
             },
             {
-              "label": "IQ",
-              "href": "/tests/iq-test-intelligence-quotient-assessment"
+              "title": "IQ Reasoning Practice",
+              "description": "Practice 30 original visual and numeric reasoning items. Raw score only until norm authority is available.",
+              "href": "/tests/iq-test-intelligence-quotient-assessment",
+              "label": "Start practice",
+              "meta": "Cognition practice",
+              "key": "iq-test-intelligence-quotient-assessment",
+              "questionsLabel": "30 questions",
+              "durationLabel": "20 min",
+              "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+              "claim_policy": {
+                "norm_authority_required": true,
+                "iq_estimate_claims_enabled": false,
+                "percentile_claims_enabled": false,
+                "copy_boundary": "raw score and original reasoning practice only",
+                "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+              },
+              "media": {
+                "asset_key": "iq-beta30-original-card",
+                "source": "media_library_required",
+                "authority": "backend_cms_media_library",
+                "status": "metadata_only_no_frontend_asset",
+                "fallback_allowed": false,
+                "alt": "Original IQ reasoning practice card",
+                "variants": {
+                  "card_asset_key": "iq-beta30-original-card",
+                  "og_asset_key": "iq-beta30-original-og",
+                  "report_cover_asset_key": "iq-full-report-cover"
+                }
+              },
+              "primaryActions": [
+                {
+                  "label": "30-item beta",
+                  "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+                  "form_code": "IQ_BETA_30_ORIGINAL"
+                }
+              ]
             },
             {
               "label": "EQ",
@@ -424,11 +501,42 @@
             ]
           },
           {
-            "title": "IQ Test",
-            "description": "Get a quick baseline for cognitive ability.",
+            "title": "IQ Reasoning Practice",
+            "description": "Practice 30 original visual and numeric reasoning items. Raw score only until norm authority is available.",
             "href": "/tests/iq-test-intelligence-quotient-assessment",
-            "label": "Start test",
-            "meta": "Ability assessment"
+            "label": "Start practice",
+            "meta": "Cognition practice",
+            "key": "iq-test-intelligence-quotient-assessment",
+            "questionsLabel": "30 questions",
+            "durationLabel": "20 min",
+            "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+            "claim_policy": {
+              "norm_authority_required": true,
+              "iq_estimate_claims_enabled": false,
+              "percentile_claims_enabled": false,
+              "copy_boundary": "raw score and original reasoning practice only",
+              "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+            },
+            "media": {
+              "asset_key": "iq-beta30-original-card",
+              "source": "media_library_required",
+              "authority": "backend_cms_media_library",
+              "status": "metadata_only_no_frontend_asset",
+              "fallback_allowed": false,
+              "alt": "Original IQ reasoning practice card",
+              "variants": {
+                "card_asset_key": "iq-beta30-original-card",
+                "og_asset_key": "iq-beta30-original-og",
+                "report_cover_asset_key": "iq-full-report-cover"
+              }
+            },
+            "primaryActions": [
+              {
+                "label": "30-item beta",
+                "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+                "form_code": "IQ_BETA_30_ORIGINAL"
+              }
+            ]
           },
           {
             "title": "Depression and Anxiety Assessment",
@@ -825,8 +933,44 @@
                 "href": "/tests/big-five-personality-test-ocean-model"
               },
               {
-                "title": "IQ",
-                "href": "/tests/iq-test-intelligence-quotient-assessment"
+                "title": "IQ Reasoning Practice",
+                "description": "Use 30 original visual-spatial, pattern, and numeric reasoning items. Current output is raw score and dimension reference only.",
+                "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+                "key": "iq-test-intelligence-quotient-assessment",
+                "questionsLabel": "30 questions",
+                "durationLabel": "20 min",
+                "detailsHref": "/en/tests/iq-test-intelligence-quotient-assessment",
+                "secondaryLabel": "View boundaries",
+                "previewVariant": "matrix",
+                "primaryLabel": "Start 30-item practice",
+                "outputLabel": "Raw score, dimension performance, and stability notes; no formal IQ or percentile claim",
+                "claim_policy": {
+                  "norm_authority_required": true,
+                  "iq_estimate_claims_enabled": false,
+                  "percentile_claims_enabled": false,
+                  "copy_boundary": "raw score and original reasoning practice only",
+                  "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+                },
+                "media": {
+                  "asset_key": "iq-beta30-original-card",
+                  "source": "media_library_required",
+                  "authority": "backend_cms_media_library",
+                  "status": "metadata_only_no_frontend_asset",
+                  "fallback_allowed": false,
+                  "alt": "Original IQ reasoning practice card",
+                  "variants": {
+                    "card_asset_key": "iq-beta30-original-card",
+                    "og_asset_key": "iq-beta30-original-og",
+                    "report_cover_asset_key": "iq-full-report-cover"
+                  }
+                },
+                "primaryActions": [
+                  {
+                    "label": "30-item beta",
+                    "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+                    "form_code": "IQ_BETA_30_ORIGINAL"
+                  }
+                ]
               },
               {
                 "title": "EQ",
@@ -857,8 +1001,42 @@
                 "href": "/tests/big-five-personality-test-ocean-model"
               },
               {
-                "label": "IQ",
-                "href": "/tests/iq-test-intelligence-quotient-assessment"
+                "title": "IQ Reasoning Practice",
+                "description": "Practice 30 original visual and numeric reasoning items. Raw score only until norm authority is available.",
+                "href": "/tests/iq-test-intelligence-quotient-assessment",
+                "label": "Start practice",
+                "meta": "Cognition practice",
+                "key": "iq-test-intelligence-quotient-assessment",
+                "questionsLabel": "30 questions",
+                "durationLabel": "20 min",
+                "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+                "claim_policy": {
+                  "norm_authority_required": true,
+                  "iq_estimate_claims_enabled": false,
+                  "percentile_claims_enabled": false,
+                  "copy_boundary": "raw score and original reasoning practice only",
+                  "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+                },
+                "media": {
+                  "asset_key": "iq-beta30-original-card",
+                  "source": "media_library_required",
+                  "authority": "backend_cms_media_library",
+                  "status": "metadata_only_no_frontend_asset",
+                  "fallback_allowed": false,
+                  "alt": "Original IQ reasoning practice card",
+                  "variants": {
+                    "card_asset_key": "iq-beta30-original-card",
+                    "og_asset_key": "iq-beta30-original-og",
+                    "report_cover_asset_key": "iq-full-report-cover"
+                  }
+                },
+                "primaryActions": [
+                  {
+                    "label": "30-item beta",
+                    "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+                    "form_code": "IQ_BETA_30_ORIGINAL"
+                  }
+                ]
               },
               {
                 "label": "EQ",

--- a/content_baselines/landing_surfaces/home.zh-CN.json
+++ b/content_baselines/landing_surfaces/home.zh-CN.json
@@ -95,8 +95,15 @@
           "media": {
             "asset_key": "iq-beta30-original-card",
             "source": "media_library_required",
+            "authority": "backend_cms_media_library",
             "status": "metadata_only_no_frontend_asset",
-            "alt": "原创 IQ 推理练习卡片"
+            "fallback_allowed": false,
+            "alt": "原创 IQ 推理练习卡片",
+            "variants": {
+              "card_asset_key": "iq-beta30-original-card",
+              "og_asset_key": "iq-beta30-original-og",
+              "report_cover_asset_key": "iq-full-report-cover"
+            }
           },
           "primaryActions": [
             {
@@ -279,8 +286,44 @@
               "href": "/tests/big-five-personality-test-ocean-model"
             },
             {
-              "title": "IQ",
-              "href": "/tests/iq-test-intelligence-quotient-assessment"
+              "title": "IQ 推理练习",
+              "description": "适合先练习原创视觉空间、图形规律与数字规律题，当前只给出原始分和维度参考。",
+              "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+              "key": "iq-test-intelligence-quotient-assessment",
+              "questionsLabel": "30 题",
+              "durationLabel": "约 20 分钟",
+              "detailsHref": "/zh/tests/iq-test-intelligence-quotient-assessment",
+              "secondaryLabel": "查看边界说明",
+              "previewVariant": "matrix",
+              "primaryLabel": "开始 30 题练习",
+              "outputLabel": "原始分、维度表现与稳定性提示；不输出正式 IQ 或百分位",
+              "claim_policy": {
+                "norm_authority_required": true,
+                "iq_estimate_claims_enabled": false,
+                "percentile_claims_enabled": false,
+                "copy_boundary": "仅限原创推理练习和原始分参考",
+                "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+              },
+              "media": {
+                "asset_key": "iq-beta30-original-card",
+                "source": "media_library_required",
+                "authority": "backend_cms_media_library",
+                "status": "metadata_only_no_frontend_asset",
+                "fallback_allowed": false,
+                "alt": "原创 IQ 推理练习卡片",
+                "variants": {
+                  "card_asset_key": "iq-beta30-original-card",
+                  "og_asset_key": "iq-beta30-original-og",
+                  "report_cover_asset_key": "iq-full-report-cover"
+                }
+              },
+              "primaryActions": [
+                {
+                  "label": "30 题 Beta 版",
+                  "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+                  "form_code": "IQ_BETA_30_ORIGINAL"
+                }
+              ]
             },
             {
               "title": "EQ",
@@ -304,8 +347,42 @@
               "href": "/tests/big-five-personality-test-ocean-model"
             },
             {
-              "label": "IQ",
-              "href": "/tests/iq-test-intelligence-quotient-assessment"
+              "title": "IQ 推理练习",
+              "description": "练习 30 道原创视觉与数字推理题。在常模权威上线前，仅提供原始分参考。",
+              "href": "/tests/iq-test-intelligence-quotient-assessment",
+              "label": "开始练习",
+              "meta": "认知练习",
+              "key": "iq-test-intelligence-quotient-assessment",
+              "questionsLabel": "30 题",
+              "durationLabel": "约 20 分钟",
+              "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+              "claim_policy": {
+                "norm_authority_required": true,
+                "iq_estimate_claims_enabled": false,
+                "percentile_claims_enabled": false,
+                "copy_boundary": "仅限原创推理练习和原始分参考",
+                "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+              },
+              "media": {
+                "asset_key": "iq-beta30-original-card",
+                "source": "media_library_required",
+                "authority": "backend_cms_media_library",
+                "status": "metadata_only_no_frontend_asset",
+                "fallback_allowed": false,
+                "alt": "原创 IQ 推理练习卡片",
+                "variants": {
+                  "card_asset_key": "iq-beta30-original-card",
+                  "og_asset_key": "iq-beta30-original-og",
+                  "report_cover_asset_key": "iq-full-report-cover"
+                }
+              },
+              "primaryActions": [
+                {
+                  "label": "30 题 Beta 版",
+                  "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+                  "form_code": "IQ_BETA_30_ORIGINAL"
+                }
+              ]
             },
             {
               "label": "EQ",
@@ -424,11 +501,42 @@
             ]
           },
           {
-            "title": "IQ 智商测试",
-            "description": "快速了解你的认知能力基线",
+            "title": "IQ 推理练习",
+            "description": "练习 30 道原创视觉与数字推理题。在常模权威上线前，仅提供原始分参考。",
             "href": "/tests/iq-test-intelligence-quotient-assessment",
-            "label": "开始测试",
-            "meta": "能力测评"
+            "label": "开始练习",
+            "meta": "认知练习",
+            "key": "iq-test-intelligence-quotient-assessment",
+            "questionsLabel": "30 题",
+            "durationLabel": "约 20 分钟",
+            "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+            "claim_policy": {
+              "norm_authority_required": true,
+              "iq_estimate_claims_enabled": false,
+              "percentile_claims_enabled": false,
+              "copy_boundary": "仅限原创推理练习和原始分参考",
+              "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+            },
+            "media": {
+              "asset_key": "iq-beta30-original-card",
+              "source": "media_library_required",
+              "authority": "backend_cms_media_library",
+              "status": "metadata_only_no_frontend_asset",
+              "fallback_allowed": false,
+              "alt": "原创 IQ 推理练习卡片",
+              "variants": {
+                "card_asset_key": "iq-beta30-original-card",
+                "og_asset_key": "iq-beta30-original-og",
+                "report_cover_asset_key": "iq-full-report-cover"
+              }
+            },
+            "primaryActions": [
+              {
+                "label": "30 题 Beta 版",
+                "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+                "form_code": "IQ_BETA_30_ORIGINAL"
+              }
+            ]
           },
           {
             "title": "抑郁焦虑综合症测试",
@@ -848,8 +956,44 @@
                 "href": "/tests/big-five-personality-test-ocean-model"
               },
               {
-                "title": "IQ",
-                "href": "/tests/iq-test-intelligence-quotient-assessment"
+                "title": "IQ 推理练习",
+                "description": "适合先练习原创视觉空间、图形规律与数字规律题，当前只给出原始分和维度参考。",
+                "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+                "key": "iq-test-intelligence-quotient-assessment",
+                "questionsLabel": "30 题",
+                "durationLabel": "约 20 分钟",
+                "detailsHref": "/zh/tests/iq-test-intelligence-quotient-assessment",
+                "secondaryLabel": "查看边界说明",
+                "previewVariant": "matrix",
+                "primaryLabel": "开始 30 题练习",
+                "outputLabel": "原始分、维度表现与稳定性提示；不输出正式 IQ 或百分位",
+                "claim_policy": {
+                  "norm_authority_required": true,
+                  "iq_estimate_claims_enabled": false,
+                  "percentile_claims_enabled": false,
+                  "copy_boundary": "仅限原创推理练习和原始分参考",
+                  "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+                },
+                "media": {
+                  "asset_key": "iq-beta30-original-card",
+                  "source": "media_library_required",
+                  "authority": "backend_cms_media_library",
+                  "status": "metadata_only_no_frontend_asset",
+                  "fallback_allowed": false,
+                  "alt": "原创 IQ 推理练习卡片",
+                  "variants": {
+                    "card_asset_key": "iq-beta30-original-card",
+                    "og_asset_key": "iq-beta30-original-og",
+                    "report_cover_asset_key": "iq-full-report-cover"
+                  }
+                },
+                "primaryActions": [
+                  {
+                    "label": "30 题 Beta 版",
+                    "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+                    "form_code": "IQ_BETA_30_ORIGINAL"
+                  }
+                ]
               },
               {
                 "title": "EQ",
@@ -880,8 +1024,42 @@
                 "href": "/tests/big-five-personality-test-ocean-model"
               },
               {
-                "label": "IQ",
-                "href": "/tests/iq-test-intelligence-quotient-assessment"
+                "title": "IQ 推理练习",
+                "description": "练习 30 道原创视觉与数字推理题。在常模权威上线前，仅提供原始分参考。",
+                "href": "/tests/iq-test-intelligence-quotient-assessment",
+                "label": "开始练习",
+                "meta": "认知练习",
+                "key": "iq-test-intelligence-quotient-assessment",
+                "questionsLabel": "30 题",
+                "durationLabel": "约 20 分钟",
+                "detailsHref": "/tests/iq-test-intelligence-quotient-assessment",
+                "claim_policy": {
+                  "norm_authority_required": true,
+                  "iq_estimate_claims_enabled": false,
+                  "percentile_claims_enabled": false,
+                  "copy_boundary": "仅限原创推理练习和原始分参考",
+                  "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+                },
+                "media": {
+                  "asset_key": "iq-beta30-original-card",
+                  "source": "media_library_required",
+                  "authority": "backend_cms_media_library",
+                  "status": "metadata_only_no_frontend_asset",
+                  "fallback_allowed": false,
+                  "alt": "原创 IQ 推理练习卡片",
+                  "variants": {
+                    "card_asset_key": "iq-beta30-original-card",
+                    "og_asset_key": "iq-beta30-original-og",
+                    "report_cover_asset_key": "iq-full-report-cover"
+                  }
+                },
+                "primaryActions": [
+                  {
+                    "label": "30 题 Beta 版",
+                    "href": "/tests/iq-test-intelligence-quotient-assessment/take",
+                    "form_code": "IQ_BETA_30_ORIGINAL"
+                  }
+                ]
               },
               {
                 "label": "EQ",

--- a/content_baselines/landing_surfaces/tests.en.json
+++ b/content_baselines/landing_surfaces/tests.en.json
@@ -354,17 +354,17 @@
           ],
           "tests": [
             {
-              "key": "iq-test-intelligence-quotient-assessment",
               "title": "IQ Reasoning Practice",
               "description": "Use 30 original visual-spatial, pattern, and numeric reasoning items. Current output is raw score and dimension reference only.",
+              "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+              "key": "iq-test-intelligence-quotient-assessment",
               "questionsLabel": "30 questions",
               "durationLabel": "20 min",
-              "outputLabel": "Raw score, dimension performance, and stability notes; no formal IQ or percentile claim",
               "detailsHref": "/en/tests/iq-test-intelligence-quotient-assessment",
               "secondaryLabel": "View boundaries",
               "previewVariant": "matrix",
-              "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
               "primaryLabel": "Start 30-item practice",
+              "outputLabel": "Raw score, dimension performance, and stability notes; no formal IQ or percentile claim",
               "claim_policy": {
                 "norm_authority_required": true,
                 "iq_estimate_claims_enabled": false,
@@ -375,8 +375,15 @@
               "media": {
                 "asset_key": "iq-beta30-original-card",
                 "source": "media_library_required",
+                "authority": "backend_cms_media_library",
                 "status": "metadata_only_no_frontend_asset",
-                "alt": "Original IQ reasoning practice card"
+                "fallback_allowed": false,
+                "alt": "Original IQ reasoning practice card",
+                "variants": {
+                  "card_asset_key": "iq-beta30-original-card",
+                  "og_asset_key": "iq-beta30-original-og",
+                  "report_cover_asset_key": "iq-full-report-cover"
+                }
               },
               "primaryActions": [
                 {
@@ -883,17 +890,44 @@
             ],
             "tests": [
               {
-                "key": "iq-test-intelligence-quotient-assessment",
-                "title": "IQ Test",
-                "description": "When you want a read on reasoning performance, pattern recognition, and cognitive strengths.",
-                "questionsLabel": "40 questions",
-                "durationLabel": "20 min",
-                "outputLabel": "Ability baseline, reasoning profile, and reference notes",
-                "detailsHref": "/en/tests/iq-test-intelligence-quotient-assessment",
-                "secondaryLabel": "View details",
-                "previewVariant": "matrix",
+                "title": "IQ Reasoning Practice",
+                "description": "Use 30 original visual-spatial, pattern, and numeric reasoning items. Current output is raw score and dimension reference only.",
                 "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
-                "primaryLabel": "Start test"
+                "key": "iq-test-intelligence-quotient-assessment",
+                "questionsLabel": "30 questions",
+                "durationLabel": "20 min",
+                "detailsHref": "/en/tests/iq-test-intelligence-quotient-assessment",
+                "secondaryLabel": "View boundaries",
+                "previewVariant": "matrix",
+                "primaryLabel": "Start 30-item practice",
+                "outputLabel": "Raw score, dimension performance, and stability notes; no formal IQ or percentile claim",
+                "claim_policy": {
+                  "norm_authority_required": true,
+                  "iq_estimate_claims_enabled": false,
+                  "percentile_claims_enabled": false,
+                  "copy_boundary": "raw score and original reasoning practice only",
+                  "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+                },
+                "media": {
+                  "asset_key": "iq-beta30-original-card",
+                  "source": "media_library_required",
+                  "authority": "backend_cms_media_library",
+                  "status": "metadata_only_no_frontend_asset",
+                  "fallback_allowed": false,
+                  "alt": "Original IQ reasoning practice card",
+                  "variants": {
+                    "card_asset_key": "iq-beta30-original-card",
+                    "og_asset_key": "iq-beta30-original-og",
+                    "report_cover_asset_key": "iq-full-report-cover"
+                  }
+                },
+                "primaryActions": [
+                  {
+                    "label": "30-item beta",
+                    "href": "/en/tests/iq-test-intelligence-quotient-assessment/take",
+                    "form_code": "IQ_BETA_30_ORIGINAL"
+                  }
+                ]
               }
             ]
           },

--- a/content_baselines/landing_surfaces/tests.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests.zh-CN.json
@@ -354,17 +354,17 @@
           ],
           "tests": [
             {
-              "key": "iq-test-intelligence-quotient-assessment",
               "title": "IQ 推理练习",
               "description": "适合先练习原创视觉空间、图形规律与数字规律题，当前只给出原始分和维度参考。",
+              "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+              "key": "iq-test-intelligence-quotient-assessment",
               "questionsLabel": "30 题",
               "durationLabel": "约 20 分钟",
-              "outputLabel": "原始分、维度表现与稳定性提示；不输出正式 IQ 或百分位",
               "detailsHref": "/zh/tests/iq-test-intelligence-quotient-assessment",
               "secondaryLabel": "查看边界说明",
               "previewVariant": "matrix",
-              "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
               "primaryLabel": "开始 30 题练习",
+              "outputLabel": "原始分、维度表现与稳定性提示；不输出正式 IQ 或百分位",
               "claim_policy": {
                 "norm_authority_required": true,
                 "iq_estimate_claims_enabled": false,
@@ -375,8 +375,15 @@
               "media": {
                 "asset_key": "iq-beta30-original-card",
                 "source": "media_library_required",
+                "authority": "backend_cms_media_library",
                 "status": "metadata_only_no_frontend_asset",
-                "alt": "原创 IQ 推理练习卡片"
+                "fallback_allowed": false,
+                "alt": "原创 IQ 推理练习卡片",
+                "variants": {
+                  "card_asset_key": "iq-beta30-original-card",
+                  "og_asset_key": "iq-beta30-original-og",
+                  "report_cover_asset_key": "iq-full-report-cover"
+                }
               },
               "primaryActions": [
                 {
@@ -883,17 +890,44 @@
             ],
             "tests": [
               {
-                "key": "iq-test-intelligence-quotient-assessment",
-                "title": "智商测试",
-                "description": "当你想看推理表现、问题处理速度与认知优势线索时。",
-                "questionsLabel": "40 题",
-                "durationLabel": "约 20 分钟",
-                "outputLabel": "能力基线、推理表现与后续参考",
-                "detailsHref": "/zh/tests/iq-test-intelligence-quotient-assessment",
-                "secondaryLabel": "查看详情",
-                "previewVariant": "matrix",
+                "title": "IQ 推理练习",
+                "description": "适合先练习原创视觉空间、图形规律与数字规律题，当前只给出原始分和维度参考。",
                 "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
-                "primaryLabel": "开始测试"
+                "key": "iq-test-intelligence-quotient-assessment",
+                "questionsLabel": "30 题",
+                "durationLabel": "约 20 分钟",
+                "detailsHref": "/zh/tests/iq-test-intelligence-quotient-assessment",
+                "secondaryLabel": "查看边界说明",
+                "previewVariant": "matrix",
+                "primaryLabel": "开始 30 题练习",
+                "outputLabel": "原始分、维度表现与稳定性提示；不输出正式 IQ 或百分位",
+                "claim_policy": {
+                  "norm_authority_required": true,
+                  "iq_estimate_claims_enabled": false,
+                  "percentile_claims_enabled": false,
+                  "copy_boundary": "仅限原创推理练习和原始分参考",
+                  "deferred_norm_authority_pr": "IQ-SCORE-30-01"
+                },
+                "media": {
+                  "asset_key": "iq-beta30-original-card",
+                  "source": "media_library_required",
+                  "authority": "backend_cms_media_library",
+                  "status": "metadata_only_no_frontend_asset",
+                  "fallback_allowed": false,
+                  "alt": "原创 IQ 推理练习卡片",
+                  "variants": {
+                    "card_asset_key": "iq-beta30-original-card",
+                    "og_asset_key": "iq-beta30-original-og",
+                    "report_cover_asset_key": "iq-full-report-cover"
+                  }
+                },
+                "primaryActions": [
+                  {
+                    "label": "30 题 Beta 版",
+                    "href": "/zh/tests/iq-test-intelligence-quotient-assessment/take",
+                    "form_code": "IQ_BETA_30_ORIGINAL"
+                  }
+                ]
               }
             ]
           },

--- a/content_baselines/media_assets/default_media_assets.json
+++ b/content_baselines/media_assets/default_media_assets.json
@@ -106,5 +106,137 @@
         "height": 258
       }
     ]
+  },
+  {
+    "asset_key": "iq-beta30-original-card",
+    "disk": "media_library",
+    "path": "iq/beta30/original-card-v1.png",
+    "mime_type": "image/png",
+    "width": 1200,
+    "height": 900,
+    "alt": "Original IQ reasoning practice landing card",
+    "caption": "CMS-owned IQ_BETA_30_ORIGINAL landing card media metadata.",
+    "variants": [
+      {
+        "variant_key": "card",
+        "path": "iq/beta30/original-card-v1.png",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 900
+      },
+      {
+        "variant_key": "thumbnail",
+        "path": "iq/beta30/original-card-thumb-v1.png",
+        "mime_type": "image/png",
+        "width": 600,
+        "height": 450
+      }
+    ],
+    "payload_json": {
+      "authority": "backend_cms_media_library",
+      "render_surface": [
+        "landing_card",
+        "tests_hub_card"
+      ],
+      "applies_to": {
+        "scale_code": [
+          "IQ_BETA_30_ORIGINAL"
+        ],
+        "test_slug": "iq-test-intelligence-quotient-assessment"
+      },
+      "frontend_fallback_allowed": false,
+      "requires_media_library_upload": true,
+      "copyright_boundary": "FermatMind original metadata; no third-party IQ test asset reuse."
+    }
+  },
+  {
+    "asset_key": "iq-beta30-original-og",
+    "disk": "media_library",
+    "path": "iq/beta30/original-og-v1.png",
+    "mime_type": "image/png",
+    "width": 1200,
+    "height": 630,
+    "alt": "Original IQ reasoning practice social preview",
+    "caption": "CMS-owned IQ_BETA_30_ORIGINAL OG/share media metadata.",
+    "variants": [
+      {
+        "variant_key": "og",
+        "path": "iq/beta30/original-og-v1.png",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 630
+      },
+      {
+        "variant_key": "twitter",
+        "path": "iq/beta30/original-twitter-v1.png",
+        "mime_type": "image/png",
+        "width": 1200,
+        "height": 675
+      }
+    ],
+    "payload_json": {
+      "authority": "backend_cms_media_library",
+      "render_surface": [
+        "seo_og",
+        "social_share"
+      ],
+      "applies_to": {
+        "scale_code": [
+          "IQ_BETA_30_ORIGINAL"
+        ],
+        "test_slug": "iq-test-intelligence-quotient-assessment"
+      },
+      "frontend_fallback_allowed": false,
+      "requires_media_library_upload": true,
+      "claim_policy": {
+        "iq_estimate_claims_enabled": false,
+        "percentile_claims_enabled": false
+      }
+    }
+  },
+  {
+    "asset_key": "iq-full-report-cover",
+    "disk": "media_library",
+    "path": "iq/reports/full-report-cover-v1.png",
+    "mime_type": "image/png",
+    "width": 1600,
+    "height": 1000,
+    "alt": "IQ full report cover media",
+    "caption": "CMS-owned IQ paid report cover and PDF header media metadata.",
+    "variants": [
+      {
+        "variant_key": "report_cover",
+        "path": "iq/reports/full-report-cover-v1.png",
+        "mime_type": "image/png",
+        "width": 1600,
+        "height": 1000
+      },
+      {
+        "variant_key": "pdf_header",
+        "path": "iq/reports/full-report-pdf-header-v1.png",
+        "mime_type": "image/png",
+        "width": 1600,
+        "height": 420
+      }
+    ],
+    "payload_json": {
+      "authority": "backend_cms_media_library",
+      "render_surface": [
+        "paid_report",
+        "pdf_report"
+      ],
+      "applies_to": {
+        "scale_code": [
+          "IQ_BETA_30_ORIGINAL"
+        ],
+        "report_modules": [
+          "iq_core",
+          "iq_full"
+        ]
+      },
+      "frontend_fallback_allowed": false,
+      "requires_media_library_upload": true,
+      "entitlement_required_for_full_report": true
+    }
   }
 ]

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T15:57:38.415Z",
+  "updated_at": "2026-05-31T16:21:14.932455Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22791,20 +22791,20 @@
       "branch": "codex/iq-paid-report-01-entitlement-contract",
       "base": "main",
       "title": "IQ-PAID-REPORT-01 define paid report entitlement contract",
-      "status": "planned",
+      "status": "merged",
       "depends_on": [
         "IQ-NORM-03"
       ],
       "checks": {},
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T15:48:58Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
       "transitions": [
         {
@@ -22812,8 +22812,16 @@
           "from": "missing",
           "to": "planned",
           "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T16:20:05.375075Z",
+          "from": "planned",
+          "to": "merged",
+          "note": "Reconciled from GitHub PR #1812 merge commit 60eabe326f7e24e71a1bef555493dc9a1d6e6f13; branch deleted and local cleanup completed during PR train."
         }
-      ]
+      ],
+      "commit_sha": "60eabe326f7e24e71a1bef555493dc9a1d6e6f13",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1812"
     },
     "IQ-PAID-REPORT-02": {
       "id": "IQ-PAID-REPORT-02",
@@ -22851,20 +22859,34 @@
       "branch": "codex/iq-cms-media-01-authority-metadata",
       "base": "main",
       "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
-      "status": "planned",
+      "status": "local_checks_passed",
       "depends_on": [
         "IQ-PAID-REPORT-02"
       ],
-      "checks": {},
+      "checks": {
+        "python3 JSON parse changed baselines": "passed",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi": "passed_with_existing_warnings",
+        "git diff --check": "passed"
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
-        "post_merge_revalidated": null
+        "post_merge_revalidated": null,
+        "changed_files": [
+          "backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
+          "content_baselines/landing_surfaces/home.en.json",
+          "content_baselines/landing_surfaces/home.zh-CN.json",
+          "content_baselines/landing_surfaces/tests.en.json",
+          "content_baselines/landing_surfaces/tests.zh-CN.json",
+          "content_baselines/media_assets/default_media_assets.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ]
       },
       "transitions": [
         {
@@ -22872,8 +22894,23 @@
           "from": "missing",
           "to": "planned",
           "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T16:20:05.375075Z",
+          "from": "planned",
+          "to": "implementation_in_progress",
+          "note": "Started scoped backend CMS media authority metadata PR in isolated worktree /private/tmp/fap-api-iq-cms-media-01 after dependency PRs were merged."
+        },
+        {
+          "at": "2026-05-31T16:21:14.932455Z",
+          "from": "implementation_in_progress",
+          "to": "local_checks_passed",
+          "note": "Changed files stayed within IQ-CMS-MEDIA-01 allowed_paths; manifest local validation commands passed."
         }
-      ]
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "updated_at": "2026-05-31T16:21:14.932455Z"
     },
     "IQ-CMS-MEDIA-02": {
       "id": "IQ-CMS-MEDIA-02",
@@ -30413,9 +30450,9 @@
       }
     },
     "IQ-PAID-REPORT-01": {
-      "status": "github_checks_green",
+      "status": "merged",
       "branch": "codex/iq-paid-report-01-entitlement-contract",
-      "commit_sha": "fce8088297cbcb907c81245524a2aa281e47d1d0",
+      "commit_sha": "60eabe326f7e24e71a1bef555493dc9a1d6e6f13",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1812",
       "pr_number": 1812,
       "checks": {
@@ -30427,10 +30464,10 @@
         "bigfive_freeze_classifier_local": "passed_with_existing_warning"
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
-      "updated_at": "2026-06-01T00:12:00+08:00",
+      "merged_at": "2026-05-31T15:48:58Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
+      "updated_at": "2026-05-31T16:20:05.375075Z",
       "scope_validation": {
         "allowed_paths_only": true,
         "changed_files": [
@@ -30444,6 +30481,47 @@
           "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
         ]
       }
+    },
+    "IQ-CMS-MEDIA-01": {
+      "id": "IQ-CMS-MEDIA-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-cms-media-01-authority-metadata",
+      "base": "main",
+      "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
+      "status": "local_checks_passed",
+      "depends_on": [
+        "IQ-PAID-REPORT-02"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_iq_paid_report_02": "passed: fermatmind/fap-web#943 merged at 2026-05-31T16:12:12Z",
+        "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-cms-media-01; primary worktree untouched",
+        "python3 JSON parse changed baselines": "passed",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi": "passed_with_existing_warnings",
+        "git diff --check": "passed"
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "changed_files": [
+          "backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
+          "content_baselines/landing_surfaces/home.en.json",
+          "content_baselines/landing_surfaces/home.zh-CN.json",
+          "content_baselines/landing_surfaces/tests.en.json",
+          "content_baselines/landing_surfaces/tests.zh-CN.json",
+          "content_baselines/media_assets/default_media_assets.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ],
+        "local_validation_passed": true,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "updated_at": "2026-05-31T16:21:14.932455Z"
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:21:14.932455Z",
+  "updated_at": "2026-05-31T16:22:06.368532Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22859,7 +22859,7 @@
       "branch": "codex/iq-cms-media-01-authority-metadata",
       "base": "main",
       "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
-      "status": "local_checks_passed",
+      "status": "pr_opened",
       "depends_on": [
         "IQ-PAID-REPORT-02"
       ],
@@ -22906,11 +22906,18 @@
           "from": "implementation_in_progress",
           "to": "local_checks_passed",
           "note": "Changed files stayed within IQ-CMS-MEDIA-01 allowed_paths; manifest local validation commands passed."
+        },
+        {
+          "at": "2026-05-31T16:22:06.368532Z",
+          "from": "local_checks_passed",
+          "to": "pr_opened",
+          "note": "Opened GitHub PR #1817 after local validation passed."
         }
       ],
-      "commit_sha": null,
-      "pr_url": null,
-      "updated_at": "2026-05-31T16:21:14.932455Z"
+      "commit_sha": "bea2250c268bbea96ee2304fa823c1d6e5468472",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1817",
+      "updated_at": "2026-05-31T16:22:06.368532Z",
+      "pr_number": 1817
     },
     "IQ-CMS-MEDIA-02": {
       "id": "IQ-CMS-MEDIA-02",
@@ -30488,12 +30495,12 @@
       "branch": "codex/iq-cms-media-01-authority-metadata",
       "base": "main",
       "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
-      "status": "local_checks_passed",
+      "status": "pr_opened",
       "depends_on": [
         "IQ-PAID-REPORT-02"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "bea2250c268bbea96ee2304fa823c1d6e5468472",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1817",
       "checks": {
         "dependency_iq_paid_report_02": "passed: fermatmind/fap-web#943 merged at 2026-05-31T16:12:12Z",
         "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-cms-media-01; primary worktree untouched",
@@ -30521,7 +30528,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "updated_at": "2026-05-31T16:21:14.932455Z"
+      "updated_at": "2026-05-31T16:22:06.368532Z",
+      "pr_number": 1817
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18168,6 +18168,15 @@ prs:
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: IQ-CMS-MEDIA-02
 
+    allowed_paths:
+      - content_baselines/media_assets/default_media_assets.json
+      - content_baselines/landing_surfaces/home.en.json
+      - content_baselines/landing_surfaces/home.zh-CN.json
+      - content_baselines/landing_surfaces/tests.en.json
+      - content_baselines/landing_surfaces/tests.zh-CN.json
+      - backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
   - id: IQ-CMS-MEDIA-02
     repo: fap-web
     depends_on: [IQ-CMS-MEDIA-01]


### PR DESCRIPTION
## What changed
- Registered IQ landing card, OG/share, and paid report cover media metadata in the backend Media Library baseline.
- Updated IQ landing/test hub baseline cards to reference backend CMS media authority keys with frontend fallback disabled.
- Added LandingSurface baseline assertions that IQ media keys exist, are backend Media Library authoritative, and do not reference frontend/public fallback assets.
- Registered the scoped allowed paths for `IQ-CMS-MEDIA-01` and reconciled the fap-api train ledger for `IQ-PAID-REPORT-01`.

## Why
IQ launch media must be governed by CMS/Media Library authority before frontend rendering work starts. This keeps mutable landing, OG, and report media out of fap-web public/static assets and prevents frontend fallback ownership.

## Validation
- `python3 -m json.tool content_baselines/media_assets/default_media_assets.json >/dev/null && python3 -m json.tool content_baselines/landing_surfaces/home.en.json >/dev/null && python3 -m json.tool content_baselines/landing_surfaces/home.zh-CN.json >/dev/null && python3 -m json.tool content_baselines/landing_surfaces/tests.en.json >/dev/null && python3 -m json.tool content_baselines/landing_surfaces/tests.zh-CN.json >/dev/null`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi` (passed with existing Laravel file_get_contents warnings)
- `git diff --check`

## Intentionally deferred
- No frontend rendering behavior changes. That remains `IQ-CMS-MEDIA-02`.
- No SEO ramp publication or sitemap/GEO expansion. That remains `IQ-SEO-RAMP-01+`.
- No actual binary upload is introduced in this PR; the baseline records the backend authority metadata and upload requirement.

## Repository rule impact
IQ landing, OG, and report media are CMS/backend-authoritative through Media Library metadata. Frontend remains renderer-only and must not add local public media fallbacks.
