### PR TITLE
RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01 release train sidecar soft alerts

### DIFF
--- a/backend/docs/seo/generated/release-train-sidecar-soft-alert-01.v1.json
+++ b/backend/docs/seo/generated/release-train-sidecar-soft-alert-01.v1.json
@@ -1,0 +1,46 @@
+{
+  "schema_version": "release_train_sidecar_soft_alert.v1",
+  "task": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01",
+  "final_decision": "release_train_sidecar_soft_alert_completed_ready_for_deploy_readiness",
+  "hard_block_checks": [
+    "required_github_checks",
+    "core_page_api_smoke",
+    "sitemap_private_url_leakage",
+    "held_slug_exposure",
+    "clinical_depression_exposure",
+    "search_channel_anomaly",
+    "staging_containment_regression",
+    "deploy_wrapper_failure"
+  ],
+  "soft_alert_eligible_surfaces": [
+    "llms-full",
+    "llms_full",
+    "llms-full.txt",
+    "llms_full_txt",
+    "discoverability_artifact",
+    "geo_artifact"
+  ],
+  "soft_alert_required_manifest_fields": {
+    "smoke_check": {
+      "surface": "llms-full",
+      "soft_alert": true,
+      "hard_block": false,
+      "core_smoke": false
+    },
+    "sidecar_policy": {
+      "allow_discoverability_artifact_soft_alerts": true
+    }
+  },
+  "private_or_held_exposure_still_blocks": true,
+  "search_channel_or_staging_guard_still_blocks": true,
+  "core_smoke_still_blocks": true,
+  "required_checks_still_block": true,
+  "deploy_performed": false,
+  "rollback_performed": false,
+  "cms_mutation_performed": false,
+  "db_mutation_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "external_search_api_call_performed": false,
+  "next_task": "DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes"
+}

--- a/backend/docs/seo/release-train-sidecar-soft-alert-01.md
+++ b/backend/docs/seo/release-train-sidecar-soft-alert-01.md
@@ -1,0 +1,59 @@
+# RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01 Report
+
+## 1. Executive Summary
+
+This PR adds an explicit release-train policy for non-core discoverability artifact instability. The policy allows `llms-full`-class artifact read failures to be recorded as sidecar soft alerts only when the manifest opts in and the check is not a core page/API smoke, private or held URL exposure, Search Channel anomaly, staging containment regression, or required GitHub check.
+
+## 2. Hard-Block Rules
+
+The following remain hard-blocking:
+
+- required GitHub checks
+- core page/API smoke failures
+- sitemap/private URL leakage
+- held career slug exposure
+- clinical/depression exposure
+- Search Channel anomalies
+- staging containment regressions
+- deploy wrapper failures
+
+## 3. Soft-Alert Boundary
+
+`llms-full` and equivalent GEO/discoverability artifacts may become non-blocking sidecars only when the smoke check sets:
+
+- `surface: llms-full`
+- `soft_alert: true`
+- `hard_block: false`
+- `core_smoke: false`
+
+The manifest item must also set `sidecar_policy.allow_discoverability_artifact_soft_alerts: true`.
+
+## 4. Implementation
+
+The release train now carries smoke-check metadata through `smoke.py`, classifies discoverability artifact failures in `sidecar.py`, and records sidecar payloads from `release_train.py` when an allowed non-core artifact failure occurs.
+
+## 5. Validation
+
+Targeted tests cover:
+
+- `llms-full` timeout as an allowed discoverability sidecar
+- private/staging guard failures remaining blocking
+- release train `evaluate_item` continuing on allowed `llms-full` sidecar
+- release train blocking staging guard failures even when marked soft-alert
+
+## 6. What Was Not Done
+
+- No deploy.
+- No rollback.
+- No Search Channel enqueue or URL submission.
+- No CMS/DB mutation.
+- No runtime promotion.
+- No weakening of core smoke or private/staging guards.
+
+## 7. Final Decision
+
+release_train_sidecar_soft_alert_completed_ready_for_deploy_readiness
+
+## 8. Next Task
+
+DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes

--- a/backend/tests/Feature/SeoIntel/ReleaseTrainSidecarSoftAlert01Test.php
+++ b/backend/tests/Feature/SeoIntel/ReleaseTrainSidecarSoftAlert01Test.php
@@ -1,0 +1,109 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ReleaseTrainSidecarSoftAlert01Test extends TestCase
+{
+    #[Test]
+    public function generated_artifact_records_soft_alert_boundaries(): void
+    {
+        $payload = $this->payload();
+
+        $this->assertSame('release_train_sidecar_soft_alert.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01', $payload['task'] ?? null);
+        $this->assertSame(
+            'release_train_sidecar_soft_alert_completed_ready_for_deploy_readiness',
+            $payload['final_decision'] ?? null,
+        );
+
+        foreach ([
+            'required_github_checks',
+            'core_page_api_smoke',
+            'sitemap_private_url_leakage',
+            'held_slug_exposure',
+            'clinical_depression_exposure',
+            'search_channel_anomaly',
+            'staging_containment_regression',
+            'deploy_wrapper_failure',
+        ] as $hardBlock) {
+            $this->assertContains($hardBlock, $payload['hard_block_checks'] ?? []);
+        }
+
+        $this->assertContains('llms-full', $payload['soft_alert_eligible_surfaces'] ?? []);
+        $this->assertTrue((bool) data_get($payload, 'soft_alert_required_manifest_fields.smoke_check.soft_alert'));
+        $this->assertFalse((bool) data_get($payload, 'soft_alert_required_manifest_fields.smoke_check.hard_block'));
+        $this->assertFalse((bool) data_get($payload, 'soft_alert_required_manifest_fields.smoke_check.core_smoke'));
+    }
+
+    #[Test]
+    public function non_mutation_and_guard_flags_are_fail_closed(): void
+    {
+        $payload = $this->payload();
+
+        foreach ([
+            'private_or_held_exposure_still_blocks',
+            'search_channel_or_staging_guard_still_blocks',
+            'core_smoke_still_blocks',
+            'required_checks_still_block',
+        ] as $flag) {
+            $this->assertTrue((bool) ($payload[$flag] ?? false), $flag);
+        }
+
+        foreach ([
+            'deploy_performed',
+            'rollback_performed',
+            'cms_mutation_performed',
+            'db_mutation_performed',
+            'search_channel_action_performed',
+            'url_submission_performed',
+            'external_search_api_call_performed',
+        ] as $flag) {
+            $this->assertFalse((bool) ($payload[$flag] ?? true), $flag);
+        }
+    }
+
+    #[Test]
+    public function report_records_required_sections_and_next_task(): void
+    {
+        $path = base_path('docs/seo/release-train-sidecar-soft-alert-01.md');
+
+        $this->assertFileExists($path);
+
+        $report = (string) file_get_contents($path);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. Hard-Block Rules',
+            '## 3. Soft-Alert Boundary',
+            '## 4. Implementation',
+            '## 5. Validation',
+            '## 6. What Was Not Done',
+            '## 7. Final Decision',
+            '## 8. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+
+        $this->assertSame(
+            'DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes',
+            $this->payload()['next_task'] ?? null,
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function payload(): array
+    {
+        $path = base_path('docs/seo/generated/release-train-sidecar-soft-alert-01.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:31:45Z",
+  "updated_at": "2026-05-31T16:44:29Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22455,25 +22455,107 @@
       "branch": "codex/release-train-sidecar-soft-alert-01",
       "base": "main",
       "title": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01 release train sidecar soft alerts",
-      "status": "pending",
+      "status": "pr_open_checks_pending",
       "depends_on": [
         "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01"
       ],
-      "checks": {},
+      "checks": {
+        "dependency_preflight": {
+          "status": "pass",
+          "evidence": "Dependency CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01 merged as PR #1814; branch rebased onto latest origin/main after PRs #1815/#1819 advanced main."
+        },
+        "iq_pint_cleanup_sidecar": {
+          "status": "resolved",
+          "evidence": "Scoped IQ Pint cleanup PR #1816 merged at 5f891c5640885a4d2cc84cc395b12b15a6074546; vendor/bin/pint --test passed before PR open."
+        },
+        "python_ops_tests": {
+          "status": "pass",
+          "command": "python3 -m unittest tests.ops.test_sidecar_policy tests.ops.test_smoke tests.ops.test_release_train_manifest tests.ops.test_release_train_soft_alerts",
+          "evidence": "15 tests passed after rebase onto latest origin/main."
+        },
+        "manifest_validation": {
+          "status": "pass",
+          "command": "python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json",
+          "evidence": "Manifest validation returned ok=true after rebase."
+        },
+        "focused_php_test": {
+          "status": "pass_with_warnings",
+          "command": "php artisan test --filter=ReleaseTrainSidecarSoftAlert01 --no-ansi",
+          "evidence": "3 tests completed with 39 assertions after rebase; PHPUnit emitted warnings but returned success."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "php artisan route:list --no-ansi",
+          "evidence": "Route list completed successfully after rebase, 209 routes."
+        },
+        "pint": {
+          "status": "pass",
+          "command": "vendor/bin/pint --test",
+          "evidence": "Pint passed across 3682 files after rebase."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "composer validate --strict",
+          "evidence": "composer.json is valid after rebase."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found after rebase."
+        },
+        "github_pr": {
+          "status": "created",
+          "evidence": "https://github.com/fermatmind/fap-api/pull/1820"
+        },
+        "json_yaml_diff_checks": {
+          "status": "pass",
+          "evidence": "Generated JSON parsed, pr-train-state JSON parsed, pr-train YAML parsed, and git diff --check passed after rebase."
+        }
+      },
       "failure_reason": null,
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "b4f6118927cdcd22f9336f9c4a40db0f08fea03a",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1820",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [],
-      "sidecars": [],
+      "transitions": [
+        {
+          "at": "2026-05-31T16:42:20Z",
+          "from": "pr_open_checks_pending_dirty",
+          "to": "rebased_pending_validation",
+          "note": "Rebased PR #1820 onto latest origin/main after GitHub reported mergeStateStatus=DIRTY."
+        },
+        {
+          "at": "2026-05-31T16:44:29Z",
+          "from": "rebased_pending_validation",
+          "to": "pr_open_checks_pending",
+          "note": "Re-ran required local validation after rebase; force-push pending for PR #1820."
+        }
+      ],
+      "sidecars": [
+        {
+          "source_pr": "RELEASE-TRAIN-SIDECAR-SOFT-ALERT-01",
+          "repo": "fap-api",
+          "branch": "codex/release-train-sidecar-soft-alert-01",
+          "command_or_check": "vendor/bin/pint --test",
+          "status": "resolved_by_pr_1816",
+          "evidence": "PR #1816 merged at 5f891c5640885a4d2cc84cc395b12b15a6074546; full Pint blocker resolved before PR7 opening.",
+          "failure_summary": "Out-of-scope IQ report contract test Pint formatting issue previously blocked PR7 local validation.",
+          "why_external_to_current_pr": "PR7 changes release-train soft-alert policy, docs, and tests; IQ report contract test is outside PR7 scope.",
+          "impact_on_current_pr": "Resolved before PR7 commit/PR; no remaining local validation blocker.",
+          "owner": "backend/IQ upstream",
+          "follow_up_recommendation": "None for this blocker; continue PR7 submit/merge workflow.",
+          "required_checks_status": "github_checks_previously_green_before_rebase",
+          "scope_validation_status": "allowed_paths_only_and_local_validation_passed",
+          "continue_train_decision": "continue_pr7"
+        }
+      ],
       "next_task": "DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes"
     },
     "IQ-NORM-01": {

--- a/docs/ops/release-train.md
+++ b/docs/ops/release-train.md
@@ -117,12 +117,24 @@ deploy file from repository-controlled configuration.
 - status expectation
 - must contain / must not contain
 - optional forbidden marker scan for high-risk URLs
+- optional soft-alert metadata for non-core discoverability artifacts:
+  - `surface: llms-full`
+  - `soft_alert: true`
+  - `hard_block: false`
+  - `core_smoke: false`
+  - `owner`
+  - `recommended_followup`
 
 ## Sidecar policy
 - Required check failures are blocking.
-- Non-required checks can be sidecar only when:
-  - failure is explicitly external
-- `5xx`, `timeout`, private URL exposure, held slug exposure, clinical/depression exposure, core smoke failures are never sidecar.
+- Non-required checks can be sidecar only when failure is explicitly external.
+- `5xx`, `timeout`, private URL exposure, held slug exposure, clinical/depression exposure, core smoke failures, Search Channel checks, and staging containment checks are hard-blocking by default.
+- `llms-full` and equivalent GEO/discoverability artifacts may be downgraded to sidecar only when all are true:
+  - the smoke check explicitly sets `soft_alert: true`, `hard_block: false`, and `core_smoke: false`
+  - the item `sidecar_policy.allow_discoverability_artifact_soft_alerts` is true
+  - the failure is not a private/held URL exposure, Search Channel anomaly, staging containment regression, or core route/API failure
+  - a follow-up owner and recommendation are recorded
+- Soft-alert sidecars are not a pass for the artifact itself; they only prevent non-core artifact instability from automatically rolling back or stopping unrelated production release flow.
 
 ## Risk classifier
 High-risk paths require manual approval and are blocked by default:

--- a/ops/release-train/examples/release-train.example.json
+++ b/ops/release-train/examples/release-train.example.json
@@ -39,7 +39,19 @@
         { "url": "https://fermatmind.com/api/v0.5/seo/sitemap-source", "expected_status": 200, "method": "GET", "timeout_seconds": 8, "retries": 2 },
         { "url": "https://fermatmind.com/sitemap.xml", "expected_status": 200, "method": "GET", "timeout_seconds": 8, "retries": 2 },
         { "url": "https://fermatmind.com/llms.txt", "expected_status": 200, "method": "GET", "timeout_seconds": 10, "retries": 2 },
-        { "url": "https://fermatmind.com/llms-full.txt", "expected_status": 200, "method": "GET", "timeout_seconds": 10, "retries": 2 },
+        {
+          "url": "https://fermatmind.com/llms-full.txt",
+          "expected_status": 200,
+          "method": "GET",
+          "timeout_seconds": 10,
+          "retries": 2,
+          "surface": "llms-full",
+          "soft_alert": true,
+          "hard_block": false,
+          "core_smoke": false,
+          "owner": "seo-ops",
+          "recommended_followup": "Inspect llms-full artifact cache and rerun post-deploy discoverability smoke."
+        },
         { "url": "https://fermatmind.com/robots.txt", "expected_status": 200, "method": "GET", "timeout_seconds": 8, "retries": 2 },
         { "url": "https://fermatmind.com/api/v0.5/career/datasets/occupations?locale=zh-CN", "expected_status": 200, "method": "GET", "timeout_seconds": 10, "retries": 2 },
         { "url": "https://fermatmind.com/api/v0.5/career/jobs/software-developers?locale=zh-CN", "expected_status": 404, "method": "GET", "timeout_seconds": 10, "retries": 2 }
@@ -50,6 +62,7 @@
       },
       "sidecar_policy": {
         "allow_nonblocking_sidecars": false,
+        "allow_discoverability_artifact_soft_alerts": true,
         "create_issue": false,
         "issue_title_prefix": "release-train-sidecar"
       }

--- a/ops/release-train/release_train.py
+++ b/ops/release-train/release_train.py
@@ -43,6 +43,14 @@ ALLOWED_COMPONENTS = {"backend", "frontend", "both", "docs", "ops"}
 ALLOWED_RISK = {"low", "medium", "high"}
 ALLOWED_DEPLOY_ORDER = {"backend_first", "frontend_first", "none"}
 ALLOWED_CHECK_POLICIES = {"required_only", "all_checks"}
+DISCOVERABILITY_ARTIFACT_SURFACES = {
+    "llms-full",
+    "llms_full",
+    "llms-full.txt",
+    "llms_full_txt",
+    "discoverability_artifact",
+    "geo_artifact",
+}
 FORBIDDEN_DEPLOY_OVERRIDE_FIELDS = {
     "deployer_bin",
     "deployer_file",
@@ -289,17 +297,49 @@ def evaluate_item(
         result["smoke"] = smoke_results
         failed_smoke = [entry for entry in smoke_results if not entry["success"]]
         if failed_smoke:
-            result["status"] = "blocked"
-            result["failures"].append("smoke_failed")
+            policy = item.get("sidecar_policy") or {}
+            blocking_smoke = []
             for entry in failed_smoke:
-                result["sidecars"].append(
-                    classify_check_failure(
-                        check_name=f"smoke:{entry['url']}",
-                        required=True,
-                        observed_failure="|".join(entry["errors"]),
-                        is_core_smoke=True,
-                    )
+                observed_failure = "|".join(entry["errors"])
+                surface = str(entry.get("surface") or "").lower()
+                soft_alert_requested = bool(entry.get("soft_alert", False))
+                is_discoverability_artifact = surface in DISCOVERABILITY_ARTIFACT_SURFACES
+                classification = classify_check_failure(
+                    check_name=f"smoke:{entry.get('name') or entry['url']}",
+                    required=bool(entry.get("hard_block", True)),
+                    observed_failure=observed_failure,
+                    is_core_smoke=bool(entry.get("core_smoke", True)),
+                    is_private_or_held_exposure=bool(entry.get("private_or_held_exposure_guard", False)),
+                    is_discoverability_artifact=is_discoverability_artifact,
+                    allow_discoverability_soft_alert=(
+                        soft_alert_requested
+                        and is_discoverability_artifact
+                        and bool(policy.get("allow_discoverability_artifact_soft_alerts", False))
+                    ),
+                    is_search_channel_or_staging_guard=bool(entry.get("search_channel_or_staging_guard", False)),
+                    likely_external=soft_alert_requested,
                 )
+                result["sidecars"].append(classification)
+                if classification.get("allow_nonblocking"):
+                    result.setdefault("sidecar_records", []).append(
+                        build_sidecar_payload(
+                            train_id=manifest["train_id"],
+                            pr_number=str(pr_number),
+                            repo=repo,
+                            component=item.get("component", ""),
+                            check_name=classification["check_name"],
+                            observed_failure=observed_failure,
+                            why_nonblocking=classification["reason"],
+                            recommended_followup=str(entry.get("recommended_followup") or "rerun smoke and inspect artifact cache"),
+                            owner=str(entry.get("owner") or "ops"),
+                            severity="medium",
+                        )
+                    )
+                    continue
+                blocking_smoke.append(entry)
+            if blocking_smoke:
+                result["status"] = "blocked"
+                result["failures"].append("smoke_failed")
         else:
             # content scan guard
             for entry in smoke_results:

--- a/ops/release-train/schema/release-train.schema.json
+++ b/ops/release-train/schema/release-train.schema.json
@@ -43,7 +43,15 @@
         "timeout_seconds": { "type": "number", "minimum": 0.1 },
         "retries": { "type": "integer", "minimum": 1 },
         "must_contain": { "type": "string" },
-        "must_not_contain": { "type": "string" }
+        "must_not_contain": { "type": "string" },
+        "surface": { "type": "string" },
+        "soft_alert": { "type": "boolean" },
+        "hard_block": { "type": "boolean" },
+        "core_smoke": { "type": "boolean" },
+        "private_or_held_exposure_guard": { "type": "boolean" },
+        "search_channel_or_staging_guard": { "type": "boolean" },
+        "owner": { "type": "string" },
+        "recommended_followup": { "type": "string" }
       },
       "additionalProperties": true
     },
@@ -63,6 +71,7 @@
         "allow_nonblocking_sidecars": { "type": "boolean" },
         "create_issue": { "type": "boolean" },
         "issue_title_prefix": { "type": "string" },
+        "allow_discoverability_artifact_soft_alerts": { "type": "boolean" },
         "labels": { "type": "array", "items": { "type": "string" } }
       },
       "additionalProperties": true

--- a/ops/release-train/sidecar.py
+++ b/ops/release-train/sidecar.py
@@ -10,21 +10,43 @@ def classify_check_failure(
     observed_failure: str,
     is_core_smoke: bool = False,
     is_private_or_held_exposure: bool = False,
+    is_discoverability_artifact: bool = False,
+    allow_discoverability_soft_alert: bool = False,
+    is_search_channel_or_staging_guard: bool = False,
     likely_external: bool = False,
 ) -> dict:
-    blocking = required or is_core_smoke or is_private_or_held_exposure
+    observed = observed_failure.lower()
+    transport_failure = "5xx" in observed or "timeout" in observed
+    blocking = (
+        required
+        or is_core_smoke
+        or is_private_or_held_exposure
+        or is_search_channel_or_staging_guard
+    )
     reason = ""
 
     if check_name.startswith("required_") and required:
         blocking = True
         reason = "required check failed"
-    if "5xx" in observed_failure.lower() or "timeout" in observed_failure.lower():
+    if transport_failure:
         blocking = True
         reason = "critical transport or backend availability failure"
+        if (
+            is_discoverability_artifact
+            and allow_discoverability_soft_alert
+            and not required
+            and not is_core_smoke
+            and not is_private_or_held_exposure
+            and not is_search_channel_or_staging_guard
+        ):
+            blocking = False
+            reason = "discoverability artifact transport failure allowed as soft-alert sidecar"
     if is_private_or_held_exposure:
         blocking = True
         reason = "private or held exposure policy violation"
+    if is_search_channel_or_staging_guard:
         blocking = True
+        reason = "Search Channel or staging guard failure"
 
     allow_nonblocking = not blocking and likely_external
 
@@ -34,6 +56,9 @@ def classify_check_failure(
         "observed_failure": observed_failure,
         "is_core_smoke": is_core_smoke,
         "is_private_or_held_exposure": is_private_or_held_exposure,
+        "is_discoverability_artifact": is_discoverability_artifact,
+        "allow_discoverability_soft_alert": allow_discoverability_soft_alert,
+        "is_search_channel_or_staging_guard": is_search_channel_or_staging_guard,
         "likely_external": likely_external,
         "allow_nonblocking": allow_nonblocking,
         "reason": reason or "allowed as non-blocking sidecar",

--- a/ops/release-train/smoke.py
+++ b/ops/release-train/smoke.py
@@ -91,6 +91,7 @@ def run_smoke_checks(checks: List[dict], request_fn: Optional[RequestFn] = None)
             request_fn=request_fn,
         )
         item = {
+            "name": check.get("name") or check.get("id") or check["url"],
             "url": result["url"],
             "expected_status": result["expected_status"],
             "method": result["method"],
@@ -101,6 +102,14 @@ def run_smoke_checks(checks: List[dict], request_fn: Optional[RequestFn] = None)
             "success": result["success"],
             "errors": result["errors"],
             "response_snippet": result["response_snippet"],
+            "surface": check.get("surface"),
+            "soft_alert": bool(check.get("soft_alert", False)),
+            "hard_block": bool(check.get("hard_block", not bool(check.get("soft_alert", False)))),
+            "core_smoke": bool(check.get("core_smoke", not bool(check.get("soft_alert", False)))),
+            "private_or_held_exposure_guard": bool(check.get("private_or_held_exposure_guard", False)),
+            "search_channel_or_staging_guard": bool(check.get("search_channel_or_staging_guard", False)),
+            "owner": check.get("owner", "ops"),
+            "recommended_followup": check.get("recommended_followup", "record sidecar issue and rerun after clearance"),
         }
         results.append(item)
     return results

--- a/tests/ops/test_release_train_soft_alerts.py
+++ b/tests/ops/test_release_train_soft_alerts.py
@@ -1,0 +1,125 @@
+import importlib.util
+import sys
+import unittest
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+MODULE_DIR = ROOT / "ops" / "release-train"
+if str(MODULE_DIR) not in sys.path:
+    sys.path.insert(0, str(MODULE_DIR))
+
+MODULE_PATH = MODULE_DIR / "release_train.py"
+spec = importlib.util.spec_from_file_location("release_train", MODULE_PATH)
+module = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(module)  # type: ignore[union-attr]
+
+
+class FakeGitHub:
+    def get_pull_request(self, repo, pr_number):
+        return {"head": {"sha": "abc123"}}
+
+    def get_required_checks(self, repo, sha):
+        return {"CI": "success"}
+
+    def get_pull_request_changed_files(self, repo, pr_number):
+        return ["ops/release-train/release_train.py"]
+
+
+class ReleaseTrainSoftAlertTest(unittest.TestCase):
+    def test_llms_full_soft_alert_does_not_block_train(self):
+        original = module.run_smoke_checks
+        module.run_smoke_checks = lambda checks: [
+            {
+                "name": "llms-full",
+                "url": "https://fermatmind.com/llms-full.txt",
+                "success": False,
+                "errors": ["attempt 1: request timeout"],
+                "surface": "llms-full",
+                "soft_alert": True,
+                "hard_block": False,
+                "core_smoke": False,
+                "private_or_held_exposure_guard": False,
+                "search_channel_or_staging_guard": False,
+                "owner": "seo-ops",
+                "recommended_followup": "Inspect llms-full artifact cache.",
+                "response_snippet": "",
+            }
+        ]
+        try:
+            result = module.evaluate_item(
+                self.item(),
+                manifest={"train_id": "test-train"},
+                github=FakeGitHub(),
+                execute_smoke=True,
+                mode="run",
+            )
+        finally:
+            module.run_smoke_checks = original
+
+        self.assertEqual(result["status"], "ok")
+        self.assertEqual(result["failures"], [])
+        self.assertEqual(len(result.get("sidecar_records", [])), 1)
+        self.assertTrue(result["sidecars"][0]["allow_nonblocking"])
+
+    def test_staging_guard_still_blocks_even_if_marked_soft_alert(self):
+        original = module.run_smoke_checks
+        module.run_smoke_checks = lambda checks: [
+            {
+                "name": "staging-containment",
+                "url": "https://staging.fermatmind.com/llms-full.txt",
+                "success": False,
+                "errors": ["attempt 1: request timeout"],
+                "surface": "llms-full",
+                "soft_alert": True,
+                "hard_block": False,
+                "core_smoke": False,
+                "private_or_held_exposure_guard": False,
+                "search_channel_or_staging_guard": True,
+                "owner": "ops",
+                "recommended_followup": "Inspect staging containment.",
+                "response_snippet": "",
+            }
+        ]
+        try:
+            result = module.evaluate_item(
+                self.item(),
+                manifest={"train_id": "test-train"},
+                github=FakeGitHub(),
+                execute_smoke=True,
+                mode="run",
+            )
+        finally:
+            module.run_smoke_checks = original
+
+        self.assertEqual(result["status"], "blocked")
+        self.assertIn("smoke_failed", result["failures"])
+        self.assertFalse(result["sidecars"][0]["allow_nonblocking"])
+
+    def item(self):
+        return {
+            "id": "test-item",
+            "repo": "fap-api",
+            "pr_number": 1,
+            "expected_head_sha": "abc123",
+            "component": "ops",
+            "risk_level": "low",
+            "deploy_required": False,
+            "deploy_order": "none",
+            "required_checks_policy": "required_only",
+            "allowed_files": ["ops/release-train/**"],
+            "allowed_generated_paths": [],
+            "scope_validation": "required_scope_only",
+            "smoke_checks": [{"url": "https://fermatmind.com/llms-full.txt", "expected_status": 200}],
+            "rollback": {"enabled": False, "wrapper": "backend/scripts/deploy/rollback_backend.sh"},
+            "sidecar_policy": {
+                "allow_nonblocking_sidecars": True,
+                "allow_discoverability_artifact_soft_alerts": True,
+                "create_issue": False,
+                "issue_title_prefix": "release-train-sidecar",
+            },
+        }
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/ops/test_sidecar_policy.py
+++ b/tests/ops/test_sidecar_policy.py
@@ -39,3 +39,41 @@ class SidecarPolicyTest(unittest.TestCase):
             likely_external=False,
         )
         self.assertFalse(result["allow_nonblocking"])
+
+    def test_llms_full_timeout_can_be_discoverability_soft_alert(self):
+        result = module.classify_check_failure(
+            check_name="smoke:llms-full",
+            required=False,
+            observed_failure="request timeout",
+            is_core_smoke=False,
+            is_discoverability_artifact=True,
+            allow_discoverability_soft_alert=True,
+            likely_external=True,
+        )
+        self.assertTrue(result["allow_nonblocking"])
+        self.assertIn("discoverability artifact", result["reason"])
+
+    def test_discoverability_soft_alert_does_not_override_private_or_staging_guard(self):
+        private_result = module.classify_check_failure(
+            check_name="smoke:llms-full",
+            required=False,
+            observed_failure="request timeout",
+            is_core_smoke=False,
+            is_private_or_held_exposure=True,
+            is_discoverability_artifact=True,
+            allow_discoverability_soft_alert=True,
+            likely_external=True,
+        )
+        staging_result = module.classify_check_failure(
+            check_name="smoke:staging",
+            required=False,
+            observed_failure="request timeout",
+            is_core_smoke=False,
+            is_discoverability_artifact=True,
+            allow_discoverability_soft_alert=True,
+            is_search_channel_or_staging_guard=True,
+            likely_external=True,
+        )
+
+        self.assertFalse(private_result["allow_nonblocking"])
+        self.assertFalse(staging_result["allow_nonblocking"])


### PR DESCRIPTION
## What changed
- Added release-train sidecar soft-alert policy support for non-core discoverability artifacts such as llms-full.
- Extended smoke metadata, manifest schema, example manifest, docs, and release-train evaluation so opt-in discoverability timeout/5xx failures can create sidecar records without hard-blocking the train.
- Preserved hard blocks for core smoke, required checks, private/held exposure guards, Search Channel guards, and staging guards.
- Added focused Python and SeoIntel tests plus generated report artifacts.

## Why
- Large discoverability artifacts can have transient generation/cache issues; these should be recorded and followed up when explicitly non-core, without turning a production release train into a false hard failure.
- The policy remains fail-closed unless the manifest/check metadata opts in and all hard-block guards remain false.

## Validation
- `python3 -m unittest tests.ops.test_sidecar_policy tests.ops.test_smoke tests.ops.test_release_train_manifest tests.ops.test_release_train_soft_alerts`
- `python3 ops/release-train/release_train.py validate-manifest --manifest ops/release-train/examples/release-train.example.json`
- `cd backend && php artisan test --filter=ReleaseTrainSidecarSoftAlert01 --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/release-train-sidecar-soft-alert-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/codex/pr-train.yaml").read_text())'`
- `git diff --check`
- `git diff --cached --check`

## Sidecars
- Prior full Pint blocker in `backend/tests/Feature/V0_3/IqReportContractTest.php` was resolved by scoped cleanup PR #1816 (`5f891c5640885a4d2cc84cc395b12b15a6074546`) before this PR was opened.

## Deferred
- No deploy.
- No production runtime change outside release-train evaluation code.
- No Search Channel action or URL submission.
- No CMS/DB mutation.
- No changes to fap-web.
