### PR TITLE
CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01 sitemap career exposure directory authority

### DIFF
--- a/backend/app/Services/Career/CareerDirectoryAuthorityService.php
+++ b/backend/app/Services/Career/CareerDirectoryAuthorityService.php
@@ -88,6 +88,17 @@ final class CareerDirectoryAuthorityService
     /**
      * @return list<array<string, mixed>>
      */
+    public function indexableItems(string $locale): array
+    {
+        $publicLocale = $this->normalizePublicLocale($locale);
+        $localePrefix = $publicLocale === 'zh-CN' ? 'zh' : 'en';
+
+        return $this->directoryItems($publicLocale, $localePrefix);
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
     private function directoryItems(string $publicLocale, string $localePrefix): array
     {
         $payload = $this->responseCache->jobIndexPayload($publicLocale);

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -9,6 +9,7 @@ use App\Models\CareerJobDisplayAsset;
 use App\Models\ContentPage;
 use App\Models\PersonalityProfileVariant;
 use App\Models\TopicProfile;
+use App\Services\Career\CareerDirectoryAuthorityService;
 use App\Services\Career\Dataset\CareerDatasetPublicationMetadataService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\CareerGuideSeoService;
@@ -46,6 +47,7 @@ class SitemapGenerator
         private readonly TopicProfileSeoService $topicProfileSeoService,
         private readonly ScaleRegistry $scaleRegistry,
         private readonly CareerDatasetPublicationMetadataService $datasetPublicationMetadataService,
+        private readonly CareerDirectoryAuthorityService $careerDirectoryAuthorityService,
     ) {
         $configuredPrefix = trim((string) config('services.seo.tests_url_prefix', ''));
         if ($configuredPrefix === '') {
@@ -118,7 +120,7 @@ class SitemapGenerator
 
     public function generateApprovedCareerJobDetailUrls(): array
     {
-        return $this->getDisplayAssetCareerJobDetailUrls();
+        return $this->getDirectoryAuthorityCareerJobDetailUrls();
     }
 
     private function getScaleUrls(string $locale): array
@@ -430,10 +432,40 @@ class SitemapGenerator
 
     private function getCareerJobDetailUrls(): array
     {
-        return array_merge(
-            $this->getCmsCareerJobDetailUrls(),
-            $this->getDisplayAssetCareerJobDetailUrls()
-        );
+        return $this->getDirectoryAuthorityCareerJobDetailUrls();
+    }
+
+    private function getDirectoryAuthorityCareerJobDetailUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $urls = [];
+        foreach ([
+            'en' => 'en',
+            'zh-CN' => 'zh',
+        ] as $locale => $segment) {
+            foreach ($this->careerDirectoryAuthorityService->indexableItems($locale) as $item) {
+                $slug = strtolower(trim((string) ($item['slug'] ?? '')));
+                $path = trim((string) ($item['canonical_path'] ?? ''));
+                if ($slug === '' || $path === '') {
+                    continue;
+                }
+
+                $updatedAt = $this->parseUpdatedAt((string) ($item['updated_at'] ?? '')) ?? now('UTC');
+
+                $urls[] = [
+                    'loc' => $baseUrl.$path,
+                    'lastmod' => $updatedAt->toAtomString(),
+                    'slug' => 'career-jobs:'.$segment.':'.$slug,
+                    'updated_at' => $updatedAt->toDateTimeString(),
+                ];
+            }
+        }
+
+        return $urls;
     }
 
     private function getCmsCareerJobDetailUrls(): array

--- a/backend/docs/seo/career-sitemap-exposure-directory-authority-01.md
+++ b/backend/docs/seo/career-sitemap-exposure-directory-authority-01.md
@@ -1,0 +1,29 @@
+# CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01
+
+## Summary
+
+Career detail sitemap exposure now enumerates public/indexable career detail URLs from the backend career directory authority service introduced by `CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01`.
+
+## Authority Boundary
+
+- Backend career directory authority remains the public career detail source for discoverability enumeration.
+- Sitemap generation no longer derives career detail URLs directly from display-asset-only rows.
+- Runtime projection filtering in the sitemap source API remains in place as a final safety gate.
+
+## Safety Rules
+
+- Held slugs remain excluded:
+  - `software-developers`
+  - `digital-forensics-analysts`
+  - `computer-occupations-all-other`
+- Draft, noindex, non-public, display-only, fallback-only, and projection-blocked career detail URLs remain excluded.
+- No frontend, CMS mutation, DB mutation, Search Channel action, URL submission, or deployment was performed.
+
+## Validation Intent
+
+The focused regression test verifies that:
+
+- Directory-authority career jobs produce EN/ZH sitemap URLs.
+- Display-asset-only career jobs are not enough to enter the sitemap.
+- Held slugs are not emitted.
+- The generated sitemap XML follows the same directory-authority career detail exposure.

--- a/backend/docs/seo/generated/career-sitemap-exposure-directory-authority-01.v1.json
+++ b/backend/docs/seo/generated/career-sitemap-exposure-directory-authority-01.v1.json
@@ -1,0 +1,24 @@
+{
+  "schema_version": "1.0",
+  "task": "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01",
+  "final_decision": "career_sitemap_exposure_directory_authority_completed_ready_for_frontend_paginated_directory_shell",
+  "authority_source": "career.directory_authority.v1",
+  "sitemap_career_detail_source": "CareerDirectoryAuthorityService::indexableItems",
+  "runtime_projection_filter_preserved": true,
+  "expected_current_public_detail_count": 1046,
+  "expected_current_sitemap_career_detail_url_count": 2092,
+  "held_slugs_excluded": [
+    "software-developers",
+    "digital-forensics-analysts",
+    "computer-occupations-all-other"
+  ],
+  "display_asset_only_rows_excluded": true,
+  "frontend_changed": false,
+  "cms_mutation_performed": false,
+  "db_mutation_performed": false,
+  "deploy_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "external_search_api_call_performed": false,
+  "next_task": "CAREER-JOBS-PAGINATED-DIRECTORY-SHELL-01"
+}

--- a/backend/tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php
+++ b/backend/tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php
@@ -1,0 +1,151 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationFamily;
+use App\Services\SEO\SitemapGenerator;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
+use Tests\TestCase;
+
+final class CareerSitemapExposureDirectoryAuthorityTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+    }
+
+    public function test_career_detail_sitemap_urls_are_enumerated_from_directory_authority(): void
+    {
+        $this->createOccupation('accountants-and-auditors', 'Accountants and Auditors', '会计师与审计师');
+        $this->createOccupation('actuaries', 'Actuaries', '精算师');
+        $this->createDisplayAsset($this->createOccupation('display-asset-only', 'Display Asset Only', '仅展示资产'));
+        $this->createOccupation('software-developers', 'Software Developers', '软件开发人员');
+
+        $this->publishRuntimeProjection(['accountants-and-auditors', 'actuaries', 'software-developers']);
+
+        $urls = app(SitemapGenerator::class)->generateApprovedCareerJobDetailUrls();
+        $locs = array_values(array_map(static fn (array $url): string => (string) ($url['loc'] ?? ''), $urls));
+        sort($locs, SORT_STRING);
+
+        $this->assertSame([
+            'https://fermatmind.com/en/career/jobs/accountants-and-auditors',
+            'https://fermatmind.com/en/career/jobs/actuaries',
+            'https://fermatmind.com/zh/career/jobs/accountants-and-auditors',
+            'https://fermatmind.com/zh/career/jobs/actuaries',
+        ], $locs);
+
+        $xml = (string) app(SitemapGenerator::class)->generate()['xml'];
+        $this->assertStringContainsString('https://fermatmind.com/en/career/jobs/accountants-and-auditors', $xml);
+        $this->assertStringContainsString('https://fermatmind.com/zh/career/jobs/actuaries', $xml);
+        $this->assertStringNotContainsString('display-asset-only', $xml);
+        $this->assertStringNotContainsString('software-developers', $xml);
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function publishRuntimeProjection(array $slugs): void
+    {
+        $items = [];
+        foreach ($slugs as $slug) {
+            $items[$slug.'|en'] = [
+                'slug' => $slug,
+                'locale' => 'en',
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'detail_route_enabled' => true,
+                'robots_indexable' => true,
+                'release_gate_pass' => true,
+                'runtime_publish_state' => 'published',
+            ];
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                items: $items,
+            ),
+        );
+
+        Cache::flush();
+    }
+
+    private function createOccupation(string $slug, string $titleEn, string $titleZh): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'business-finance'],
+            [
+                'title_en' => 'Business and Finance',
+                'title_zh' => '商业与金融',
+            ],
+        );
+
+        return Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $titleEn,
+            'canonical_title_zh' => $titleZh,
+            'search_h1_zh' => $titleZh,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+        ]);
+    }
+
+    private function createDisplayAsset(Occupation $occupation): CareerJobDisplayAsset
+    {
+        return CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => (string) $occupation->canonical_slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => range(1, 24),
+            'page_payload_json' => [
+                'zh' => ['hero' => ['title' => $occupation->canonical_title_zh]],
+                'en' => ['hero' => ['title' => $occupation->canonical_title_en]],
+            ],
+            'seo_payload_json' => [
+                'indexability_state' => 'index',
+                'robots_policy' => 'index,follow',
+            ],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+        ]);
+    }
+}

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -431,7 +431,7 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'), $xml);
     }
 
-    public function test_generate_includes_only_indexable_global_career_job_urls_with_locale_aware_paths(): void
+    public function test_generate_includes_career_job_list_urls_without_cms_only_detail_urls(): void
     {
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);
 
@@ -538,10 +538,10 @@ class SitemapGeneratorTest extends TestCase
         $xml = (string) ($payload['xml'] ?? '');
 
         $this->assertStringContainsString('https://staging.fermatmind.com/zh/career/jobs', $xml);
-        $this->assertStringContainsString('https://staging.fermatmind.com/zh/career/jobs/product-manager', $xml);
 
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/product-manager', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/career/jobs/product-manager', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/career/jobs/robots-noindex', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/draft-role', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/private-role', $xml);
@@ -560,7 +560,6 @@ class SitemapGeneratorTest extends TestCase
             data_get($seoService->buildJsonLd($eligibleZh, 'zh-CN'), 'mainEntityOfPage')
         );
         $this->assertSame('Occupation', data_get($seoService->buildJsonLd($eligibleZh, 'zh-CN'), '@type'));
-        $this->assertStringContainsString(data_get($seoService->buildMeta($eligibleZh, 'zh-CN'), 'canonical'), $xml);
     }
 
     public function test_generate_includes_only_indexable_global_career_guide_urls_with_locale_aware_paths_and_lastmod(): void

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Feature\SEO;
 
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\Article;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
@@ -15,7 +16,9 @@ use App\Models\PersonalityProfileVariantSeoMeta;
 use App\Models\TopicProfile;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Illuminate\Support\Facades\DB;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
 use Tests\TestCase;
 
 class SitemapXmlTest extends TestCase
@@ -385,6 +388,7 @@ class SitemapXmlTest extends TestCase
             $this->createOccupation('software-developers', 'Software Developers'),
             ['updated_at' => Carbon::create(2026, 1, 31, 12, 56, 0)]
         );
+        $this->publishRuntimeProjection(['agricultural-inspectors', 'software-developers']);
 
         $guideEn = $this->createCareerGuide([
             'guide_code' => 'career-planning-101',
@@ -751,6 +755,40 @@ class SitemapXmlTest extends TestCase
             'created_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
             'updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
         ], $overrides));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function publishRuntimeProjection(array $slugs): void
+    {
+        $items = [];
+        foreach ($slugs as $slug) {
+            $items[$slug.'|en'] = [
+                'slug' => $slug,
+                'locale' => 'en',
+                'dataset_visible' => true,
+                'search_visible' => true,
+                'detail_route_enabled' => true,
+                'robots_indexable' => true,
+                'release_gate_pass' => true,
+                'runtime_publish_state' => 'published',
+            ];
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                items: $items,
+            ),
+        );
+
+        Cache::flush();
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-01T04:19:00Z",
+  "updated_at": "2026-06-01T04:22:00Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -38083,13 +38083,13 @@
     "repo": "fap-api",
     "branch": "codex/career-sitemap-exposure-directory-authority-01",
     "base": "main",
-    "status": "committed",
+    "status": "pr_opened_with_sidecar",
     "title": "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01 sitemap career exposure directory authority",
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01"
     ],
     "commit_sha": "568c88a837b8dc2c66c67815d6c68dd260c4b8aa",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1832",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -38169,6 +38169,11 @@
         "at": "2026-06-01T04:18:00Z",
         "status": "committed",
         "summary": "Committed scoped PR2 changes locally as 568c88a8."
+      },
+      {
+        "at": "2026-06-01T04:22:00Z",
+        "status": "pr_opened_with_sidecar",
+        "summary": "Opened PR #1832. Local scoped validation passed; full Pint sidecar remains out-of-scope."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -37746,7 +37746,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-fdn-social-sync-readiness",
     "base": "main",
-    "status": "pr_opened_with_sidecar",
+    "status": "ci_fix_validated_with_sidecar",
     "title": "docs(foundation): add Daily Giving social sync readiness",
     "commit_sha": "25e47f6b7dff748935293e5600d10046d9673e6d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1819",
@@ -38111,6 +38111,10 @@
         "status": "pass",
         "evidence": "Sitemap generator regression tests passed after updating the old CMS-only career detail expectation: 6 tests, 90 assertions."
       },
+      "php artisan test --filter=SitemapXmlTest --no-ansi": {
+        "status": "pass",
+        "evidence": "Sitemap XML regression test now binds runtime projection truth for the public career detail fixture and passed: 4 tests, 77 assertions."
+      },
       "php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi": {
         "status": "pass",
         "evidence": "Big Five runtime freeze branch-diff guard passed with the sitemap/directory authority diff."
@@ -38119,7 +38123,7 @@
         "status": "pass",
         "evidence": "Route list completed successfully; no route changes were made in this PR."
       },
-      "vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php tests/Feature/SEO/SitemapGeneratorTest.php": {
+      "vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php": {
         "status": "pass",
         "evidence": "Scoped Pint passed for current PR PHP files."
       },
@@ -38174,6 +38178,11 @@
         "at": "2026-06-01T04:22:00Z",
         "status": "pr_opened_with_sidecar",
         "summary": "Opened PR #1832. Local scoped validation passed; full Pint sidecar remains out-of-scope."
+      },
+      {
+        "at": "2026-06-01T04:23:00Z",
+        "status": "ci_fix_validated_with_sidecar",
+        "summary": "Inspected GitHub failures in verify-mbti-legacy and verify-mbti-v2; both failed because SitemapXmlTest expected a career detail URL without binding runtime projection truth. Added the fixture binding in current scope and validated SitemapXmlTest plus focused sitemap checks locally."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-01T03:02:27Z",
+  "updated_at": "2026-06-01T04:19:00Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -37972,10 +37972,10 @@
     "repo": "fap-api",
     "branch": "codex/career-directory-authority-artifact-api-01",
     "base": "main",
-    "status": "ci_fix_validated_with_sidecar",
+    "status": "merged",
     "title": "CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01 career directory authority artifact API",
     "depends_on": [],
-    "commit_sha": "22c84ad5c11fe0bf5d547bcf9fa587a1b71f6369",
+    "commit_sha": "68f2b2dfc0b3b587a53ad85dc52a4b0f4b2eabcf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1830",
     "checks": {
       "manifest_registration": {
@@ -38036,9 +38036,9 @@
       }
     },
     "failure_reason": "Sidecar only: full Pint reports out-of-scope EQ test formatting issues; scoped current PR files and current-scope CI fixes passed locally.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-01T03:48:22Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "next_task": "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01",
     "history": [
       {
@@ -38070,6 +38070,105 @@
         "at": "2026-06-01T03:43:00Z",
         "status": "ci_fix_committed",
         "summary": "Committed current-scope CI fixes as 22c84ad5c11fe0bf5d547bcf9fa587a1b71f6369."
+      },
+      {
+        "at": "2026-06-01T03:55:00Z",
+        "status": "merged",
+        "summary": "Reconciled PR1 after GitHub confirmed PR #1830 merged, origin/main contains merge commit 68f2b2d, and local/remote branches were cleaned up."
+      }
+    ]
+  },
+  "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01": {
+    "id": "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01",
+    "repo": "fap-api",
+    "branch": "codex/career-sitemap-exposure-directory-authority-01",
+    "base": "main",
+    "status": "committed",
+    "title": "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01 sitemap career exposure directory authority",
+    "depends_on": [
+      "CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01"
+    ],
+    "commit_sha": "568c88a837b8dc2c66c67815d6c68dd260c4b8aa",
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User approved the five-PR career directory 10k-scale train; this entry adds only PR2 after PR1 merged."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Changed files are limited to directory authority service, sitemap generator, focused sitemap tests/report, and current PR ledger metadata."
+      },
+      "php artisan test --filter=CareerSitemapExposureDirectoryAuthorityTest --no-ansi": {
+        "status": "pass",
+        "evidence": "Focused directory-authority sitemap exposure test passed: 1 test, 5 assertions."
+      },
+      "php artisan test --filter=SitemapSourceApiTest --no-ansi": {
+        "status": "pass",
+        "evidence": "Sitemap source API contract and runtime projection filtering tests passed: 7 tests, 316 assertions."
+      },
+      "php artisan test --filter=SitemapGeneratorTest --no-ansi": {
+        "status": "pass",
+        "evidence": "Sitemap generator regression tests passed after updating the old CMS-only career detail expectation: 6 tests, 90 assertions."
+      },
+      "php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi": {
+        "status": "pass",
+        "evidence": "Big Five runtime freeze branch-diff guard passed with the sitemap/directory authority diff."
+      },
+      "php artisan route:list --no-ansi": {
+        "status": "pass",
+        "evidence": "Route list completed successfully; no route changes were made in this PR."
+      },
+      "vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php tests/Feature/SEO/SitemapGeneratorTest.php": {
+        "status": "pass",
+        "evidence": "Scoped Pint passed for current PR PHP files."
+      },
+      "vendor/bin/pint --test": {
+        "status": "sidecar_external_failure",
+        "evidence": "Full Pint still reports the pre-existing out-of-scope new_with_parentheses issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php. Current PR does not touch those files; scoped Pint passed."
+      },
+      "composer validate --strict": {
+        "status": "pass",
+        "evidence": "Composer schema validation passed."
+      },
+      "composer audit --locked --no-interaction --ignore-unreachable": {
+        "status": "pass",
+        "evidence": "No locked dependency advisories reported."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "evidence": "Generated JSON, pr-train-state JSON, and pr-train YAML parse successfully."
+      },
+      "git diff --check && git diff --cached --check": {
+        "status": "pass",
+        "evidence": "Both unstaged and cached whitespace checks passed after path-limited staging."
+      }
+    },
+    "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused checks passed locally.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "next_task": "CAREER-JOBS-PAGINATED-DIRECTORY-SHELL-01",
+    "history": [
+      {
+        "at": "2026-06-01T04:02:00Z",
+        "status": "in_progress",
+        "summary": "Initialized PR2 after user authorization; started from latest origin/main and added sitemap career exposure directory authority scope."
+      },
+      {
+        "at": "2026-06-01T04:15:00Z",
+        "status": "local_checks_passed_with_sidecar",
+        "summary": "Focused sitemap/directory authority tests, SitemapSourceApiTest, SitemapGeneratorTest, route:list, scoped Pint, composer validation, composer audit, JSON/YAML parsing, and diff checks passed. Full Pint sidecar remains limited to out-of-scope EQ test formatting files."
+      },
+      {
+        "at": "2026-06-01T04:17:00Z",
+        "status": "scope_validation_passed",
+        "summary": "Path-limited staging includes only PR2 allowed files; git diff --cached --check passed."
+      },
+      {
+        "at": "2026-06-01T04:18:00Z",
+        "status": "committed",
+        "summary": "Committed scoped PR2 changes locally as 568c88a8."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18933,6 +18933,7 @@ prs:
       - backend/app/Services/SEO/SitemapGenerator.php
       - backend/tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php
       - backend/tests/Feature/SEO/SitemapGeneratorTest.php
+      - backend/tests/Feature/SEO/SitemapXmlTest.php
       - backend/docs/seo/career-sitemap-exposure-directory-authority-01.md
       - backend/docs/seo/generated/career-sitemap-exposure-directory-authority-01.v1.json
       - docs/codex/pr-train.yaml
@@ -18945,9 +18946,11 @@ prs:
     validation:
       - cd backend && php artisan test --filter=CareerSitemapExposureDirectoryAuthorityTest --no-ansi
       - cd backend && php artisan test --filter=SitemapSourceApiTest --no-ansi
+      - cd backend && php artisan test --filter=SitemapGeneratorTest --no-ansi
+      - cd backend && php artisan test --filter=SitemapXmlTest --no-ansi
       - cd backend && php artisan route:list --no-ansi
       - cd backend && vendor/bin/pint --test
-      - cd backend && vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php
+      - cd backend && vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php
       - cd backend && composer validate --strict
       - cd backend && composer audit --locked --no-interaction --ignore-unreachable
       - python3 -m json.tool backend/docs/seo/generated/career-sitemap-exposure-directory-authority-01.v1.json >/dev/null

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18914,3 +18914,46 @@ prs:
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01
+
+  - id: CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01
+    repo: fap-api
+    depends_on: [CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01]
+    branch: codex/career-sitemap-exposure-directory-authority-01
+    base: main
+    title: "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01 sitemap career exposure directory authority"
+    train_scope: career_directory_10k_scale
+    status: in_progress
+    scope:
+      - Make backend sitemap career detail URL enumeration consume the career directory authority service.
+      - Preserve the sitemap source runtime projection safety filter.
+      - Preserve current 1046 public details / 2092 EN/ZH career detail URL truth.
+      - Exclude held, noindex, display-asset-only, draft, private, and fallback-only career slugs.
+    allowed_paths:
+      - backend/app/Services/Career/CareerDirectoryAuthorityService.php
+      - backend/app/Services/SEO/SitemapGenerator.php
+      - backend/tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php
+      - backend/tests/Feature/SEO/SitemapGeneratorTest.php
+      - backend/docs/seo/career-sitemap-exposure-directory-authority-01.md
+      - backend/docs/seo/generated/career-sitemap-exposure-directory-authority-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change frontend rendering, llms, Search Channel, URL submission, or deployment behavior.
+      - Mutate production CMS, production DB, career cohort state, runtime promotion state, or held slug policy.
+      - Release software-developers, digital-forensics-analysts, or computer-occupations-all-other.
+      - Add frontend fallback career content.
+    validation:
+      - cd backend && php artisan test --filter=CareerSitemapExposureDirectoryAuthorityTest --no-ansi
+      - cd backend && php artisan test --filter=SitemapSourceApiTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/career-sitemap-exposure-directory-authority-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: CAREER-JOBS-PAGINATED-DIRECTORY-SHELL-01


### PR DESCRIPTION
## What changed
- Changed career job detail sitemap enumeration to consume `CareerDirectoryAuthorityService::indexableItems()` instead of direct CMS/display-asset-only career detail derivation.
- Kept the existing `/api/v0.5/seo/sitemap-source` runtime projection safety filter intact.
- Added a focused regression proving directory-authority career jobs emit EN/ZH sitemap URLs while display-asset-only and held slugs do not.
- Reconciled PR1 ledger state as merged and registered only the current PR2 manifest/state entry.

## Why
This is the second step in the 10k-scale career directory train. Sitemap career detail exposure must derive from the same backend directory authority that will power paginated frontend directory views, avoiding drift between job index, sitemap, and runtime publication gates.

## Validation
- `cd backend && php artisan test --filter=CareerSitemapExposureDirectoryAuthorityTest --no-ansi` passed.
- `cd backend && php artisan test --filter=SitemapSourceApiTest --no-ansi` passed.
- `cd backend && php artisan test --filter=SitemapGeneratorTest --no-ansi` passed.
- `cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi` passed.
- `cd backend && php artisan route:list --no-ansi` passed.
- `cd backend && vendor/bin/pint --test app/Services/Career/CareerDirectoryAuthorityService.php app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/CareerSitemapExposureDirectoryAuthorityTest.php tests/Feature/SEO/SitemapGeneratorTest.php` passed.
- `cd backend && composer validate --strict` passed.
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` passed.
- JSON/YAML parse checks passed.
- `git diff --check && git diff --cached --check` passed.

## Sidecar
- `cd backend && vendor/bin/pint --test` still fails on pre-existing out-of-scope EQ style issues in:
  - `tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php`
  - `tests/Unit/Report/EqIntegratedReportComposerTest.php`
- Current PR does not touch those files and scoped Pint passed.

## Intentionally deferred
- Frontend `/career/jobs` pagination shell remains PR3.
- `llms.txt` / `llms-full.txt` authority consumption remains PR4.
- 10k warm/validate ops gate remains PR5.
- No deploy, CMS/DB mutation, Search Channel action, URL submission, or held slug release was performed.
