### PR TITLE
IQ-OBS-01 add production observability guards

### DIFF
--- a/backend/app/Services/Iq/IqProductionObservability.php
+++ b/backend/app/Services/Iq/IqProductionObservability.php
@@ -1,0 +1,351 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Iq;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Analytics\EventRecorder;
+
+final class IqProductionObservability
+{
+    public const SCALE_CODE = 'IQ_INTELLIGENCE_QUOTIENT';
+
+    public const EVENT_COMPLETION = 'iq_completion';
+
+    public const EVENT_NORM_MISS = 'iq_norm_miss';
+
+    public const EVENT_ENTITLEMENT_MISS = 'iq_entitlement_miss';
+
+    public const EVENT_SCORING_ANOMALY = 'iq_scoring_anomaly';
+
+    public const EVENT_VERSION_DRIFT = 'iq_version_drift';
+
+    /**
+     * @var list<string>
+     */
+    private const ALLOWED_EXTRA_KEYS = [
+        'request_id',
+        'source',
+        'surface',
+        'variant',
+        'locked',
+        'report_access_level',
+        'entitlement_status',
+        'scoring_status',
+        'scoring_mode',
+        'reason_code',
+        'norms_status',
+        'quality_level',
+        'raw_score',
+        'final_score',
+        'answer_count',
+        'expected_item_count',
+        'correct_count',
+        'dimension_count',
+        'bank_id',
+        'norm_table_version',
+        'scoring_engine_version',
+        'scoring_spec_version',
+        'content_package_version',
+        'content_manifest_hash',
+        'pack_version',
+    ];
+
+    public function __construct(
+        private readonly EventRecorder $events,
+    ) {}
+
+    /**
+     * Emit the full IQ production guard snapshot for a completed attempt.
+     *
+     * The emitted events intentionally contain aggregate status and version data only. They must
+     * never include answer keys, answer text, item payloads, or paid-report private payloads.
+     *
+     * @param  array<string,mixed>  $extra
+     */
+    public function recordCompletionSnapshot(Attempt $attempt, Result $result, array $extra = []): void
+    {
+        $score = $this->extractScoreResult($result);
+        $base = $this->buildBaseMeta($attempt, $result, $score, $extra);
+
+        $this->record($attempt, $result, self::EVENT_COMPLETION, $base);
+
+        $normsStatus = strtolower(trim((string) ($base['norms_status'] ?? '')));
+        $normTableVersion = strtolower(trim((string) ($base['norm_table_version'] ?? '')));
+        if ($normsStatus === '' || str_contains($normsStatus, 'unavailable') || in_array($normTableVersion, ['', 'unavailable'], true)) {
+            $this->record($attempt, $result, self::EVENT_NORM_MISS, $base);
+        }
+
+        if ((bool) ($base['locked'] ?? false) || strtolower(trim((string) ($base['entitlement_status'] ?? ''))) === 'missing') {
+            $this->record($attempt, $result, self::EVENT_ENTITLEMENT_MISS, $base);
+        }
+
+        $anomalyReasons = $this->detectScoringAnomalies($base);
+        if ($anomalyReasons !== []) {
+            $this->record($attempt, $result, self::EVENT_SCORING_ANOMALY, [
+                ...$base,
+                'reason_code' => implode(',', $anomalyReasons),
+            ]);
+        }
+
+        $driftReasons = $this->detectVersionDrift($attempt, $result, $score);
+        if ($driftReasons !== []) {
+            $this->record($attempt, $result, self::EVENT_VERSION_DRIFT, [
+                ...$base,
+                'reason_code' => implode(',', $driftReasons),
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    public function recordNormMiss(Attempt $attempt, ?Result $result = null, array $meta = []): void
+    {
+        $this->record($attempt, $result, self::EVENT_NORM_MISS, $this->safeMeta($meta));
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    public function recordEntitlementMiss(Attempt $attempt, ?Result $result = null, array $meta = []): void
+    {
+        $this->record($attempt, $result, self::EVENT_ENTITLEMENT_MISS, $this->safeMeta($meta));
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    public function recordScoringAnomaly(Attempt $attempt, ?Result $result = null, array $meta = []): void
+    {
+        $this->record($attempt, $result, self::EVENT_SCORING_ANOMALY, $this->safeMeta($meta));
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    public function recordVersionDrift(Attempt $attempt, ?Result $result = null, array $meta = []): void
+    {
+        $this->record($attempt, $result, self::EVENT_VERSION_DRIFT, $this->safeMeta($meta));
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @param  array<string,mixed>  $extra
+     * @return array<string,mixed>
+     */
+    private function buildBaseMeta(Attempt $attempt, Result $result, array $score, array $extra): array
+    {
+        $quality = is_array($score['quality'] ?? null) ? $score['quality'] : [];
+        $norms = is_array($score['norms'] ?? null) ? $score['norms'] : [];
+        $dimensions = is_array($score['dimension_scores'] ?? null) ? $score['dimension_scores'] : [];
+        $snapshot = is_array($score['version_snapshot'] ?? null) ? $score['version_snapshot'] : [];
+
+        return $this->safeMeta([
+            'source' => 'iq_production_observability',
+            'scale_code' => self::SCALE_CODE,
+            'scoring_status' => $score['status'] ?? null,
+            'scoring_mode' => $score['scoring_mode'] ?? null,
+            'reason_code' => $score['reason_code'] ?? null,
+            'norms_status' => $norms['status'] ?? null,
+            'quality_level' => $quality['level'] ?? null,
+            'raw_score' => $score['raw_score'] ?? null,
+            'final_score' => $score['final_score'] ?? null,
+            'answer_count' => $score['answer_count'] ?? null,
+            'expected_item_count' => $score['expected_item_count'] ?? null,
+            'correct_count' => $score['correct_count'] ?? null,
+            'dimension_count' => count($dimensions),
+            'bank_id' => $score['bank_id'] ?? null,
+            'norm_table_version' => $score['norm_table_version'] ?? ($norms['norm_table_version'] ?? null),
+            'scoring_engine_version' => $score['scoring_engine_version'] ?? null,
+            'scoring_spec_version' => $result->scoring_spec_version ?? $attempt->scoring_spec_version ?? ($snapshot['scoring_spec_version'] ?? null),
+            'content_package_version' => $result->content_package_version ?? $attempt->content_package_version ?? ($snapshot['pack_version'] ?? null),
+            'content_manifest_hash' => $snapshot['content_manifest_hash'] ?? null,
+            'pack_version' => $snapshot['pack_version'] ?? $result->dir_version ?? $attempt->dir_version ?? null,
+            ...$extra,
+        ]);
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     * @return array<string,mixed>
+     */
+    private function safeMeta(array $meta): array
+    {
+        $safe = [
+            'scale_code' => self::SCALE_CODE,
+            'observability_schema' => 'iq.production_observability.v1',
+        ];
+
+        foreach (self::ALLOWED_EXTRA_KEYS as $key) {
+            if (! array_key_exists($key, $meta)) {
+                continue;
+            }
+
+            $value = $meta[$key];
+            if (is_array($value) || is_object($value)) {
+                continue;
+            }
+
+            $safe[$key] = $this->normalizeScalar($value);
+        }
+
+        return array_filter(
+            $safe,
+            static fn (mixed $value): bool => $value !== null && $value !== ''
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $meta
+     */
+    private function record(Attempt $attempt, ?Result $result, string $eventCode, array $meta): void
+    {
+        $this->events->record(
+            $eventCode,
+            $this->nullableInt($attempt->user_id ?? null),
+            $meta,
+            [
+                'org_id' => $this->nullableInt($attempt->org_id ?? null) ?? 0,
+                'user_id' => $this->nullableInt($attempt->user_id ?? null),
+                'anon_id' => $this->nullableString($attempt->anon_id ?? null),
+                'attempt_id' => $this->nullableString($attempt->id ?? null),
+                'scale_code' => self::SCALE_CODE,
+                'scale_code_v2' => self::SCALE_CODE,
+                'pack_id' => $this->nullableString($result->pack_id ?? $attempt->pack_id ?? null),
+                'dir_version' => $this->nullableString($result->dir_version ?? $attempt->dir_version ?? null),
+                'region' => $this->nullableString($attempt->region ?? null),
+                'locale' => $this->nullableString($attempt->locale ?? null),
+            ]
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function extractScoreResult(Result $result): array
+    {
+        $candidates = [
+            $result->normed_json ?? null,
+            data_get($result->result_json, 'normed_json'),
+            data_get($result->result_json, 'breakdown_json.score_result'),
+            data_get($result->result_json, 'axis_scores_json.score_result'),
+            $result->result_json,
+        ];
+
+        foreach ($candidates as $candidate) {
+            if (! is_array($candidate)) {
+                continue;
+            }
+
+            if (
+                array_key_exists('status', $candidate)
+                || array_key_exists('quality', $candidate)
+                || array_key_exists('norms', $candidate)
+                || array_key_exists('dimension_scores', $candidate)
+            ) {
+                return $candidate;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $base
+     * @return list<string>
+     */
+    private function detectScoringAnomalies(array $base): array
+    {
+        $reasons = [];
+        $status = strtolower(trim((string) ($base['scoring_status'] ?? '')));
+        if ($status !== '' && $status !== 'scored') {
+            $reasons[] = 'scoring_status_not_scored';
+        }
+
+        $rawScore = $this->numericOrNull($base['raw_score'] ?? null);
+        $expected = $this->numericOrNull($base['expected_item_count'] ?? null);
+        $answerCount = $this->numericOrNull($base['answer_count'] ?? null);
+        $correctCount = $this->numericOrNull($base['correct_count'] ?? null);
+
+        if ($rawScore !== null && $expected !== null && ($rawScore < 0.0 || $rawScore > $expected)) {
+            $reasons[] = 'raw_score_out_of_expected_range';
+        }
+        if ($answerCount !== null && $expected !== null && $answerCount !== $expected) {
+            $reasons[] = 'answer_count_mismatch';
+        }
+        if ($correctCount !== null && $answerCount !== null && $correctCount > $answerCount) {
+            $reasons[] = 'correct_count_exceeds_answer_count';
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @return list<string>
+     */
+    private function detectVersionDrift(Attempt $attempt, Result $result, array $score): array
+    {
+        $reasons = [];
+        $snapshot = is_array($score['version_snapshot'] ?? null) ? $score['version_snapshot'] : [];
+
+        foreach ([
+            'content_package_version' => [$attempt->content_package_version ?? null, $result->content_package_version ?? null],
+            'scoring_spec_version' => [$attempt->scoring_spec_version ?? null, $result->scoring_spec_version ?? null],
+            'pack_id' => [$attempt->pack_id ?? null, $result->pack_id ?? ($snapshot['pack_id'] ?? null)],
+            'dir_version' => [$attempt->dir_version ?? null, $result->dir_version ?? ($snapshot['pack_version'] ?? null)],
+        ] as $field => [$attemptValue, $resultValue]) {
+            $left = trim((string) $attemptValue);
+            $right = trim((string) $resultValue);
+            if ($left !== '' && $right !== '' && $left !== $right) {
+                $reasons[] = $field.'_mismatch';
+            }
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    private function normalizeScalar(mixed $value): mixed
+    {
+        if (is_bool($value) || is_int($value) || is_float($value)) {
+            return $value;
+        }
+
+        if (is_numeric($value)) {
+            return $value + 0;
+        }
+
+        return trim((string) $value);
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized !== '' ? $normalized : null;
+    }
+
+    private function nullableInt(mixed $value): ?int
+    {
+        if (is_int($value)) {
+            return $value;
+        }
+
+        if (is_string($value) || is_numeric($value)) {
+            $normalized = trim((string) $value);
+            if ($normalized !== '' && preg_match('/^\d+$/', $normalized) === 1) {
+                return (int) $normalized;
+            }
+        }
+
+        return null;
+    }
+
+    private function numericOrNull(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
+    }
+}

--- a/backend/tests/Feature/V0_3/IqObservabilityTest.php
+++ b/backend/tests/Feature/V0_3/IqObservabilityTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\V0_3;
+
+use App\Models\Attempt;
+use App\Models\Result;
+use App\Services\Iq\IqProductionObservability;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class IqObservabilityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_iq_observability_emits_completion_norm_entitlement_anomaly_and_version_drift_guards_without_private_payload(): void
+    {
+        $attempt = Attempt::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'anon_id' => 'anon_iq_obs_safe',
+            'scale_code' => 'IQ_RAVEN',
+            'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 30,
+            'client_platform' => 'test',
+            'answers_summary_json' => ['stage' => 'seed'],
+            'started_at' => now()->subMinutes(15),
+            'submitted_at' => now()->subMinute(),
+            'pack_id' => 'IQ_BETA_30_ORIGINAL',
+            'dir_version' => 'iq_beta30_original_v1',
+            'content_package_version' => 'iq_beta30_original_v1',
+            'scoring_spec_version' => 'iq_spec_v1',
+        ]);
+
+        $score = [
+            'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'status' => 'scored',
+            'scoring_mode' => 'scored',
+            'bank_id' => 'IQ_BETA_30_ORIGINAL',
+            'answer_key_version' => 'must_not_emit',
+            'norm_table_version' => 'unavailable',
+            'scoring_engine_version' => 'iq_scoring_v2',
+            'raw_score' => 31.0,
+            'final_score' => 31.0,
+            'answer_count' => 29,
+            'expected_item_count' => 30,
+            'correct_count' => 31,
+            'quality' => ['level' => 'B'],
+            'norms' => [
+                'status' => 'unavailable_without_norm_table',
+                'iq_estimate' => null,
+                'percentile' => null,
+                'confidence_interval' => null,
+            ],
+            'dimension_scores' => [
+                'VSI' => ['raw_score' => 10],
+                'VSPR' => ['raw_score' => 11],
+                'NPR' => ['raw_score' => 10],
+            ],
+            'version_snapshot' => [
+                'pack_id' => 'IQ_BETA_30_ORIGINAL',
+                'pack_version' => 'iq_beta30_original_v1',
+                'scoring_spec_version' => 'iq_spec_v1',
+                'content_manifest_hash' => 'manifest_safe_hash',
+            ],
+            'items' => [
+                [
+                    'question_id' => 'IQ001',
+                    'selected_code' => 'B',
+                    'correct_answer' => 'A',
+                    'solution_rule' => 'must_not_emit',
+                ],
+            ],
+        ];
+
+        $result = Result::create([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'attempt_id' => (string) $attempt->id,
+            'scale_code' => 'IQ_RAVEN',
+            'scale_code_v2' => 'IQ_INTELLIGENCE_QUOTIENT',
+            'scale_version' => 'v0.3',
+            'type_code' => '',
+            'scores_json' => [],
+            'scores_pct' => [],
+            'axis_states' => [],
+            'content_package_version' => 'iq_beta30_result_drift',
+            'result_json' => [
+                'normed_json' => $score,
+                'breakdown_json' => ['score_result' => $score],
+                'axis_scores_json' => ['score_result' => $score],
+            ],
+            'pack_id' => 'IQ_BETA_30_ORIGINAL',
+            'dir_version' => 'iq_beta30_result_drift',
+            'scoring_spec_version' => 'iq_spec_v2',
+            'report_engine_version' => 'v1.2',
+            'is_valid' => true,
+            'computed_at' => now(),
+        ]);
+
+        app(IqProductionObservability::class)->recordCompletionSnapshot($attempt, $result, [
+            'surface' => 'report',
+            'variant' => 'free',
+            'locked' => true,
+            'report_access_level' => 'free',
+            'entitlement_status' => 'missing',
+            'answer_key' => ['IQ001' => 'A'],
+            'correct_answer' => 'A',
+            'report' => ['iq_pro' => ['pdf_payload' => ['private' => true]]],
+            'pdf_payload' => ['private' => true],
+            'certificate_payload' => ['private' => true],
+        ]);
+
+        foreach ([
+            IqProductionObservability::EVENT_COMPLETION,
+            IqProductionObservability::EVENT_NORM_MISS,
+            IqProductionObservability::EVENT_ENTITLEMENT_MISS,
+            IqProductionObservability::EVENT_SCORING_ANOMALY,
+            IqProductionObservability::EVENT_VERSION_DRIFT,
+        ] as $eventCode) {
+            $event = DB::table('events')->where('event_code', $eventCode)->first();
+            $this->assertNotNull($event, $eventCode.' was not emitted.');
+            $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($event->scale_code ?? ''));
+            $this->assertSame((string) $attempt->id, (string) ($event->attempt_id ?? ''));
+
+            $meta = $this->decodeMeta($event->meta_json ?? null);
+            $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', (string) ($meta['scale_code'] ?? ''));
+            $this->assertSame('iq.production_observability.v1', (string) ($meta['observability_schema'] ?? ''));
+            $this->assertSame('IQ_BETA_30_ORIGINAL', (string) ($meta['bank_id'] ?? ''));
+            $this->assertArrayNotHasKey('iq_estimate', $meta);
+            $this->assertArrayNotHasKey('percentile', $meta);
+            $this->assertArrayNotHasKey('confidence_interval', $meta);
+            $this->assertPayloadHasNoPrivateIqFields($meta);
+        }
+
+        $anomalyMeta = $this->decodeMeta(DB::table('events')->where('event_code', IqProductionObservability::EVENT_SCORING_ANOMALY)->value('meta_json'));
+        $this->assertStringContainsString('raw_score_out_of_expected_range', (string) ($anomalyMeta['reason_code'] ?? ''));
+        $this->assertStringContainsString('answer_count_mismatch', (string) ($anomalyMeta['reason_code'] ?? ''));
+        $this->assertStringContainsString('correct_count_exceeds_answer_count', (string) ($anomalyMeta['reason_code'] ?? ''));
+
+        $driftMeta = $this->decodeMeta(DB::table('events')->where('event_code', IqProductionObservability::EVENT_VERSION_DRIFT)->value('meta_json'));
+        $this->assertStringContainsString('content_package_version_mismatch', (string) ($driftMeta['reason_code'] ?? ''));
+        $this->assertStringContainsString('scoring_spec_version_mismatch', (string) ($driftMeta['reason_code'] ?? ''));
+        $this->assertStringContainsString('dir_version_mismatch', (string) ($driftMeta['reason_code'] ?? ''));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeMeta(mixed $raw): array
+    {
+        if (is_array($raw)) {
+            return $raw;
+        }
+        if (! is_string($raw) || trim($raw) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($raw, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertPayloadHasNoPrivateIqFields(array $payload): void
+    {
+        $forbidden = [
+            'answer_key',
+            'answerKey',
+            'answer_key_version',
+            'correct_answer',
+            'correctAnswer',
+            'solution_rule',
+            'solutionRule',
+            'distractor_logic',
+            'distractorLogic',
+            'asset_hashes',
+            'assetHashes',
+            'generator_metadata',
+            'generatorMetadata',
+            'items',
+            'report',
+            'report_json',
+            'iq_pro',
+            'pdf_payload',
+            'certificate_payload',
+            'sections',
+        ];
+
+        foreach ($payload as $key => $value) {
+            $this->assertNotContains((string) $key, $forbidden);
+            $this->assertNotSame('A', $value);
+            $this->assertNotSame('IQ001', $value);
+            $this->assertNotSame('must_not_emit', $value);
+
+            if (is_array($value)) {
+                $this->assertPayloadHasNoPrivateIqFields($value);
+            }
+        }
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1660,6 +1660,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_iq_production_observability_guard_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Iq/IqProductionObservability.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_iq_result_secrecy_redaction_only(): void
     {
         $changed = [
@@ -3051,6 +3060,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isIqProductionObservabilityGuardFile($file)) {
+                continue;
+            }
+
             if ($this->isRiasecMeasurementContractComparePolicyFile($file)) {
                 continue;
             }
@@ -3776,6 +3789,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isIqNormImportDryRunCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/NormsIqImport.php';
+    }
+
+    private function isIqProductionObservabilityGuardFile(string $file): bool
+    {
+        return $file === 'backend/app/Services/Iq/IqProductionObservability.php';
     }
 
     private function isIqResultSecrecyRedactionFile(string $file): bool

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T17:49:03.958680Z",
+  "updated_at": "2026-05-31T17:53:56.360791Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -23271,7 +23271,7 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "ci_fix_validated",
+      "status": "github_checks_green",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
@@ -23285,7 +23285,8 @@
         "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger",
         "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0",
         "github verify-bigfive": "failed_then_fixed: freeze classifier flagged backend/app/Services/Iq/IqProductionObservability.php; added IQ-specific ignore coverage without changing Big Five runtime behavior.",
-        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=runtime_freeze_classifier_ignores_iq_production_observability_guard_changes --no-ansi": "passed_with_existing_warning"
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=runtime_freeze_classifier_ignores_iq_production_observability_guard_changes --no-ansi": "passed_with_existing_warning",
+        "github_checks": "passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, verify-mbti-v2"
       },
       "failure_reason": null,
       "merged_at": null,
@@ -23294,7 +23295,7 @@
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
+        "github_checks_green": true,
         "post_merge_revalidated": null,
         "changed_files_expected": [
           "backend/app/Services/Iq/IqProductionObservability.php",
@@ -23344,10 +23345,16 @@
           "from": "pr_open_checks_pending",
           "to": "ci_fix_validated",
           "note": "Fixed verify-bigfive freeze classifier allowlist for the new IQ observability guard and reran scoped local checks."
+        },
+        {
+          "at": "2026-05-31T17:53:56.360791Z",
+          "from": "ci_fix_validated",
+          "to": "github_checks_green",
+          "note": "GitHub checks passed for PR #1823 after the scoped verify-bigfive freeze classifier fix."
         }
       ],
-      "updated_at": "2026-05-31T17:49:03.958680Z",
-      "commit_sha": "f31a7893",
+      "updated_at": "2026-05-31T17:53:56.360791Z",
+      "commit_sha": "d029f7c6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1823",
       "pr_number": 1823
     },
@@ -30897,11 +30904,11 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "ci_fix_validated",
+      "status": "github_checks_green",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
-      "commit_sha": "f31a7893",
+      "commit_sha": "d029f7c6",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1823",
       "checks": {
         "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
@@ -30913,7 +30920,8 @@
         "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger",
         "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0",
         "github verify-bigfive": "failed_then_fixed: freeze classifier flagged backend/app/Services/Iq/IqProductionObservability.php; added IQ-specific ignore coverage without changing Big Five runtime behavior.",
-        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=runtime_freeze_classifier_ignores_iq_production_observability_guard_changes --no-ansi": "passed_with_existing_warning"
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=runtime_freeze_classifier_ignores_iq_production_observability_guard_changes --no-ansi": "passed_with_existing_warning",
+        "github_checks": "passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, verify-mbti-v2"
       },
       "failure_reason": null,
       "merged_at": null,
@@ -30922,7 +30930,7 @@
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
+        "github_checks_green": true,
         "post_merge_revalidated": null,
         "changed_files_expected": [
           "backend/app/Services/Iq/IqProductionObservability.php",
@@ -30936,7 +30944,7 @@
           "docs/codex/pr-train-state.json"
         ]
       },
-      "updated_at": "2026-05-31T17:49:03.958680Z",
+      "updated_at": "2026-05-31T17:53:56.360791Z",
       "transitions": [
         {
           "at": "2026-05-31T17:39:32.634261Z",
@@ -30967,6 +30975,12 @@
           "from": "pr_open_checks_pending",
           "to": "ci_fix_validated",
           "note": "Fixed verify-bigfive freeze classifier allowlist for the new IQ observability guard and reran scoped local checks."
+        },
+        {
+          "at": "2026-05-31T17:53:56.360791Z",
+          "from": "ci_fix_validated",
+          "to": "github_checks_green",
+          "note": "GitHub checks passed for PR #1823 after the scoped verify-bigfive freeze classifier fix."
         }
       ],
       "pr_number": 1823

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T17:40:49.933746Z",
+  "updated_at": "2026-05-31T17:41:15.961282Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -23271,7 +23271,7 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "local_scope_validation_passed",
+      "status": "committed",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
@@ -23282,7 +23282,8 @@
         "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warnings",
         "git diff --check": "passed",
         "composer_autoload_refresh": "local_environment_only: refreshed copied vendor autoload paths before manifest checks; vendor not staged",
-        "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger"
+        "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger",
+        "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0"
       },
       "failure_reason": null,
       "merged_at": null,
@@ -23322,9 +23323,16 @@
           "from": "implementation_in_progress",
           "to": "local_scope_validation_passed",
           "note": "IQ observability guard service and contract tests passed manifest local checks with existing warning output only."
+        },
+        {
+          "at": "2026-05-31T17:41:15.961282Z",
+          "from": "local_scope_validation_passed",
+          "to": "committed",
+          "note": "Committed scoped IQ-OBS-01 implementation at 3ca9dc70."
         }
       ],
-      "updated_at": "2026-05-31T17:40:49.933746Z"
+      "updated_at": "2026-05-31T17:41:15.961282Z",
+      "commit_sha": "3ca9dc70"
     },
     "IQ-RELEASE-01": {
       "id": "IQ-RELEASE-01",
@@ -30872,11 +30880,11 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "local_scope_validation_passed",
+      "status": "committed",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
-      "commit_sha": null,
+      "commit_sha": "3ca9dc70",
       "pr_url": null,
       "checks": {
         "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
@@ -30885,7 +30893,8 @@
         "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warnings",
         "git diff --check": "passed",
         "composer_autoload_refresh": "local_environment_only: refreshed copied vendor autoload paths before manifest checks; vendor not staged",
-        "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger"
+        "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger",
+        "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0"
       },
       "failure_reason": null,
       "merged_at": null,
@@ -30907,7 +30916,7 @@
           "docs/codex/pr-train-state.json"
         ]
       },
-      "updated_at": "2026-05-31T17:40:49.933746Z",
+      "updated_at": "2026-05-31T17:41:15.961282Z",
       "transitions": [
         {
           "at": "2026-05-31T12:37:59+00:00",
@@ -30926,6 +30935,12 @@
           "from": "implementation_in_progress",
           "to": "local_scope_validation_passed",
           "note": "IQ observability guard service and contract tests passed manifest local checks with existing warning output only."
+        },
+        {
+          "at": "2026-05-31T17:41:15.961282Z",
+          "from": "local_scope_validation_passed",
+          "to": "committed",
+          "note": "Committed scoped IQ-OBS-01 implementation at 3ca9dc70."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T16:59:12.092390Z",
+  "updated_at": "2026-05-31T17:40:49.933746Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -23228,21 +23228,23 @@
       "branch": "codex/iq-live-ramp-01-authenticated-smoke",
       "base": "main",
       "title": "IQ-LIVE-RAMP-01 add authenticated production smoke fixture gate",
-      "status": "planned",
+      "status": "merged_reconciled_cross_repo",
       "depends_on": [
         "IQ-SEO-RAMP-02",
         "IQ-PAID-REPORT-02"
       ],
-      "checks": {},
+      "checks": {
+        "cross_repo_reconciliation": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z with commit 9767723ca43c9d949d7d6b775bcfcf6fde7ae675; remote branch deleted; local cleanup completed in fap-web train."
+      },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
+      "merged_at": "2026-05-31T17:32:31Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true,
       "scope_validation": {
         "allowed_paths_only": null,
         "local_validation_passed": null,
-        "github_checks_green": null,
-        "post_merge_revalidated": null
+        "github_checks_green": true,
+        "post_merge_revalidated": true
       },
       "transitions": [
         {
@@ -23250,8 +23252,18 @@
           "from": "missing",
           "to": "planned",
           "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T17:39:32.634261Z",
+          "from": "planned",
+          "to": "merged_reconciled_cross_repo",
+          "note": "Reconciled fap-web IQ-LIVE-RAMP-01 merge state to unblock fap-api IQ-OBS-01 dependency."
         }
-      ]
+      ],
+      "commit_sha": "9767723ca43c9d949d7d6b775bcfcf6fde7ae675",
+      "pr_url": "https://github.com/fermatmind/fap-web/pull/947",
+      "pr_number": 947,
+      "updated_at": "2026-05-31T17:39:32.634261Z"
     },
     "IQ-OBS-01": {
       "id": "IQ-OBS-01",
@@ -23259,20 +23271,38 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "planned",
+      "status": "local_scope_validation_passed",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
-      "checks": {},
+      "checks": {
+        "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
+        "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-obs-01; primary worktrees untouched",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi": "passed_with_existing_warnings",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warnings",
+        "git diff --check": "passed",
+        "composer_autoload_refresh": "local_environment_only: refreshed copied vendor autoload paths before manifest checks; vendor not staged",
+        "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger"
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
-        "allowed_paths_only": null,
-        "local_validation_passed": null,
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
         "github_checks_green": null,
-        "post_merge_revalidated": null
+        "post_merge_revalidated": null,
+        "changed_files_expected": [
+          "backend/app/Services/Iq/IqProductionObservability.php",
+          "backend/tests/Feature/V0_3/IqObservabilityTest.php",
+          "docs/codex/pr-train-state.json"
+        ],
+        "changed_files": [
+          "backend/app/Services/Iq/IqProductionObservability.php",
+          "backend/tests/Feature/V0_3/IqObservabilityTest.php",
+          "docs/codex/pr-train-state.json"
+        ]
       },
       "transitions": [
         {
@@ -23280,8 +23310,21 @@
           "from": "missing",
           "to": "planned",
           "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T17:39:32.634261Z",
+          "from": "planned",
+          "to": "implementation_in_progress",
+          "note": "Started IQ production observability guard implementation after cross-repo dependency reconciliation."
+        },
+        {
+          "at": "2026-05-31T17:40:49.933746Z",
+          "from": "implementation_in_progress",
+          "to": "local_scope_validation_passed",
+          "note": "IQ observability guard service and contract tests passed manifest local checks with existing warning output only."
         }
-      ]
+      ],
+      "updated_at": "2026-05-31T17:40:49.933746Z"
     },
     "IQ-RELEASE-01": {
       "id": "IQ-RELEASE-01",
@@ -30822,6 +30865,69 @@
         }
       ],
       "pr_number": 1821
+    },
+    "IQ-OBS-01": {
+      "id": "IQ-OBS-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-obs-01-production-guards",
+      "base": "main",
+      "title": "IQ-OBS-01 add production observability guards",
+      "status": "local_scope_validation_passed",
+      "depends_on": [
+        "IQ-LIVE-RAMP-01"
+      ],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
+        "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-obs-01; primary worktrees untouched",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi": "passed_with_existing_warnings",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warnings",
+        "git diff --check": "passed",
+        "composer_autoload_refresh": "local_environment_only: refreshed copied vendor autoload paths before manifest checks; vendor not staged",
+        "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger"
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": null,
+        "post_merge_revalidated": null,
+        "changed_files_expected": [
+          "backend/app/Services/Iq/IqProductionObservability.php",
+          "backend/tests/Feature/V0_3/IqObservabilityTest.php",
+          "docs/codex/pr-train-state.json"
+        ],
+        "changed_files": [
+          "backend/app/Services/Iq/IqProductionObservability.php",
+          "backend/tests/Feature/V0_3/IqObservabilityTest.php",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "updated_at": "2026-05-31T17:40:49.933746Z",
+      "transitions": [
+        {
+          "at": "2026-05-31T12:37:59+00:00",
+          "from": "missing",
+          "to": "planned",
+          "note": "User authorized IQ production PR train manifest/state registration."
+        },
+        {
+          "at": "2026-05-31T17:39:32.634261Z",
+          "from": "planned",
+          "to": "implementation_in_progress",
+          "note": "Started IQ production observability guard implementation after cross-repo dependency reconciliation."
+        },
+        {
+          "at": "2026-05-31T17:40:49.933746Z",
+          "from": "implementation_in_progress",
+          "to": "local_scope_validation_passed",
+          "note": "IQ observability guard service and contract tests passed manifest local checks with existing warning output only."
+        }
+      ]
     }
   },
   "RESULT-EN-PARITY-04": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T17:41:56.775463Z",
+  "updated_at": "2026-05-31T17:49:03.958680Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -23271,19 +23271,21 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "pr_open_checks_pending",
+      "status": "ci_fix_validated",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
       "checks": {
         "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
         "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-obs-01; primary worktrees untouched",
-        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi": "passed_with_existing_warnings",
-        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warnings",
-        "git diff --check": "passed",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi": "passed_with_existing_warning_after_ci_fix",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warning_after_ci_fix",
+        "git diff --check": "passed_after_ci_fix",
         "composer_autoload_refresh": "local_environment_only: refreshed copied vendor autoload paths before manifest checks; vendor not staged",
         "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger",
-        "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0"
+        "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0",
+        "github verify-bigfive": "failed_then_fixed: freeze classifier flagged backend/app/Services/Iq/IqProductionObservability.php; added IQ-specific ignore coverage without changing Big Five runtime behavior.",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=runtime_freeze_classifier_ignores_iq_production_observability_guard_changes --no-ansi": "passed_with_existing_warning"
       },
       "failure_reason": null,
       "merged_at": null,
@@ -23302,6 +23304,7 @@
         "changed_files": [
           "backend/app/Services/Iq/IqProductionObservability.php",
           "backend/tests/Feature/V0_3/IqObservabilityTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train-state.json"
         ]
       },
@@ -23335,9 +23338,15 @@
           "from": "committed",
           "to": "pr_open_checks_pending",
           "note": "Opened GitHub PR #1823 after local manifest checks passed."
+        },
+        {
+          "at": "2026-05-31T17:49:03.958680Z",
+          "from": "pr_open_checks_pending",
+          "to": "ci_fix_validated",
+          "note": "Fixed verify-bigfive freeze classifier allowlist for the new IQ observability guard and reran scoped local checks."
         }
       ],
-      "updated_at": "2026-05-31T17:41:56.775463Z",
+      "updated_at": "2026-05-31T17:49:03.958680Z",
       "commit_sha": "f31a7893",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1823",
       "pr_number": 1823
@@ -30888,7 +30897,7 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "pr_open_checks_pending",
+      "status": "ci_fix_validated",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
@@ -30897,12 +30906,14 @@
       "checks": {
         "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
         "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-obs-01; primary worktrees untouched",
-        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi": "passed_with_existing_warnings",
-        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warnings",
-        "git diff --check": "passed",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi": "passed_with_existing_warning_after_ci_fix",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi": "passed_with_existing_warning_after_ci_fix",
+        "git diff --check": "passed_after_ci_fix",
         "composer_autoload_refresh": "local_environment_only: refreshed copied vendor autoload paths before manifest checks; vendor not staged",
         "scope_validation": "passed: changed files limited to IQ-OBS-01 observability service, contract test, and train state ledger",
-        "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0"
+        "commit_sha": "recorded: 3ca9dc704752c43db05a1c4039eee30dfb3618b0",
+        "github verify-bigfive": "failed_then_fixed: freeze classifier flagged backend/app/Services/Iq/IqProductionObservability.php; added IQ-specific ignore coverage without changing Big Five runtime behavior.",
+        "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=runtime_freeze_classifier_ignores_iq_production_observability_guard_changes --no-ansi": "passed_with_existing_warning"
       },
       "failure_reason": null,
       "merged_at": null,
@@ -30921,10 +30932,11 @@
         "changed_files": [
           "backend/app/Services/Iq/IqProductionObservability.php",
           "backend/tests/Feature/V0_3/IqObservabilityTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train-state.json"
         ]
       },
-      "updated_at": "2026-05-31T17:41:56.775463Z",
+      "updated_at": "2026-05-31T17:49:03.958680Z",
       "transitions": [
         {
           "at": "2026-05-31T17:39:32.634261Z",
@@ -30949,6 +30961,12 @@
           "from": "committed",
           "to": "pr_open_checks_pending",
           "note": "Opened GitHub PR #1823 after local manifest checks passed."
+        },
+        {
+          "at": "2026-05-31T17:49:03.958680Z",
+          "from": "pr_open_checks_pending",
+          "to": "ci_fix_validated",
+          "note": "Fixed verify-bigfive freeze classifier allowlist for the new IQ observability guard and reran scoped local checks."
         }
       ],
       "pr_number": 1823

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-05-31T17:41:15.961282Z",
+  "updated_at": "2026-05-31T17:41:56.775463Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -23271,7 +23271,7 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "committed",
+      "status": "pr_open_checks_pending",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
@@ -23329,10 +23329,18 @@
           "from": "local_scope_validation_passed",
           "to": "committed",
           "note": "Committed scoped IQ-OBS-01 implementation at 3ca9dc70."
+        },
+        {
+          "at": "2026-05-31T17:41:56.775463Z",
+          "from": "committed",
+          "to": "pr_open_checks_pending",
+          "note": "Opened GitHub PR #1823 after local manifest checks passed."
         }
       ],
-      "updated_at": "2026-05-31T17:41:15.961282Z",
-      "commit_sha": "3ca9dc70"
+      "updated_at": "2026-05-31T17:41:56.775463Z",
+      "commit_sha": "f31a7893",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1823",
+      "pr_number": 1823
     },
     "IQ-RELEASE-01": {
       "id": "IQ-RELEASE-01",
@@ -30880,12 +30888,12 @@
       "branch": "codex/iq-obs-01-production-guards",
       "base": "main",
       "title": "IQ-OBS-01 add production observability guards",
-      "status": "committed",
+      "status": "pr_open_checks_pending",
       "depends_on": [
         "IQ-LIVE-RAMP-01"
       ],
-      "commit_sha": "3ca9dc70",
-      "pr_url": null,
+      "commit_sha": "f31a7893",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1823",
       "checks": {
         "dependency_iq_live_ramp_01": "passed: fap-web PR #947 merged at 2026-05-31T17:32:31Z and reconciled in fap-api ledger.",
         "workspace_safety": "using isolated worktree /private/tmp/fap-api-iq-obs-01; primary worktrees untouched",
@@ -30916,14 +30924,8 @@
           "docs/codex/pr-train-state.json"
         ]
       },
-      "updated_at": "2026-05-31T17:41:15.961282Z",
+      "updated_at": "2026-05-31T17:41:56.775463Z",
       "transitions": [
-        {
-          "at": "2026-05-31T12:37:59+00:00",
-          "from": "missing",
-          "to": "planned",
-          "note": "User authorized IQ production PR train manifest/state registration."
-        },
         {
           "at": "2026-05-31T17:39:32.634261Z",
           "from": "planned",
@@ -30941,8 +30943,15 @@
           "from": "local_scope_validation_passed",
           "to": "committed",
           "note": "Committed scoped IQ-OBS-01 implementation at 3ca9dc70."
+        },
+        {
+          "at": "2026-05-31T17:41:56.775463Z",
+          "from": "committed",
+          "to": "pr_open_checks_pending",
+          "note": "Opened GitHub PR #1823 after local manifest checks passed."
         }
-      ]
+      ],
+      "pr_number": 1823
     }
   },
   "RESULT-EN-PARITY-04": {


### PR DESCRIPTION
## What changed
- Added `IqProductionObservability` as the backend IQ production observability guard service.
- Emits sanitized IQ events for completion, norm miss, entitlement miss, scoring anomaly, and version drift.
- Added `IqObservabilityTest` to lock the no-private-payload boundary for observability meta.
- Reconciled fap-api train state for the already-merged cross-repo `IQ-LIVE-RAMP-01` dependency.

## Why
`IQ-OBS-01` adds production-safe observability signals needed before wider IQ launch/ramp while preserving the IQ answer-key and paid-report secrecy boundaries.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqObservability --no-ansi` passed with existing warning output.
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=IqReportContractTest --no-ansi` passed with existing warning output.
- `git diff --check` passed.

## Intentionally deferred
- No external dashboard, alert threshold, or production deployment wiring in this PR.
- No answer key, answer text, item payload, paid report PDF/certificate payload, or private report section logging.

## Repository rule impact
- IQ remains backend-authoritative for scoring, norm, entitlement, and report guard signals.
- No frontend content authority, CMS runtime fallback, public SEO enumeration, or mutable media ownership changed.
