### PR TITLE
PR-HIRING-01-POST-PUBLISH-SMOKE careers runtime smoke

### DIFF
--- a/backend/docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json
+++ b/backend/docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json
@@ -1,0 +1,188 @@
+{
+  "schema_version": "pr_hiring_01_post_publish_smoke.v1",
+  "task": "PR-HIRING-01-POST-PUBLISH-SMOKE",
+  "final_decision": "pr_hiring_01_post_publish_smoke_completed_stable",
+  "source_prs": [
+    {
+      "number": 1760,
+      "title": "PR-HIRING-01A: Align EN careers content authority",
+      "state": "merged",
+      "merge_commit": "a2b24d6c0bb93895c88615cfd15942931ddc00e6"
+    },
+    {
+      "number": 1762,
+      "title": "PR-HIRING-01: Add open roles to careers pages",
+      "state": "merged",
+      "merge_commit": "afb66d2a670fda1a1ac91d6043ee9a4eef65ebc7"
+    },
+    {
+      "number": 1795,
+      "title": "PR-HIRING-01 hiring content authority package",
+      "state": "merged",
+      "merge_commit": "6b50e9ab5ed00c2bfc0365d0d4ffc48a8696f58e"
+    }
+  ],
+  "target_pages": [
+    "careers"
+  ],
+  "locales": [
+    "en",
+    "zh-CN"
+  ],
+  "role_draft_keys": [
+    "technical-partner-engineering-lead",
+    "product-design-brand-systems-lead",
+    "growth-seo-content-operations-lead"
+  ],
+  "cms_record_state": {
+    "en": {
+      "slug": "careers",
+      "locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-05-30",
+      "updated_at": "2026-05-31 00:07:07"
+    },
+    "zh-CN": {
+      "slug": "careers",
+      "locale": "zh-CN",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-04-19",
+      "updated_at": "2026-05-31 00:07:08"
+    }
+  },
+  "api_runtime_check": {
+    "apex_same_origin": {
+      "en": {
+        "url": "https://fermatmind.com/api/v0.5/content-pages/careers?locale=en&org_id=0",
+        "http_status": 200
+      },
+      "zh-CN": {
+        "url": "https://fermatmind.com/api/v0.5/content-pages/careers?locale=zh-CN&org_id=0",
+        "http_status": 200
+      }
+    },
+    "api_host": {
+      "en": {
+        "url": "https://api.fermatmind.com/api/v0.5/content-pages/careers?locale=en&org_id=0",
+        "http_status": 200
+      },
+      "zh-CN": {
+        "url": "https://api.fermatmind.com/api/v0.5/content-pages/careers?locale=zh-CN&org_id=0",
+        "http_status": 200
+      }
+    }
+  },
+  "public_runtime_check": {
+    "en": {
+      "url": "https://fermatmind.com/en/careers",
+      "http_status": 200,
+      "title": "Work With FermatMind | FermatMind | FermatMind",
+      "h1": "Work With FermatMind",
+      "canonical": "https://fermatmind.com/en/careers",
+      "robots": "index, follow",
+      "staging_canonical_detected": false
+    },
+    "zh-CN": {
+      "url": "https://fermatmind.com/zh/careers",
+      "http_status": 200,
+      "title": "加入费马测试 | FermatMind",
+      "h1": "加入费马测试",
+      "canonical": "https://fermatmind.com/zh/careers",
+      "robots": "index, follow",
+      "staging_canonical_detected": false
+    }
+  },
+  "role_draft_runtime_check": {
+    "technical-partner-engineering-lead": {
+      "url": "https://fermatmind.com/en/careers/technical-partner-engineering-lead",
+      "http_status": 404,
+      "runtime_exposed": false
+    },
+    "product-design-brand-systems-lead": {
+      "url": "https://fermatmind.com/en/careers/product-design-brand-systems-lead",
+      "http_status": 404,
+      "runtime_exposed": false
+    },
+    "growth-seo-content-operations-lead": {
+      "url": "https://fermatmind.com/en/careers/growth-seo-content-operations-lead",
+      "http_status": 404,
+      "runtime_exposed": false
+    }
+  },
+  "discoverability_check": {
+    "sitemap_xml": {
+      "careers_en_present": true,
+      "careers_zh_present": true,
+      "role_draft_hits": 0
+    },
+    "llms_txt": {
+      "careers_en_present": false,
+      "careers_zh_present": false,
+      "role_draft_hits": 0
+    },
+    "llms_full_txt": {
+      "careers_en_present": true,
+      "careers_zh_present": true,
+      "role_draft_hits": 0
+    },
+    "footer_nav": {
+      "careers_en_present": true,
+      "careers_zh_present": true,
+      "role_draft_hits": 0
+    }
+  },
+  "search_channel_check": {
+    "queue_counts": {
+      "https://fermatmind.com/en/careers": 0,
+      "https://fermatmind.com/zh/careers": 0,
+      "https://fermatmind.com/en/careers/technical-partner-engineering-lead": 0,
+      "https://fermatmind.com/en/careers/product-design-brand-systems-lead": 0,
+      "https://fermatmind.com/en/careers/growth-seo-content-operations-lead": 0
+    },
+    "queue_item_2_state": {
+      "id": 2,
+      "canonical_url": "https://fermatmind.com/en/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "queue_item_3_state": {
+      "id": 3,
+      "canonical_url": "https://fermatmind.com/zh/tests/mbti-personality-test-16-personality-types",
+      "channel": "indexnow",
+      "approval_state": "approved",
+      "execution_state": "submitted"
+    },
+    "search_channel_action_performed": false
+  },
+  "claim_boundary_check": {
+    "role_package_status": "draft_review_only",
+    "role_package_runtime_exposed": false,
+    "forbidden_claim_hits": [],
+    "blocked_claim_classes": [
+      "hiring_suitability_guarantee",
+      "salary_guarantee",
+      "career_success_guarantee",
+      "diagnosis",
+      "treatment",
+      "cure"
+    ]
+  },
+  "sidecars": [
+    "llms.txt does not include Careers pages while sitemap.xml and llms-full.txt do include them; recorded as read-only observation, not changed in this task."
+  ],
+  "no_cms_mutation": true,
+  "no_publish": true,
+  "no_deploy": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "no_env_dns_nginx_edit": true,
+  "no_raw_log_read": true,
+  "no_fap_web_mutation": true,
+  "next_task": "none_foundation_hiring_smoke_train_complete"
+}

--- a/backend/docs/seo/pr-hiring-01-post-publish-smoke.md
+++ b/backend/docs/seo/pr-hiring-01-post-publish-smoke.md
@@ -1,0 +1,124 @@
+# PR-HIRING-01-POST-PUBLISH-SMOKE Report
+
+## 1. Executive Summary
+
+The Careers content page runtime is stable after the PR-HIRING-01 content
+authority work and related Careers content updates. Public Careers pages return
+HTTP 200 with exact apex canonicals and `index, follow` robots metadata.
+
+The three PR-HIRING-01 role drafts remain non-runtime and are not exposed as
+public role detail pages, sitemap entries, llms entries, footer/nav links, or
+Search Channel queue items.
+
+Final decision: `pr_hiring_01_post_publish_smoke_completed_stable`.
+
+## 2. Source PR State
+
+Relevant merged PRs:
+
+- PR #1760: `PR-HIRING-01A: Align EN careers content authority`
+- PR #1762: `PR-HIRING-01: Add open roles to careers pages`
+- PR #1795: `PR-HIRING-01 hiring content authority package`
+
+All three are merged with green GitHub checks.
+
+## 3. CMS Published State
+
+| Locale | Slug | Status | Public | Indexable | Published at | Updated at |
+| --- | --- | --- | --- | --- | --- | --- |
+| `en` | `careers` | `published` | true | true | 2026-05-30 | 2026-05-31 00:07:07 |
+| `zh-CN` | `careers` | `published` | true | true | 2026-04-19 | 2026-05-31 00:07:08 |
+
+## 4. API Runtime Check
+
+The following public read-only API checks returned HTTP 200:
+
+- `https://fermatmind.com/api/v0.5/content-pages/careers?locale=en&org_id=0`
+- `https://fermatmind.com/api/v0.5/content-pages/careers?locale=zh-CN&org_id=0`
+- `https://api.fermatmind.com/api/v0.5/content-pages/careers?locale=en&org_id=0`
+- `https://api.fermatmind.com/api/v0.5/content-pages/careers?locale=zh-CN&org_id=0`
+
+## 5. Public Runtime Check
+
+| URL | HTTP | Title | H1 | Canonical | Robots |
+| --- | --- | --- | --- | --- | --- |
+| `https://fermatmind.com/en/careers` | 200 | `Work With FermatMind | FermatMind | FermatMind` | `Work With FermatMind` | `https://fermatmind.com/en/careers` | `index, follow` |
+| `https://fermatmind.com/zh/careers` | 200 | `加入费马测试 | FermatMind` | `加入费马测试` | `https://fermatmind.com/zh/careers` | `index, follow` |
+
+No staging canonical was observed.
+
+## 6. Role Draft Exposure Check
+
+The PR-HIRING-01 role package is still `draft_review_only`. Public role detail
+paths return 404:
+
+- `/en/careers/technical-partner-engineering-lead`
+- `/en/careers/product-design-brand-systems-lead`
+- `/en/careers/growth-seo-content-operations-lead`
+
+The role keys were not found in public Careers page HTML, sitemap, `llms.txt`,
+`llms-full.txt`, or public home navigation checks.
+
+## 7. Sitemap / llms / Footer Exposure
+
+Careers page exposure:
+
+- `sitemap.xml`: EN and ZH Careers pages present.
+- `llms.txt`: Careers pages not present in the short llms index.
+- `llms-full.txt`: EN and ZH Careers pages present.
+- Public `/en` and `/zh` navigation surfaces include the matching Careers link.
+
+Role draft exposure:
+
+- `sitemap.xml`: 0 role draft hits.
+- `llms.txt`: 0 role draft hits.
+- `llms-full.txt`: 0 role draft hits.
+- Public `/en` and `/zh` navigation surfaces: 0 role draft hits.
+
+## 8. Search Channel Safety
+
+Production read-only checks found zero Search Channel queue items for:
+
+- `https://fermatmind.com/en/careers`
+- `https://fermatmind.com/zh/careers`
+- `https://fermatmind.com/en/careers/technical-partner-engineering-lead`
+- `https://fermatmind.com/en/careers/product-design-brand-systems-lead`
+- `https://fermatmind.com/en/careers/growth-seo-content-operations-lead`
+
+Queue item 2 remains the EN MBTI IndexNow item in `approved/submitted` state.
+Queue item 3 remains the ZH MBTI IndexNow item in `approved/submitted` state.
+
+## 9. Claim Boundary
+
+The published Careers pages and the non-runtime role draft package do not
+create a hiring suitability guarantee, salary guarantee, career success
+guarantee, diagnosis, treatment, or cure claim in this task. No page body copy
+was modified.
+
+## 10. Sidecar Issues
+
+`llms.txt` does not include the Careers pages while `sitemap.xml` and
+`llms-full.txt` do include them. This is recorded as an observation only
+because this task is read-only and did not change llms generation policy.
+
+## 11. Validation
+
+Focused validation:
+
+- `php artisan test --filter=PrHiring01PostPublishSmoke --no-ansi`
+
+Additional repository validation is recorded in the generated JSON artifact.
+
+## 12. What Was Not Done
+
+No CMS mutation, production data mutation, publish, deploy, Search Channel
+action, URL submission, external search API call, env/DNS/nginx edit, raw log
+read, or fap-web mutation was performed.
+
+## 13. Final Decision
+
+`pr_hiring_01_post_publish_smoke_completed_stable`
+
+## 14. Next Task
+
+`none_foundation_hiring_smoke_train_complete`

--- a/backend/tests/Feature/SeoIntel/PrHiring01PostPublishSmokeTest.php
+++ b/backend/tests/Feature/SeoIntel/PrHiring01PostPublishSmokeTest.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class PrHiring01PostPublishSmokeTest extends TestCase
+{
+    #[Test]
+    public function generated_artifact_records_careers_runtime_and_role_boundaries(): void
+    {
+        $payload = $this->artifact();
+
+        $this->assertSame('pr_hiring_01_post_publish_smoke.v1', $payload['schema_version'] ?? null);
+        $this->assertSame('PR-HIRING-01-POST-PUBLISH-SMOKE', $payload['task'] ?? null);
+        $this->assertSame('pr_hiring_01_post_publish_smoke_completed_stable', $payload['final_decision'] ?? null);
+        $this->assertSame(['careers'], $payload['target_pages'] ?? null);
+        $this->assertSame(['en', 'zh-CN'], $payload['locales'] ?? null);
+        $this->assertCount(3, $payload['role_draft_keys'] ?? []);
+
+        foreach (['en', 'zh-CN'] as $locale) {
+            $this->assertSame('published', data_get($payload, "cms_record_state.$locale.status"));
+            $this->assertTrue((bool) data_get($payload, "cms_record_state.$locale.is_public"));
+            $this->assertTrue((bool) data_get($payload, "cms_record_state.$locale.is_indexable"));
+            $this->assertSame(200, data_get($payload, "public_runtime_check.$locale.http_status"));
+            $this->assertSame('index, follow', data_get($payload, "public_runtime_check.$locale.robots"));
+            $this->assertFalse((bool) data_get($payload, "public_runtime_check.$locale.staging_canonical_detected"));
+        }
+
+        foreach ($payload['role_draft_runtime_check'] ?? [] as $role) {
+            $this->assertSame(404, $role['http_status'] ?? null);
+            $this->assertFalse((bool) ($role['runtime_exposed'] ?? true));
+        }
+
+        $this->assertSame(0, data_get($payload, 'discoverability_check.sitemap_xml.role_draft_hits'));
+        $this->assertSame(0, data_get($payload, 'discoverability_check.llms_txt.role_draft_hits'));
+        $this->assertSame(0, data_get($payload, 'discoverability_check.llms_full_txt.role_draft_hits'));
+        $this->assertSame(0, data_get($payload, 'discoverability_check.footer_nav.role_draft_hits'));
+        $this->assertFalse((bool) data_get($payload, 'claim_boundary_check.role_package_runtime_exposed'));
+        $this->assertSame([], data_get($payload, 'claim_boundary_check.forbidden_claim_hits'));
+
+        foreach ([
+            'no_cms_mutation',
+            'no_publish',
+            'no_deploy',
+            'no_search_channel_action',
+            'no_url_submission',
+            'no_external_search_api_call',
+            'no_env_dns_nginx_edit',
+            'no_raw_log_read',
+            'no_fap_web_mutation',
+        ] as $flag) {
+            $this->assertTrue((bool) ($payload[$flag] ?? false), $flag);
+        }
+    }
+
+    #[Test]
+    public function report_contains_required_sections(): void
+    {
+        $reportPath = base_path('docs/seo/pr-hiring-01-post-publish-smoke.md');
+
+        $this->assertFileExists($reportPath);
+
+        $report = (string) file_get_contents($reportPath);
+
+        foreach ([
+            '## 1. Executive Summary',
+            '## 2. Source PR State',
+            '## 3. CMS Published State',
+            '## 4. API Runtime Check',
+            '## 5. Public Runtime Check',
+            '## 6. Role Draft Exposure Check',
+            '## 7. Sitemap / llms / Footer Exposure',
+            '## 8. Search Channel Safety',
+            '## 9. Claim Boundary',
+            '## 10. Sidecar Issues',
+            '## 11. Validation',
+            '## 12. What Was Not Done',
+            '## 13. Final Decision',
+            '## 14. Next Task',
+        ] as $heading) {
+            $this->assertStringContainsString($heading, $report);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json');
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35838,12 +35838,12 @@
     "branch": "codex/pr-hiring-01-post-publish-smoke",
     "base": "main",
     "title": "PR-HIRING-01-POST-PUBLISH-SMOKE careers runtime smoke",
-    "status": "local_checks_passed_with_sidecar",
+    "status": "pr_opened_with_sidecar",
     "depends_on": [
       "PR-HIRING-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "92d4ae4d8f8c922089ae8bb41450e4da11db3a3e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1839",
     "checks": [
       {
         "command": "manifest/state authorization",
@@ -35930,6 +35930,11 @@
         "status": "local_checks_passed_with_sidecar",
         "at": "2026-06-01T20:20:00+08:00",
         "summary": "Focused tests, route list, scoped Pint, composer validate/audit, JSON/YAML parsing, and diff checks passed. Full Pint failure is limited to pre-existing out-of-scope EQ test files and recorded as a sidecar."
+      },
+      {
+        "status": "pr_opened_with_sidecar",
+        "at": "2026-06-01T20:24:00+08:00",
+        "summary": "Committed, pushed, and opened PR #1839 with external sidecars recorded."
       }
     ],
     "scope_validation": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35103,7 +35103,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "git_diff_check": "passed",
-      "git_diff_cached_check": null
+      "git_diff_cached_check": true
     },
     "sidecars": [],
     "next_task": "Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization"
@@ -35728,11 +35728,11 @@
     "branch": "codex/pr-pol-01-ledger-reconcile-and-smoke",
     "base": "main",
     "title": "PR-POL-01-LEDGER-RECONCILE-AND-SMOKE policies runtime reconcile and smoke",
-    "status": "pr_opened_with_sidecar",
+    "status": "merged_with_sidecar",
     "depends_on": [
       "PR-POL-01"
     ],
-    "commit_sha": "4fcf6043",
+    "commit_sha": "9453a65a2ad98ce99694fa6b8685ad6f4678b0c4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1838",
     "checks": [
       {
@@ -35792,8 +35792,8 @@
       }
     ],
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-06-01T19:55:15+08:00",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "transitions": [
       {
@@ -35815,6 +35815,11 @@
         "status": "pr_opened_with_sidecar",
         "at": "2026-06-01T20:00:00+08:00",
         "summary": "Committed, pushed, and opened PR #1838 with the external Pint sidecar recorded."
+      },
+      {
+        "status": "merged_with_sidecar",
+        "at": "2026-06-01T19:55:15+08:00",
+        "summary": "PR #1838 passed GitHub required checks and was squash merged at 49427b78cf8dda30d74243fcae83141300583aca. Remote branch was deleted; local cleanup script was unavailable in this repository."
       }
     ],
     "scope_validation": {
@@ -35826,6 +35831,117 @@
       "Full vendor/bin/pint --test fails on pre-existing out-of-scope EQ test files not touched by this PR."
     ],
     "next_task": "PR-HIRING-01-POST-PUBLISH-SMOKE"
+  },
+  "PR-HIRING-01-POST-PUBLISH-SMOKE": {
+    "id": "PR-HIRING-01-POST-PUBLISH-SMOKE",
+    "repo": "fap-api",
+    "branch": "codex/pr-hiring-01-post-publish-smoke",
+    "base": "main",
+    "title": "PR-HIRING-01-POST-PUBLISH-SMOKE careers runtime smoke",
+    "status": "local_checks_passed_with_sidecar",
+    "depends_on": [
+      "PR-HIRING-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "manifest/state authorization",
+        "status": "passed",
+        "summary": "User explicitly authorized updating fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json for PR-HIRING-01-POST-PUBLISH-SMOKE."
+      },
+      {
+        "command": "source PR verification",
+        "status": "passed",
+        "summary": "PR #1760, PR #1762, and PR #1795 are merged with green GitHub checks."
+      },
+      {
+        "command": "read-only production CMS/API/runtime/Search Channel verification",
+        "status": "passed",
+        "summary": "Careers EN/ZH API and runtime checks returned 200; CMS rows are published/public/indexable; role draft paths return 404; Search Channel queue count for Careers and role draft URLs is zero; queue items 2 and 3 remain approved/submitted."
+      },
+      {
+        "command": "php artisan test --filter=PrHiring01PostPublishSmoke --no-ansi",
+        "status": "passed",
+        "summary": "PASS: 2 tests, 55 assertions."
+      },
+      {
+        "command": "php artisan route:list --no-ansi",
+        "status": "passed",
+        "summary": "PASS: route list rendered 210 routes."
+      },
+      {
+        "command": "vendor/bin/pint --test tests/Feature/SeoIntel/PrHiring01PostPublishSmokeTest.php",
+        "status": "passed",
+        "summary": "PASS: scoped Pint check passed for the focused test file."
+      },
+      {
+        "command": "vendor/bin/pint --test",
+        "status": "failed_external_sidecar",
+        "summary": "Full Pint remains blocked by two pre-existing out-of-scope EQ files: tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php."
+      },
+      {
+        "command": "composer validate --strict",
+        "status": "passed",
+        "summary": "PASS: composer.json is valid."
+      },
+      {
+        "command": "composer audit --locked --no-interaction --ignore-unreachable",
+        "status": "passed",
+        "summary": "PASS: no security vulnerability advisories found."
+      },
+      {
+        "command": "python3 -m json.tool backend/docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json >/dev/null",
+        "status": "passed",
+        "summary": "PASS: generated JSON parses."
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed",
+        "summary": "PASS: PR train state JSON parses."
+      },
+      {
+        "command": "python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('yaml ok')\nPY",
+        "status": "passed",
+        "summary": "PASS: PR train manifest YAML parses."
+      },
+      {
+        "command": "git diff --check",
+        "status": "passed",
+        "summary": "PASS: no whitespace errors."
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "status": "authorized",
+        "at": "2026-06-01T20:03:00+08:00",
+        "summary": "User authorized adding and executing PR-HIRING-01-POST-PUBLISH-SMOKE as a read-only post-publish smoke report."
+      },
+      {
+        "status": "in_progress",
+        "at": "2026-06-01T20:04:00+08:00",
+        "summary": "Started from latest origin/main on codex/pr-hiring-01-post-publish-smoke after PR-POL-01-LEDGER-RECONCILE-AND-SMOKE merged."
+      },
+      {
+        "status": "local_checks_passed_with_sidecar",
+        "at": "2026-06-01T20:20:00+08:00",
+        "summary": "Focused tests, route list, scoped Pint, composer validate/audit, JSON/YAML parsing, and diff checks passed. Full Pint failure is limited to pre-existing out-of-scope EQ test files and recorded as a sidecar."
+      }
+    ],
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "git_diff_check": true,
+      "git_diff_cached_check": null
+    },
+    "sidecars": [
+      "llms.txt does not include Careers pages while sitemap.xml and llms-full.txt do include them; recorded as read-only observation.",
+      "Full Pint is blocked by pre-existing out-of-scope EQ style issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php."
+    ],
+    "next_task": null
   },
   "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01": {
     "id": "PAYMENT-ALIPAY-PENDING-COMPENSATION-SCHEDULER-01",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18088,6 +18088,58 @@ prs:
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: CAREER-1046-INTERNAL-LINKING-AUTHORITY-01
 
+  - id: PR-HIRING-01-POST-PUBLISH-SMOKE
+    repo: fap-api
+    depends_on:
+      - PR-HIRING-01
+    branch: codex/pr-hiring-01-post-publish-smoke
+    base: main
+    title: "PR-HIRING-01-POST-PUBLISH-SMOKE careers runtime smoke"
+    train_scope: career_1046_growth_foundation
+    risk_level: p2_read_only_runtime_smoke
+    allowed_paths:
+      - backend/docs/seo/pr-hiring-01-post-publish-smoke.md
+      - backend/docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json
+      - backend/tests/Feature/SeoIntel/PrHiring01PostPublishSmokeTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Verify production Careers content page runtime after PR-HIRING-01 related content authority work.
+      - Confirm EN/ZH Careers CMS rows are published, public, and indexable.
+      - Confirm public runtime 200, exact canonicals, index/follow robots, no staging canonical, and expected sitemap/llms/footer exposure.
+      - Confirm PR-HIRING-01 role drafts remain non-runtime, absent from sitemap/llms/footer, and absent from Search Channel.
+    do_not:
+      - Mutate CMS or production data.
+      - Publish pages or role drafts.
+      - Deploy backend or frontend.
+      - Enqueue Search Channel, submit URLs, or call external search APIs.
+      - Edit env, DNS, nginx, or read raw logs.
+      - Modify fap-web.
+    validation:
+      - cd backend && php artisan test --filter=PrHiring01PostPublishSmoke --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    broad_pseo_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: null
+
   - id: CAREER-1046-INTERNAL-LINKING-AUTHORITY-01
     repo: fap-api
     depends_on:


### PR DESCRIPTION
## What changed
- Added the read-only PR-HIRING-01 post-publish smoke report for Careers runtime state.
- Added generated evidence JSON covering CMS/API/runtime, draft role non-exposure, sitemap/llms/footer, Search Channel safety, and queue item 2/3 protection.
- Added a focused feature test for the generated evidence artifact.
- Updated fap-api PR train manifest/state for the authorized task and reconciled the preceding PR-POL smoke merge metadata.

## Why
- The Careers content and hiring authority work was merged/deployed previously, so this records the post-publish runtime smoke without mutating production.
- The report confirms the public Careers pages are stable while the three role drafts remain non-public and do not enter sitemap/llms/footer/Search Channel surfaces.

## Validation
- `php artisan test --filter=PrHiring01PostPublishSmoke --no-ansi`
- `php artisan route:list --no-ansi`
- `vendor/bin/pint --test tests/Feature/SeoIntel/PrHiring01PostPublishSmokeTest.php`
- `composer validate --strict`
- `composer audit --locked --no-interaction --ignore-unreachable`
- `python3 -m json.tool backend/docs/seo/generated/pr-hiring-01-post-publish-smoke.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 - <<'PY' ... yaml.safe_load(...) ... PY`
- `git diff --check`
- `git diff --cached --check`

## Sidecars
- Full-repo `vendor/bin/pint --test` remains blocked by pre-existing out-of-scope EQ style issues in `tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php` and `tests/Unit/Report/EqIntegratedReportComposerTest.php`.
- `llms.txt` does not include Careers pages while `sitemap.xml` and `llms-full.txt` do include them; recorded as read-only observation.

## Intentionally deferred
- No CMS mutation, publish, deploy, Search Channel action, URL submission, external API call, env/DNS/nginx edit, raw log access, or fap-web mutation.
