### PR TITLE
PR-POL-01-LEDGER-RECONCILE-AND-SMOKE policies runtime reconcile and smoke

### DIFF
--- a/backend/docs/seo/generated/pr-pol-01-ledger-reconcile-and-smoke.v1.json
+++ b/backend/docs/seo/generated/pr-pol-01-ledger-reconcile-and-smoke.v1.json
@@ -1,0 +1,136 @@
+{
+  "schema_version": "pr_pol_01_ledger_reconcile_and_smoke.v1",
+  "task": "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE",
+  "final_decision": "pr_pol_01_ledger_reconcile_and_smoke_completed_stable",
+  "source_pr": {
+    "id": "PR-POL-01",
+    "github_pr": "https://github.com/fermatmind/fap-api/pull/1769",
+    "github_state": "merged",
+    "merged_at": "2026-05-30T23:21:04Z"
+  },
+  "target_pages": [
+    "policies"
+  ],
+  "locales": [
+    "en",
+    "zh-CN"
+  ],
+  "cms_record_state": {
+    "en": {
+      "slug": "policies",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-04-21",
+      "updated_at": "2026-05-31 00:07:08"
+    },
+    "zh-CN": {
+      "slug": "policies",
+      "locale": "zh-CN",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-04-19",
+      "updated_at": "2026-05-31 00:07:08"
+    }
+  },
+  "api_runtime_check": {
+    "apex_same_origin": {
+      "en": {
+        "url": "https://fermatmind.com/api/v0.5/content-pages/policies?locale=en&org_id=0",
+        "http_status": 200
+      },
+      "zh-CN": {
+        "url": "https://fermatmind.com/api/v0.5/content-pages/policies?locale=zh-CN&org_id=0",
+        "http_status": 200
+      }
+    },
+    "api_host": {
+      "en": {
+        "url": "https://api.fermatmind.com/api/v0.5/content-pages/policies?locale=en&org_id=0",
+        "http_status": 200
+      },
+      "zh-CN": {
+        "url": "https://api.fermatmind.com/api/v0.5/content-pages/policies?locale=zh-CN&org_id=0",
+        "http_status": 200
+      }
+    }
+  },
+  "public_runtime_check": {
+    "en": {
+      "url": "https://fermatmind.com/en/policies",
+      "http_status": 200,
+      "title": "Policies Overview | FermatMind",
+      "h1": "Policies Overview",
+      "canonical": "https://fermatmind.com/en/policies",
+      "robots": "index, follow",
+      "noindex_detected": false,
+      "staging_canonical_detected": false,
+      "frontend_fallback_marker_detected": false
+    },
+    "zh-CN": {
+      "url": "https://fermatmind.com/zh/policies",
+      "http_status": 200,
+      "title": "政策总览 | FermatMind",
+      "h1": "政策总览",
+      "canonical": "https://fermatmind.com/zh/policies",
+      "robots": "index, follow",
+      "noindex_detected": false,
+      "staging_canonical_detected": false,
+      "frontend_fallback_marker_detected": false
+    }
+  },
+  "discoverability_check": {
+    "sitemap_xml": {
+      "http_status": 200,
+      "en_policies_present": true,
+      "zh_policies_present": true
+    },
+    "llms_txt": {
+      "http_status": 200,
+      "en_policies_present": true,
+      "zh_policies_present": true
+    },
+    "llms_full_txt": {
+      "http_status": 200,
+      "en_policies_present": true,
+      "zh_policies_present": true
+    },
+    "footer_nav": {
+      "en_policies_present": true,
+      "zh_policies_present": true
+    }
+  },
+  "search_channel_check": {
+    "policies_queue_items": {
+      "https://fermatmind.com/en/policies": 0,
+      "https://fermatmind.com/zh/policies": 0
+    },
+    "queue_item_2_state": {
+      "id": 2,
+      "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "queue_item_3_state": {
+      "id": 3,
+      "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "search_channel_action_performed": false
+  },
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_env_dns_nginx_edit": true,
+  "no_raw_log_read": true,
+  "no_fap_web_mutation": true,
+  "next_task": "PR-HIRING-01-POST-PUBLISH-SMOKE"
+}

--- a/backend/docs/seo/pr-pol-01-ledger-reconcile-and-smoke.md
+++ b/backend/docs/seo/pr-pol-01-ledger-reconcile-and-smoke.md
@@ -1,0 +1,86 @@
+# PR-POL-01-LEDGER-RECONCILE-AND-SMOKE Report
+
+## 1. Executive Summary
+
+PR-POL-01 is merged and the production Policies content pages are runtime healthy.
+Both `/en/policies` and `/zh/policies` return HTTP 200 with exact apex
+canonicals, `index, follow` robots metadata, and no staging canonical.
+
+Final decision: `pr_pol_01_ledger_reconcile_and_smoke_completed_stable`.
+
+## 2. PR / Ledger Reconciliation
+
+GitHub shows PR-POL-01 as merged in fap-api PR #1769. The current production
+CMS rows for `policies` were updated on 2026-05-31 and remain published,
+public, and indexable.
+
+## 3. CMS Published State
+
+| Locale | Slug | Status | Public | Indexable | Published at | Updated at |
+| --- | --- | --- | --- | --- | --- | --- |
+| `en` | `policies` | `published` | true | true | 2026-04-21 | 2026-05-31 00:07:08 |
+| `zh-CN` | `policies` | `published` | true | true | 2026-04-19 | 2026-05-31 00:07:08 |
+
+## 4. API Runtime Check
+
+The following public read-only API checks returned HTTP 200:
+
+- `https://fermatmind.com/api/v0.5/content-pages/policies?locale=en&org_id=0`
+- `https://fermatmind.com/api/v0.5/content-pages/policies?locale=zh-CN&org_id=0`
+- `https://api.fermatmind.com/api/v0.5/content-pages/policies?locale=en&org_id=0`
+- `https://api.fermatmind.com/api/v0.5/content-pages/policies?locale=zh-CN&org_id=0`
+
+## 5. Public Runtime Check
+
+| URL | HTTP | Title | H1 | Canonical | Robots |
+| --- | --- | --- | --- | --- | --- |
+| `https://fermatmind.com/en/policies` | 200 | `Policies Overview | FermatMind` | `Policies Overview` | `https://fermatmind.com/en/policies` | `index, follow` |
+| `https://fermatmind.com/zh/policies` | 200 | `政策总览 | FermatMind` | `政策总览` | `https://fermatmind.com/zh/policies` | `index, follow` |
+
+No staging canonical, no `noindex` regression, and no frontend fallback marker
+were observed.
+
+## 6. Sitemap / llms / Footer Exposure
+
+Policies exposure is present as expected for published/indexable policy pages:
+
+- `sitemap.xml`: EN and ZH policies present.
+- `llms.txt`: EN and ZH policies present.
+- `llms-full.txt`: EN and ZH policies present.
+- Public `/en` and `/zh` navigation surfaces include the matching policies link.
+
+## 7. Search Channel Safety
+
+Production read-only checks found no Search Channel queue items for:
+
+- `https://fermatmind.com/en/policies`
+- `https://fermatmind.com/zh/policies`
+
+Queue item 2 remains the EN MBTI IndexNow item in `approved/submitted` state.
+Queue item 3 remains the ZH MBTI IndexNow item in `approved/submitted` state.
+
+## 8. Sidecar Issues
+
+No blocking sidecars were found for this task.
+
+## 9. Validation
+
+Focused validation:
+
+- `php artisan test --filter=PrPol01LedgerReconcileAndSmoke --no-ansi`
+
+Additional repository validation is recorded in the generated JSON artifact.
+
+## 10. What Was Not Done
+
+No CMS mutation, production data mutation, deploy, Search Channel action, URL
+submission, external search API call, env/DNS/nginx edit, raw log read, or
+fap-web mutation was performed.
+
+## 11. Final Decision
+
+`pr_pol_01_ledger_reconcile_and_smoke_completed_stable`
+
+## 12. Next Task
+
+`PR-HIRING-01-POST-PUBLISH-SMOKE`

--- a/backend/tests/Feature/SeoIntel/PrPol01LedgerReconcileAndSmokeTest.php
+++ b/backend/tests/Feature/SeoIntel/PrPol01LedgerReconcileAndSmokeTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PrPol01LedgerReconcileAndSmokeTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_records_runtime_and_safety_boundaries(): void
+    {
+        $payload = $this->artifact();
+
+        $this->assertSame('pr_pol_01_ledger_reconcile_and_smoke.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('PR-POL-01-LEDGER-RECONCILE-AND-SMOKE', $payload['task'] ?? null);
+        $this->assertSame('pr_pol_01_ledger_reconcile_and_smoke_completed_stable', $payload['final_decision'] ?? null);
+        $this->assertSame(['policies'], $payload['target_pages'] ?? null);
+        $this->assertSame(['en', 'zh-CN'], $payload['locales'] ?? null);
+
+        foreach (['en', 'zh-CN'] as $locale) {
+            $this->assertSame('published', data_get($payload, "cms_record_state.$locale.status"));
+            $this->assertTrue((bool) data_get($payload, "cms_record_state.$locale.is_public"));
+            $this->assertTrue((bool) data_get($payload, "cms_record_state.$locale.is_indexable"));
+            $this->assertSame(200, data_get($payload, "public_runtime_check.$locale.http_status"));
+            $this->assertSame('index, follow', data_get($payload, "public_runtime_check.$locale.robots"));
+            $this->assertFalse((bool) data_get($payload, "public_runtime_check.$locale.noindex_detected"));
+            $this->assertFalse((bool) data_get($payload, "public_runtime_check.$locale.staging_canonical_detected"));
+            $this->assertFalse((bool) data_get($payload, "public_runtime_check.$locale.frontend_fallback_marker_detected"));
+        }
+
+        $policiesQueueItems = data_get($payload, 'search_channel_check.policies_queue_items');
+        $this->assertSame(0, $policiesQueueItems['https://fermatmind.com/en/policies'] ?? null);
+        $this->assertSame(0, $policiesQueueItems['https://fermatmind.com/zh/policies'] ?? null);
+        $this->assertSame('submitted', data_get($payload, 'search_channel_check.queue_item_2_state.execution_state'));
+        $this->assertSame('submitted', data_get($payload, 'search_channel_check.queue_item_3_state.execution_state'));
+
+        foreach ([
+            'no_cms_mutation',
+            'no_publish',
+            'no_deploy',
+            'no_search_channel_action',
+            'no_url_submission',
+            'no_external_search_api_call',
+            'no_env_dns_nginx_edit',
+            'no_raw_log_read',
+            'no_fap_web_mutation',
+        ] as $flag) {
+            $this->assertTrue((bool) ($payload[$flag] ?? false), $flag);
+        }
+
+        $this->assertSame('PR-HIRING-01-POST-PUBLISH-SMOKE', $payload['next_task'] ?? null);
+    }
+
+    #[Test]
+    public function report_contains_required_sections(): void
+    {
+        $reportPath = base_path('docs/seo/pr-pol-01-ledger-reconcile-and-smoke.md');
+
+        $this->assertFileExists($reportPath);
+
+        $report = (string) file_get_contents($reportPath);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. PR / Ledger Reconciliation',
+            '## 3. CMS Published State',
+            '## 4. API Runtime Check',
+            '## 5. Public Runtime Check',
+            '## 6. Sitemap / llms / Footer Exposure',
+            '## 7. Search Channel Safety',
+            '## 8. Sidecar Issues',
+            '## 9. Validation',
+            '## 10. What Was Not Done',
+            '## 11. Final Decision',
+            '## 12. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/pr-pol-01-ledger-reconcile-and-smoke.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35728,12 +35728,12 @@
     "branch": "codex/pr-pol-01-ledger-reconcile-and-smoke",
     "base": "main",
     "title": "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE policies runtime reconcile and smoke",
-    "status": "local_checks_passed_with_sidecar",
+    "status": "pr_opened_with_sidecar",
     "depends_on": [
       "PR-POL-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "4fcf6043",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1838",
     "checks": [
       {
         "command": "manifest/state authorization",
@@ -35784,6 +35784,11 @@
         "command": "git diff --cached --check",
         "status": "passed",
         "summary": "Cached diff whitespace check passed after path-limited staging."
+      },
+      {
+        "command": "gh pr create --title \"PR-POL-01-LEDGER-RECONCILE-AND-SMOKE policies runtime reconcile and smoke\" --base main --head codex/pr-pol-01-ledger-reconcile-and-smoke",
+        "status": "passed",
+        "summary": "Opened PR #1838."
       }
     ],
     "failure_reason": null,
@@ -35805,6 +35810,11 @@
         "status": "local_checks_passed_with_sidecar",
         "at": "2026-06-01T19:57:00+08:00",
         "summary": "Focused PHPUnit, route list, scoped Pint, Composer validate/audit, JSON/YAML parse, and diff check passed; full Pint failure is external to current PR scope."
+      },
+      {
+        "status": "pr_opened_with_sidecar",
+        "at": "2026-06-01T20:00:00+08:00",
+        "summary": "Committed, pushed, and opened PR #1838 with the external Pint sidecar recorded."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35722,6 +35722,101 @@
     ],
     "next_task": "post-merge cleanup only after PR-POL-01 merge"
   },
+  "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE": {
+    "id": "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE",
+    "repo": "fap-api",
+    "branch": "codex/pr-pol-01-ledger-reconcile-and-smoke",
+    "base": "main",
+    "title": "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE policies runtime reconcile and smoke",
+    "status": "local_checks_passed_with_sidecar",
+    "depends_on": [
+      "PR-POL-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "manifest/state authorization",
+        "status": "passed",
+        "summary": "User explicitly authorized updating fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for PR-POL-01-LEDGER-RECONCILE-AND-SMOKE."
+      },
+      {
+        "command": "read-only production CMS/API/runtime/Search Channel verification",
+        "status": "passed",
+        "summary": "Policies EN/ZH public API and runtime checks returned 200; CMS rows are published/public/indexable; Search Channel queue count for EN/ZH policies is zero; queue items 2 and 3 remain approved/submitted."
+      },
+      {
+        "command": "cd backend && php artisan test --filter=PrPol01LedgerReconcileAndSmoke --no-ansi",
+        "status": "passed",
+        "summary": "2 tests passed, 49 assertions."
+      },
+      {
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "210 routes listed successfully."
+      },
+      {
+        "command": "cd backend && vendor/bin/pint --test",
+        "status": "failed_external_sidecar",
+        "summary": "Full Pint failed on pre-existing out-of-scope EQ test files: tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php."
+      },
+      {
+        "command": "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/PrPol01LedgerReconcileAndSmokeTest.php",
+        "status": "passed",
+        "summary": "Scoped Pint validation passed for the only PHP file touched by this PR."
+      },
+      {
+        "command": "cd backend && composer validate --strict",
+        "status": "passed",
+        "summary": "composer.json is valid."
+      },
+      {
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "No security vulnerability advisories found."
+      },
+      {
+        "command": "JSON/YAML parse and git diff --check",
+        "status": "passed",
+        "summary": "Generated JSON, PR train state JSON, PR train YAML, and unstaged diff whitespace checks passed."
+      },
+      {
+        "command": "git diff --cached --check",
+        "status": "passed",
+        "summary": "Cached diff whitespace check passed after path-limited staging."
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-06-01T19:45:00+08:00",
+        "summary": "User authorized adding and executing PR-POL-01-LEDGER-RECONCILE-AND-SMOKE as a read-only post-publish reconcile/smoke report."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-06-01T19:46:00+08:00",
+        "summary": "Started from latest origin/main on codex/pr-pol-01-ledger-reconcile-and-smoke."
+      },
+      {
+        "status": "local_checks_passed_with_sidecar",
+        "at": "2026-06-01T19:57:00+08:00",
+        "summary": "Focused PHPUnit, route list, scoped Pint, Composer validate/audit, JSON/YAML parse, and diff check passed; full Pint failure is external to current PR scope."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": "passed",
+      "git_diff_cached_check": "passed"
+    },
+    "sidecars": [
+      "Full vendor/bin/pint --test fails on pre-existing out-of-scope EQ test files not touched by this PR."
+    ],
+    "next_task": "PR-HIRING-01-POST-PUBLISH-SMOKE"
+  },
   "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01": {
     "id": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01",
     "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -17453,6 +17453,58 @@ prs:
     frontend_fallback_authority: false
     next_task: post-merge cleanup only after PR-POL-01 merge
 
+  - id: PR-POL-01-LEDGER-RECONCILE-AND-SMOKE
+    repo: fap-api
+    branch: codex/pr-pol-01-ledger-reconcile-and-smoke
+    base: main
+    title: "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE policies runtime reconcile and smoke"
+    train_scope: content_pages_policies_dashboard_post_publish_smoke
+    risk_level: p2_read_only_runtime_smoke
+    depends_on:
+      - PR-POL-01
+    allowed_paths:
+      - backend/docs/seo/pr-pol-01-ledger-reconcile-and-smoke.md
+      - backend/docs/seo/generated/pr-pol-01-ledger-reconcile-and-smoke.v1.json
+      - backend/tests/Feature/SeoIntel/PrPol01LedgerReconcileAndSmokeTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Reconcile PR-POL-01 merged state and verify production policies content page runtime.
+      - Verify EN/ZH policies CMS rows remain published, public, and indexable.
+      - Verify public runtime 200, exact canonicals, index/follow robots, sitemap/llms/footer exposure, and no staging canonical or frontend fallback marker.
+      - Verify no policies Search Channel queue item exists and protected queue item 2/3 states remain unchanged.
+    do_not:
+      - Mutate CMS or production data.
+      - Publish or unpublish pages.
+      - Deploy backend or frontend.
+      - Enqueue Search Channel, submit URLs, or call external search APIs.
+      - Edit env, DNS, nginx, or read raw logs.
+      - Modify fap-web.
+    validation:
+      - cd backend && php artisan test --filter=PrPol01LedgerReconcileAndSmoke --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/pr-pol-01-ledger-reconcile-and-smoke.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: PR-HIRING-01-POST-PUBLISH-SMOKE
+
   - id: PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01
     repo: fap-api
     branch: codex/payment-alipay-pending-compensation-scheduler-01


### PR DESCRIPTION
## What changed
- Added a read-only PR-POL-01 post-publish reconcile/smoke report.
- Recorded generated runtime evidence for EN/ZH policies pages, public APIs, sitemap/llms/footer exposure, and Search Channel queue safety.
- Added focused artifact/report coverage and registered the scoped PR train entry.

## Why
- Confirm the published Policies Dashboard content is stable in production after PR-POL-01.

## Validation
- cd backend && php artisan test --filter=PrPol01LedgerReconcileAndSmoke --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/PrPol01LedgerReconcileAndSmokeTest.php
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool backend/docs/seo/generated/pr-pol-01-ledger-reconcile-and-smoke.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check
- git diff --cached --check

## Sidecar
- Full `cd backend && vendor/bin/pint --test` currently fails on pre-existing out-of-scope EQ test files: `tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php` and `tests/Unit/Report/EqIntegratedReportComposerTest.php`. The scoped touched PHP file passes Pint.

## Deferred
- No CMS mutation, deploy, Search Channel action, URL submission, external search API call, env/DNS/nginx edit, raw log read, or fap-web mutation.