### PR TITLE
docs(foundation): validate Daily Giving backend runtime

### DIFF
--- a/backend/docs/seo/generated/pr-fdn-02a-post-deploy-runtime-validation.v1.json
+++ b/backend/docs/seo/generated/pr-fdn-02a-post-deploy-runtime-validation.v1.json
@@ -1,0 +1,127 @@
+{
+  "schema_version": "pr-fdn-02a-post-deploy-runtime-validation.v1",
+  "task": "PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION",
+  "final_decision": "pr_fdn_02a_post_deploy_runtime_validation_completed_with_ops_sidecar",
+  "validated_at": "2026-06-01T04:27:53Z",
+  "backend_mvp_pr": {
+    "number": 1758,
+    "title": "PR-FDN-02A: Add daily giving ledger backend MVP",
+    "merge_commit": "dc51d31168027a105b644da5e6e85338cbbb4277",
+    "merged_at": "2026-05-30T02:10:57Z",
+    "github_checks": "success"
+  },
+  "route_contract": {
+    "registered": true,
+    "routes": [
+      "GET /api/v0.5/foundation/giving-records",
+      "GET /api/v0.5/foundation/giving-records/{recordCode}",
+      "GET /api/v0.5/foundation/giving-records/months",
+      "GET /api/v0.5/foundation/giving-records/months/{yearMonth}"
+    ]
+  },
+  "runtime_state": {
+    "direct_api_node_https": {
+      "records_endpoint": {
+        "status": 200,
+        "content_type": "application/json",
+        "keys": [
+          "ok",
+          "items",
+          "pagination"
+        ],
+        "item_count": 0
+      },
+      "months_endpoint": {
+        "status": 200,
+        "content_type": "application/json",
+        "keys": [
+          "ok",
+          "months"
+        ],
+        "month_count": 0
+      }
+    },
+    "direct_api_curl": {
+      "status": "ops_sidecar_ssl_error_syscall",
+      "http_code": "000",
+      "ssl_verify_result": 1
+    },
+    "apex_same_origin": {
+      "records_endpoint": {
+        "status": 200,
+        "content_type": "application/json",
+        "keys": [
+          "ok",
+          "items",
+          "pagination"
+        ],
+        "item_count": 0,
+        "pagination_total": 0
+      },
+      "months_endpoint": {
+        "status": 200,
+        "content_type": "application/json",
+        "keys": [
+          "ok",
+          "months"
+        ],
+        "month_count": 0
+      }
+    },
+    "www_same_origin": {
+      "records_endpoint": {
+        "status": 200,
+        "after_redirect": true
+      }
+    }
+  },
+  "api_contract_state": {
+    "list_shape": [
+      "ok",
+      "items",
+      "pagination"
+    ],
+    "months_shape": [
+      "ok",
+      "months"
+    ],
+    "current_public_record_count": 0,
+    "current_public_month_count": 0,
+    "empty_public_ledger_response_expected": true
+  },
+  "privacy_boundary_state": {
+    "private_fields_excluded_by_contract": true,
+    "private_fields": [
+      "proof_private_path",
+      "receipt_reference_private",
+      "internal_notes",
+      "proof_redaction_notes",
+      "created_by_admin_user_id",
+      "updated_by_admin_user_id"
+    ],
+    "live_payload_private_field_check": "not_applicable_empty_public_items",
+    "source_and_focused_tests_verify_boundary": true
+  },
+  "publication_gate_state": {
+    "published_public_scope_present": true,
+    "planned_records_excluded": true,
+    "voided_records_excluded": true,
+    "non_public_records_excluded": true
+  },
+  "sidecars": [
+    {
+      "id": "api_direct_curl_tls_reset",
+      "status": "open",
+      "description": "Direct macOS curl to api.fermatmind.com returns LibreSSL SSL_ERROR_SYSCALL, while Node HTTPS and apex same-origin reads return HTTP 200."
+    }
+  ],
+  "no_production_mutation": true,
+  "no_cms_mutation": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_api_call": true,
+  "no_credentials_handled": true,
+  "no_env_dns_nginx_edit": true,
+  "next_task": "PR-FDN-02B-POST-DEPLOY-RUNTIME-SMOKE"
+}

--- a/backend/docs/seo/pr-fdn-02a-post-deploy-runtime-validation.md
+++ b/backend/docs/seo/pr-fdn-02a-post-deploy-runtime-validation.md
@@ -1,0 +1,86 @@
+# PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION
+
+## Executive Summary
+
+PR-FDN-02A backend MVP is deployed and the public Foundation Daily Giving API contract is reachable through the production runtime.
+
+Read-only runtime checks on 2026-06-01 confirmed:
+
+- `https://api.fermatmind.com/api/v0.5/foundation/giving-records` returns HTTP 200 through Node HTTPS.
+- `https://api.fermatmind.com/api/v0.5/foundation/giving-records/months` returns HTTP 200 through Node HTTPS.
+- `https://fermatmind.com/api/v0.5/foundation/giving-records` returns HTTP 200 through apex same-origin.
+- `https://fermatmind.com/api/v0.5/foundation/giving-records/months` returns HTTP 200 through apex same-origin.
+- Current public record count is 0, so the live payload is an empty public ledger response, not a private-data fixture.
+
+The only remaining runtime sidecar is the already-known direct `curl` path issue to `api.fermatmind.com`, where macOS LibreSSL reports `SSL_ERROR_SYSCALL`. Application-layer Node HTTPS and same-origin apex API reads are healthy.
+
+## Backend MVP Source
+
+The backend MVP was introduced by fap-api PR #1758:
+
+- PR: `PR-FDN-02A: Add daily giving ledger backend MVP`
+- Merge commit: `dc51d31168027a105b644da5e6e85338cbbb4277`
+- Merged at: `2026-05-30T02:10:57Z`
+- GitHub checks: passed
+
+## Route Contract
+
+Local route registration confirms the Foundation Daily Giving public API routes are present:
+
+- `GET /api/v0.5/foundation/giving-records`
+- `GET /api/v0.5/foundation/giving-records/{recordCode}`
+- `GET /api/v0.5/foundation/giving-records/months`
+- `GET /api/v0.5/foundation/giving-records/months/{yearMonth}`
+
+## Runtime Contract
+
+Observed production payload shapes:
+
+- List endpoint: `ok`, `items`, `pagination`
+- Months endpoint: `ok`, `months`
+
+The live list currently returns `items=[]` and pagination total `0`. That is acceptable for a deployed MVP with no public ledger rows yet.
+
+## Privacy Boundary
+
+The deployed source contract and focused backend tests keep private operational fields out of public API payloads:
+
+- `proof_private_path`
+- `receipt_reference_private`
+- `internal_notes`
+- `proof_redaction_notes`
+- `created_by_admin_user_id`
+- `updated_by_admin_user_id`
+
+The public API uses the `publishedPublic()` record scope and the `toPublicArray()` model boundary.
+
+## Publication Gate
+
+The public API is bounded to published public records. Planned, voided, and non-public records are excluded by model scope and feature tests.
+
+## Sidecar Issues
+
+`curl` direct to `https://api.fermatmind.com` still fails from the local macOS path with LibreSSL `SSL_ERROR_SYSCALL`. This is classified as the existing OPS API direct TLS path sidecar. It does not block the backend MVP validation because:
+
+- Node HTTPS direct API reads return HTTP 200.
+- Apex same-origin API reads return HTTP 200.
+- Frontend Node1 can use same-origin public API rewrites for Foundation surfaces.
+
+## What Was Not Done
+
+- No production data was mutated.
+- No CMS data was mutated.
+- No deploy was performed.
+- No Search Channel action was performed.
+- No URLs were submitted.
+- No external search or social API was called.
+- No credentials were handled.
+- No env, DNS, or nginx changes were made.
+
+## Final Decision
+
+`pr_fdn_02a_post_deploy_runtime_validation_completed_with_ops_sidecar`
+
+## Next Task
+
+`PR-FDN-02B-POST-DEPLOY-RUNTIME-SMOKE`

--- a/backend/tests/Feature/Foundation/PrFdn02aPostDeployRuntimeValidationTest.php
+++ b/backend/tests/Feature/Foundation/PrFdn02aPostDeployRuntimeValidationTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PrFdn02aPostDeployRuntimeValidationTest extends TestCase
+{
+    #[Test]
+    public function generated_runtime_validation_artifact_locks_read_only_boundaries(): void
+    {
+        $reportPath = base_path('docs/seo/pr-fdn-02a-post-deploy-runtime-validation.md');
+        $generatedPath = base_path('docs/seo/generated/pr-fdn-02a-post-deploy-runtime-validation.v1.json');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($generatedPath);
+
+        $payload = json_decode((string) file_get_contents($generatedPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION', $payload['task'] ?? null);
+        $this->assertSame(
+            'pr_fdn_02a_post_deploy_runtime_validation_completed_with_ops_sidecar',
+            $payload['final_decision'] ?? null
+        );
+        $this->assertSame(1758, $payload['backend_mvp_pr']['number'] ?? null);
+        $this->assertSame(
+            'dc51d31168027a105b644da5e6e85338cbbb4277',
+            $payload['backend_mvp_pr']['merge_commit'] ?? null
+        );
+
+        $this->assertTrue($payload['route_contract']['registered'] ?? false);
+        $this->assertSame(200, $payload['runtime_state']['apex_same_origin']['records_endpoint']['status'] ?? null);
+        $this->assertSame(200, $payload['runtime_state']['direct_api_node_https']['records_endpoint']['status'] ?? null);
+        $this->assertSame(
+            'ops_sidecar_ssl_error_syscall',
+            $payload['runtime_state']['direct_api_curl']['status'] ?? null
+        );
+
+        $this->assertTrue($payload['privacy_boundary_state']['private_fields_excluded_by_contract'] ?? false);
+        $this->assertContains('proof_private_path', $payload['privacy_boundary_state']['private_fields'] ?? []);
+        $this->assertTrue($payload['publication_gate_state']['planned_records_excluded'] ?? false);
+        $this->assertTrue($payload['publication_gate_state']['voided_records_excluded'] ?? false);
+        $this->assertTrue($payload['publication_gate_state']['non_public_records_excluded'] ?? false);
+
+        $this->assertTrue($payload['no_production_mutation'] ?? false);
+        $this->assertTrue($payload['no_cms_mutation'] ?? false);
+        $this->assertTrue($payload['no_deploy'] ?? false);
+        $this->assertTrue($payload['no_search_channel_action'] ?? false);
+        $this->assertTrue($payload['no_url_submission'] ?? false);
+        $this->assertTrue($payload['no_external_api_call'] ?? false);
+        $this->assertTrue($payload['no_credentials_handled'] ?? false);
+        $this->assertTrue($payload['no_env_dns_nginx_edit'] ?? false);
+        $this->assertNotEmpty($payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36523,7 +36523,7 @@
     "repo": "fap-api",
     "branch": "codex/payment-alipay-owner-mismatch-controlled-repair-04",
     "base": "main",
-    "status": "local_checks_passed_with_sidecar",
+    "status": "pr_opened_with_sidecar",
     "title": "PAYMENT-ALIPAY-OWNER-MISMATCH-CONTROLLED-REPAIR-04 state-sync owner mismatch candidate",
     "commit_sha": "a547cf12",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1815",
@@ -37738,6 +37738,89 @@
         "at": "2026-05-31T15:18:00Z",
         "status": "pr_opened_with_sidecar",
         "summary": "Opened PR #1809 and rebased onto latest origin/main from implementation commit c240dd9468f99a4c3411dd2d5e669f50694edca4; GitHub checks must rerun after force-push."
+      }
+    ]
+  },
+  "PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION": {
+    "id": "PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION",
+    "repo": "fap-api",
+    "branch": "codex/pr-fdn-02a-post-deploy-runtime-validation",
+    "base": "main",
+    "status": "local_checks_passed_with_sidecar",
+    "title": "docs(foundation): validate Daily Giving backend runtime",
+    "depends_on": [],
+    "commit_sha": "322bf0d8f0884c48730fc23c2713710315d19863",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1833",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION to fap-api pr-train manifest/state."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to a read-only post-deploy runtime validation report, generated JSON, focused test, and pr-train metadata. No production mutation, CMS mutation, deploy, Search Channel action, URL submission, external API call, credential handling, or env/DNS/nginx edit is performed."
+      },
+      "backend_mvp_source": {
+        "status": "pass",
+        "evidence": "fap-api PR #1758 merged at dc51d31168027a105b644da5e6e85338cbbb4277 with GitHub checks green."
+      },
+      "public_runtime_observation": {
+        "status": "pass_with_sidecar",
+        "evidence": "Node HTTPS direct API and apex same-origin API returned HTTP 200 for Foundation Daily Giving records and months endpoints. Direct macOS curl to api.fermatmind.com remains an OPS TLS path sidecar."
+      },
+      "php artisan test --filter=PrFdn02aPostDeployRuntimeValidation --no-ansi": {
+        "status": "pass",
+        "evidence": "Focused generated-artifact boundary test passed: 1 test, 24 assertions, after initializing local .env in the isolated worktree."
+      },
+      "php artisan route:list --path=foundation --no-ansi": {
+        "status": "pass",
+        "evidence": "Route listing completed successfully and shows four Foundation Daily Giving public API routes."
+      },
+      "vendor/bin/pint --test tests/Feature/Foundation/PrFdn02aPostDeployRuntimeValidationTest.php": {
+        "status": "pass",
+        "evidence": "Scoped formatting check passed for the only PHP file touched by this PR."
+      },
+      "composer validate --strict": {
+        "status": "pass",
+        "evidence": "Composer schema validation passed."
+      },
+      "composer audit --locked --no-interaction --ignore-unreachable": {
+        "status": "pass",
+        "evidence": "No locked dependency advisories reported."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "evidence": "Generated report JSON, pr-train-state JSON, and pr-train YAML parsed successfully."
+      },
+      "git diff --check": {
+        "status": "pass",
+        "evidence": "Whitespace diff check passed before staging."
+      },
+      "reference_fap_web_status": {
+        "status": "pass",
+        "evidence": "Reference-only fap-web worktree is clean and was not modified."
+      }
+    },
+    "failure_reason": "Sidecar only: direct macOS curl to api.fermatmind.com still reports LibreSSL SSL_ERROR_SYSCALL; Node HTTPS and apex same-origin public API reads are healthy.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "next_task": "PR-FDN-02B-POST-DEPLOY-RUNTIME-SMOKE",
+    "history": [
+      {
+        "at": "2026-06-01T04:27:53Z",
+        "status": "in_progress",
+        "summary": "Initialized after user authorization; using isolated worktree from latest origin/main and recording read-only Foundation Daily Giving backend MVP runtime evidence."
+      },
+      {
+        "at": "2026-06-01T04:27:53Z",
+        "status": "local_checks_passed_with_sidecar",
+        "summary": "Focused test, route:list, scoped Pint, composer validate, composer audit, JSON/YAML parsing, and diff checks passed. Direct API curl TLS reset remains an external OPS sidecar."
+      },
+      {
+        "at": "2026-06-01T04:27:53Z",
+        "status": "pr_opened_with_sidecar",
+        "summary": "Opened PR #1833 for the read-only runtime validation report. GitHub checks are pending."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18831,6 +18831,42 @@ prs:
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: PR-FDN-SOCIAL-SYNC-MVP-01
 
+  - id: PR-FDN-02A-POST-DEPLOY-RUNTIME-VALIDATION
+    repo: fap-api
+    depends_on: []
+    branch: codex/pr-fdn-02a-post-deploy-runtime-validation
+    base: main
+    title: "docs(foundation): validate Daily Giving backend runtime"
+    train_scope: foundation_daily_giving_backend_mvp
+    status: in_progress
+    scope:
+      - Produce a read-only post-deploy runtime validation report for the Foundation Daily Giving backend MVP.
+      - Verify public API route registration, runtime response shape, publication gates, privacy boundary, and known OPS sidecars.
+      - Confirm no production mutation, CMS mutation, deploy, Search Channel action, URL submission, external API call, credential handling, or env/DNS/nginx edit is performed.
+    allowed_paths:
+      - backend/docs/seo/pr-fdn-02a-post-deploy-runtime-validation.md
+      - backend/docs/seo/generated/pr-fdn-02a-post-deploy-runtime-validation.v1.json
+      - backend/tests/Feature/Foundation/PrFdn02aPostDeployRuntimeValidationTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate production data or CMS records.
+      - Deploy, submit URLs, enqueue Search Channel, or call external search/social APIs.
+      - Handle credentials or edit env, DNS, or nginx.
+    validation:
+      - cd backend && php artisan test --filter=PrFdn02aPostDeployRuntimeValidation --no-ansi
+      - cd backend && php artisan route:list --path=foundation --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/Foundation/PrFdn02aPostDeployRuntimeValidationTest.php
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/pr-fdn-02a-post-deploy-runtime-validation.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: PR-FDN-02B-POST-DEPLOY-RUNTIME-SMOKE
+
   - id: PR-FDN-SOCIAL-SYNC-MVP-01
     repo: fap-api
     depends_on: [PR-FDN-SOCIAL-SYNC-READINESS]


### PR DESCRIPTION
## What changed
- Added a read-only PR-FDN-02A post-deploy runtime validation report for the Foundation Daily Giving backend MVP.
- Recorded generated JSON evidence for route contract, runtime response shape, privacy boundaries, publication gates, and the known direct API curl TLS sidecar.
- Added a focused artifact test and registered the task in the fap-api PR train manifest/state.

## Why
- Confirms the deployed backend MVP is healthy before continuing Foundation Daily Giving post-deploy frontend smoke work.
- Keeps OPS direct API TLS instability recorded as a sidecar rather than blocking same-origin/runtime validation.

## Validation
- cd backend && php artisan test --filter=PrFdn02aPostDeployRuntimeValidation --no-ansi
- cd backend && php artisan route:list --path=foundation --no-ansi
- cd backend && vendor/bin/pint --test tests/Feature/Foundation/PrFdn02aPostDeployRuntimeValidationTest.php
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/pr-fdn-02a-post-deploy-runtime-validation.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No production mutation, CMS mutation, deploy, Search Channel action, URL submission, external API call, credential handling, or env/DNS/nginx edit.
- Direct macOS curl TLS issue to api.fermatmind.com remains an OPS sidecar; Node HTTPS and apex same-origin reads are healthy.