### PR TITLE
PR-EQ-SJT-05 EQ-SJT validation telemetry and QA

### DIFF
--- a/backend/app/Services/Eq/EqSjtValidationTelemetryContract.php
+++ b/backend/app/Services/Eq/EqSjtValidationTelemetryContract.php
@@ -1,0 +1,196 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Eq;
+
+final class EqSjtValidationTelemetryContract
+{
+    private const FORBIDDEN_CLAIM_FRAGMENTS = [
+        'true emotional ability',
+        'true eq ability',
+        'msceit-like',
+        'msceit equivalent',
+        'certified emotional intelligence',
+        'certified ei',
+        'hiring suitable',
+        'clinical assessment',
+        'predicts job performance',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @param  array<string,mixed>  $context
+     * @return array{event_code:string,meta:array<string,mixed>,context:array<string,mixed>}
+     */
+    public function scoredEvent(array $score, array $context = []): array
+    {
+        return [
+            'event_code' => 'eq_sjt16_scored',
+            'meta' => [
+                'scale_code' => 'EQ_SJT_16',
+                'measurement_type' => 'scenario_based_emotional_judgment',
+                'answer_mode' => $this->string($score['answer_mode'] ?? null) ?: 'likely_response',
+                'score_method' => $this->string($score['score_method'] ?? null),
+                'score_pct' => $this->number($score['score_pct'] ?? null),
+                'band' => $this->string($score['band'] ?? null),
+                'quality_level' => $this->string(data_get($score, 'quality.level')),
+                'quality_flags' => array_values(array_map('strval', (array) data_get($score, 'quality.flags', []))),
+                'top_strategy' => $this->string($score['top_strategy'] ?? null),
+                'lowest_strategy' => $this->string($score['lowest_strategy'] ?? null),
+                'content_version' => $this->string(data_get($score, 'version_snapshot.content_version')) ?: 'EQ_SJT_16/v1',
+                'rubric_version' => $this->string(data_get($score, 'version_snapshot.rubric_version')) ?: 'eq_sjt_16.rubric.v1_draft',
+                'validation_status' => 'draft_not_yet_validated',
+                'stable_validation_claim_allowed' => false,
+                'claim_boundary' => $this->claimBoundary($score),
+            ],
+            'context' => $this->safeContext($context, 'EQ_SJT_16'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $report
+     * @param  array<string,mixed>  $context
+     * @return array{event_code:string,meta:array<string,mixed>,context:array<string,mixed>}
+     */
+    public function integratedReportComposedEvent(array $report, array $context = []): array
+    {
+        return [
+            'event_code' => 'eq_integrated_report_composed',
+            'meta' => [
+                'scale_code' => 'EQ_INTEGRATED',
+                'eq_report_mode' => 'integrated',
+                'measurement_type' => 'integrated_self_report_and_scenario_judgment',
+                'gap_count' => count((array) data_get($report, 'interpretation.gap_map', [])),
+                'pressure_pattern_id' => $this->string(data_get($report, 'interpretation.pressure_pattern.pattern_id')),
+                'scenario_script_count' => count((array) data_get($report, 'interpretation.scenario_script_ids', [])),
+                'integrated_action_duration_days' => (int) data_get($report, 'interpretation.integrated_action_path.duration_days', 0),
+                'report_version' => $this->string(data_get($report, 'methodology.report_version')),
+                'validation_status' => $this->string(data_get($report, 'methodology.validation_status')) ?: 'draft_not_yet_validated',
+                'public_runtime_enabled' => (bool) data_get($report, 'visibility.public_runtime_enabled', false),
+                'frontend_integrated_report_visible' => (bool) data_get($report, 'visibility.frontend_integrated_report_visible', false),
+                'stable_validation_claim_allowed' => false,
+                'claim_boundary' => $this->claimBoundary($report),
+            ],
+            'context' => $this->safeContext($context, 'EQ_INTEGRATED'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $score
+     * @param  array<string,mixed>  $report
+     * @return array<string,mixed>
+     */
+    public function qaGate(array $score, array $report): array
+    {
+        $issues = [];
+        $issues = array_merge($issues, $this->claimBoundaryIssues($score, 'score'));
+        $issues = array_merge($issues, $this->claimBoundaryIssues($report, 'integrated_report'));
+
+        if ((bool) data_get($report, 'visibility.public_runtime_enabled', false)) {
+            $issues[] = 'integrated_report_public_runtime_enabled';
+        }
+        if ((bool) data_get($report, 'visibility.frontend_integrated_report_visible', false)) {
+            $issues[] = 'integrated_report_frontend_visible_before_release';
+        }
+        if ($this->string(data_get($report, 'methodology.validation_status')) !== 'draft_not_yet_validated') {
+            $issues[] = 'integrated_report_validation_status_overclaims';
+        }
+
+        return [
+            'status' => $issues === [] ? 'pass_for_internal_qa_only' : 'blocked',
+            'public_release_allowed' => false,
+            'stable_validation_claim_allowed' => false,
+            'issues' => array_values(array_unique($issues)),
+            'required_next_evidence' => [
+                'expert_rubric_calibration',
+                'locale_bias_review',
+                'scenario_item_pilot_statistics',
+                'strategy_score_reliability_review',
+                'integrated_report_rendered_qa',
+            ],
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function forbiddenClaimFragments(): array
+    {
+        return self::FORBIDDEN_CLAIM_FRAGMENTS;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return list<string>
+     */
+    private function claimBoundaryIssues(array $payload, string $prefix): array
+    {
+        $issues = [];
+        $encoded = strtolower((string) json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        foreach (self::FORBIDDEN_CLAIM_FRAGMENTS as $fragment) {
+            if (str_contains($encoded, strtolower($fragment))) {
+                $issues[] = "{$prefix}_forbidden_claim_".str_replace([' ', '-'], '_', strtolower($fragment));
+            }
+        }
+
+        $boundary = $this->claimBoundary($payload);
+        foreach ([
+            'not_clinical',
+            'not_hiring',
+            'not_certified_capability_evaluation',
+            'not_msceit_equivalent',
+        ] as $required) {
+            if (($boundary[$required] ?? false) !== true) {
+                $issues[] = "{$prefix}_missing_{$required}";
+            }
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     * @return array<string,bool>
+     */
+    private function claimBoundary(array $payload): array
+    {
+        $boundary = (array) ($payload['claim_boundary'] ?? []);
+
+        return [
+            'not_clinical' => (bool) ($boundary['not_clinical'] ?? false),
+            'not_hiring' => (bool) ($boundary['not_hiring'] ?? false),
+            'not_certified_capability_evaluation' => (bool) ($boundary['not_certified_capability_evaluation'] ?? false),
+            'not_msceit_equivalent' => (bool) ($boundary['not_msceit_equivalent'] ?? false),
+            'not_true_emotional_ability_score' => (bool) ($boundary['not_true_emotional_ability_score'] ?? true),
+            'does_not_predict_job_performance' => (bool) ($boundary['does_not_predict_job_performance'] ?? true),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function safeContext(array $context, string $scaleCode): array
+    {
+        return [
+            'scale_code' => $scaleCode,
+            'attempt_id' => $this->string($context['attempt_id'] ?? null),
+            'anon_id' => $this->string($context['anon_id'] ?? null),
+            'user_id' => is_numeric($context['user_id'] ?? null) ? (int) $context['user_id'] : null,
+            'locale' => $this->string($context['locale'] ?? null),
+            'region' => $this->string($context['region'] ?? null),
+            'org_id' => is_numeric($context['org_id'] ?? null) ? (int) $context['org_id'] : 0,
+        ];
+    }
+
+    private function string(mixed $value): string
+    {
+        return is_scalar($value) ? trim((string) $value) : '';
+    }
+
+    private function number(mixed $value): ?float
+    {
+        return is_numeric($value) ? (float) $value : null;
+    }
+}

--- a/backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php
+++ b/backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Eq;
+
+use App\Services\Assessment\Scorers\EqSjt16Scorer;
+use App\Services\Eq\EqSjtValidationTelemetryContract;
+use App\Services\Report\EqIntegratedReportComposer;
+use Tests\TestCase;
+
+final class EqSjtValidationTelemetryContractTest extends TestCase
+{
+    public function test_sjt_scored_telemetry_is_safe_and_does_not_include_answers(): void
+    {
+        $score = $this->scoreGoldenCase('boundary_gap');
+        $event = (new EqSjtValidationTelemetryContract())->scoredEvent($score, [
+            'attempt_id' => 'attempt-eq-sjt-telemetry',
+            'anon_id' => 'anon-eq-sjt-telemetry',
+            'locale' => 'en',
+            'region' => 'GLOBAL',
+        ]);
+
+        $this->assertSame('eq_sjt16_scored', $event['event_code']);
+        $this->assertSame('EQ_SJT_16', $event['meta']['scale_code']);
+        $this->assertSame('scenario_based_emotional_judgment', $event['meta']['measurement_type']);
+        $this->assertSame('likely_response', $event['meta']['answer_mode']);
+        $this->assertSame('draft_not_yet_validated', $event['meta']['validation_status']);
+        $this->assertFalse($event['meta']['stable_validation_claim_allowed']);
+        $this->assertSame('BND', $event['meta']['lowest_strategy']);
+        $this->assertSame([], $event['meta']['quality_flags']);
+        $this->assertTrue($event['meta']['claim_boundary']['not_msceit_equivalent']);
+
+        $encoded = json_encode($event, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+        $this->assertIsString($encoded);
+        $this->assertStringNotContainsString('selected_options', $encoded);
+        $this->assertStringNotContainsString('answers', $encoded);
+        $this->assertStringNotContainsString('response_options', $encoded);
+    }
+
+    public function test_low_quality_sjt_path_is_telemetry_visible_but_not_validation_claimed(): void
+    {
+        $score = $this->scoreGoldenCase('low_effectiveness');
+        $event = (new EqSjtValidationTelemetryContract())->scoredEvent($score);
+
+        $this->assertSame('B', $event['meta']['quality_level']);
+        $this->assertSame(['low_effectiveness_pattern'], $event['meta']['quality_flags']);
+        $this->assertSame('low_effectiveness', $event['meta']['band']);
+        $this->assertFalse($event['meta']['stable_validation_claim_allowed']);
+    }
+
+    public function test_integrated_report_telemetry_and_qa_gate_keep_public_release_closed(): void
+    {
+        $score = $this->scoreGoldenCase('boundary_gap');
+        $report = (new EqIntegratedReportComposer())->compose($this->eq60Report('en'), $score, ['locale' => 'en']);
+        $contract = new EqSjtValidationTelemetryContract();
+        $event = $contract->integratedReportComposedEvent($report, [
+            'attempt_id' => 'attempt-integrated-eq',
+            'locale' => 'en',
+        ]);
+        $gate = $contract->qaGate($score, $report);
+
+        $this->assertSame('eq_integrated_report_composed', $event['event_code']);
+        $this->assertSame('integrated', $event['meta']['eq_report_mode']);
+        $this->assertSame('draft_not_yet_validated', $event['meta']['validation_status']);
+        $this->assertFalse($event['meta']['public_runtime_enabled']);
+        $this->assertFalse($event['meta']['frontend_integrated_report_visible']);
+        $this->assertSame('boundary_under_pressure', $event['meta']['pressure_pattern_id']);
+
+        $this->assertSame('pass_for_internal_qa_only', $gate['status']);
+        $this->assertFalse($gate['public_release_allowed']);
+        $this->assertFalse($gate['stable_validation_claim_allowed']);
+        $this->assertSame([], $gate['issues']);
+        $this->assertContains('expert_rubric_calibration', $gate['required_next_evidence']);
+        $this->assertContains('locale_bias_review', $gate['required_next_evidence']);
+    }
+
+    public function test_zh_cn_and_en_integrated_contracts_share_boundaries_without_paid_runtime(): void
+    {
+        $score = $this->scoreGoldenCase('balanced_effective');
+        foreach (['zh-CN', 'en'] as $locale) {
+            $report = (new EqIntegratedReportComposer())->compose($this->eq60Report($locale), $score, ['locale' => $locale]);
+
+            $this->assertSame($locale, $report['locale']);
+            $this->assertTrue($report['access']['all_results_free']);
+            $this->assertFalse($report['access']['locked']);
+            $this->assertFalse($report['access']['blur']);
+            $this->assertFalse($report['access']['paywall']);
+            $this->assertFalse($report['visibility']['public_runtime_enabled']);
+            $this->assertFalse($report['visibility']['frontend_integrated_report_visible']);
+            $this->assertSame('draft_not_yet_validated', $report['methodology']['validation_status']);
+
+            $encoded = json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES);
+            $this->assertIsString($encoded);
+            foreach (['SKU_EQ_60_FULL_299', 'EQ_60_FULL', 'premium', 'unlock', 'MSCEIT-like', 'certified emotional intelligence'] as $forbidden) {
+                $this->assertStringNotContainsString($forbidden, $encoded);
+            }
+        }
+    }
+
+    public function test_claim_boundary_gate_blocks_overclaiming_payloads(): void
+    {
+        $contract = new EqSjtValidationTelemetryContract();
+        $score = $this->scoreGoldenCase('balanced_effective');
+        $report = (new EqIntegratedReportComposer())->compose($this->eq60Report('en'), $score, ['locale' => 'en']);
+        $report['claim_copy'] = 'This is a MSCEIT-like certified emotional intelligence clinical assessment.';
+        $report['visibility']['frontend_integrated_report_visible'] = true;
+
+        $gate = $contract->qaGate($score, $report);
+
+        $this->assertSame('blocked', $gate['status']);
+        $this->assertContains('integrated_report_frontend_visible_before_release', $gate['issues']);
+        $this->assertContains('integrated_report_forbidden_claim_msceit_like', $gate['issues']);
+        $this->assertContains('integrated_report_forbidden_claim_certified_emotional_intelligence', $gate['issues']);
+        $this->assertContains('integrated_report_forbidden_claim_clinical_assessment', $gate['issues']);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function scoreGoldenCase(string $caseId): array
+    {
+        $cases = $this->jsonFile(base_path('content_packs/EQ_SJT_16/v1/raw/golden_cases.json'));
+        $case = collect((array) ($cases['cases'] ?? []))->firstWhere('case_id', $caseId);
+        $this->assertIsArray($case, $caseId);
+
+        return (new EqSjt16Scorer())->score((array) ($case['answers'] ?? []), $this->items(), [
+            'scoring_spec_version' => 'eq_sjt_16_partial_credit_v1',
+            'content_version' => 'EQ_SJT_16/v1',
+        ]);
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function items(): array
+    {
+        $payload = $this->jsonFile(base_path('content_packs/EQ_SJT_16/v1/raw/items.json'));
+        $items = [];
+        foreach ((array) ($payload['items'] ?? []) as $item) {
+            $this->assertIsArray($item);
+            $itemId = (string) ($item['item_id'] ?? '');
+            $this->assertNotSame('', $itemId);
+            $items[$itemId] = $item;
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function eq60Report(string $locale): array
+    {
+        return [
+            'locale' => $locale,
+            'eq_report_mode' => 'self_report',
+            'measurement_type' => 'self_report_trait_mixed_ei',
+            'quality' => ['level' => 'A', 'confidence_label' => 'high'],
+            'scores' => [
+                'global' => ['standard_score' => 104, 'percentile' => 61, 'band' => 'stable'],
+                'dimensions' => [
+                    'SA' => ['standard_score' => 106, 'percentile' => 65, 'band' => 'stable'],
+                    'ER' => ['standard_score' => 92, 'percentile' => 30, 'band' => 'developing'],
+                    'EM' => ['standard_score' => 110, 'percentile' => 70, 'band' => 'proficient'],
+                    'RM' => ['standard_score' => 101, 'percentile' => 52, 'band' => 'stable'],
+                ],
+            ],
+            'interpretation' => ['core_formulation_id' => 'high_empathy_low_recovery'],
+            'methodology' => ['content_version' => 'EQ_60/v1'],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonFile(string $path): array
+    {
+        $this->assertFileExists($path);
+        $decoded = json_decode((string) file_get_contents($path), true);
+        $this->assertIsArray($decoded, $path);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -471,6 +471,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_eq_sjt_validation_telemetry_contract(): void
+    {
+        $changed = [
+            'backend/app/Services/Eq/EqSjtValidationTelemetryContract.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_journey_state_contract_changes(): void
     {
         $changed = [
@@ -3011,6 +3020,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isEqSjtValidationTelemetryContractChange($file)) {
+                continue;
+            }
+
             if ($this->isEq60JourneyStateContractChange($file)) {
                 continue;
             }
@@ -4127,6 +4140,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isEqIntegratedReportComposerDraftChange(string $file): bool
     {
         return $file === 'backend/app/Services/Report/EqIntegratedReportComposer.php';
+    }
+
+    private function isEqSjtValidationTelemetryContractChange(string $file): bool
+    {
+        return $file === 'backend/app/Services/Eq/EqSjtValidationTelemetryContract.php';
     }
 
     private function isEq60JourneyStateContractChange(string $file): bool

--- a/docs/audits/eq/eq_sjt_16_validation_telemetry_qa_2026-05-31.md
+++ b/docs/audits/eq/eq_sjt_16_validation_telemetry_qa_2026-05-31.md
@@ -1,0 +1,142 @@
+# EQ-SJT 16 Validation Telemetry and QA Contract
+
+## 1. Purpose
+
+This document records the validation, telemetry, and QA boundary for the planned EQ-SJT 16 scenario module and the future integrated EQ report.
+
+EQ-SJT 16 remains a scenario-based emotional judgment module. It supplements EQ-60 self-report signals; it does not replace EQ-60, does not create a true emotional ability score, and is not positioned as MSCEIT, a certified emotional intelligence assessment, a clinical assessment, or a hiring-screening instrument.
+
+## 2. Current Release State
+
+- EQ-60 remains the only public EQ result surface.
+- EQ-SJT 16 has scorer-ready internal fixtures, but no public take entry is enabled by this PR.
+- Integrated EQ report composition exists as a backend draft contract, but no user-visible integrated report is enabled by this PR.
+- Stable validation claims are explicitly blocked until expert calibration, localization review, pilot data, telemetry review, and rendered QA evidence exist.
+
+## 3. Telemetry Events
+
+### `eq_sjt16_scored`
+
+Internal event envelope for a scored EQ-SJT 16 result.
+
+Allowed metadata:
+- `scale_code`
+- `measurement_type`
+- `answer_mode`
+- `score_method`
+- `score_pct`
+- `band`
+- `quality_level`
+- `quality_flags`
+- `top_strategy`
+- `lowest_strategy`
+- `content_version`
+- `rubric_version`
+- `validation_status`
+- `stable_validation_claim_allowed`
+- `claim_boundary`
+
+Forbidden metadata:
+- raw answers
+- selected response options
+- response option text
+- scenario stems
+- user-facing interpretation copy
+- paid or unlock fields
+
+### `eq_integrated_report_composed`
+
+Internal event envelope for the draft integrated EQ report composer.
+
+Allowed metadata:
+- `scale_code`
+- `eq_report_mode`
+- `measurement_type`
+- `gap_count`
+- `pressure_pattern_id`
+- `scenario_script_count`
+- `integrated_action_duration_days`
+- `report_version`
+- `validation_status`
+- `public_runtime_enabled`
+- `frontend_integrated_report_visible`
+- `stable_validation_claim_allowed`
+- `claim_boundary`
+
+Forbidden metadata:
+- full report prose
+- raw answers
+- selected options
+- any ability, MSCEIT, certified, hiring, clinical, or job-performance claim
+
+## 4. QA Gate
+
+The internal QA gate may return `pass_for_internal_qa_only`. That status does not allow public release.
+
+Public release remains blocked until all required evidence exists:
+- expert rubric calibration
+- locale bias review
+- scenario item pilot statistics
+- strategy score reliability review
+- integrated report rendered QA
+
+The gate must return `blocked` if:
+- integrated report runtime visibility is enabled early
+- frontend integrated report visibility is enabled early
+- validation status overclaims beyond `draft_not_yet_validated`
+- forbidden claim language is present
+- claim-boundary flags are missing
+
+## 5. Required Scenario Coverage
+
+Validation fixtures must continue covering:
+- balanced effective path
+- boundary gap path
+- low-effectiveness / low-quality path
+- zh-CN locale
+- en locale
+- all-free, no locked / blur / paywall / SKU
+- no raw technical tags in user-visible report contracts
+
+## 6. Claim Boundary
+
+The following claims remain prohibited:
+- measures true emotional ability
+- MSCEIT-like
+- certified emotional intelligence
+- hiring suitable
+- clinical assessment
+- predicts job performance
+
+Safe wording:
+- scenario-based emotional judgment
+- likely response under emotional and relational situations
+- supplements EQ-60 self-report
+- draft internal validation status
+- not for clinical, hiring, or high-stakes decisions
+
+## 7. PR-EQ-SJT-05 Validation Evidence
+
+Local validation target:
+- `EqSjtValidationTelemetryContractTest`
+- `EqSjt`
+- `Eq60`
+- `Report`
+- `git diff --check`
+- `git diff --cached --check`
+
+Known external broad `Report` filter failures unrelated to EQ-SJT are recorded in `docs/codex/pr-train-state.json` as sidecar items when reproduced outside this PR scope.
+
+## 8. Follow-up Before Public Runtime
+
+Before EQ-SJT can become public, a future PR must provide:
+- user-facing take-flow release gate
+- public route authorization
+- SJT attempt lifecycle and persistence
+- telemetry dashboard or query contract
+- expert review rubric evidence
+- locale and culture bias review
+- rendered QA screenshots for zh-CN and en
+- production smoke QA
+
+Until then, EQ-SJT and integrated EQ stay planned / unavailable.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -404,7 +404,7 @@
       "depends_on": [
         "PR-EQ-SJT-04"
       ],
-      "commit_sha": "2b3c1dc69b57acbedb0d74715133330af87fdf53",
+      "commit_sha": "1b92cd3d2edb895add2086220dc67bfc9a389356",
       "pr_url": null,
       "checks": {
         "local": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -352,11 +352,11 @@
     "PR-EQ-SJT-04": {
       "repo": "fap-api",
       "branch": "codex/pr-eq-sjt-04-integrated-report-composer",
-      "status": "open",
+      "status": "merged",
       "depends_on": [
         "PR-EQ-SJT-03"
       ],
-      "commit_sha": "72596195a0ad976a7e4f636561873c5958bdef59",
+      "commit_sha": "6c13f952b40650952d126ce28e5dbeac9b81add8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1822",
       "checks": {
         "local": {
@@ -393,20 +393,55 @@
         }
       },
       "failure_reason": null,
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false
+      "merged_at": "2026-05-31T17:31:03Z",
+      "remote_branch_deleted": true,
+      "local_cleanup_executed": true
     },
     "PR-EQ-SJT-05": {
       "repo": "fap-api",
       "branch": "codex/pr-eq-sjt-05-validation-telemetry-qa",
-      "status": "pending",
+      "status": "local_checks_passed",
       "depends_on": [
         "PR-EQ-SJT-04"
       ],
-      "commit_sha": null,
+      "commit_sha": "2b3c1dc69b57acbedb0d74715133330af87fdf53",
       "pr_url": null,
-      "checks": {},
+      "checks": {
+        "local": {
+          "status": "passed_with_external_sidecar",
+          "commands": [
+            "php -l backend/app/Services/Eq/EqSjtValidationTelemetryContract.php",
+            "php -l backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqSjtValidationTelemetryContractTest",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_eq_sjt_validation_telemetry_contract'",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff'",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqSjt",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60",
+            "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Report",
+            "git diff --check",
+            "git diff --cached --check"
+          ],
+          "scope_validation": "passed",
+          "notes": [
+            "EqSjtValidationTelemetryContractTest passed: 5 tests, 249 assertions, with existing file_get_contents warnings.",
+            "EqSjt exited 0 with existing file_get_contents warnings.",
+            "Eq60 exited 0 with existing file_get_contents warnings.",
+            "BigFive runtime freeze guard needed an exact file-level exemption for the internal EQ-SJT validation telemetry contract; focused guard tests exit 0 with warnings only.",
+            "Report filter failed in unrelated Career/Email/Ops/Enneagram/MBTI/AttemptReportAccess tests; failures are outside PR-EQ-SJT-05 touched paths and do not affect the validation telemetry/QA contract."
+          ]
+        },
+        "sidecar": {
+          "status": "external_failures_recorded",
+          "issues": [
+            "Report filter: FirstWavePublishReadyValidator::validationMemoKey missing in Career tests.",
+            "Report filter: AccessResolverTest Enneagram expectation drift.",
+            "Report filter: EmailOutboxLifecycleContext checkout 404.",
+            "Report filter: AttemptChainAuditCommandTest exact attempt selection drift.",
+            "Report filter: AttemptReportAccessReadTest warning expectation drift.",
+            "Report filter: MbtiResultTelemetryContractTest calibration_policy_version drift."
+          ]
+        }
+      },
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -400,12 +400,12 @@
     "PR-EQ-SJT-05": {
       "repo": "fap-api",
       "branch": "codex/pr-eq-sjt-05-validation-telemetry-qa",
-      "status": "local_checks_passed",
+      "status": "open",
       "depends_on": [
         "PR-EQ-SJT-04"
       ],
       "commit_sha": "1b92cd3d2edb895add2086220dc67bfc9a389356",
-      "pr_url": null,
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1824",
       "checks": {
         "local": {
           "status": "passed_with_external_sidecar",


### PR DESCRIPTION
## What changed
- Added an internal EQ-SJT validation telemetry contract for scored SJT and draft integrated EQ report events.
- Added unit coverage for safe telemetry metadata, claim-boundary blocking, low-quality paths, zh-CN/en integrated contracts, and no paid/runtime visibility.
- Added a docs audit for EQ-SJT validation telemetry and QA gates.
- Added a narrow BigFive runtime-freeze classifier exemption for the exact internal telemetry contract file.
- Reconciled PR-EQ-SJT-04 as merged in the PR train state and recorded PR-EQ-SJT-05 local validation.

## Why
PR-EQ-SJT-05 locks the final SJT phase with validation, telemetry, QA, and claim-boundary evidence before any public SJT or integrated EQ release. It keeps SJT as draft/planned until future validation evidence exists.

## Validation
- `php -l backend/app/Services/Eq/EqSjtValidationTelemetryContract.php`
- `php -l backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqSjtValidationTelemetryContractTest`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_eq_sjt_validation_telemetry_contract'`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff'`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=EqSjt`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Eq60`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=Report` *(fails in pre-existing external Career/Email/Enneagram/MBTI/AttemptReportAccess tests; recorded as sidecar in state)*
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No SJT public route, take page, or frontend entry.
- No integrated EQ user-visible report.
- No scorer or rubric changes.
- No stable validation claim.
- No ability/MSCEIT/certified/hiring/clinical/job-performance claim.

## Repository rule impact
Backend remains the authority for SJT validation and report-contract boundaries. This PR adds internal contract/test/docs only; it does not introduce a new CMS/frontend content authority surface.
