### PR TITLE
PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 compensate Alipay return immediately

### DIFF
--- a/backend/app/Http/Controllers/API/V0_3/CommerceController.php
+++ b/backend/app/Http/Controllers/API/V0_3/CommerceController.php
@@ -8,6 +8,7 @@ use App\Services\BigFive\BigFivePublicFormSummaryBuilder;
 use App\Services\Commerce\Checkout\AlipayCheckoutService;
 use App\Services\Commerce\Checkout\LemonSqueezyCheckoutService;
 use App\Services\Commerce\Checkout\WechatPayCheckoutService;
+use App\Services\Commerce\Compensation\PendingOrderCompensationService;
 use App\Services\Commerce\MbtiAccessHubBuilder;
 use App\Services\Commerce\OrderManager;
 use App\Services\Commerce\SkuCatalog;
@@ -45,6 +46,7 @@ class CommerceController extends Controller
         private WechatPayCheckoutService $wechatPayCheckout,
         private AlipayCheckoutService $alipayCheckout,
         private ResultAccessTokenService $resultAccessTokens,
+        private PendingOrderCompensationService $pendingOrderCompensation,
     ) {}
 
     /**
@@ -326,6 +328,9 @@ class CommerceController extends Controller
             ], $bindingError['status']);
         }
 
+        $this->compensateAlipayReturnOrder($normalizedRouteOrderNo);
+        $order = $this->orders->findOrderByOrderNo($normalizedRouteOrderNo, $this->orgContext->orgId()) ?? $order;
+
         $paymentRecoveryToken = $this->orders->issuePaymentRecoveryToken($order);
         $recoveryUrls = $this->orders->presentPaymentRecoveryUrls(
             $order,
@@ -340,6 +345,37 @@ class CommerceController extends Controller
             'wait_url' => $recoveryUrls['wait_url'],
             'result_url' => $recoveryUrls['result_url'],
         ]);
+    }
+
+    private function compensateAlipayReturnOrder(string $orderNo): void
+    {
+        try {
+            $summary = $this->pendingOrderCompensation->compensate([
+                'provider' => 'alipay',
+                'order' => $orderNo,
+                'limit' => 1,
+                'older_than_minutes' => 0,
+                'include_created' => true,
+                'only_stale' => false,
+                'close_expired' => false,
+                'dry_run' => false,
+            ]);
+
+            Log::info('ALIPAY_RETURN_RECOVERY_COMPENSATED', [
+                'order_no' => $orderNo,
+                'candidate_count' => (int) ($summary['candidate_count'] ?? 0),
+                'queried_count' => (int) ($summary['queried_count'] ?? 0),
+                'paid_count' => (int) ($summary['paid_count'] ?? 0),
+                'repair_candidate_count' => (int) ($summary['repair_candidate_count'] ?? 0),
+                'repair_repaired_count' => (int) ($summary['repair_repaired_count'] ?? 0),
+                'unresolved_count' => (int) ($summary['unresolved_count'] ?? 0),
+            ]);
+        } catch (\Throwable $e) {
+            Log::warning('ALIPAY_RETURN_RECOVERY_COMPENSATION_FAILED', [
+                'order_no' => $orderNo,
+                'exception' => mb_substr($e->getMessage(), 0, 255),
+            ]);
+        }
     }
 
     /**

--- a/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
+++ b/backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\V0_3;
 
+use App\Models\Order;
+use App\Models\PaymentAttempt;
+use App\Services\Commerce\Compensation\Gateways\AlipayLifecycleGateway;
+use Database\Seeders\Pr19CommerceSeeder;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Str;
@@ -67,6 +71,72 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         $response->assertJsonPath('payment_recovery_token', fn ($value) => is_string($value) && $value !== '');
         $this->assertStringContainsString('/en/pay/wait?order_no='.$orderNo, (string) $response->json('wait_url'));
         $this->assertStringNotContainsString('payment_recovery_token=', (string) $response->json('wait_url'));
+    }
+
+    public function test_recover_alipay_return_immediately_queries_provider_and_repairs_paid_order(): void
+    {
+        ['private' => $privateKey, 'public' => $publicKey] = $this->generateRsaKeyPair();
+        config([
+            'app.frontend_url' => 'https://web.example.test',
+            'payments.providers.alipay.enabled' => true,
+            'pay.alipay.default.app_id' => 'app_alipay_return_recovery',
+            'pay.alipay.default.seller_id' => 'seller_alipay_return_recovery',
+            'pay.alipay.default.alipay_public_cert_path' => $publicKey,
+        ]);
+        (new Pr19CommerceSeeder)->run();
+
+        $attemptId = $this->insertAttempt('anon_alipay_return_recovery_compensate');
+        $orderNo = $this->insertOrder('anon_alipay_return_recovery_compensate', [
+            'sku' => 'MBTI_REPORT_FULL',
+            'item_sku' => 'MBTI_REPORT_FULL',
+            'target_attempt_id' => $attemptId,
+            'provider_app' => 'app_alipay_return_recovery',
+            'status' => Order::STATUS_PENDING,
+            'payment_state' => Order::PAYMENT_STATE_PENDING,
+            'grant_state' => Order::GRANT_STATE_NOT_STARTED,
+        ]);
+        $orderId = (string) DB::table('orders')->where('order_no', $orderNo)->value('id');
+        $this->insertPaymentAttempt($orderId, $orderNo);
+
+        $this->app->instance(AlipayLifecycleGateway::class, new class extends AlipayLifecycleGateway
+        {
+            protected function dispatchQuery(array $order): array
+            {
+                return [
+                    'trade_status' => 'TRADE_SUCCESS',
+                    'trade_no' => 'ali_trade_return_recovery_compensate',
+                    'gmt_payment' => '2026-04-02 12:00:00',
+                ];
+            }
+        });
+
+        $payload = [
+            'app_id' => 'app_alipay_return_recovery',
+            'seller_id' => 'seller_alipay_return_recovery',
+            'out_trade_no' => $orderNo,
+            'trade_no' => 'ali_trade_return_recovery_compensate',
+            'trade_status' => 'TRADE_SUCCESS',
+            'total_amount' => '19.90',
+            'sign_type' => 'RSA2',
+            'notify_time' => '2026-04-02 12:00:00',
+        ];
+        $payload['sign'] = $this->buildAlipaySignature($payload, $privateKey);
+
+        $response = $this->withHeaders([
+            'X-Anon-Id' => 'anon_alipay_return_recovery_compensate',
+            'X-Locale' => 'zh',
+        ])->get('/api/v0.3/orders/'.$orderNo.'/recover/alipay-return?'.http_build_query($payload));
+
+        $response->assertOk();
+        $response->assertJsonPath('ok', true);
+
+        $freshOrder = DB::table('orders')->where('order_no', $orderNo)->first();
+        $this->assertSame(Order::PAYMENT_STATE_PAID, (string) ($freshOrder->payment_state ?? ''));
+        $this->assertSame(Order::GRANT_STATE_GRANTED, (string) ($freshOrder->grant_state ?? ''));
+        $this->assertSame(Order::STATUS_FULFILLED, (string) ($freshOrder->status ?? ''));
+        $this->assertSame('ali_trade_return_recovery_compensate', (string) ($freshOrder->provider_trade_no ?? ''));
+        $this->assertNotNull($freshOrder->last_reconciled_at ?? null);
+        $this->assertSame(1, DB::table('benefit_grants')->where('order_no', $orderNo)->where('status', 'active')->count());
     }
 
     public function test_recover_alipay_return_rejects_invalid_signature(): void
@@ -430,6 +500,72 @@ final class AlipayReturnRecoveryEndpointTest extends TestCase
         ], $overrides));
 
         return $orderNo;
+    }
+
+    private function insertAttempt(string $anonId): string
+    {
+        $attemptId = (string) Str::uuid();
+        $timestamp = now()->subHours(2);
+
+        DB::table('attempts')->insert([
+            'id' => $attemptId,
+            'org_id' => 0,
+            'anon_id' => $anonId,
+            'user_id' => null,
+            'scale_code' => 'MBTI',
+            'scale_version' => 'v0.3',
+            'region' => 'CN_MAINLAND',
+            'locale' => 'zh-CN',
+            'question_count' => 144,
+            'answers_summary_json' => json_encode(['stage' => 'alipay-return-compensation'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'test',
+            'started_at' => $timestamp,
+            'submitted_at' => $timestamp,
+            'pack_id' => 'MBTI.cn-mainland.zh-CN.v0.3',
+            'dir_version' => 'MBTI-CN-v0.3',
+            'content_package_version' => 'v0.3',
+            'scoring_spec_version' => '2026.01',
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
+
+        return $attemptId;
+    }
+
+    private function insertPaymentAttempt(string $orderId, string $orderNo): void
+    {
+        $timestamp = now()->subHours(2);
+
+        DB::table('payment_attempts')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => 0,
+            'order_id' => $orderId,
+            'order_no' => $orderNo,
+            'attempt_no' => 1,
+            'provider' => 'alipay',
+            'channel' => 'web',
+            'provider_app' => 'app_alipay_return_recovery',
+            'pay_scene' => 'web',
+            'state' => PaymentAttempt::STATE_CLIENT_PRESENTED,
+            'external_trade_no' => null,
+            'provider_trade_no' => null,
+            'provider_session_ref' => null,
+            'amount_expected' => 1990,
+            'currency' => 'CNY',
+            'payload_meta_json' => json_encode(['source' => 'test'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'latest_payment_event_id' => null,
+            'initiated_at' => $timestamp,
+            'provider_created_at' => $timestamp,
+            'client_presented_at' => $timestamp,
+            'callback_received_at' => null,
+            'verified_at' => null,
+            'finalized_at' => null,
+            'last_error_code' => null,
+            'last_error_message' => null,
+            'meta_json' => null,
+            'created_at' => $timestamp,
+            'updated_at' => $timestamp,
+        ]);
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31103,6 +31103,132 @@
           "note": "Recorded cross-repo fap-web IQ-RELEASE-01 completion in fap-api state because fap-api manifest also declares this train item."
         }
       ]
+    },
+    "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05": {
+      "id": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05",
+      "repo": "fap-api",
+      "branch": "codex/payment-alipay-return-immediate-compensation-05",
+      "base": "main",
+      "status": "pr_open",
+      "title": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 compensate Alipay return immediately",
+      "depends_on": [
+        "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02"
+      ],
+      "commit_sha": "a843d4f1",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1834",
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User requested the three-PR payment/result train and authorized implementing PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 under one-PR-one-scope discipline."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "Scope is limited to Alipay return recovery immediate compensation in CommerceController, focused Alipay return recovery coverage, and pr-train metadata; no production env, deploy, CMS/content, Search Channel, URL submission, or fap-web changes."
+        },
+        "alipay_return_recovery_endpoint": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=AlipayReturnRecoveryEndpoint --no-ansi",
+          "evidence": "PASS: 13 tests, 45 assertions; includes immediate provider query + paid/grant repair on signed Alipay return."
+        },
+        "pending_order_lifecycle_compensation": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi",
+          "evidence": "PASS: 2 tests, 15 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "PASS: route:list rendered 210 routes."
+        },
+        "pint_full": {
+          "status": "external_sidecar",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "FAILED only on pre-existing out-of-scope style issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php."
+        },
+        "pint_scoped": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/CommerceController.php tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php",
+          "evidence": "PASS: 2 scoped files."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "PASS: composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "PASS: no security vulnerability advisories found."
+        },
+        "json_yaml_parse": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "evidence": "PASS: JSON and YAML parsed."
+        },
+        "diff_check": {
+          "status": "pass",
+          "command": "git diff --check && git diff --cached --check",
+          "evidence": "PASS: working and cached diff whitespace checks passed."
+        },
+        "fap_web_reference_status": {
+          "status": "pass",
+          "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
+          "evidence": "PASS: fap-web reference worktree clean."
+        },
+        "pr_created": {
+          "status": "pass",
+          "pr_url": "https://github.com/fermatmind/fap-api/pull/1834",
+          "title": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 compensate Alipay return immediately"
+        },
+        "github_checks": {
+          "status": "pending",
+          "evidence": "PR opened; remote checks pending."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "git_diff_check": "passed",
+        "git_diff_cached_check": "passed"
+      },
+      "transitions": [
+        {
+          "status": "authorized",
+          "at": "2026-06-01T12:21:00+08:00",
+          "summary": "User authorized a three-PR train and requested PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 as the second scoped PR."
+        },
+        {
+          "status": "in_progress",
+          "at": "2026-06-01T12:21:00+08:00",
+          "summary": "Implementing immediate targeted Alipay pending compensation after signed return recovery binding passes."
+        },
+        {
+          "status": "local_checks_passed_with_sidecar",
+          "at": "2026-06-01T12:52:00+08:00",
+          "summary": "Focused Alipay return recovery, pending compensation lifecycle, route:list, scoped Pint, composer validate/audit, JSON/YAML parse, fap-web reference status, and diff checks passed. Full Pint external sidecar recorded for out-of-scope pre-existing style issues."
+        },
+        {
+          "status": "committed",
+          "at": "2026-06-01T13:02:00+08:00",
+          "summary": "Committed scoped Alipay return immediate compensation at a843d4f1."
+        },
+        {
+          "status": "pr_open",
+          "at": "2026-06-01T13:04:00+08:00",
+          "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1834 after scoped local validation."
+        }
+      ],
+      "sidecars": [
+        {
+          "id": "FAP-API-PINT-EXTERNAL-EQ-REPORT-STYLE",
+          "status": "open_external",
+          "summary": "Full vendor/bin/pint --test currently fails on two pre-existing out-of-scope unit test style issues unrelated to this Alipay return compensation PR; scoped Pint on changed files passes."
+        }
+      ],
+      "next_task": "PAYMENT-WAIT-PAID-REDIRECT-CONTRACT-06"
     }
   },
   "RESULT-EN-PARITY-04": {
@@ -38072,5 +38198,131 @@
         "summary": "Committed current-scope CI fixes as 22c84ad5c11fe0bf5d547bcf9fa587a1b71f6369."
       }
     ]
+  },
+  "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05": {
+    "id": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05",
+    "repo": "fap-api",
+    "branch": "codex/payment-alipay-return-immediate-compensation-05",
+    "base": "main",
+    "status": "pr_open",
+    "title": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 compensate Alipay return immediately",
+    "depends_on": [
+      "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02"
+    ],
+    "commit_sha": "a843d4f1",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1834",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User requested the three-PR payment/result train and authorized implementing PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 under one-PR-one-scope discipline."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to Alipay return recovery immediate compensation in CommerceController, focused Alipay return recovery coverage, and pr-train metadata; no production env, deploy, CMS/content, Search Channel, URL submission, or fap-web changes."
+      },
+      "alipay_return_recovery_endpoint": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AlipayReturnRecoveryEndpoint --no-ansi",
+        "evidence": "PASS: 13 tests, 45 assertions; includes immediate provider query + paid/grant repair on signed Alipay return."
+      },
+      "pending_order_lifecycle_compensation": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi",
+        "evidence": "PASS: 2 tests, 15 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS: route:list rendered 210 routes."
+      },
+      "pint_full": {
+        "status": "external_sidecar",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "FAILED only on pre-existing out-of-scope style issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php."
+      },
+      "pint_scoped": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/CommerceController.php tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php",
+        "evidence": "PASS: 2 scoped files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS: composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS: no security vulnerability advisories found."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+        "evidence": "PASS: JSON and YAML parsed."
+      },
+      "diff_check": {
+        "status": "pass",
+        "command": "git diff --check && git diff --cached --check",
+        "evidence": "PASS: working and cached diff whitespace checks passed."
+      },
+      "fap_web_reference_status": {
+        "status": "pass",
+        "command": "cd /Users/rainie/Desktop/GitHub/fap-web && git status --short",
+        "evidence": "PASS: fap-web reference worktree clean."
+      },
+      "pr_created": {
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1834",
+        "title": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 compensate Alipay return immediately"
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR opened; remote checks pending."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-06-01T12:21:00+08:00",
+        "summary": "User authorized a three-PR train and requested PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 as the second scoped PR."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-06-01T12:21:00+08:00",
+        "summary": "Implementing immediate targeted Alipay pending compensation after signed return recovery binding passes."
+      },
+      {
+        "status": "local_checks_passed_with_sidecar",
+        "at": "2026-06-01T12:52:00+08:00",
+        "summary": "Focused Alipay return recovery, pending compensation lifecycle, route:list, scoped Pint, composer validate/audit, JSON/YAML parse, fap-web reference status, and diff checks passed. Full Pint external sidecar recorded for out-of-scope pre-existing style issues."
+      },
+      {
+        "status": "committed",
+        "at": "2026-06-01T13:02:00+08:00",
+        "summary": "Committed scoped Alipay return immediate compensation at a843d4f1."
+      },
+      {
+        "status": "pr_open",
+        "at": "2026-06-01T13:04:00+08:00",
+        "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1834 after scoped local validation."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "FAP-API-PINT-EXTERNAL-EQ-REPORT-STYLE",
+        "status": "open_external",
+        "summary": "Full vendor/bin/pint --test currently fails on two pre-existing out-of-scope unit test style issues unrelated to this Alipay return compensation PR; scoped Pint on changed files passes."
+      }
+    ],
+    "next_task": "PAYMENT-WAIT-PAID-REDIRECT-CONTRACT-06"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17543,6 +17543,50 @@ prs:
     frontend_fallback_authority: false
     next_task: deploy-readiness and production scheduler runner verification required after merge
 
+  - id: PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05
+    repo: fap-api
+    branch: codex/payment-alipay-return-immediate-compensation-05
+    base: main
+    title: "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05 compensate Alipay return immediately"
+    train_scope: payment_alipay_return_immediate_compensation
+    risk_level: p1_payment_fulfillment_reliability
+    depends_on:
+      - PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_3/CommerceController.php
+      - backend/tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - After Alipay return/recovery signature validation and order binding succeed, immediately run the existing targeted Alipay pending-order compensation service for that order.
+      - Reuse the existing provider query, paid transition, grant repair, and projection repair chain instead of adding a new payment repair path.
+      - Keep the return recovery response available even if the provider query has a transient failure; record bounded compensation telemetry without printing secrets.
+      - Do not change production env, deploy, mutate CMS/content, submit URLs, enqueue Search Channel actions, or modify fap-web in this PR.
+    validation:
+      - cd backend && php artisan test --filter=AlipayReturnRecoveryEndpoint --no-ansi
+      - cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: PAYMENT-WAIT-PAID-REDIRECT-CONTRACT-06
+
   - id: PAYMENT-ALIPAY-OWNER-MISMATCH-REVIEW-03
     repo: fap-api
     branch: codex/payment-alipay-owner-mismatch-review-03


### PR DESCRIPTION
## What changed
- Runs the existing targeted Alipay pending-order compensation service immediately after signed Alipay return recovery and order-binding validation succeeds.
- Refreshes the order before issuing the payment recovery token so wait/result URLs see the repaired paid/grant/projection state as soon as possible.
- Adds focused coverage proving a signed Alipay return triggers provider query, paid transition, active grant repair, and fulfilled lifecycle state.
- Registers this scoped PR in the fap-api PR train ledger.

## Why
Alipay can show payment success in the browser while the local webhook/scheduler path has not repaired the order yet. The return/recovery endpoint should not wait for the stale-order scheduler before repairing a provider-confirmed paid order.

## Validation
- `cd backend && php artisan test --filter=AlipayReturnRecoveryEndpoint --no-ansi`
- `cd backend && php artisan test --filter=PendingOrderLifecycleCompensation --no-ansi`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && vendor/bin/pint --test app/Http/Controllers/API/V0_3/CommerceController.php tests/Feature/V0_3/AlipayReturnRecoveryEndpointTest.php`
- `cd backend && composer validate --strict`
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- Full `vendor/bin/pint --test` currently reports two pre-existing out-of-scope style issues in `tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php` and `tests/Unit/Report/EqIntegratedReportComposerTest.php`; scoped Pint on changed files passes and the external issue is recorded as a sidecar.
- No production env changes, deploy, CMS mutation, Search Channel action, URL submission, or fap-web changes.
