### PR TITLE
ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03 fix report_ready timestamp merge

### DIFF
--- a/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+++ b/backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
@@ -708,7 +708,7 @@ final class AnalyticsFunnelDailyBuilder
         $map = $this->collectReportSnapshotReadyMap($from, $to, $orgIds);
 
         foreach ($this->collectProjectionAccessReadyMap($from, $to, $orgIds) as $attemptId => $stageAt) {
-            $map[$attemptId] = $this->minTimestamp($map[$attemptId] ?? null, $stageAt);
+            $map[$attemptId] = $stageAt;
         }
 
         ksort($map);

--- a/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
@@ -166,12 +166,38 @@ final class AnalyticsFunnelDailyBuilderTest extends TestCase
         $this->assertSame(1, (int) ($row['report_ready_attempts'] ?? 0));
     }
 
+    public function test_projection_ready_time_wins_over_stale_snapshot_time(): void
+    {
+        $day = CarbonImmutable::parse('2026-02-07 09:00:00');
+
+        $this->seedProjectionAccessAttempt(
+            orgId: 105,
+            day: $day,
+            withSnapshot: true,
+            snapshotAt: $day->addMinutes(12)
+        );
+
+        $payload = app(AnalyticsFunnelDailyBuilder::class)->build(
+            new \DateTimeImmutable($day->toDateString()),
+            new \DateTimeImmutable($day->toDateString()),
+            [105],
+        );
+
+        $row = collect($payload['rows'])->firstWhere('locale', 'en');
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) ($row['paid_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($row['unlocked_attempts'] ?? 0));
+        $this->assertSame(1, (int) ($row['report_ready_attempts'] ?? 0));
+    }
+
     private function seedProjectionAccessAttempt(
         int $orgId,
         CarbonImmutable $day,
         bool $withProjection = true,
         bool $withGrant = true,
-        bool $withSnapshot = false
+        bool $withSnapshot = false,
+        ?CarbonImmutable $snapshotAt = null
     ): string {
         $attemptId = (string) Str::uuid();
         $orderNo = 'ord_projection_'.$orgId;
@@ -193,7 +219,7 @@ final class AnalyticsFunnelDailyBuilderTest extends TestCase
         }
 
         if ($withSnapshot) {
-            $this->insertReportSnapshot($attemptId, $orderNo, $orgId, $day->addMinutes(45));
+            $this->insertReportSnapshot($attemptId, $orderNo, $orgId, $snapshotAt ?? $day->addMinutes(45));
         }
 
         return $attemptId;

--- a/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
@@ -63,7 +63,7 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
     {
         $day = CarbonImmutable::parse('2026-02-06 09:00:00');
 
-        $this->seedProjectionAccessAttempt(92, $day);
+        $this->seedProjectionAccessAttempt(92, $day, withStaleSnapshot: true);
 
         $this->artisan('analytics:refresh-funnel-daily', [
             '--from' => $day->toDateString(),
@@ -89,7 +89,7 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
         $this->assertSame(1, (int) ($row['report_ready_attempts'] ?? 0));
     }
 
-    private function seedProjectionAccessAttempt(int $orgId, CarbonImmutable $day): string
+    private function seedProjectionAccessAttempt(int $orgId, CarbonImmutable $day, bool $withStaleSnapshot = false): string
     {
         $attemptId = (string) Str::uuid();
         $orderNo = 'ord_projection_refresh_'.$orgId;
@@ -102,6 +102,10 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
         $this->insertBenefitGrant($attemptId, $orderNo, $orgId, $day->addMinutes(30));
         $this->insertAttemptReceipt($attemptId, $day->addMinutes(35));
         $this->insertUnifiedAccessProjection($attemptId, $day->addMinutes(40));
+
+        if ($withStaleSnapshot) {
+            $this->insertReportSnapshot($attemptId, $orderNo, $orgId, $day->addMinutes(12));
+        }
 
         return $attemptId;
     }
@@ -140,6 +144,25 @@ final class RefreshAnalyticsFunnelDailyCommandTest extends TestCase
             'refreshed_at' => $readyAt,
             'created_at' => $readyAt,
             'updated_at' => $readyAt,
+        ]);
+    }
+
+    private function insertReportSnapshot(string $attemptId, string $orderNo, int $orgId, CarbonImmutable $updatedAt): void
+    {
+        DB::table('report_snapshots')->insert([
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'order_no' => $orderNo,
+            'scale_code' => 'MBTI',
+            'pack_id' => 'MBTI',
+            'dir_version' => 'mbti_dir_2026_01',
+            'scoring_spec_version' => 'scoring_2026_01',
+            'report_engine_version' => 'report_2026_01',
+            'snapshot_version' => 'v1',
+            'report_json' => json_encode(['summary' => 'stale-ready'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'status' => 'ready',
+            'created_at' => $updatedAt->subMinutes(2),
+            'updated_at' => $updatedAt,
         ]);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38281,7 +38281,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-fdn-02a-post-deploy-runtime-validation",
     "base": "main",
-    "status": "committed_pending_pr",
+    "status": "pr_open_checks_pending",
     "title": "docs(foundation): validate Daily Giving backend runtime",
     "depends_on": [],
     "commit_sha": "322bf0d8f0884c48730fc23c2713710315d19863",
@@ -38509,7 +38509,7 @@
       "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01"
     ],
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1844",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -39297,6 +39297,12 @@
         "from": "local_checks_passed_with_sidecar",
         "to": "committed_pending_pr",
         "note": "Committed scoped implementation locally and set commit_sha to pending_remote_pr_head before PR creation to avoid amend hash churn."
+      },
+      {
+        "at": "2026-06-01T16:21:17Z",
+        "from": "committed_pending_pr",
+        "to": "pr_open_checks_pending",
+        "note": "Opened GitHub PR #1844 after scoped local validation passed with an external full-Pint sidecar."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38281,7 +38281,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-fdn-02a-post-deploy-runtime-validation",
     "base": "main",
-    "status": "local_checks_passed_with_sidecar",
+    "status": "committed_pending_pr",
     "title": "docs(foundation): validate Daily Giving backend runtime",
     "depends_on": [],
     "commit_sha": "322bf0d8f0884c48730fc23c2713710315d19863",
@@ -38440,7 +38440,7 @@
     "depends_on": [
       "PR-FDN-SOCIAL-SYNC-READINESS"
     ],
-    "commit_sha": null,
+    "commit_sha": "pending_remote_pr_head",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1829",
     "checks": {
       "manifest_registration": {
@@ -39076,11 +39076,11 @@
     "branch": "codex/analytics-funnel-report-ready-projection-mapping-02",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02 map report_ready to projection truth",
-    "status": "pr_open_checks_pending",
+    "status": "merged_reconciled",
     "depends_on": [
       "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-WRITE-GUARD-01"
     ],
-    "commit_sha": "pending_remote_pr_head",
+    "commit_sha": "c28f04a1f1ea95c89d4038375d818c70ee506284",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1842",
     "checks": {
       "manifest_registration": {
@@ -39137,13 +39137,13 @@
       }
     },
     "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused analytics checks passed locally.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-06-01T13:39:50Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -39176,6 +39176,12 @@
         "from": "commit_sha_pending_remote_head",
         "to": "pr_open_checks_pending",
         "note": "Opened GitHub PR #1842 after scoped local validation passed with an external full-Pint sidecar."
+      },
+      {
+        "at": "2026-06-02T00:00:00Z",
+        "from": "pr_open_checks_pending",
+        "to": "merged_reconciled",
+        "note": "Reconciled dependency before ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03: GitHub PR #1842 is MERGED at c28f04a1f1ea95c89d4038375d818c70ee506284, origin/main contains the merge commit, and the remote branch is absent."
       }
     ],
     "sidecars": [
@@ -39192,5 +39198,120 @@
       }
     ],
     "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02"
+  },
+  "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03": {
+    "id": "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-report-ready-merge-timestamp-03",
+    "base": "main",
+    "title": "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03 fix report_ready timestamp merge",
+    "status": "local_checks_passed_with_sidecar",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03 to fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      "dependency_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #1842 is MERGED at c28f04a1f1ea95c89d4038375d818c70ee506284; origin/main contains the merge commit and the remote branch is absent."
+      },
+      "workspace_safety": {
+        "status": "pass",
+        "evidence": "Started from clean /Users/rainie/Desktop/GitHub/fap-api main after git pull --ff-only origin main."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Changed files are limited to AnalyticsFunnelDailyBuilder, focused analytics tests, and PR train metadata. No production DB mutation, analytics refresh, payment repair, benefit grant creation, payment provider call, CMS mutation, GA/Baidu setting change, Search Channel action, URL submission, deploy, or fap-web change was performed."
+      },
+      "analytics_builder": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi",
+        "evidence": "PASS: 7 tests, 43 assertions."
+      },
+      "refresh_command": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi",
+        "evidence": "PASS: 2 tests, 18 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "Route list rendered successfully with 210 routes."
+      },
+      "scoped_pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test app/Services/Analytics/AnalyticsFunnelDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php",
+        "evidence": "Scoped Pint passed for the three PHP files touched by this PR."
+      },
+      "full_pint": {
+        "status": "sidecar_external_failure",
+        "command": "cd backend && vendor/bin/pint --test",
+        "evidence": "Full Pint still reports pre-existing out-of-scope new_with_parentheses style issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php. Current PR does not touch those files."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check",
+        "evidence": "State JSON parsed, train YAML parsed, and unstaged diff whitespace check passed."
+      }
+    },
+    "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; scoped current PR files and required focused analytics checks passed locally.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T16:21:17Z",
+        "from": "authorized",
+        "to": "implementation_in_progress",
+        "note": "Started scoped report_ready timestamp merge fix after user authorized manifest/state registration."
+      },
+      {
+        "at": "2026-06-01T16:21:17Z",
+        "from": "implementation_in_progress",
+        "to": "local_checks_passed_with_sidecar",
+        "note": "Focused analytics tests, route:list, scoped Pint, composer validate/audit, JSON/YAML parsing, and diff checks passed. Full Pint sidecar remains out-of-scope in EQ tests."
+      },
+      {
+        "at": "2026-06-01T16:21:17Z",
+        "from": "local_checks_passed_with_sidecar",
+        "to": "committed_pending_pr",
+        "note": "Committed scoped implementation locally and set commit_sha to pending_remote_pr_head before PR creation to avoid amend hash churn."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "out_of_scope_eq_pint_new_with_parentheses",
+        "status": "open_external_sidecar",
+        "summary": "Full vendor/bin/pint --test reports pre-existing new_with_parentheses style issues in EQ unit tests outside this analytics funnel scope.",
+        "files": [
+          "backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php",
+          "backend/tests/Unit/Report/EqIntegratedReportComposerTest.php"
+        ],
+        "impact_on_current_pr": "No runtime or read-model impact; scoped Pint and focused analytics tests pass.",
+        "follow_up_recommendation": "Resolve in a separate scoped EQ Pint cleanup PR."
+      }
+    ],
+    "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -16777,6 +16777,53 @@ prs:
     frontend_fallback_authority: false
     next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02
 
+  - id: ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03
+    repo: fap-api
+    branch: codex/analytics-funnel-report-ready-merge-timestamp-03
+    base: main
+    title: "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03 fix report_ready timestamp merge"
+    train_scope: analytics_funnel_report_ready_merge_timestamp
+    risk_level: p1_analytics_funnel_observability
+    depends_on:
+      - ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02
+    allowed_paths:
+      - backend/app/Services/Analytics/AnalyticsFunnelDailyBuilder.php
+      - backend/tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php
+      - backend/tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    scope:
+      - Fix report_ready timestamp merging so projection-ready access is not overridden by stale snapshot-ready timestamps on the same attempt.
+      - Prefer projection-ready time when projection truth represents actual paid access readiness while preserving snapshot-only report_ready behavior.
+      - Preserve de-duplication, org/date/scale/locale scoping, payment_success semantics, and report_unlock semantics.
+      - Do not run analytics refresh, mutate production DB, repair payments, create benefit grants, call payment providers, deploy, mutate CMS, change GA/Baidu settings, enqueue Search Channel, or submit URLs.
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
+      - cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_repair_allowed: false
+    payment_provider_call: false
+    analytics_refresh_allowed: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03
+
 
   - id: CONTENT-PACKS-INDEX-ARTIFACT-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Changed analytics_funnel_daily report_ready merging so projection-ready access time wins when an attempt also has an older report_snapshot ready timestamp.
- Added regression coverage for stale snapshot time before unlock/projection repair.
- Registered ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03 in the PR train ledger and reconciled dependency PR #1842 as merged.

## Why
Production dry-run after #1842 showed collectProjectionAccessReadyMap finds 6 ready attempts, but report_ready_attempts stayed 0 because stale snapshot timestamps were merged before projection timestamps and then dropped by stage normalization.

## Validation
- cd backend && php artisan test --filter=AnalyticsFunnelDailyBuilder --no-ansi
- cd backend && php artisan test --filter=RefreshAnalyticsFunnelDailyCommand --no-ansi
- cd backend && php artisan route:list --no-ansi
- cd backend && vendor/bin/pint --test app/Services/Analytics/AnalyticsFunnelDailyBuilder.php tests/Feature/Analytics/AnalyticsFunnelDailyBuilderTest.php tests/Feature/Analytics/RefreshAnalyticsFunnelDailyCommandTest.php
- cd backend && composer validate --strict
- cd backend && composer audit --locked --no-interaction --ignore-unreachable
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check
- git diff --cached --check

## Intentionally deferred
- No production analytics refresh.
- No production DB mutation, payment repair, benefit grant creation, payment provider call, CMS mutation, Search Channel action, URL submission, or deploy.
- Full Pint still has an existing out-of-scope EQ sidecar in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php; scoped Pint for this PR passed.