### PR TITLE
CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01 legacy full jobs index consumer audit

### DIFF
--- a/backend/docs/seo/career-legacy-full-jobs-index-consumer-audit-01.md
+++ b/backend/docs/seo/career-legacy-full-jobs-index-consumer-audit-01.md
@@ -1,0 +1,66 @@
+# CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01
+
+## 1. Executive Summary
+
+This report audits remaining consumers of the legacy public full jobs index endpoint:
+
+`GET /api/v0.5/career/jobs`
+
+The endpoint is still valid as a legacy compatibility surface, but it returns the full public career job collection and should not be used for 10k-scale directory, sitemap, llms, or frontend entry-page rendering. The preferred 10k path is the backend career directory authority endpoint and authority artifacts.
+
+## 2. Backend Consumer Findings
+
+- Public route still exists: `backend/routes/api.php` maps `/career/jobs` to `CareerJobListController@index`.
+- The controller path is `backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php`.
+- Release and validation commands still use public job counts as compatibility checks, not as the long-term directory authority.
+- Some import/validation console commands contain production public jobs API constants for validation/import workflows.
+
+## 3. Frontend Reference Findings
+
+Reference-only scan of `fap-web` found that the main `/career/jobs` page has already moved away from `fetchCareerJobIndex`, but full-index consumers remain:
+
+- `lib/career/api/fetchCareerJobIndex.ts`
+- `app/(localized)/[locale]/career/industries/page.tsx`
+- `app/(localized)/[locale]/career/industries/[slug]/page.tsx`
+- several contracts that mock or assert the legacy path for compatibility.
+
+These are not changed in this backend PR.
+
+## 4. Risk Classification
+
+- P1: industry pages still consume the full index and can become a 10k-scale SSR/render cost.
+- P1: the legacy endpoint contract can be accidentally reused by future frontend work.
+- P2: backend validation scripts still mention the legacy public jobs API, but current use is operational verification rather than public page rendering.
+
+No P0 exposure was found because sitemap/llms career URL exposure already uses authority-oriented paths and held slugs remain excluded.
+
+## 5. Migration Plan
+
+1. Keep `/api/v0.5/career/jobs` stable as legacy compatibility until all known consumers are migrated.
+2. Move industry pages to the directory authority endpoint or a bounded family/facet authority endpoint.
+3. Add a drift gate proving sitemap/llms/directory/detail counts agree and held slugs remain absent.
+4. After consumers are migrated, consider response budget hardening or deprecation documentation for the full jobs index.
+
+## 6. Safety Boundaries
+
+No backend runtime behavior, DB state, CMS state, career cohort, sitemap, llms, Search Channel, URL submission, or frontend code was changed.
+
+## 7. Validation
+
+Required local validation:
+
+- `cd backend && php artisan test --filter=CareerLegacyFullJobsIndexConsumerAudit01 --no-ansi`
+- `cd backend && php artisan route:list --no-ansi`
+- `cd backend && vendor/bin/pint --test`
+- `cd backend && composer validate --strict`
+- `cd backend && composer audit --locked --no-interaction --ignore-unreachable`
+- JSON/YAML parse checks
+- `git diff --check`
+
+## 8. Final Decision
+
+`career_legacy_full_jobs_index_consumer_audit_completed_ready_for_directory_authority_drift_gate`
+
+## 9. Next Task
+
+`CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01`

--- a/backend/docs/seo/generated/career-legacy-full-jobs-index-consumer-audit-01.v1.json
+++ b/backend/docs/seo/generated/career-legacy-full-jobs-index-consumer-audit-01.v1.json
@@ -1,0 +1,103 @@
+{
+  "schema_version": "career_legacy_full_jobs_index_consumer_audit.v1",
+  "task": "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01",
+  "mode": "report_only",
+  "final_decision": "career_legacy_full_jobs_index_consumer_audit_completed_ready_for_directory_authority_drift_gate",
+  "legacy_endpoint": {
+    "method": "GET",
+    "path": "/api/v0.5/career/jobs",
+    "status": "compatibility_surface_keep_stable",
+    "ten_k_directory_authority": false
+  },
+  "backend_consumers": [
+    {
+      "file": "backend/routes/api.php",
+      "consumer": "Route::get('/career/jobs', [CareerJobListController::class, 'index'])",
+      "risk": "compatibility_surface",
+      "recommendation": "keep_stable_until_all_consumers_migrated"
+    },
+    {
+      "file": "backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php",
+      "consumer": "CareerJobListController@index",
+      "risk": "full_index_response_budget",
+      "recommendation": "do_not_expand_for_10k_directory_shell"
+    },
+    {
+      "file": "backend/app/Console/Commands/ReleaseVerifyPublicContent.php",
+      "consumer": "career jobs public count verification",
+      "risk": "ops_verification_only",
+      "recommendation": "eventually_compare_against_directory_authority_count"
+    },
+    {
+      "file": "backend/app/Console/Commands/CareerValidateDisplayBatch.php",
+      "consumer": "PUBLIC_CAREER_JOB_API",
+      "risk": "batch_validation_dependency",
+      "recommendation": "keep_as_validation_or_migrate_to_directory_authority_when_batch_checks_need_pagination"
+    },
+    {
+      "file": "backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php",
+      "consumer": "PUBLIC_CAREER_JOB_API",
+      "risk": "import_validation_dependency",
+      "recommendation": "keep_out_of_runtime_request_path"
+    },
+    {
+      "file": "backend/app/Console/Commands/CareerAlignSelectedOnetCrosswalks.php",
+      "consumer": "PUBLIC_CAREER_JOB_API",
+      "risk": "ops_alignment_dependency",
+      "recommendation": "keep_out_of_runtime_request_path"
+    }
+  ],
+  "frontend_reference_consumers": [
+    {
+      "file": "lib/career/api/fetchCareerJobIndex.ts",
+      "consumer": "legacy full jobs index fetcher",
+      "risk": "p1_legacy_fetcher_can_be_reused",
+      "recommendation": "restrict new consumers and migrate industry pages"
+    },
+    {
+      "file": "app/(localized)/[locale]/career/industries/page.tsx",
+      "consumer": "fetchCareerJobIndex({ locale })",
+      "risk": "p1_industry_index_full_collection_render_cost",
+      "recommendation": "migrate_to_directory_or_family_authority_endpoint"
+    },
+    {
+      "file": "app/(localized)/[locale]/career/industries/[slug]/page.tsx",
+      "consumer": "fetchCareerJobIndex({ locale })",
+      "risk": "p1_industry_detail_full_collection_render_cost",
+      "recommendation": "migrate_to_directory_family_filter_or_family_authority_endpoint"
+    }
+  ],
+  "non_consumers_confirmed": {
+    "frontend_career_jobs_page_uses_directory_endpoint": true,
+    "sitemap_should_not_depend_on_legacy_full_index": true,
+    "llms_should_not_depend_on_legacy_full_index": true
+  },
+  "risk_summary": {
+    "p0": [],
+    "p1": [
+      "frontend_industry_pages_still_consume_full_jobs_index",
+      "legacy_fetcher_can_be_reintroduced_into_directory_or_llms_paths"
+    ],
+    "p2": [
+      "ops_scripts_reference_public_full_jobs_api_for_validation"
+    ]
+  },
+  "migration_plan": [
+    "keep_legacy_endpoint_stable",
+    "migrate_industry_pages_to_directory_or_family_authority",
+    "add_directory_detail_sitemap_llms_drift_gate",
+    "document_deprecation_or_budget_constraints_after_consumers_migrate"
+  ],
+  "safety_boundaries": {
+    "production_write_performed": false,
+    "database_mutation_performed": false,
+    "cms_mutation_performed": false,
+    "runtime_promotion_performed": false,
+    "deploy_performed": false,
+    "fap_web_change_performed": false,
+    "search_channel_action_performed": false,
+    "url_submission_performed": false,
+    "external_search_api_call_performed": false
+  },
+  "next_task": "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
+}

--- a/backend/tests/Feature/SeoIntel/CareerLegacyFullJobsIndexConsumerAudit01Test.php
+++ b/backend/tests/Feature/SeoIntel/CareerLegacyFullJobsIndexConsumerAudit01Test.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class CareerLegacyFullJobsIndexConsumerAudit01Test extends TestCase
+{
+    public function test_legacy_full_jobs_index_consumer_audit_artifact_is_complete(): void
+    {
+        $reportPath = base_path('docs/seo/generated/career-legacy-full-jobs-index-consumer-audit-01.v1.json');
+
+        $this->assertFileExists($reportPath);
+
+        $report = json_decode((string) file_get_contents($reportPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('career_legacy_full_jobs_index_consumer_audit.v1', $report['schema_version'] ?? null);
+        $this->assertSame('CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01', $report['task'] ?? null);
+        $this->assertSame(
+            'career_legacy_full_jobs_index_consumer_audit_completed_ready_for_directory_authority_drift_gate',
+            $report['final_decision'] ?? null,
+        );
+
+        $this->assertSame('/api/v0.5/career/jobs', $report['legacy_endpoint']['path'] ?? null);
+        $this->assertFalse($report['legacy_endpoint']['ten_k_directory_authority'] ?? true);
+
+        $backendFiles = array_column($report['backend_consumers'] ?? [], 'file');
+        foreach ([
+            'backend/routes/api.php',
+            'backend/app/Http/Controllers/API/V0_5/Career/CareerJobListController.php',
+            'backend/app/Console/Commands/ReleaseVerifyPublicContent.php',
+            'backend/app/Console/Commands/CareerValidateDisplayBatch.php',
+            'backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php',
+            'backend/app/Console/Commands/CareerAlignSelectedOnetCrosswalks.php',
+        ] as $expectedFile) {
+            $this->assertContains($expectedFile, $backendFiles);
+        }
+
+        $frontendFiles = array_column($report['frontend_reference_consumers'] ?? [], 'file');
+        foreach ([
+            'lib/career/api/fetchCareerJobIndex.ts',
+            'app/(localized)/[locale]/career/industries/page.tsx',
+            'app/(localized)/[locale]/career/industries/[slug]/page.tsx',
+        ] as $expectedFile) {
+            $this->assertContains($expectedFile, $frontendFiles);
+        }
+
+        $this->assertTrue($report['non_consumers_confirmed']['frontend_career_jobs_page_uses_directory_endpoint'] ?? false);
+        $this->assertTrue($report['non_consumers_confirmed']['sitemap_should_not_depend_on_legacy_full_index'] ?? false);
+        $this->assertTrue($report['non_consumers_confirmed']['llms_should_not_depend_on_legacy_full_index'] ?? false);
+
+        $this->assertContains('frontend_industry_pages_still_consume_full_jobs_index', $report['risk_summary']['p1'] ?? []);
+        $this->assertContains('legacy_fetcher_can_be_reintroduced_into_directory_or_llms_paths', $report['risk_summary']['p1'] ?? []);
+
+        foreach ([
+            'production_write_performed',
+            'database_mutation_performed',
+            'cms_mutation_performed',
+            'runtime_promotion_performed',
+            'deploy_performed',
+            'fap_web_change_performed',
+            'search_channel_action_performed',
+            'url_submission_performed',
+            'external_search_api_call_performed',
+        ] as $field) {
+            $this->assertFalse($report['safety_boundaries'][$field] ?? true, $field);
+        }
+
+        $this->assertSame('CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01', $report['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -39319,5 +39319,210 @@
       }
     ],
     "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03"
+  },
+  "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01": {
+    "id": "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01",
+    "repo": "fap-api",
+    "branch": "codex/career-legacy-full-jobs-index-consumer-audit-01",
+    "base": "main",
+    "status": "pr_open_checks_pending",
+    "title": "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01 legacy full jobs index consumer audit",
+    "depends_on": [],
+    "commit_sha": "pending_remote_pr_head",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1845",
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized manifest/state updates for all eight PRs in the career 10k scale train."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Current PR scope is report-only: docs/generated/test/state for legacy full jobs index consumer audit."
+      },
+      "php artisan test --filter=CareerLegacyFullJobsIndexConsumerAudit01 --no-ansi": {
+        "status": "pass",
+        "evidence": "Focused SeoIntel artifact test passed: 1 test, 30 assertions."
+      },
+      "php artisan route:list --no-ansi": {
+        "status": "pass",
+        "evidence": "Route list completed successfully with 210 routes; no route changes were made."
+      },
+      "vendor/bin/pint --test tests/Feature/SeoIntel/CareerLegacyFullJobsIndexConsumerAudit01Test.php": {
+        "status": "pass",
+        "evidence": "Scoped Pint passed for the only PHP file touched by this PR."
+      },
+      "vendor/bin/pint --test": {
+        "status": "sidecar_external_failure",
+        "evidence": "Full Pint reports pre-existing out-of-scope new_with_parentheses issues in tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and tests/Unit/Report/EqIntegratedReportComposerTest.php. Current PR does not touch those files; scoped Pint passed."
+      },
+      "composer validate --strict": {
+        "status": "pass",
+        "evidence": "composer.json is valid."
+      },
+      "composer audit --locked --no-interaction --ignore-unreachable": {
+        "status": "pass",
+        "evidence": "No security vulnerability advisories found."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "evidence": "Generated JSON, pr-train-state JSON, and pr-train YAML parse successfully; git diff --check passed."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the current report, generated JSON, focused test, and train metadata."
+      }
+    },
+    "failure_reason": "Sidecar only: full Pint reports pre-existing out-of-scope EQ test formatting issues; current PR focused test, route:list, scoped Pint, composer validate/audit, JSON/YAML, and diff checks pass.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "authorized",
+        "to": "implementation_in_progress",
+        "note": "Started scoped report-only legacy full jobs index consumer audit."
+      },
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "implementation_in_progress",
+        "to": "local_checks_passed_with_sidecar",
+        "note": "Focused test, route:list, scoped Pint, composer validate/audit, JSON/YAML parsing, and diff checks passed. Full Pint sidecar remains out-of-scope in EQ tests."
+      },
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "local_checks_passed_with_sidecar",
+        "to": "committed_pending_pr",
+        "note": "Committed scoped report-only audit locally after validation passed with an external full-Pint sidecar."
+      },
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "committed_pending_pr",
+        "to": "pr_open_checks_pending",
+        "note": "Opened GitHub PR #1845 after scoped local validation passed with an external full-Pint sidecar."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "out_of_scope_eq_pint_new_with_parentheses",
+        "status": "open_external_sidecar",
+        "summary": "Full vendor/bin/pint --test reports pre-existing new_with_parentheses style issues in EQ unit tests outside this report-only career audit scope.",
+        "files": [
+          "backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php",
+          "backend/tests/Unit/Report/EqIntegratedReportComposerTest.php"
+        ],
+        "impact_on_current_pr": "No runtime, report, or audit impact; scoped Pint and focused artifact test pass.",
+        "follow_up_recommendation": "Resolve in a separate scoped EQ Pint cleanup PR."
+      }
+    ],
+    "next_task": "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
+  },
+  "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01": {
+    "id": "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01",
+    "repo": "fap-api",
+    "branch": "codex/career-directory-authority-drift-gate-01",
+    "base": "main",
+    "status": "planned",
+    "title": "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01 directory authority drift gate",
+    "depends_on": [
+      "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "missing",
+        "to": "planned",
+        "note": "Initialized by user authorization for the career 10k scale train."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "CAREER-LLMS-FULL-10K-BUDGET-GATE-01"
+  },
+  "CAREER-SEARCH-CHANNEL-READINESS-GATE-01": {
+    "id": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01",
+    "repo": "fap-api",
+    "branch": "codex/career-search-channel-readiness-gate-01",
+    "base": "main",
+    "status": "planned",
+    "title": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate",
+    "depends_on": [
+      "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "missing",
+        "to": "planned",
+        "note": "Initialized by user authorization for the career 10k scale train."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01"
+  },
+  "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01": {
+    "id": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01",
+    "repo": "fap-api",
+    "branch": "codex/career-10k-rollout-architecture-spec-01",
+    "base": "main",
+    "status": "planned",
+    "title": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec",
+    "depends_on": [
+      "CAREER-SEARCH-CHANNEL-READINESS-GATE-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "local_validation_passed": null,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-01T16:53:26Z",
+        "from": "missing",
+        "to": "planned",
+        "note": "Initialized by user authorization for the career 10k scale train."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "none"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19331,3 +19331,146 @@ prs:
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     next_task: none
+
+  - id: CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01
+    repo: fap-api
+    depends_on: []
+    branch: codex/career-legacy-full-jobs-index-consumer-audit-01
+    base: main
+    title: "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01 legacy full jobs index consumer audit"
+    train_scope: career_10k_scale
+    status: in_progress
+    scope:
+      - Audit remaining backend consumers of /api/v0.5/career/jobs and reference-only fap-web full jobs index consumers.
+      - Produce report-only consumer list, risk classification, and migration plan.
+      - Do not change runtime behavior, frontend code, career cohort state, sitemap, llms, Search Channel, or URL submission.
+    allowed_paths:
+      - backend/docs/seo/career-legacy-full-jobs-index-consumer-audit-01.md
+      - backend/docs/seo/generated/career-legacy-full-jobs-index-consumer-audit-01.v1.json
+      - backend/tests/Feature/SeoIntel/CareerLegacyFullJobsIndexConsumerAudit01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate production CMS, production DB, career cohort state, runtime projection, or held slug policy.
+      - Change fap-web, sitemap, llms, frontend rendering, Search Channel, URL submission, or deployment behavior.
+      - Release software-developers, digital-forensics-analysts, or computer-occupations-all-other.
+      - Add frontend fallback career content.
+    validation:
+      - cd backend && php artisan test --filter=CareerLegacyFullJobsIndexConsumerAudit01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/CareerLegacyFullJobsIndexConsumerAudit01Test.php
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/career-legacy-full-jobs-index-consumer-audit-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01
+
+  - id: CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01
+    repo: fap-api
+    depends_on: [CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01]
+    branch: codex/career-directory-authority-drift-gate-01
+    base: main
+    title: "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01 directory authority drift gate"
+    train_scope: career_10k_scale
+    status: planned
+    scope:
+      - Add a backend gate that compares directory count, public detail indexable count, sitemap career URL count, llms career URL count, and held slug exclusions.
+      - Produce artifact report proving directory/detail/sitemap/llms truth cannot drift silently.
+      - Do not mutate production state or expose new URLs.
+    allowed_paths:
+      - backend/docs/seo/career-directory-authority-drift-gate-01.md
+      - backend/docs/seo/generated/career-directory-authority-drift-gate-01.v1.json
+      - backend/tests/Feature/SeoIntel/CareerDirectoryAuthorityDriftGate01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate production CMS, production DB, career cohort state, runtime projection, sitemap, llms, Search Channel, or URL submission.
+      - Release software-developers, digital-forensics-analysts, or computer-occupations-all-other.
+    validation:
+      - cd backend && php artisan test --filter=CareerDirectoryAuthorityDriftGate01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/career-directory-authority-drift-gate-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: CAREER-LLMS-FULL-10K-BUDGET-GATE-01
+
+  - id: CAREER-SEARCH-CHANNEL-READINESS-GATE-01
+    repo: fap-api
+    depends_on: [CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01]
+    branch: codex/career-search-channel-readiness-gate-01
+    base: main
+    title: "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate"
+    train_scope: career_10k_scale
+    status: planned
+    scope:
+      - Add a read-only Search Channel readiness gate for the 2092 career detail URLs.
+      - Produce GO/HOLD decision and staged rollout proposal without enqueueing or submitting URLs.
+      - Verify sitemap, llms, held slug exclusions, robots, and claim-boundary readiness inputs.
+    allowed_paths:
+      - backend/docs/seo/career-search-channel-readiness-gate-01.md
+      - backend/docs/seo/generated/career-search-channel-readiness-gate-01.v1.json
+      - backend/tests/Feature/SeoIntel/CareerSearchChannelReadinessGate01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Enqueue Search Channel, submit URLs, call external search APIs, mutate CMS/DB, deploy, or change frontend behavior.
+      - Release held slugs or expand career claims.
+    validation:
+      - cd backend && php artisan test --filter=CareerSearchChannelReadinessGate01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/career-search-channel-readiness-gate-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01
+
+  - id: CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01
+    repo: fap-api
+    depends_on: [CAREER-SEARCH-CHANNEL-READINESS-GATE-01]
+    branch: codex/career-10k-rollout-architecture-spec-01
+    base: main
+    title: "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec"
+    train_scope: career_10k_scale
+    status: planned
+    scope:
+      - Produce the backend-owned 10k career rollout architecture specification.
+      - Cover authority source, rollout gates, held slug policy, directory API budget, sitemap/llms policy, smoke/SLO, rollback, and future PR boundaries.
+      - Do not implement runtime changes or expose new URLs.
+    allowed_paths:
+      - backend/docs/career/README.md
+      - backend/docs/seo/career-10k-rollout-architecture-spec-01.md
+      - backend/docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json
+      - backend/tests/Feature/SeoIntel/Career10kRolloutArchitectureSpec01Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS/DB, deploy, change fap-web, enqueue Search Channel, submit URLs, or release held slugs.
+    validation:
+      - cd backend && php artisan test --filter=Career10kRolloutArchitectureSpec01 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    next_task: none


### PR DESCRIPTION
## What changed
- Added the report-only `CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01` artifact for remaining `/api/v0.5/career/jobs` full-index consumers.
- Recorded backend compatibility consumers and reference-only fap-web consumers that still depend on the legacy full jobs index.
- Added a focused SeoIntel test proving the generated JSON artifact is complete and no production/search/deploy mutation occurred.
- Registered the authorized fap-api-owned career 10k scale train entries for PR3, PR4, PR7, and PR8 only.

## Why
The career directory path is now the 10k-scale authority direction. This PR documents remaining full-index consumers so future PRs can gate drift and migrate high-risk paths without accidentally reintroducing full collection fanout.

## Validation
- `cd backend && php artisan test --filter=CareerLegacyFullJobsIndexConsumerAudit01 --no-ansi` ✅
- `cd backend && php artisan route:list --no-ansi` ✅
- `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/CareerLegacyFullJobsIndexConsumerAudit01Test.php` ✅
- `cd backend && composer validate --strict` ✅
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` ✅
- `python3 -m json.tool backend/docs/seo/generated/career-legacy-full-jobs-index-consumer-audit-01.v1.json >/dev/null` ✅
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` ✅
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"` ✅
- `git diff --check && git diff --cached --check` ✅

## Sidecar
- `cd backend && vendor/bin/pint --test` still reports pre-existing out-of-scope `new_with_parentheses` issues in:
  - `backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php`
  - `backend/tests/Unit/Report/EqIntegratedReportComposerTest.php`
- Current PR does not touch those files; scoped Pint for the current PHP test passed.

## Intentionally deferred
- No runtime change to `/api/v0.5/career/jobs`.
- No fap-web changes.
- No sitemap, llms, Search Channel, URL submission, CMS/DB, deploy, or held slug changes.
- Industry-page migration remains a later frontend/backend migration item.
