### PR TITLE
IQ-SEO-RAMP-01 publish CMS SEO ramp authority

### DIFF
--- a/backend/tests/Feature/SeoIntel/IqSeoRampAuthorityTest.php
+++ b/backend/tests/Feature/SeoIntel/IqSeoRampAuthorityTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\LandingSurface;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class IqSeoRampAuthorityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_iq_seo_ramp_authority_is_backend_cms_owned_and_claim_safe(): void
+    {
+        $this->artisan('landing-surfaces:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => 'published',
+            '--source-dir' => '../content_baselines/landing_surfaces',
+        ])->assertExitCode(0);
+
+        $en = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('surface_key', 'tests')
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $zh = LandingSurface::query()
+            ->withoutGlobalScopes()
+            ->where('surface_key', 'tests')
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $enAuthority = (array) data_get($en->payload_json, 'seo.iq_ramp_authority', []);
+        $zhAuthority = (array) data_get($zh->payload_json, 'seo.iq_ramp_authority', []);
+
+        $this->assertSame('iq.seo_ramp_authority.v1', (string) ($enAuthority['schema'] ?? ''));
+        $this->assertSame('backend_cms_landing_surface', (string) ($enAuthority['authority_source'] ?? ''));
+        $this->assertSame('iq-test-intelligence-quotient-assessment', (string) ($enAuthority['test_slug'] ?? ''));
+        $this->assertSame('IQ_BETA_30_ORIGINAL', (string) ($enAuthority['form_code'] ?? ''));
+        $this->assertSame('/en/tests/iq-test-intelligence-quotient-assessment', (string) ($enAuthority['canonical_path'] ?? ''));
+        $this->assertSame('/zh/tests/iq-test-intelligence-quotient-assessment', (string) data_get($enAuthority, 'localized_paths.zh'));
+        $this->assertSame('index,follow', (string) ($enAuthority['robots'] ?? ''));
+        $this->assertTrue((bool) ($enAuthority['is_indexable'] ?? false));
+        $this->assertTrue((bool) ($enAuthority['sitemap_eligible'] ?? false));
+        $this->assertTrue((bool) ($enAuthority['llms_eligible'] ?? false));
+        $this->assertTrue((bool) ($enAuthority['jsonld_eligible'] ?? false));
+
+        $this->assertSame('/zh/tests/iq-test-intelligence-quotient-assessment', (string) ($zhAuthority['canonical_path'] ?? ''));
+        $this->assertSame('zh-CN', (string) ($zhAuthority['locale'] ?? ''));
+        $this->assertSame('iq-beta30-original-og', (string) data_get($zhAuthority, 'media.og_asset_key'));
+        $this->assertSame('iq-full-report-cover', (string) data_get($zhAuthority, 'media.report_cover_asset_key'));
+
+        $this->assertTrue((bool) data_get($enAuthority, 'claim_policy.norm_authority_required'));
+        $this->assertSame('IQ-NORM-03', (string) data_get($enAuthority, 'claim_policy.norm_authority_pr'));
+        $this->assertFalse((bool) data_get($enAuthority, 'claim_policy.public_copy_iq_estimate_claims_enabled', true));
+        $this->assertFalse((bool) data_get($enAuthority, 'claim_policy.public_copy_percentile_claims_enabled', true));
+        $this->assertSame('original_reasoning_practice', (string) data_get($enAuthority, 'structured_data.assessment_mode'));
+        $this->assertSame('raw_score_dimension_reference_paid_report_gated', (string) data_get($enAuthority, 'structured_data.result_scope'));
+
+        $json = json_encode([$enAuthority, $zhAuthority], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_THROW_ON_ERROR);
+        foreach ([
+            'official IQ',
+            'certified IQ',
+            'clinical diagnosis',
+            'hiring selection',
+            '人群百分位',
+            '官方智商',
+            '招聘筛选',
+        ] as $blockedClaim) {
+            $this->assertStringNotContainsString($blockedClaim, $json);
+        }
+    }
+}

--- a/content_baselines/landing_surfaces/tests.en.json
+++ b/content_baselines/landing_surfaces/tests.en.json
@@ -10,7 +10,56 @@
   "payload_json": {
     "seo": {
       "title": "Tests Hub",
-      "description": "Start from a clearer question or category and choose the right FermatMind assessment more quickly."
+      "description": "Start from a clearer question or category and choose the right FermatMind assessment more quickly.",
+      "iq_ramp_authority": {
+        "schema": "iq.seo_ramp_authority.v1",
+        "authority_source": "backend_cms_landing_surface",
+        "locale": "en",
+        "test_slug": "iq-test-intelligence-quotient-assessment",
+        "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+        "form_code": "IQ_BETA_30_ORIGINAL",
+        "canonical_path": "/en/tests/iq-test-intelligence-quotient-assessment",
+        "localized_paths": {
+          "en": "/en/tests/iq-test-intelligence-quotient-assessment",
+          "zh": "/zh/tests/iq-test-intelligence-quotient-assessment"
+        },
+        "robots": "index,follow",
+        "is_indexable": true,
+        "sitemap_eligible": true,
+        "llms_eligible": true,
+        "llms_full_eligible": false,
+        "jsonld_eligible": true,
+        "meta_title": "IQ Reasoning Practice | 30 Original Reasoning Items",
+        "meta_description": "Practice original visual-spatial, pattern, and numeric reasoning items with raw score, dimension reference, and explicit method boundaries.",
+        "og_title": "IQ Reasoning Practice",
+        "og_description": "Original 30-item reasoning practice; public copy stays limited to score context and method boundaries.",
+        "media": {
+          "card_asset_key": "iq-beta30-original-card",
+          "og_asset_key": "iq-beta30-original-og",
+          "report_cover_asset_key": "iq-full-report-cover",
+          "source": "media_library_required",
+          "authority": "backend_cms_media_library",
+          "fallback_allowed": false
+        },
+        "claim_policy": {
+          "norm_authority_required": true,
+          "norm_authority_pr": "IQ-NORM-03",
+          "public_copy_iq_estimate_claims_enabled": false,
+          "public_copy_percentile_claims_enabled": false,
+          "result_context_iq_estimate_requires_backend_report": true,
+          "paid_report_claims_require_backend_entitlement": true,
+          "copy_boundary": "raw score, dimension reference, original reasoning practice, and method boundary only"
+        },
+        "structured_data": {
+          "@type": "Quiz",
+          "assessment_mode": "original_reasoning_practice",
+          "result_scope": "raw_score_dimension_reference_paid_report_gated",
+          "is_free": true,
+          "question_count": 30,
+          "time_required_minutes": 20,
+          "not_for": "medical, employment, or certification decisions"
+        }
+      }
     },
     "hero": {
       "eyebrow": "Tests",

--- a/content_baselines/landing_surfaces/tests.zh-CN.json
+++ b/content_baselines/landing_surfaces/tests.zh-CN.json
@@ -10,7 +10,56 @@
   "payload_json": {
     "seo": {
       "title": "测评入口中心",
-      "description": "按问题或分类进入 FermatMind 测评入口，更快判断从哪一个测试开始。"
+      "description": "按问题或分类进入 FermatMind 测评入口，更快判断从哪一个测试开始。",
+      "iq_ramp_authority": {
+        "schema": "iq.seo_ramp_authority.v1",
+        "authority_source": "backend_cms_landing_surface",
+        "locale": "zh-CN",
+        "test_slug": "iq-test-intelligence-quotient-assessment",
+        "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+        "form_code": "IQ_BETA_30_ORIGINAL",
+        "canonical_path": "/zh/tests/iq-test-intelligence-quotient-assessment",
+        "localized_paths": {
+          "en": "/en/tests/iq-test-intelligence-quotient-assessment",
+          "zh": "/zh/tests/iq-test-intelligence-quotient-assessment"
+        },
+        "robots": "index,follow",
+        "is_indexable": true,
+        "sitemap_eligible": true,
+        "llms_eligible": true,
+        "llms_full_eligible": false,
+        "jsonld_eligible": true,
+        "meta_title": "IQ 推理练习 | 30 题原创推理测评",
+        "meta_description": "练习原创视觉空间、图形规律与数字规律题；当前 SEO 文案仅承诺原始分、维度参考和方法边界。",
+        "og_title": "IQ 推理练习",
+        "og_description": "原创 30 题推理练习；公开文案仅保留分数语境与方法边界。",
+        "media": {
+          "card_asset_key": "iq-beta30-original-card",
+          "og_asset_key": "iq-beta30-original-og",
+          "report_cover_asset_key": "iq-full-report-cover",
+          "source": "media_library_required",
+          "authority": "backend_cms_media_library",
+          "fallback_allowed": false
+        },
+        "claim_policy": {
+          "norm_authority_required": true,
+          "norm_authority_pr": "IQ-NORM-03",
+          "public_copy_iq_estimate_claims_enabled": false,
+          "public_copy_percentile_claims_enabled": false,
+          "result_context_iq_estimate_requires_backend_report": true,
+          "paid_report_claims_require_backend_entitlement": true,
+          "copy_boundary": "仅限原始分、维度参考、原创推理练习与方法边界"
+        },
+        "structured_data": {
+          "@type": "Quiz",
+          "assessment_mode": "original_reasoning_practice",
+          "result_scope": "raw_score_dimension_reference_paid_report_gated",
+          "is_free": true,
+          "question_count": 30,
+          "time_required_minutes": 20,
+          "not_for": "医疗、雇佣或认证决策"
+        }
+      }
     },
     "hero": {
       "eyebrow": "测评入口",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:58:50.038408Z",
+  "updated_at": "2026-05-31T16:59:12.092390Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -23056,7 +23056,7 @@
       "branch": "codex/iq-seo-ramp-01-cms-authority",
       "base": "main",
       "title": "IQ-SEO-RAMP-01 publish CMS SEO ramp authority",
-      "status": "local_scope_validation_passed_external_sidecar",
+      "status": "pr_open_checks_pending",
       "depends_on": [
         "IQ-CMS-MEDIA-02",
         "IQ-NORM-03"
@@ -23106,9 +23106,15 @@
           "from": "implementation_in_progress",
           "to": "local_scope_validation_passed_external_sidecar",
           "note": "IQ SEO ramp scoped checks passed; manifest broad --filter=Seo failure recorded as external sidecar per user train protocol."
+        },
+        {
+          "at": "2026-05-31T16:53:16.348171Z",
+          "from": "local_scope_validation_passed_external_sidecar",
+          "to": "pr_open_checks_pending",
+          "note": "Opened GitHub PR #1821 after scoped validation passed and external Seo suite failures were sidecarized."
         }
       ],
-      "updated_at": "2026-05-31T16:51:45.653527Z",
+      "updated_at": "2026-05-31T16:53:16.348171Z",
       "sidecar_issues": [
         {
           "id": "IQ-SEO-RAMP-01-SIDECAR-SEO-SUITE-EXTERNAL-20260601",
@@ -23131,7 +23137,10 @@
           ],
           "scope_disposition": "registered_sidecar_per_user_goal_protocol; do not repair in IQ-SEO-RAMP-01"
         }
-      ]
+      ],
+      "commit_sha": "90e9709e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1821",
+      "pr_number": 1821
     },
     "IQ-SEO-RAMP-02": {
       "id": "IQ-SEO-RAMP-02",
@@ -30690,13 +30699,13 @@
       "branch": "codex/iq-seo-ramp-01-cms-authority",
       "base": "main",
       "title": "IQ-SEO-RAMP-01 publish CMS SEO ramp authority",
-      "status": "local_scope_validation_passed_external_sidecar",
+      "status": "pr_open_checks_pending",
       "depends_on": [
         "IQ-CMS-MEDIA-02",
         "IQ-NORM-03"
       ],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "90e9709e",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1821",
       "checks": {
         "dependency_iq_cms_media_02": "passed: fermatmind/fap-web#944 merged at 2026-05-31T16:40:02Z",
         "dependency_iq_norm_03": "passed: merged earlier in train",
@@ -30724,7 +30733,7 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "updated_at": "2026-05-31T16:51:45.653527Z",
+      "updated_at": "2026-05-31T16:53:16.348171Z",
       "sidecar_issues": [
         {
           "id": "IQ-SEO-RAMP-01-SIDECAR-SEO-SUITE-EXTERNAL-20260601",
@@ -30754,8 +30763,15 @@
           "from": "implementation_in_progress",
           "to": "local_scope_validation_passed_external_sidecar",
           "note": "IQ SEO ramp scoped checks passed; manifest broad --filter=Seo failure recorded as external sidecar per user train protocol."
+        },
+        {
+          "at": "2026-05-31T16:53:16.348171Z",
+          "from": "local_scope_validation_passed_external_sidecar",
+          "to": "pr_open_checks_pending",
+          "note": "Opened GitHub PR #1821 after scoped validation passed and external Seo suite failures were sidecarized."
         }
-      ]
+      ],
+      "pr_number": 1821
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:44:29Z",
+  "updated_at": "2026-05-31T16:58:50.038408Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -22960,7 +22960,7 @@
       "branch": "codex/iq-cms-media-01-authority-metadata",
       "base": "main",
       "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
-      "status": "pr_opened",
+      "status": "merged",
       "depends_on": [
         "IQ-PAID-REPORT-02"
       ],
@@ -22970,14 +22970,14 @@
         "git diff --check": "passed"
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T16:27:40Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
-        "post_merge_revalidated": null,
+        "github_checks_green": true,
+        "post_merge_revalidated": true,
         "changed_files": [
           "backend/tests/Feature/LandingSurfaces/LandingSurfacePublicApiTest.php",
           "content_baselines/landing_surfaces/home.en.json",
@@ -23015,9 +23015,9 @@
           "note": "Opened GitHub PR #1817 after local validation passed."
         }
       ],
-      "commit_sha": "bea2250c268bbea96ee2304fa823c1d6e5468472",
+      "commit_sha": "1b65569a048dede8461c3574616364ac901ed807",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1817",
-      "updated_at": "2026-05-31T16:22:06.368532Z",
+      "updated_at": "2026-05-31T16:43:47.480353Z",
       "pr_number": 1817
     },
     "IQ-CMS-MEDIA-02": {
@@ -23056,21 +23056,37 @@
       "branch": "codex/iq-seo-ramp-01-cms-authority",
       "base": "main",
       "title": "IQ-SEO-RAMP-01 publish CMS SEO ramp authority",
-      "status": "planned",
+      "status": "local_scope_validation_passed_external_sidecar",
       "depends_on": [
         "IQ-CMS-MEDIA-02",
         "IQ-NORM-03"
       ],
-      "checks": {},
+      "checks": {
+        "dependency_iq_cms_media_02": "passed: fermatmind/fap-web#944 merged at 2026-05-31T16:40:02Z",
+        "dependency_iq_norm_03": "passed: merged earlier in train",
+        "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-seo-ramp-01; primary worktree untouched",
+        "python3 json/yaml parse + git diff --check": "passed",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi": "passed_with_existing_warnings",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqSeoRampAuthorityTest --no-ansi": "passed_with_existing_warning",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Seo --no-ansi": "failed_external_sidecar: 13 failures outside IQ-SEO-RAMP-01 scope; IqSeoRampAuthorityTest passed inside broad suite; examples include CareerLiveAcceptance1048CloseoutPlannerTest, CareerProgressiveCohortCloseoutPlannerTest, SeoIntelCrawlerLogProductionCanaryRuntimeTest, SeoIntelOpsSeo* dashboard tests, SeoIntelSearchChannelLive02PreflightTest, and CareerJobPublicApiTest SEO endpoint tests.",
+        "scope_validation": "passed: changed files limited to IQ-SEO-RAMP-01 allowed_paths after removing test-generated EQ_60 compiled artifacts"
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
-        "post_merge_revalidated": null
+        "post_merge_revalidated": null,
+        "changed_files": [
+          "backend/tests/Feature/SeoIntel/IqSeoRampAuthorityTest.php",
+          "content_baselines/landing_surfaces/tests.en.json",
+          "content_baselines/landing_surfaces/tests.zh-CN.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ]
       },
       "transitions": [
         {
@@ -23078,6 +23094,42 @@
           "from": "missing",
           "to": "planned",
           "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T16:43:47.480353Z",
+          "from": "planned",
+          "to": "implementation_in_progress",
+          "note": "Started after IQ-CMS-MEDIA-02 and IQ-NORM-03 dependency verification."
+        },
+        {
+          "at": "2026-05-31T16:51:45.653527Z",
+          "from": "implementation_in_progress",
+          "to": "local_scope_validation_passed_external_sidecar",
+          "note": "IQ SEO ramp scoped checks passed; manifest broad --filter=Seo failure recorded as external sidecar per user train protocol."
+        }
+      ],
+      "updated_at": "2026-05-31T16:51:45.653527Z",
+      "sidecar_issues": [
+        {
+          "id": "IQ-SEO-RAMP-01-SIDECAR-SEO-SUITE-EXTERNAL-20260601",
+          "status": "open_external",
+          "introduced_by_current_pr": false,
+          "blocking_current_train": false,
+          "detected_at": "2026-05-31T16:51:45.653527Z",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Seo --no-ansi",
+          "summary": "Broad Seo-filtered suite fails in existing Career/SEO ops/CareerJob tests unrelated to IQ SEO ramp authority. Current IQ-specific test passed in isolation and inside the broad suite.",
+          "failed_test_families": [
+            "Tests\\Unit\\Domain\\Career\\Audit\\CareerLiveAcceptance1048CloseoutPlannerTest",
+            "Tests\\Unit\\Domain\\Career\\Audit\\CareerProgressiveCohortCloseoutPlannerTest",
+            "Tests\\Feature\\Console\\CareerCloseoutCanonicalProgressiveCohortCommandTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelCrawlerLogProductionCanaryRuntimeTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoCrawlerObservationUiTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoNativeDashboardAccessBoundaryTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoNativeDashboardPanelsTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelSearchChannelLive02PreflightTest",
+            "Tests\\Feature\\V0_5\\CareerJobPublicApiTest"
+          ],
+          "scope_disposition": "registered_sidecar_per_user_goal_protocol; do not repair in IQ-SEO-RAMP-01"
         }
       ]
     },
@@ -30596,11 +30648,11 @@
       "branch": "codex/iq-cms-media-01-authority-metadata",
       "base": "main",
       "title": "IQ-CMS-MEDIA-01 register CMS media authority metadata",
-      "status": "pr_opened",
+      "status": "merged",
       "depends_on": [
         "IQ-PAID-REPORT-02"
       ],
-      "commit_sha": "bea2250c268bbea96ee2304fa823c1d6e5468472",
+      "commit_sha": "1b65569a048dede8461c3574616364ac901ed807",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1817",
       "checks": {
         "dependency_iq_paid_report_02": "passed: fermatmind/fap-web#943 merged at 2026-05-31T16:12:12Z",
@@ -30610,9 +30662,9 @@
         "git diff --check": "passed"
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T16:27:40Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": true,
         "changed_files": [
@@ -30626,11 +30678,84 @@
           "docs/codex/pr-train.yaml"
         ],
         "local_validation_passed": true,
+        "github_checks_green": true,
+        "post_merge_revalidated": true
+      },
+      "updated_at": "2026-05-31T16:43:47.480353Z",
+      "pr_number": 1817
+    },
+    "IQ-SEO-RAMP-01": {
+      "id": "IQ-SEO-RAMP-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-seo-ramp-01-cms-authority",
+      "base": "main",
+      "title": "IQ-SEO-RAMP-01 publish CMS SEO ramp authority",
+      "status": "local_scope_validation_passed_external_sidecar",
+      "depends_on": [
+        "IQ-CMS-MEDIA-02",
+        "IQ-NORM-03"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_iq_cms_media_02": "passed: fermatmind/fap-web#944 merged at 2026-05-31T16:40:02Z",
+        "dependency_iq_norm_03": "passed: merged earlier in train",
+        "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-seo-ramp-01; primary worktree untouched",
+        "python3 json/yaml parse + git diff --check": "passed",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi": "passed_with_existing_warnings",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqSeoRampAuthorityTest --no-ansi": "passed_with_existing_warning",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Seo --no-ansi": "failed_external_sidecar: 13 failures outside IQ-SEO-RAMP-01 scope; IqSeoRampAuthorityTest passed inside broad suite; examples include CareerLiveAcceptance1048CloseoutPlannerTest, CareerProgressiveCohortCloseoutPlannerTest, SeoIntelCrawlerLogProductionCanaryRuntimeTest, SeoIntelOpsSeo* dashboard tests, SeoIntelSearchChannelLive02PreflightTest, and CareerJobPublicApiTest SEO endpoint tests.",
+        "scope_validation": "passed: changed files limited to IQ-SEO-RAMP-01 allowed_paths after removing test-generated EQ_60 compiled artifacts"
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "changed_files": [
+          "backend/tests/Feature/SeoIntel/IqSeoRampAuthorityTest.php",
+          "content_baselines/landing_surfaces/tests.en.json",
+          "content_baselines/landing_surfaces/tests.zh-CN.json",
+          "docs/codex/pr-train-state.json",
+          "docs/codex/pr-train.yaml"
+        ],
+        "local_validation_passed": true,
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "updated_at": "2026-05-31T16:22:06.368532Z",
-      "pr_number": 1817
+      "updated_at": "2026-05-31T16:51:45.653527Z",
+      "sidecar_issues": [
+        {
+          "id": "IQ-SEO-RAMP-01-SIDECAR-SEO-SUITE-EXTERNAL-20260601",
+          "status": "open_external",
+          "introduced_by_current_pr": false,
+          "blocking_current_train": false,
+          "detected_at": "2026-05-31T16:51:45.653527Z",
+          "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Seo --no-ansi",
+          "summary": "Broad Seo-filtered suite fails in existing Career/SEO ops/CareerJob tests unrelated to IQ SEO ramp authority. Current IQ-specific test passed in isolation and inside the broad suite.",
+          "failed_test_families": [
+            "Tests\\Unit\\Domain\\Career\\Audit\\CareerLiveAcceptance1048CloseoutPlannerTest",
+            "Tests\\Unit\\Domain\\Career\\Audit\\CareerProgressiveCohortCloseoutPlannerTest",
+            "Tests\\Feature\\Console\\CareerCloseoutCanonicalProgressiveCohortCommandTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelCrawlerLogProductionCanaryRuntimeTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoCrawlerObservationUiTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoNativeDashboardAccessBoundaryTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelOpsSeoNativeDashboardPanelsTest",
+            "Tests\\Feature\\SeoIntel\\SeoIntelSearchChannelLive02PreflightTest",
+            "Tests\\Feature\\V0_5\\CareerJobPublicApiTest"
+          ],
+          "scope_disposition": "registered_sidecar_per_user_goal_protocol; do not repair in IQ-SEO-RAMP-01"
+        }
+      ],
+      "transitions": [
+        {
+          "at": "2026-05-31T16:51:45.653527Z",
+          "from": "implementation_in_progress",
+          "to": "local_scope_validation_passed_external_sidecar",
+          "note": "IQ SEO ramp scoped checks passed; manifest broad --filter=Seo failure recorded as external sidecar per user train protocol."
+        }
+      ]
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18269,6 +18269,12 @@ prs:
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: IQ-SEO-RAMP-02
 
+    allowed_paths:
+      - content_baselines/landing_surfaces/tests.en.json
+      - content_baselines/landing_surfaces/tests.zh-CN.json
+      - backend/tests/Feature/SeoIntel/IqSeoRampAuthorityTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
   - id: IQ-SEO-RAMP-02
     repo: fap-web
     depends_on: [IQ-SEO-RAMP-01]


### PR DESCRIPTION
## What changed
- Adds backend CMS-owned IQ SEO ramp authority metadata to the existing tests landing surface baselines for `en` and `zh-CN`.
- Locks canonical paths, indexability flags, CMS Media Library asset keys, and claim-policy gates for IQ SEO ramp.
- Adds `IqSeoRampAuthorityTest` to verify backend CMS authority, media authority, norm gate dependency, and no public overclaim language.
- Updates PR train manifest/state for `IQ-SEO-RAMP-01`, including an external sidecar for the broad SEO suite failures outside this PR scope.

## Why
- IQ SEO ramp must be backend/CMS-authoritative and gated by `IQ-NORM-03` before frontend sitemap/llms/jsonld expansion.
- Public SEO copy must not claim official IQ, percentile, diagnosis, hiring, or paid-report private fields.

## Validation
- `python3 -m json.tool content_baselines/landing_surfaces/tests.en.json >/dev/null`
- `python3 -m json.tool content_baselines/landing_surfaces/tests.zh-CN.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c 'import yaml, pathlib; yaml.safe_load(pathlib.Path("docs/codex/pr-train.yaml").read_text())'`
- `git diff --check`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=LandingSurfacePublicApiTest --no-ansi` passed with existing warnings.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqSeoRampAuthorityTest --no-ansi` passed with existing warning.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Seo --no-ansi` failed external sidecar: 13 failures in existing Career/SEO ops/CareerJob tests outside IQ SEO ramp scope; `IqSeoRampAuthorityTest` passed inside the broad suite.

## Intentionally deferred
- No frontend sitemap, `llms.txt`, JSON-LD, route, or public SEO expansion in this PR.
- No static public image fallback and no frontend editorial fallback content.
- Existing broad SEO suite failures are recorded as a sidecar and not repaired in this IQ-scoped PR.

## Repository rule impact
- Content authority remains backend CMS landing surface metadata plus Media Library asset keys.
- IQ norm authority remains backend-owned via `IQ-NORM-03`; frontend and CMS do not become norm authority.
- This PR adds SEO ramp metadata only and does not activate frontend enumeration.
