### PR TITLE
ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02 map report_ready to projection truth

### DIFF
--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -705,6 +705,23 @@ final class AnalyticsFunnelDailyBuilder
      */
     private function collectReportReadyMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
     {
+        $map = $this->collectReportSnapshotReadyMap($from, $to, $orgIds);
+
+        foreach ($this->collectProjectionAccessReadyMap($from, $to, $orgIds) as $attemptId => $stageAt) {
+            $map[$attemptId] = $this->minTimestamp($map[$attemptId] ?? null, $stageAt);
+        }
+
+        ksort($map);
+
+        return $map;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectReportSnapshotReadyMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
         if (! SchemaBaseline::hasTable('report_snapshots')) {
             return [];
         }
@@ -743,6 +760,86 @@ final class AnalyticsFunnelDailyBuilder
             ]);
 
             if ($attemptId === '' || $stageAt === null) {
+                continue;
+            }
+
+            $map[$attemptId] = $this->minTimestamp($map[$attemptId] ?? null, $stageAt);
+        }
+
+        ksort($map);
+
+        return $map;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array<string,string>
+     */
+    private function collectProjectionAccessReadyMap(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        foreach (['attempts', 'benefit_grants', 'results', 'unified_access_projections', 'attempt_receipts'] as $table) {
+            if (! SchemaBaseline::hasTable($table)) {
+                return [];
+            }
+        }
+
+        if (! SchemaBaseline::hasColumn('benefit_grants', 'attempt_id')) {
+            return [];
+        }
+
+        $receiptAttempts = DB::table('attempt_receipts')
+            ->whereNotNull('attempt_id')
+            ->where('attempt_id', '!=', '')
+            ->select('attempt_id')
+            ->selectRaw('MIN(COALESCE(recorded_at, occurred_at, created_at, updated_at)) as receipt_at')
+            ->groupBy('attempt_id');
+
+        $query = DB::table('unified_access_projections')
+            ->join('attempts', 'attempts.id', '=', 'unified_access_projections.attempt_id')
+            ->join('benefit_grants', 'benefit_grants.attempt_id', '=', 'attempts.id')
+            ->join('results', 'results.attempt_id', '=', 'attempts.id')
+            ->joinSub($receiptAttempts, 'ready_receipts', function ($join): void {
+                $join->on('ready_receipts.attempt_id', '=', 'attempts.id');
+            })
+            ->whereRaw("lower(coalesce(unified_access_projections.access_state, '')) = ?", ['ready'])
+            ->whereRaw("lower(coalesce(unified_access_projections.report_state, '')) = ?", ['ready'])
+            ->whereRaw("lower(coalesce(benefit_grants.status, '')) = ?", ['active'])
+            ->whereNotNull('unified_access_projections.attempt_id')
+            ->where('unified_access_projections.attempt_id', '!=', '')
+            ->select('attempts.id as attempt_id')
+            ->selectRaw('MIN(benefit_grants.created_at) as grant_at')
+            ->selectRaw('MAX(COALESCE(unified_access_projections.refreshed_at, unified_access_projections.produced_at, unified_access_projections.updated_at, unified_access_projections.created_at)) as projection_at')
+            ->selectRaw('MIN(ready_receipts.receipt_at) as receipt_at')
+            ->selectRaw('MAX(COALESCE(results.computed_at, results.updated_at, results.created_at)) as result_at')
+            ->groupBy('attempts.id');
+
+        if (SchemaBaseline::hasColumn('benefit_grants', 'revoked_at')) {
+            $query->whereNull('benefit_grants.revoked_at');
+        }
+
+        if (SchemaBaseline::hasColumn('benefit_grants', 'expires_at')) {
+            $query->where(function (QueryBuilder $query): void {
+                $query->whereNull('benefit_grants.expires_at')
+                    ->orWhere('benefit_grants.expires_at', '>', now());
+            });
+        }
+
+        if ($orgIds !== []) {
+            $query->whereIn('attempts.org_id', $orgIds);
+        }
+
+        $map = [];
+
+        foreach ($query->get() as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            $stageAt = $this->maxTimestamp([
+                $row->grant_at ?? null,
+                $row->projection_at ?? null,
+                $row->receipt_at ?? null,
+                $row->result_at ?? null,
+            ]);
+
+            if ($attemptId === '' || $stageAt === null || ! $this->timestampBetween($stageAt, $from, $to)) {
                 continue;
             }
 
@@ -1169,6 +1266,13 @@ final class AnalyticsFunnelDailyBuilder
         return CarbonImmutable::parse($left)->lessThan(CarbonImmutable::parse($right));
     }
 
+    private function timestampBetween(string $timestamp, CarbonImmutable $from, CarbonImmutable $to): bool
+    {
+        $parsed = CarbonImmutable::parse($timestamp);
+
+        return $parsed->greaterThanOrEqualTo($from) && $parsed->lessThanOrEqualTo($to);
+    }
+
     /**
      * @param  list<string>  $eventAliases
      */
@@ -1322,5 +1426,27 @@ final class AnalyticsFunnelDailyBuilder
         return CarbonImmutable::parse($left)->lessThanOrEqualTo(CarbonImmutable::parse($right))
             ? $left
             : $right;
+    }
+
+    /**
+     * @param  array<int,mixed>  $candidates
+     */
+    private function maxTimestamp(array $candidates): ?string
+    {
+        $max = null;
+
+        foreach ($candidates as $candidate) {
+            $timestamp = $this->resolveTimestamp([$candidate]);
+
+            if ($timestamp === null) {
+                continue;
+            }
+
+            if ($max === null || $this->timestampBefore($max, $timestamp)) {
+                $max = $timestamp;
+            }
+        }
+
+        return $max;
     }
 }

--- a/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
@@ -5,7 +5,10 @@ declare(strict_types=1);
 namespace Tests\Feature\Analytics;
 
 use App\Services\Analytics\AnalyticsFunnelDailyBuilder;
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\Concerns\SeedsFunnelAnalyticsScenario;
 use Tests\TestCase;
 
@@ -85,5 +88,151 @@ final class AnalyticsFunnelDailyBuilderTest extends TestCase
         $this->assertSame(2, (int) ($totals['first_view_attempts'] ?? 0), 'paywall_view must stay outside the main view stage');
         $this->assertSame(2, (int) ($totals['paid_attempts'] ?? 0));
         $this->assertSame(1, (int) ($totals['unlocked_attempts'] ?? 0), 'unlock_success must depend on active grants, not paid order status');
+    }
+
+    public function test_projection_ready_paid_access_counts_as_report_ready(): void
+    {
+        $day = CarbonImmutable::parse('2026-02-02 09:00:00');
+
+        $this->seedProjectionAccessAttempt(orgId: 101, day: $day);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($day->toDateString()),
+            new \DateTimeImmutable($day->toDateString()),
+            [101],
+        );
+
+        $row = collect($payload['rows'])->firstWhere('locale', 'en');
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) ($row['paid_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($row['unlocked_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($row['report_ready_attempts'] ?? 0));
+    }
+
+    public function test_projection_missing_does_not_count_as_report_ready(): void
+    {
+        $day = CarbonImmutable::parse('2026-02-03 09:00:00');
+
+        $this->seedProjectionAccessAttempt(orgId: 102, day: $day, withProjection: false);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($day->toDateString()),
+            new \DateTimeImmutable($day->toDateString()),
+            [102],
+        );
+
+        $row = collect($payload['rows'])->firstWhere('locale', 'en');
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) ($row['unlocked_attempts'] ?? 0));
+        $this->assertSame(0, (int) ($row['report_ready_attempts'] ?? 0));
+    }
+
+    public function test_grant_missing_does_not_count_projection_as_report_ready(): void
+    {
+        $day = CarbonImmutable::parse('2026-02-04 09:00:00');
+
+        $this->seedProjectionAccessAttempt(orgId: 103, day: $day, withGrant: false);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($day->toDateString()),
+            new \DateTimeImmutable($day->toDateString()),
+            [103],
+        );
+
+        $row = collect($payload['rows'])->firstWhere('locale', 'en');
+
+        $this->assertNotNull($row);
+        $this->assertSame(0, (int) ($row['unlocked_attempts'] ?? 0));
+        $this->assertSame(0, (int) ($row['report_ready_attempts'] ?? 0));
+    }
+
+    public function test_snapshot_and_projection_ready_sources_count_once_per_attempt(): void
+    {
+        $day = CarbonImmutable::parse('2026-02-05 09:00:00');
+
+        $this->seedProjectionAccessAttempt(orgId: 104, day: $day, withSnapshot: true);
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($day->toDateString()),
+            new \DateTimeImmutable($day->toDateString()),
+            [104],
+        );
+
+        $row = collect($payload['rows'])->firstWhere('locale', 'en');
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) ($row['report_ready_attempts'] ?? 0));
+    }
+
+    private function seedProjectionAccessAttempt(
+        int $orgId,
+        CarbonImmutable $day,
+        bool $withProjection = true,
+        bool $withGrant = true,
+        bool $withSnapshot = false
+    ): string {
+        $attemptId = (string) Str::uuid();
+        $orderNo = 'ord_projection_'.$orgId;
+
+        $this->insertAttempt($attemptId, $orgId, 'en', $day, $day->addMinutes(5));
+        $this->insertAttemptSubmission($attemptId, $orgId, $day->addMinutes(6));
+        $this->insertResult($attemptId, $orgId, $day->addMinutes(8));
+        $this->insertEvent($orgId, 'result_view', $attemptId, $day->addMinutes(10));
+        $this->insertOrder($orderNo, $attemptId, $orgId, $day->addMinutes(20), 199, $day->addMinutes(25));
+
+        if ($withGrant) {
+            $this->insertBenefitGrant($attemptId, $orderNo, $orgId, $day->addMinutes(30));
+        }
+
+        $this->insertAttemptReceipt($attemptId, $day->addMinutes(35));
+
+        if ($withProjection) {
+            $this->insertUnifiedAccessProjection($attemptId, $day->addMinutes(40));
+        }
+
+        if ($withSnapshot) {
+            $this->insertReportSnapshot($attemptId, $orderNo, $orgId, $day->addMinutes(45));
+        }
+
+        return $attemptId;
+    }
+
+    private function insertAttemptReceipt(string $attemptId, CarbonImmutable $recordedAt): void
+    {
+        DB::table('attempt_receipts')->insert([
+            'attempt_id' => $attemptId,
+            'seq' => 1,
+            'receipt_type' => 'report_access_ready',
+            'source_system' => 'analytics_test',
+            'source_ref' => 'projection_ready_fixture',
+            'actor_type' => 'system',
+            'actor_id' => null,
+            'idempotency_key' => 'receipt_'.$attemptId,
+            'payload_json' => json_encode(['ready' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $recordedAt,
+            'recorded_at' => $recordedAt,
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+    }
+
+    private function insertUnifiedAccessProjection(string $attemptId, CarbonImmutable $readyAt): void
+    {
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'not_requested',
+            'reason_code' => null,
+            'projection_version' => 1,
+            'actions_json' => json_encode(['enter_report' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode(['ready_to_enter' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => $readyAt,
+            'refreshed_at' => $readyAt,
+            'created_at' => $readyAt,
+            'updated_at' => $readyAt,
+        ]);
     }
 }

--- a/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Analytics;
 
+use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
 use Tests\Concerns\SeedsFunnelAnalyticsScenario;
 use Tests\TestCase;
 
@@ -55,5 +57,89 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
             3898,
             (int) DB::table('analytics_funnel_daily')->where('org_id', 91)->sum('paid_revenue_cents')
         );
+    }
+
+    public function test_dry_run_reports_projection_ready_attempt_without_writing(): void
+    {
+        $day = CarbonImmutable::parse('2026-02-06 09:00:00');
+
+        $this->seedProjectionAccessAttempt(92, $day);
+
+        $this->artisan('analytics:refresh-funnel-daily', [
+            '--from' => $day->toDateString(),
+            '--to' => $day->toDateString(),
+            '--org' => [92],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('attempted_rows=1')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_funnel_daily')->count());
+
+        $payload = app(\App\Services\Analytics\AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($day->toDateString()),
+            new \DateTimeImmutable($day->toDateString()),
+            [92],
+        );
+
+        $row = collect($payload['rows'])->firstWhere('locale', 'en');
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) ($row['report_ready_attempts'] ?? 0));
+    }
+
+    private function seedProjectionAccessAttempt(int $orgId, CarbonImmutable $day): string
+    {
+        $attemptId = (string) Str::uuid();
+        $orderNo = 'ord_projection_refresh_'.$orgId;
+
+        $this->insertAttempt($attemptId, $orgId, 'en', $day, $day->addMinutes(5));
+        $this->insertAttemptSubmission($attemptId, $orgId, $day->addMinutes(6));
+        $this->insertResult($attemptId, $orgId, $day->addMinutes(8));
+        $this->insertEvent($orgId, 'result_view', $attemptId, $day->addMinutes(10));
+        $this->insertOrder($orderNo, $attemptId, $orgId, $day->addMinutes(20), 199, $day->addMinutes(25));
+        $this->insertBenefitGrant($attemptId, $orderNo, $orgId, $day->addMinutes(30));
+        $this->insertAttemptReceipt($attemptId, $day->addMinutes(35));
+        $this->insertUnifiedAccessProjection($attemptId, $day->addMinutes(40));
+
+        return $attemptId;
+    }
+
+    private function insertAttemptReceipt(string $attemptId, CarbonImmutable $recordedAt): void
+    {
+        DB::table('attempt_receipts')->insert([
+            'attempt_id' => $attemptId,
+            'seq' => 1,
+            'receipt_type' => 'report_access_ready',
+            'source_system' => 'analytics_test',
+            'source_ref' => 'projection_ready_fixture',
+            'actor_type' => 'system',
+            'actor_id' => null,
+            'idempotency_key' => 'receipt_'.$attemptId,
+            'payload_json' => json_encode(['ready' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $recordedAt,
+            'recorded_at' => $recordedAt,
+            'created_at' => $recordedAt,
+            'updated_at' => $recordedAt,
+        ]);
+    }
+
+    private function insertUnifiedAccessProjection(string $attemptId, CarbonImmutable $readyAt): void
+    {
+        DB::table('unified_access_projections')->insert([
+            'attempt_id' => $attemptId,
+            'access_state' => 'ready',
+            'report_state' => 'ready',
+            'pdf_state' => 'not_requested',
+            'reason_code' => null,
+            'projection_version' => 1,
+            'actions_json' => json_encode(['enter_report' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'payload_json' => json_encode(['ready_to_enter' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'produced_at' => $readyAt,
+            'refreshed_at' => $readyAt,
+            'created_at' => $readyAt,
+            'updated_at' => $readyAt,
+        ]);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-01T06:19:00Z",
+  "updated_at": "2026-06-01T13:33:00Z",
   "items": {
     "PR-EQ-PER-01": {
       "repo": "fap-api",
@@ -24026,6 +24026,74 @@
       "transitions": [],
       "sidecars": [],
       "next_task": "CLINICAL-MH-LAUNCH-TRAIN-CLOSEOUT"
+    },
+    "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02": {
+      "repo": "fap-api",
+      "branch": "codex/analytics-funnel-report-ready-projection-mapping-02",
+      "status": "pr_open_checks_pending",
+      "depends_on": [
+        "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
+      ],
+      "commit_sha": "pending_remote_pr_head",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1842",
+      "checks": {
+        "manifest_registration": {
+          "status": "pass",
+          "evidence": "User explicitly authorized adding ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02 to fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+        },
+        "workspace_safety": {
+          "status": "pass",
+          "evidence": "Implementation is isolated in /private/tmp/fap-api-analytics-funnel-report-ready-projection-mapping-02; the dirty primary fap-api worktree is not used."
+        },
+        "scope_boundaries": {
+          "status": "pass",
+          "evidence": "Changed files are limited to AnalyticsFunnelDailyBuilder, focused analytics tests, and PR train metadata. No production DB mutation, analytics refresh, payment repair, benefit grant creation, payment provider call, CMS mutation, GA/Baidu setting change, Search Channel action, URL submission, deploy, or fap-web change was performed."
+        },
+        "analytics_builder": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+          "evidence": "PASS with existing PHPUnit warnings: 6 tests, 39 assertions."
+        },
+        "refresh_command": {
+          "status": "pass",
+          "command": "cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi",
+          "evidence": "PASS with existing PHPUnit warnings: 2 tests, 18 assertions."
+        },
+        "route_list": {
+          "status": "pass",
+          "command": "cd backend && php artisan route:list --no-ansi",
+          "evidence": "Route list rendered successfully with 210 routes."
+        },
+        "scoped_pint": {
+          "status": "pass",
+          "command": "cd backend && vendor/bin/pint --test app/Services/Analytics/AnalyticsFunnelDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php",
+          "evidence": "Scoped Pint passed for the three PHP files touched by this PR."
+        },
+        "full_pint": {
+          "status": "sidecar_external_failure",
+          "command": "cd backend && vendor/bin/pint --test",
+          "evidence": "Full Pint still reports pre-existing out-of-scope new_with_parentheses style issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php. Current PR does not touch those files."
+        },
+        "composer_validate": {
+          "status": "pass",
+          "command": "cd backend && composer validate --strict",
+          "evidence": "composer.json is valid."
+        },
+        "composer_audit": {
+          "status": "pass",
+          "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+          "evidence": "No security vulnerability advisories found."
+        },
+        "json_yaml_diff": {
+          "status": "pass",
+          "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check",
+          "evidence": "State JSON parsed, train YAML parsed, and unstaged diff whitespace check passed."
+        }
+      },
+      "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused analytics checks passed locally.",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false
     }
   },
   "SEO-DASH-PROD-03D-FIX": {
@@ -39001,5 +39069,128 @@
         "summary": "Opened PR #1835; GitHub checks passed and mergeStateStatus is CLEAN."
       }
     ]
+  },
+  "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02": {
+    "id": "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-report-ready-projection-mapping-02",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02 map report_ready to projection truth",
+    "status": "pr_open_checks_pending",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
+    ],
+    "commit_sha": "pending_remote_pr_head",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1842",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02 to fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      "workspace_safety": {
+        "status": "pass",
+        "evidence": "Implementation is isolated in /private/tmp/fap-api-analytics-funnel-report-ready-projection-mapping-02; the dirty primary fap-api worktree is not used."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Changed files are limited to AnalyticsFunnelDailyBuilder, focused analytics tests, and PR train metadata. No production DB mutation, analytics refresh, payment repair, benefit grant creation, payment provider call, CMS mutation, GA/Baidu setting change, Search Channel action, URL submission, deploy, or fap-web change was performed."
+      },
+      "analytics_builder": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "evidence": "PASS with existing PHPUnit warnings: 6 tests, 39 assertions."
+      },
+      "refresh_command": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi",
+        "evidence": "PASS with existing PHPUnit warnings: 2 tests, 18 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "Route list rendered successfully with 210 routes."
+      },
+      "scoped_pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Services/Analytics/AnalyticsFunnelDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php",
+        "evidence": "Scoped Pint passed for the three PHP files touched by this PR."
+      },
+      "full_pint": {
+        "status": "sidecar_external_failure",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "Full Pint still reports pre-existing out-of-scope new_with_parentheses style issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php. Current PR does not touch those files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check",
+        "evidence": "State JSON parsed, train YAML parsed, and unstaged diff whitespace check passed."
+      }
+    },
+    "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused analytics checks passed locally.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T12:46:21Z",
+        "from": "authorized",
+        "to": "implementation_in_progress",
+        "note": "Started scoped analytics funnel report_ready projection mapping PR from latest origin/main in an isolated worktree."
+      },
+      {
+        "at": "2026-06-01T13:18:00Z",
+        "from": "implementation_in_progress",
+        "to": "local_checks_passed_with_sidecar",
+        "note": "Focused analytics tests, route:list, scoped Pint, composer validate/audit, JSON/YAML parsing, and diff checks passed. Full Pint sidecar remains out-of-scope in EQ tests."
+      },
+      {
+        "at": "2026-06-01T13:23:00Z",
+        "from": "local_checks_passed_with_sidecar",
+        "to": "committed_pending_pr",
+        "note": "Committed scoped implementation locally at cf3d6daf7413f38b67f6bfd872e3e65d5959aade."
+      },
+      {
+        "at": "2026-06-01T13:26:00Z",
+        "from": "committed_pending_pr",
+        "to": "commit_sha_pending_remote_head",
+        "note": "Set ledger commit_sha to pending_remote_pr_head to avoid amend hash churn before PR creation."
+      },
+      {
+        "at": "2026-06-01T13:33:00Z",
+        "from": "commit_sha_pending_remote_head",
+        "to": "pr_open_checks_pending",
+        "note": "Opened GitHub PR #1842 after scoped local validation passed with an external full-Pint sidecar."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "out_of_scope_eq_pint_new_with_parentheses",
+        "status": "open_external_sidecar",
+        "summary": "Full vendor/bin/pint --test reports pre-existing new_with_parentheses style issues in EQ unit tests outside this analytics funnel scope.",
+        "files": [
+          "backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php",
+          "backend/tests/Unit/Report/EqIntegratedReportComposerTest.php"
+        ],
+        "impact_on_current_pr": "No runtime or read-model impact; scoped Pint and focused analytics tests pass.",
+        "follow_up_recommendation": "Resolve in a separate scoped EQ Pint cleanup PR."
+      }
+    ],
+    "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16729,6 +16729,54 @@ prs:
     frontend_fallback_authority: false
     next_task: ANALYTICS-PAYMENT-UNLOCK-ATTRIBUTION-REPAIR-01B
 
+  - id: ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02
+    repo: fap-api
+    branch: codex/analytics-funnel-report-ready-projection-mapping-02
+    base: main
+    title: "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02 map report_ready to projection truth"
+    train_scope: analytics_funnel_report_ready_projection_mapping
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01
+    allowed_paths:
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Map analytics_funnel_daily report_ready_attempts to the current paid report access truth from active benefit grants, ready unified access projections, attempt receipts, attempts, and results.
+      - Preserve existing ready report snapshot support and avoid duplicate attempt counting across ready sources.
+      - Preserve org/date/scale/locale scoping through attempt-led analytics rows.
+      - Do not change payment_success or report_unlock semantics.
+      - Do not run analytics refresh, mutate production DB, repair payments, create benefit grants, call payment providers, deploy, mutate CMS, change GA/Baidu settings, enqueue Search Channel, or submit URLs.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_repair_allowed: false
+    payment_provider_call: false
+    analytics_refresh_allowed: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02
+
 
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Mapped `analytics_funnel_daily.report_ready_attempts` to current paid report access truth from active benefit grants, ready unified access projections, attempt receipts, attempts, and results.
- Preserved existing `report_snapshots` ready support and de-duped attempts across snapshot and projection sources.
- Added focused coverage for projection-ready counting, missing projection/grant exclusions, duplicate source de-duping, and dry-run command behavior.
- Registered the authorized PR train manifest/state entry.

## Why
`report_ready_attempts` was still tied only to legacy report snapshot readiness, while current paid access readiness is represented by benefit grants plus unified access projections and receipts. That kept analytics at `report_ready_attempts=0` after repaired paid results became accessible.

## Validation
- `cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi` passed with existing PHPUnit warnings.
- `cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi` passed with existing PHPUnit warnings.
- `cd backend && php artisan route:list --no-ansi` passed.
- `cd backend && vendor/bin/pint --test app/Services/Analytics/AnalyticsFunnelDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php` passed.
- `cd backend && composer validate --strict` passed.
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` passed.
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` passed.
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"` passed.
- `git diff --check` and `git diff --cached --check` passed.

## Intentionally deferred
- No production analytics refresh was run.
- No production DB mutation, payment repair, benefit grant creation, payment provider call, CMS mutation, GA/Baidu setting change, Search Channel action, URL submission, deploy, or fap-web change was performed.
- Full `vendor/bin/pint --test` still reports pre-existing out-of-scope EQ test style issues in `tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php` and `tests/Unit/Report/EqIntegratedReportComposerTest.php`; scoped Pint for this PR passed.
