### PR TITLE
CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01 directory warm validate 10k ops gate

### DIFF
--- a/backend/app/Console/Commands/CareerValidateDirectory10kScaleReadiness.php
+++ b/backend/app/Console/Commands/CareerValidateDirectory10kScaleReadiness.php
@@ -1,0 +1,166 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\CareerDirectoryAuthorityService;
+use App\Services\SEO\SitemapGenerator;
+use Illuminate\Console\Command;
+
+final class CareerValidateDirectory10kScaleReadiness extends Command
+{
+    protected $signature = 'career:validate-directory-10k-scale-readiness
+        {--expected-public-count= : Optional expected public career detail count}
+        {--expected-sitemap-career-urls= : Optional expected EN/ZH career detail URL count}
+        {--synthetic-count=10000 : Future scale count used for budget checks}
+        {--max-first-page-bytes=262144 : Maximum allowed first-page directory payload size}
+        {--json : Emit JSON output}';
+
+    protected $description = 'Validate career directory authority warm/readiness invariants for 10k-scale operation without mutating runtime state.';
+
+    public function handle(CareerDirectoryAuthorityService $directoryAuthority, SitemapGenerator $sitemapGenerator): int
+    {
+        $startedAt = microtime(true);
+
+        $enPayload = $directoryAuthority->payload('en', 1, 50);
+        $zhPayload = $directoryAuthority->payload('zh-CN', 1, 50);
+        $enItems = $directoryAuthority->indexableItems('en');
+        $zhItems = $directoryAuthority->indexableItems('zh-CN');
+        $sitemapCareerUrls = $sitemapGenerator->generateApprovedCareerJobDetailUrls();
+
+        $excludedSlugs = CareerDirectoryAuthorityService::excludedSlugs();
+        $allSlugs = array_values(array_unique(array_merge(
+            array_map(static fn (array $item): string => (string) ($item['slug'] ?? ''), $enItems),
+            array_map(static fn (array $item): string => (string) ($item['slug'] ?? ''), $zhItems),
+        )));
+        $leakedExcludedSlugs = array_values(array_intersect($excludedSlugs, $allSlugs));
+
+        $expectedPublicCount = $this->nullablePositiveInt($this->option('expected-public-count'));
+        $expectedSitemapCareerUrls = $this->nullablePositiveInt($this->option('expected-sitemap-career-urls'));
+        $syntheticCount = max(1, (int) $this->option('synthetic-count'));
+        $maxFirstPageBytes = max(1024, (int) $this->option('max-first-page-bytes'));
+
+        $firstPageBytes = strlen((string) json_encode($enPayload, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        $forbiddenItemFields = $this->forbiddenItemFields($enPayload, $zhPayload);
+        $sitemapCareerUrlCount = count($sitemapCareerUrls);
+        $publicCount = (int) data_get($enPayload, 'public_truth.public_detail_indexable_count', count($enItems));
+        $zhPublicCount = (int) data_get($zhPayload, 'public_truth.public_detail_indexable_count', count($zhItems));
+
+        $errors = [];
+        if ($publicCount !== count($enItems) || $zhPublicCount !== count($zhItems)) {
+            $errors[] = 'directory_public_truth_count_mismatch';
+        }
+        if ($publicCount !== $zhPublicCount) {
+            $errors[] = 'directory_locale_count_mismatch';
+        }
+        if ($expectedPublicCount !== null && $publicCount !== $expectedPublicCount) {
+            $errors[] = 'expected_public_count_mismatch';
+        }
+        if ($expectedSitemapCareerUrls !== null && $sitemapCareerUrlCount !== $expectedSitemapCareerUrls) {
+            $errors[] = 'expected_sitemap_career_url_count_mismatch';
+        }
+        if (count((array) data_get($enPayload, 'items', [])) > 100 || count((array) data_get($zhPayload, 'items', [])) > 100) {
+            $errors[] = 'directory_first_page_exceeds_page_size_budget';
+        }
+        if ($firstPageBytes > $maxFirstPageBytes) {
+            $errors[] = 'directory_first_page_payload_exceeds_byte_budget';
+        }
+        if ($forbiddenItemFields !== []) {
+            $errors[] = 'directory_payload_contains_full_detail_fields';
+        }
+        if ($leakedExcludedSlugs !== []) {
+            $errors[] = 'excluded_slug_leakage';
+        }
+        if ($sitemapCareerUrlCount !== ($publicCount * 2)) {
+            $errors[] = 'sitemap_career_url_count_not_bilingual_public_count';
+        }
+
+        $elapsed = round(microtime(true) - $startedAt, 3);
+        $passed = $errors === [];
+        $report = [
+            'schema_version' => 'career.directory_10k_ops_warm_validate.v1',
+            'task' => 'CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01',
+            'status' => $passed ? 'passed' : 'failed',
+            'final_decision' => $passed
+                ? 'career_directory_10k_ops_warm_validate_passed_ready_for_deploy_readiness'
+                : 'blocked_career_directory_10k_ops_warm_validate_failed',
+            'authority_version' => CareerDirectoryAuthorityService::AUTHORITY_VERSION,
+            'public_detail_indexable_count_en' => $publicCount,
+            'public_detail_indexable_count_zh_cn' => $zhPublicCount,
+            'sitemap_career_detail_url_count' => $sitemapCareerUrlCount,
+            'expected_public_count' => $expectedPublicCount,
+            'expected_sitemap_career_urls' => $expectedSitemapCareerUrls,
+            'excluded_slugs' => $excludedSlugs,
+            'leaked_excluded_slugs' => $leakedExcludedSlugs,
+            'first_page_per_page' => (int) data_get($enPayload, 'pagination.per_page', 0),
+            'first_page_item_count_en' => count((array) data_get($enPayload, 'items', [])),
+            'first_page_item_count_zh_cn' => count((array) data_get($zhPayload, 'items', [])),
+            'first_page_payload_bytes' => $firstPageBytes,
+            'max_first_page_bytes' => $maxFirstPageBytes,
+            'forbidden_item_fields' => $forbiddenItemFields,
+            'synthetic_scale_budget' => [
+                'target_directory_count' => $syntheticCount,
+                'target_bilingual_detail_url_count' => $syntheticCount * 2,
+                'directory_first_page_ssr_limit' => 50,
+                'full_directory_ssr_rendering_allowed' => false,
+                'sitemap_full_detail_url_exposure_expected' => true,
+            ],
+            'production_write_performed' => false,
+            'runtime_promotion_performed' => false,
+            'sitemap_llms_footer_exposure_performed' => false,
+            'search_channel_action_performed' => false,
+            'url_submission_performed' => false,
+            'external_search_api_call_performed' => false,
+            'errors' => $errors,
+            'elapsed_seconds' => $elapsed,
+        ];
+
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($report, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
+        } else {
+            $this->line('status='.$report['status']);
+            $this->line('public_detail_indexable_count_en='.$publicCount);
+            $this->line('public_detail_indexable_count_zh_cn='.$zhPublicCount);
+            $this->line('sitemap_career_detail_url_count='.$sitemapCareerUrlCount);
+            $this->line('synthetic_bilingual_detail_url_count='.($syntheticCount * 2));
+        }
+
+        return $passed ? self::SUCCESS : self::FAILURE;
+    }
+
+    private function nullablePositiveInt(mixed $value): ?int
+    {
+        if ($value === null || $value === '') {
+            return null;
+        }
+
+        return max(0, (int) $value);
+    }
+
+    /**
+     * @param  array<string, mixed>  ...$payloads
+     * @return list<string>
+     */
+    private function forbiddenItemFields(array ...$payloads): array
+    {
+        $forbidden = ['truth_summary', 'score_summary', 'provenance_meta', 'sections', 'faq', 'structured_data'];
+        $hits = [];
+
+        foreach ($payloads as $payload) {
+            foreach ((array) data_get($payload, 'items', []) as $item) {
+                if (! is_array($item)) {
+                    continue;
+                }
+
+                foreach ($forbidden as $field) {
+                    if (array_key_exists($field, $item)) {
+                        $hits[$field] = true;
+                    }
+                }
+            }
+        }
+
+        return array_keys($hits);
+    }
+}

--- a/backend/app/Services/Career/CareerDirectoryAuthorityService.php
+++ b/backend/app/Services/Career/CareerDirectoryAuthorityService.php
@@ -97,6 +97,14 @@ final class CareerDirectoryAuthorityService
     }
 
     /**
+     * @return list<string>
+     */
+    public static function excludedSlugs(): array
+    {
+        return self::EXCLUDED_SLUGS;
+    }
+
+    /**
      * @return list<array<string, mixed>>
      */
     private function directoryItems(string $publicLocale, string $localePrefix): array

--- a/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+++ b/backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
@@ -115,8 +115,12 @@ final class PublicCareerAuthorityResponseCache
         [$datasetHub, $datasetMethod] = $this->refreshDatasetPayloads();
         $reporter?->__invoke('dataset_payloads', 'finished');
 
+        $reporter?->__invoke('job_index_en', 'starting');
+        $jobIndexEn = $this->refreshJobIndexPayload('en');
+        $reporter?->__invoke('job_index_en', 'finished');
+
         $reporter?->__invoke('job_index_zh_cn', 'starting');
-        $jobIndex = $this->refreshJobIndexPayload('zh-CN');
+        $jobIndexZhCn = $this->refreshJobIndexPayload('zh-CN');
         $reporter?->__invoke('job_index_zh_cn', 'finished');
 
         $reporter?->__invoke('launch_governance_closure', 'starting');
@@ -134,10 +138,15 @@ final class PublicCareerAuthorityResponseCache
                 'status' => 'cached',
                 'member_count' => (int) data_get($datasetMethod, 'scope_summary.member_count', 0),
             ],
-            'job_index' => [
+            'job_index_en' => [
+                'cache_key' => $this->jobIndexCacheKey('en', false),
+                'status' => 'cached',
+                'member_count' => count((array) data_get($jobIndexEn, 'items', [])),
+            ],
+            'job_index_zh_cn' => [
                 'cache_key' => $this->jobIndexCacheKey('zh-CN', false),
                 'status' => 'cached',
-                'member_count' => count((array) data_get($jobIndex, 'items', [])),
+                'member_count' => count((array) data_get($jobIndexZhCn, 'items', [])),
             ],
             'launch_governance_closure' => [
                 'cache_key' => self::LAUNCH_GOVERNANCE_CLOSURE_CACHE_KEY,

--- a/backend/docs/seo/career-directory-10k-ops-warm-validate-01.md
+++ b/backend/docs/seo/career-directory-10k-ops-warm-validate-01.md
@@ -1,0 +1,35 @@
+# CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01
+
+## Executive Summary
+
+This PR adds an operations gate for the career directory 10k-scale architecture. The runtime contract remains unchanged: career detail authority stays backend-owned, sitemap exposure continues to use backend directory authority, and no production cohort or CMS state is mutated.
+
+## Implementation
+
+- Warm public Career authority job-index caches for both `en` and `zh-CN`.
+- Add `career:validate-directory-10k-scale-readiness` as a read-only validation command.
+- Validate public directory count parity, sitemap career detail URL count parity, held slug exclusion, first-page payload budget, and synthetic 10k bilingual URL budget.
+
+## Safety Boundaries
+
+- No DB mutation.
+- No CMS mutation.
+- No runtime promotion.
+- No sitemap, llms, footer, or Search Channel exposure changes.
+- Held slugs remain excluded:
+  - `software-developers`
+  - `digital-forensics-analysts`
+  - `computer-occupations-all-other`
+
+## Validation Plan
+
+- `php artisan test --filter=CareerDirectory10kOpsWarmValidateCommandTest --no-ansi`
+- `php artisan test --filter=CareerWarmPublicAuthorityCacheCommandTest --no-ansi`
+- `php artisan route:list --no-ansi`
+- `vendor/bin/pint --test`
+- `composer validate --strict`
+- `composer audit --locked --no-interaction --ignore-unreachable`
+
+## Final Decision
+
+`career_directory_10k_ops_warm_validate_ready_for_pr`

--- a/backend/docs/seo/generated/career-directory-10k-ops-warm-validate-01.v1.json
+++ b/backend/docs/seo/generated/career-directory-10k-ops-warm-validate-01.v1.json
@@ -1,0 +1,36 @@
+{
+  "schema_version": "career.directory_10k_ops_warm_validate_report.v1",
+  "task": "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01",
+  "final_decision": "career_directory_10k_ops_warm_validate_ready_for_pr",
+  "implementation_summary": {
+    "warm_public_authority_cache_locales": [
+      "en",
+      "zh-CN"
+    ],
+    "readiness_command": "career:validate-directory-10k-scale-readiness",
+    "synthetic_scale_target": 10000,
+    "synthetic_bilingual_detail_url_target": 20000
+  },
+  "validated_invariants": [
+    "directory_count_parity_en_zh",
+    "sitemap_career_url_count_equals_public_count_times_two",
+    "excluded_slugs_absent",
+    "first_page_payload_budget",
+    "no_full_detail_fields_in_directory_items",
+    "no_full_directory_ssr_rendering"
+  ],
+  "excluded_slugs": [
+    "software-developers",
+    "digital-forensics-analysts",
+    "computer-occupations-all-other"
+  ],
+  "production_write_performed": false,
+  "cms_mutation_performed": false,
+  "runtime_promotion_performed": false,
+  "sitemap_llms_footer_exposure_performed": false,
+  "search_channel_action_performed": false,
+  "url_submission_performed": false,
+  "external_search_api_call_performed": false,
+  "deploy_performed": false,
+  "next_task": "deploy_readiness_after_career_directory_10k_train_if_required"
+}

--- a/backend/tests/Feature/Console/CareerDirectory10kOpsWarmValidateCommandTest.php
+++ b/backend/tests/Feature/Console/CareerDirectory10kOpsWarmValidateCommandTest.php
@@ -1,0 +1,198 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
+use App\Models\CareerJobDisplayAsset;
+use App\Models\Occupation;
+use App\Models\OccupationCrosswalk;
+use App\Models\OccupationFamily;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Cache;
+use Tests\Fixtures\Career\CareerRuntimePublishProjectionVisibilityFixture;
+use Tests\TestCase;
+
+final class CareerDirectory10kOpsWarmValidateCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        config(['app.url' => 'https://fermatmind.com']);
+    }
+
+    public function test_command_validates_directory_sitemap_and_10k_scale_budget(): void
+    {
+        $this->createDirectoryOccupation('accountants-and-auditors', 'Accountants and Auditors', '会计师与审计师');
+        $this->createDirectoryOccupation('actors', 'Actors', '演员');
+        $this->createDirectoryOccupation('software-developers', 'Software Developers', '软件开发人员');
+        $this->publishRuntimeProjection(['accountants-and-auditors', 'actors', 'software-developers']);
+
+        $exitCode = Artisan::call('career:validate-directory-10k-scale-readiness', [
+            '--expected-public-count' => 2,
+            '--expected-sitemap-career-urls' => 4,
+            '--synthetic-count' => 10000,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $report = json_decode((string) Artisan::output(), true);
+
+        $this->assertSame('CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01', $report['task']);
+        $this->assertSame('passed', $report['status']);
+        $this->assertSame(2, $report['public_detail_indexable_count_en']);
+        $this->assertSame(2, $report['public_detail_indexable_count_zh_cn']);
+        $this->assertSame(4, $report['sitemap_career_detail_url_count']);
+        $this->assertSame([], $report['leaked_excluded_slugs']);
+        $this->assertSame([], $report['forbidden_item_fields']);
+        $this->assertSame(10000, $report['synthetic_scale_budget']['target_directory_count']);
+        $this->assertSame(20000, $report['synthetic_scale_budget']['target_bilingual_detail_url_count']);
+        $this->assertFalse($report['synthetic_scale_budget']['full_directory_ssr_rendering_allowed']);
+        $this->assertFalse($report['production_write_performed']);
+        $this->assertFalse($report['runtime_promotion_performed']);
+        $this->assertFalse($report['search_channel_action_performed']);
+    }
+
+    public function test_command_fails_when_expected_counts_do_not_match(): void
+    {
+        $this->createDirectoryOccupation('actuaries', 'Actuaries', '精算师');
+        $this->publishRuntimeProjection(['actuaries']);
+
+        $exitCode = Artisan::call('career:validate-directory-10k-scale-readiness', [
+            '--expected-public-count' => 1046,
+            '--expected-sitemap-career-urls' => 2092,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $report = json_decode((string) Artisan::output(), true);
+
+        $this->assertSame('failed', $report['status']);
+        $this->assertContains('expected_public_count_mismatch', $report['errors']);
+        $this->assertContains('expected_sitemap_career_url_count_mismatch', $report['errors']);
+        $this->assertFalse($report['production_write_performed']);
+    }
+
+    private function createDirectoryOccupation(string $slug, string $titleEn, string $titleZh): Occupation
+    {
+        $family = OccupationFamily::query()->firstOrCreate(
+            ['canonical_slug' => 'business-finance'],
+            [
+                'title_en' => 'Business and Finance',
+                'title_zh' => '商业与金融',
+            ],
+        );
+
+        $occupation = Occupation::query()->create([
+            'family_id' => $family->id,
+            'canonical_slug' => $slug,
+            'entity_level' => 'dataset_candidate',
+            'truth_market' => 'US',
+            'display_market' => 'zh-CN',
+            'crosswalk_mode' => 'direct_match',
+            'canonical_title_en' => $titleEn,
+            'canonical_title_zh' => $titleZh,
+            'search_h1_zh' => $titleZh,
+            'structural_stability' => null,
+            'task_prototype_signature' => [],
+            'market_semantics_gap' => null,
+            'regulatory_divergence' => null,
+            'toolchain_divergence' => null,
+            'skill_gap_threshold' => null,
+            'trust_inheritance_scope' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 54, 0),
+        ]);
+
+        foreach ([
+            ['source_system' => 'us_soc', 'source_code' => '15-1252'],
+            ['source_system' => 'onet_soc_2019', 'source_code' => '15-1252.00'],
+        ] as $crosswalk) {
+            OccupationCrosswalk::query()->create([
+                'occupation_id' => $occupation->id,
+                'source_system' => $crosswalk['source_system'],
+                'source_code' => $crosswalk['source_code'],
+                'source_title' => $titleEn,
+                'mapping_type' => 'direct_match',
+                'confidence_score' => 1.0,
+            ]);
+        }
+
+        CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => $slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => range(1, 24),
+            'page_payload_json' => [
+                'zh' => ['hero' => ['title' => $titleZh]],
+                'en' => ['hero' => ['title' => $titleEn]],
+            ],
+            'seo_payload_json' => [
+                'indexability_state' => 'index',
+                'robots_policy' => 'index,follow',
+            ],
+            'sources_json' => [
+                'primary' => [
+                    ['label' => 'Fixture source', 'url' => 'https://example.test/career'],
+                ],
+            ],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => [],
+            'created_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+            'updated_at' => Carbon::create(2026, 1, 31, 12, 55, 0),
+        ]);
+
+        return $occupation;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function publishRuntimeProjection(array $slugs): void
+    {
+        $items = [];
+        foreach ($slugs as $slug) {
+            $published = $slug !== 'software-developers';
+            foreach (['en', 'zh'] as $locale) {
+                $items[$slug.'|'.$locale] = [
+                    'slug' => $slug,
+                    'locale' => $locale,
+                    'dataset_visible' => $published,
+                    'search_visible' => $published,
+                    'detail_route_enabled' => $published,
+                    'robots_indexable' => $published,
+                    'release_gate_pass' => $published,
+                    'runtime_publish_state' => $published ? 'published' : 'quarantined',
+                ];
+            }
+        }
+
+        $this->app->instance(
+            CareerRuntimePublishProjectionVisibility::class,
+            new CareerRuntimePublishProjectionVisibilityFixture(
+                defaultDatasetVisible: false,
+                defaultSearchVisible: false,
+                defaultDetailRouteEnabled: false,
+                defaultRobotsIndexable: false,
+                defaultReleaseGatePass: false,
+                items: $items,
+            ),
+        );
+
+        Cache::flush();
+    }
+}

--- a/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+++ b/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
@@ -17,12 +17,15 @@ final class CareerWarmPublicAuthorityCacheCommandTest extends TestCase
     {
         Cache::forget(PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY);
         Cache::forget(PublicCareerAuthorityResponseCache::DATASET_METHOD_CACHE_KEY);
+        Cache::forget(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':en:public');
         Cache::forget(PublicCareerAuthorityResponseCache::LAUNCH_GOVERNANCE_CLOSURE_CACHE_KEY);
         Cache::forget(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':zh-CN:public');
 
         $this->artisan('career:warm-public-authority-cache')
             ->expectsOutputToContain('career_warm_phase=dataset_payloads state=starting')
             ->expectsOutputToContain('career_warm_phase=dataset_payloads state=finished')
+            ->expectsOutputToContain('career_warm_phase=job_index_en state=starting')
+            ->expectsOutputToContain('career_warm_phase=job_index_en state=finished')
             ->expectsOutputToContain('career_warm_phase=job_index_zh_cn state=starting')
             ->expectsOutputToContain('career_warm_phase=job_index_zh_cn state=finished')
             ->expectsOutputToContain('career_warm_phase=launch_governance_closure state=starting')
@@ -30,12 +33,14 @@ final class CareerWarmPublicAuthorityCacheCommandTest extends TestCase
             ->expectsOutputToContain('status=warmed')
             ->expectsOutputToContain(PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY)
             ->expectsOutputToContain(PublicCareerAuthorityResponseCache::DATASET_METHOD_CACHE_KEY)
+            ->expectsOutputToContain(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':en:public')
             ->expectsOutputToContain(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':zh-CN:public')
             ->expectsOutputToContain(PublicCareerAuthorityResponseCache::LAUNCH_GOVERNANCE_CLOSURE_CACHE_KEY)
             ->assertExitCode(0);
 
         $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::DATASET_HUB_CACHE_KEY));
         $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::DATASET_METHOD_CACHE_KEY));
+        $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':en:public'));
         $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::JOB_INDEX_CACHE_KEY_PREFIX.':zh-CN:public'));
         $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::LAUNCH_GOVERNANCE_CLOSURE_CACHE_KEY));
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38532,13 +38532,13 @@
     "repo": "fap-api",
     "branch": "codex/career-directory-10k-ops-warm-validate-01",
     "base": "main",
-    "status": "committed",
+    "status": "open_checks_passed",
     "title": "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01 directory warm validate 10k ops gate",
     "depends_on": [
       "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01"
     ],
-    "commit_sha": "pending_remote_pr_head",
-    "pr_url": null,
+    "commit_sha": "e1a66823fad576ad61ac61f0aa8f9da5d81e28f7",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1835",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -38593,7 +38593,23 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "scope_validation": {},
+    "scope_validation": {
+      "git_diff_name_only_origin_main_head": [
+        "backend/app/Console/Commands/CareerValidateDirectory10kScaleReadiness.php",
+        "backend/app/Services/Career/CareerDirectoryAuthorityService.php",
+        "backend/app/Services/Career/PublicCareerAuthorityResponseCache.php",
+        "backend/docs/seo/career-directory-10k-ops-warm-validate-01.md",
+        "backend/docs/seo/generated/career-directory-10k-ops-warm-validate-01.v1.json",
+        "backend/tests/Feature/Console/CareerDirectory10kOpsWarmValidateCommandTest.php",
+        "backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php",
+        "docs/codex/pr-train-state.json",
+        "docs/codex/pr-train.yaml"
+      ],
+      "git_diff_check": "pass",
+      "git_diff_cached_check": "pass",
+      "github_checks": "pass",
+      "merge_state_status": "CLEAN"
+    },
     "sidecars": [
       {
         "source_pr": "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01",
@@ -38606,7 +38622,7 @@
         "impact_on_current_pr": "No impact on career directory 10k ops command behavior; scoped Pint and focused tests passed.",
         "owner": "EQ/report test owners",
         "follow_up_recommendation": "Handle in a separate scoped EQ Pint cleanup PR.",
-        "required_checks_status": "pending_github_checks",
+        "required_checks_status": "github_checks_passed",
         "scope_validation_status": "local_scope_validation_passed",
         "continue_train_decision": "continue_current_pr_with_sidecar"
       }
@@ -38637,6 +38653,11 @@
         "at": "2026-06-01T06:19:00Z",
         "status": "commit_sha_pending_remote_head",
         "summary": "Set ledger commit_sha to pending_remote_pr_head to avoid amend hash churn before PR creation."
+      },
+      {
+        "at": "2026-06-01T06:31:00Z",
+        "status": "open_checks_passed",
+        "summary": "Opened PR #1835; GitHub checks passed and mergeStateStatus is CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-01T04:22:00Z",
+  "updated_at": "2026-06-01T06:19:00Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -38292,12 +38292,12 @@
     "repo": "fap-api",
     "branch": "codex/career-sitemap-exposure-directory-authority-01",
     "base": "main",
-    "status": "pr_opened_with_sidecar",
+    "status": "merged",
     "title": "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01 sitemap career exposure directory authority",
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01"
     ],
-    "commit_sha": "568c88a837b8dc2c66c67815d6c68dd260c4b8aa",
+    "commit_sha": "dd68b36ef2e6bcf577ab6110858a702f67a32a38",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1832",
     "checks": {
       "manifest_registration": {
@@ -38358,9 +38358,9 @@
       }
     },
     "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused checks passed locally.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-01T04:29:13Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "next_task": "CAREER-JOBS-PAGINATED-DIRECTORY-SHELL-01",
     "history": [
       {
@@ -38392,8 +38392,14 @@
         "at": "2026-06-01T04:23:00Z",
         "status": "ci_fix_validated_with_sidecar",
         "summary": "Inspected GitHub failures in verify-mbti-legacy and verify-mbti-v2; both failed because SitemapXmlTest expected a career detail URL without binding runtime projection truth. Added the fixture binding in current scope and validated SitemapXmlTest plus focused sitemap checks locally."
+      },
+      {
+        "at": "2026-06-01T06:08:20Z",
+        "status": "reconciled_merged",
+        "summary": "GitHub PR #1832 is merged and origin/main contains merge commit dd68b36ef2e6bcf577ab6110858a702f67a32a38; reconciled before PR5."
       }
-    ]
+    ],
+    "merge_commit": "dd68b36ef2e6bcf577ab6110858a702f67a32a38"
   },
   "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05": {
     "id": "PAYMENT-ALIPAY-RETURN-IMMEDIATE-COMPENSATION-05",
@@ -38520,5 +38526,118 @@
       }
     ],
     "next_task": "PAYMENT-WAIT-PAID-REDIRECT-CONTRACT-06"
+  },
+  "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01": {
+    "id": "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01",
+    "repo": "fap-api",
+    "branch": "codex/career-directory-10k-ops-warm-validate-01",
+    "base": "main",
+    "status": "committed",
+    "title": "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01 directory warm validate 10k ops gate",
+    "depends_on": [
+      "CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01"
+    ],
+    "commit_sha": "pending_remote_pr_head",
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User approved the five-PR career directory 10k-scale train; this entry adds only PR5 after backend PR2 and fap-web PR3/PR4 completed."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to backend directory warm/readiness validation, report artifacts, focused tests, and train metadata."
+      },
+      "php artisan test --filter=CareerDirectory10kOpsWarmValidateCommandTest --no-ansi": {
+        "status": "pass",
+        "evidence": "Focused 10k ops warm/validate command test passed: 2 tests, 19 assertions; PHPUnit emitted non-fatal file_get_contents warnings."
+      },
+      "php artisan test --filter=CareerWarmPublicAuthorityCacheCommandTest --no-ansi": {
+        "status": "pass",
+        "evidence": "Existing public authority warm cache test passed after adding EN job-index warm coverage: 2 tests, 35 assertions; PHPUnit emitted non-fatal file_get_contents warnings."
+      },
+      "php artisan route:list --no-ansi": {
+        "status": "pass",
+        "evidence": "Route list completed successfully with 210 routes; no HTTP route changes were made."
+      },
+      "vendor/bin/pint --test scoped": {
+        "status": "pass",
+        "evidence": "Scoped Pint passed for current PR command/service/test files."
+      },
+      "vendor/bin/pint --test": {
+        "status": "sidecar_external_failure",
+        "evidence": "Full Pint still reports pre-existing out-of-scope new_with_parentheses issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php. Current PR does not touch those files; scoped Pint passed."
+      },
+      "composer validate --strict": {
+        "status": "pass",
+        "evidence": "Composer schema validation passed."
+      },
+      "composer audit --locked --no-interaction --ignore-unreachable": {
+        "status": "pass",
+        "evidence": "No locked dependency advisories reported."
+      },
+      "json_yaml_parse": {
+        "status": "pass",
+        "evidence": "Generated JSON, pr-train-state JSON, and pr-train YAML parse successfully."
+      },
+      "git diff --check && git diff --cached --check": {
+        "status": "pass",
+        "evidence": "Whitespace checks passed before staging."
+      },
+      "php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi": {
+        "status": "pass",
+        "evidence": "Big Five runtime branch-diff guard passed with 1 warning and 3 assertions; warning is non-fatal file_get_contents output."
+      }
+    },
+    "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused checks passed locally.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {},
+    "sidecars": [
+      {
+        "source_pr": "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01",
+        "repo": "fap-api",
+        "branch": "codex/career-directory-10k-ops-warm-validate-01",
+        "command_or_check": "cd backend && vendor/bin/pint --test",
+        "evidence": "Full Pint fails only on tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php new_with_parentheses style issues.",
+        "failure_summary": "Out-of-scope EQ Pint formatting issues remain on main.",
+        "why_external_to_current_pr": "Current PR changes career directory ops validation, public authority warm cache, docs, focused tests, and ledger only; it does not touch EQ test files.",
+        "impact_on_current_pr": "No impact on career directory 10k ops command behavior; scoped Pint and focused tests passed.",
+        "owner": "EQ/report test owners",
+        "follow_up_recommendation": "Handle in a separate scoped EQ Pint cleanup PR.",
+        "required_checks_status": "pending_github_checks",
+        "scope_validation_status": "local_scope_validation_passed",
+        "continue_train_decision": "continue_current_pr_with_sidecar"
+      }
+    ],
+    "next_task": "deploy_readiness_after_career_directory_10k_train_if_required",
+    "history": [
+      {
+        "at": "2026-06-01T06:08:20Z",
+        "status": "in_progress",
+        "summary": "Initialized PR5 after user authorization; started from latest origin/main and added career directory 10k ops warm/validate scope."
+      },
+      {
+        "at": "2026-06-01T06:15:30Z",
+        "status": "local_validated_with_sidecar",
+        "summary": "Focused tests, route:list, scoped Pint, composer validate/audit, JSON/YAML parsing, and diff checks passed. Full Pint sidecar remains out-of-scope in EQ tests."
+      },
+      {
+        "at": "2026-06-01T06:16:30Z",
+        "status": "runtime_freeze_guard_passed",
+        "summary": "Ran the focused Big Five runtime path guard; it passed for the PR5 diff."
+      },
+      {
+        "at": "2026-06-01T06:18:00Z",
+        "status": "committed",
+        "summary": "Committed PR5 locally as e5109c6405835981d0c7974d56ebc001904af428."
+      },
+      {
+        "at": "2026-06-01T06:19:00Z",
+        "status": "commit_sha_pending_remote_head",
+        "summary": "Set ledger commit_sha to pending_remote_pr_head to avoid amend hash churn before PR creation."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19040,3 +19040,47 @@ prs:
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: CAREER-JOBS-PAGINATED-DIRECTORY-SHELL-01
+
+  - id: CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01
+    repo: fap-api
+    depends_on: [CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01]
+    branch: codex/career-directory-10k-ops-warm-validate-01
+    base: main
+    title: "CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01 directory warm validate 10k ops gate"
+    train_scope: career_directory_10k_scale
+    status: in_progress
+    scope:
+      - Add backend Ops validation for career directory authority readiness at 10k scale.
+      - Warm both EN and ZH public career authority job-index caches.
+      - Validate directory public counts, sitemap career URL counts, held-slug exclusions, and first-page payload budget.
+      - Produce a non-runtime report and generated JSON artifact.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerValidateDirectory10kScaleReadiness.php
+      - backend/app/Services/Career/CareerDirectoryAuthorityService.php
+      - backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+      - backend/tests/Feature/Console/CareerDirectory10kOpsWarmValidateCommandTest.php
+      - backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - backend/docs/seo/career-directory-10k-ops-warm-validate-01.md
+      - backend/docs/seo/generated/career-directory-10k-ops-warm-validate-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change frontend rendering, llms, Search Channel, URL submission, or deployment behavior.
+      - Mutate production CMS, production DB, career cohort state, runtime promotion state, or held slug policy.
+      - Release software-developers, digital-forensics-analysts, or computer-occupations-all-other.
+      - Add frontend fallback career content.
+    validation:
+      - cd backend && php artisan test --filter=CareerDirectory10kOpsWarmValidateCommandTest --no-ansi
+      - cd backend && php artisan test --filter=CareerWarmPublicAuthorityCacheCommandTest --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && vendor/bin/pint --test app/Console/Commands/CareerValidateDirectory10kScaleReadiness.php app/Services/Career/CareerDirectoryAuthorityService.php app/Services/Career/PublicCareerAuthorityResponseCache.php tests/Feature/Console/CareerDirectory10kOpsWarmValidateCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/career-directory-10k-ops-warm-validate-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: none


### PR DESCRIPTION
## What changed
- Added a read-only `career:validate-directory-10k-scale-readiness` ops gate for career directory scale readiness.
- Warmed both EN and ZH public career job-index authority caches in `career:warm-public-authority-cache`.
- Exposed the canonical career directory excluded-slug list from backend authority for ops validation.
- Added focused console tests and generated SEO/ops artifacts for `CAREER-DIRECTORY-10K-OPS-WARM-VALIDATE-01`.
- Reconciled the already-merged `CAREER-SITEMAP-EXPOSURE-DIRECTORY-AUTHORITY-01` ledger state and added the current PR train entry only.

## Why
The 1046 career rollout is stable now, but the next scale step needs an ops gate that can verify directory count parity, held-slug exclusion, sitemap count alignment, first-page payload budget, and 10k synthetic readiness without exposing new URLs or mutating production state.

## Validation
Passed:
- `php artisan test --filter=CareerDirectory10kOpsWarmValidateCommandTest --no-ansi`
- `php artisan test --filter=CareerWarmPublicAuthorityCacheCommandTest --no-ansi`
- `php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test app/Console/Commands/CareerValidateDirectory10kScaleReadiness.php app/Services/Career/CareerDirectoryAuthorityService.php app/Services/Career/PublicCareerAuthorityResponseCache.php tests/Feature/Console/CareerDirectory10kOpsWarmValidateCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/career-directory-10k-ops-warm-validate-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML manifest parse check
- `git diff --check && git diff --cached --check`

Sidecar:
- Full `vendor/bin/pint --test` is blocked by pre-existing out-of-scope EQ formatting issues in `tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php` and `tests/Unit/Report/EqIntegratedReportComposerTest.php`. Scoped Pint for this PR's changed PHP files passes.

## Intentionally deferred
- No deploy.
- No DB/CMS mutation.
- No runtime promotion.
- No sitemap/llms/footer exposure change.
- No Search Channel enqueue or URL submission.
- No release of excluded/held career slugs.

## Repository rule impact
This PR adds a backend ops/discoverability validation gate. Backend remains the career authority; no frontend fallback/content ownership changes are introduced.
