### PR TITLE
CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate

### DIFF
--- a/backend/docs/seo/career-search-channel-readiness-gate-01.md
+++ b/backend/docs/seo/career-search-channel-readiness-gate-01.md
@@ -1,0 +1,61 @@
+# CAREER-SEARCH-CHANNEL-READINESS-GATE-01
+
+## Executive Summary
+
+This report records a read-only Search Channel readiness gate for the current 1046 public career detail rollout.
+
+Decision: **HOLD live submission**. The 2092 EN/ZH career detail URLs are discoverability-ready at the authority surface level, but Search Channel remains closed until a separate explicit approval starts a canary/batch submission plan.
+
+No Search Channel queue write, live submission, external search API call, CMS/DB mutation, runtime promotion, deployment, sitemap/llms mutation, or fap-web change was performed.
+
+## Readiness Inputs
+
+- Public career detail count: `1046`
+- Locales: `en`, `zh`
+- Public career detail URL count: `2092`
+- Sitemap career detail URL count: `2092`
+- `llms.txt` career detail URL count: `2092`
+- `llms-full.txt` complete artifact career detail URL count: `2092`
+- Canonical/robots expectation: detail pages are canonical exact and `index,follow`
+- Claim boundary expectation: occupation information and decision-support framing only
+
+## Held Slug Safety
+
+The following held or conflict slugs remain excluded from Search Channel readiness:
+
+- `software-developers`
+- `digital-forensics-analysts`
+- `computer-occupations-all-other`
+
+They must remain absent from runtime detail exposure, sitemap, `llms.txt`, `llms-full.txt`, and any future Search Channel candidate batch unless a separate authority reconciliation explicitly changes their state.
+
+## GO/HOLD Decision
+
+Search Channel state: `HOLD`.
+
+Reason:
+
+- The 1046 rollout is stable enough to prepare a staged plan.
+- Search submission is still a separate action requiring explicit approval.
+- No queue enqueue or live submission should happen in this gate.
+
+## Staged Rollout Proposal
+
+Future Search Channel work, if explicitly approved later, should use a staged plan:
+
+1. Canary: 10 EN + 10 ZH career detail URLs from low-risk occupation pages.
+2. Observation window: 24 hours, no duplicate queue items, no held slug leakage.
+3. Batch 1: 100 EN/ZH paired URLs if canary remains stable.
+4. Batch expansion: bounded daily batches only after sitemap/llms/robots/canonical checks remain green.
+5. Stop conditions: held slug exposure, noindex/canonical drift, Search Channel anomaly, claim boundary regression, staging contamination, or external API failure.
+
+## What Was Not Done
+
+- No Search Channel queue item was created.
+- No URL was submitted.
+- No GSC, Baidu, IndexNow, Bing, 360, Sogou, or Shenma API was called.
+- No CMS, DB, runtime projection, sitemap, llms, deployment, or frontend behavior was changed.
+
+## Final Decision
+
+`career_search_channel_readiness_gate_completed_hold_submission_ready_for_staged_plan`

--- a/backend/docs/seo/generated/career-search-channel-readiness-gate-01.v1.json
+++ b/backend/docs/seo/generated/career-search-channel-readiness-gate-01.v1.json
@@ -1,0 +1,69 @@
+{
+  "schema_version": "career_search_channel_readiness_gate.v1",
+  "task": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01",
+  "final_decision": "career_search_channel_readiness_gate_completed_hold_submission_ready_for_staged_plan",
+  "authority_source": "backend career directory/detail/sitemap/llms authority artifacts",
+  "search_channel_decision": "HOLD",
+  "public_detail_count": 1046,
+  "locales": [
+    "en",
+    "zh"
+  ],
+  "public_career_detail_url_count": 2092,
+  "sitemap_career_detail_url_count": 2092,
+  "llms_career_detail_url_count": 2092,
+  "llms_full_complete_career_detail_url_count": 2092,
+  "readiness_inputs": {
+    "directory_authority_aligned": true,
+    "sitemap_aligned": true,
+    "llms_aligned": true,
+    "llms_full_complete_artifact_aligned": true,
+    "robots_index_follow_expected": true,
+    "canonical_exact_expected": true,
+    "claim_boundary_review_required": true,
+    "claim_boundary_current_sample_state": "bounded_occupation_information_and_decision_support"
+  },
+  "held_slugs": [
+    "software-developers",
+    "digital-forensics-analysts",
+    "computer-occupations-all-other"
+  ],
+  "held_slug_absence": {
+    "runtime_detail": true,
+    "sitemap": true,
+    "llms": true,
+    "llms_full": true,
+    "search_channel_candidate_batch": true
+  },
+  "staged_rollout_proposal": {
+    "canary_size": 20,
+    "canary_shape": "10 EN + 10 ZH paired career detail URLs",
+    "observation_window_hours": 24,
+    "batch_1_size": 100,
+    "batch_expansion": "bounded daily batches only after canary remains stable",
+    "requires_explicit_future_approval": true
+  },
+  "stop_conditions": [
+    "held_slug_exposure",
+    "noindex_or_canonical_drift",
+    "search_channel_queue_anomaly",
+    "claim_boundary_regression",
+    "staging_contamination",
+    "external_search_api_failure"
+  ],
+  "safety_boundaries": {
+    "search_channel_enqueue_performed": false,
+    "live_submission_performed": false,
+    "url_submission_performed": false,
+    "external_search_api_call_performed": false,
+    "cms_mutation_performed": false,
+    "database_mutation_performed": false,
+    "runtime_promotion_performed": false,
+    "sitemap_mutation_performed": false,
+    "llms_mutation_performed": false,
+    "deploy_performed": false,
+    "fap_web_change_performed": false,
+    "held_slug_release_performed": false
+  },
+  "next_task": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01"
+}

--- a/backend/tests/Feature/SeoIntel/CareerSearchChannelReadinessGate01Test.php
+++ b/backend/tests/Feature/SeoIntel/CareerSearchChannelReadinessGate01Test.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class CareerSearchChannelReadinessGate01Test extends TestCase
+{
+    public function test_career_search_channel_readiness_gate_holds_submission_without_writes(): void
+    {
+        $reportPath = base_path('docs/seo/generated/career-search-channel-readiness-gate-01.v1.json');
+
+        $this->assertFileExists($reportPath);
+
+        $report = json_decode((string) file_get_contents($reportPath), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame('career_search_channel_readiness_gate.v1', $report['schema_version'] ?? null);
+        $this->assertSame('CAREER-SEARCH-CHANNEL-READINESS-GATE-01', $report['task'] ?? null);
+        $this->assertSame(
+            'career_search_channel_readiness_gate_completed_hold_submission_ready_for_staged_plan',
+            $report['final_decision'] ?? null,
+        );
+        $this->assertSame('HOLD', $report['search_channel_decision'] ?? null);
+        $this->assertSame(1046, $report['public_detail_count'] ?? null);
+        $this->assertSame(['en', 'zh'], $report['locales'] ?? null);
+        $this->assertSame(2092, $report['public_career_detail_url_count'] ?? null);
+        $this->assertSame($report['public_career_detail_url_count'], $report['sitemap_career_detail_url_count'] ?? null);
+        $this->assertSame($report['sitemap_career_detail_url_count'], $report['llms_career_detail_url_count'] ?? null);
+        $this->assertSame($report['sitemap_career_detail_url_count'], $report['llms_full_complete_career_detail_url_count'] ?? null);
+
+        foreach ([
+            'directory_authority_aligned',
+            'sitemap_aligned',
+            'llms_aligned',
+            'llms_full_complete_artifact_aligned',
+            'robots_index_follow_expected',
+            'canonical_exact_expected',
+            'claim_boundary_review_required',
+        ] as $field) {
+            $this->assertTrue($report['readiness_inputs'][$field] ?? false, $field);
+        }
+
+        $this->assertSame([
+            'software-developers',
+            'digital-forensics-analysts',
+            'computer-occupations-all-other',
+        ], $report['held_slugs'] ?? null);
+
+        foreach (['runtime_detail', 'sitemap', 'llms', 'llms_full', 'search_channel_candidate_batch'] as $surface) {
+            $this->assertTrue($report['held_slug_absence'][$surface] ?? false, $surface);
+        }
+
+        $this->assertSame(20, $report['staged_rollout_proposal']['canary_size'] ?? null);
+        $this->assertSame(24, $report['staged_rollout_proposal']['observation_window_hours'] ?? null);
+        $this->assertTrue($report['staged_rollout_proposal']['requires_explicit_future_approval'] ?? false);
+
+        foreach ([
+            'held_slug_exposure',
+            'noindex_or_canonical_drift',
+            'search_channel_queue_anomaly',
+            'claim_boundary_regression',
+            'staging_contamination',
+            'external_search_api_failure',
+        ] as $stopCondition) {
+            $this->assertContains($stopCondition, $report['stop_conditions'] ?? []);
+        }
+
+        foreach ([
+            'search_channel_enqueue_performed',
+            'live_submission_performed',
+            'url_submission_performed',
+            'external_search_api_call_performed',
+            'cms_mutation_performed',
+            'database_mutation_performed',
+            'runtime_promotion_performed',
+            'sitemap_mutation_performed',
+            'llms_mutation_performed',
+            'deploy_performed',
+            'fap_web_change_performed',
+            'held_slug_release_performed',
+        ] as $field) {
+            $this->assertFalse($report['safety_boundaries'][$field] ?? true, $field);
+        }
+
+        $this->assertSame('CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01', $report['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -39557,13 +39557,13 @@
     "repo": "fap-api",
     "branch": "codex/career-search-channel-readiness-gate-01",
     "base": "main",
-    "status": "implementation_in_progress",
+    "status": "pr_open",
     "title": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate",
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "a948adc520215d52d51cfc63ee0728c9e4642903",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1847",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -39630,6 +39630,12 @@
         "from": "planned",
         "to": "implementation_in_progress",
         "note": "Started read-only career Search Channel readiness gate."
+      },
+      {
+        "at": "2026-06-01T18:10:30Z",
+        "from": "implementation_in_progress",
+        "to": "pr_open",
+        "note": "Opened PR #1847 with scoped report, generated artifact, test, and ledger update."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38508,7 +38508,7 @@
     "depends_on": [
       "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01"
     ],
-    "commit_sha": null,
+    "commit_sha": "c7d8b38be1abdc982b4272c98b96fb49f6ea1364",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1844",
     "checks": {
       "manifest_registration": {
@@ -39557,21 +39557,64 @@
     "repo": "fap-api",
     "branch": "codex/career-search-channel-readiness-gate-01",
     "base": "main",
-    "status": "planned",
+    "status": "implementation_in_progress",
     "title": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate",
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized all eight career 10k scale train entries; this fap-api entry exists in manifest/state."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01 is merged in fap-api main."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to read-only Search Channel readiness report, generated JSON, focused SeoIntel test, and train metadata."
+      },
+      "focused_phpunit": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=CareerSearchChannelReadinessGate01 --no-ansi",
+        "evidence": "PASS, 1 test / 46 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS, 210 routes."
+      },
+      "scoped_pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/CareerSearchChannelReadinessGate01Test.php",
+        "evidence": "PASS, focused PR test file is formatted."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS, no security vulnerability advisories found."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "command": "python3 -m json.tool backend/docs/seo/generated/career-search-channel-readiness-gate-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check",
+        "evidence": "PASS."
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -39581,9 +39624,32 @@
         "from": "missing",
         "to": "planned",
         "note": "Initialized by user authorization for the career 10k scale train."
+      },
+      {
+        "at": "2026-06-01T18:01:05Z",
+        "from": "planned",
+        "to": "implementation_in_progress",
+        "note": "Started read-only career Search Channel readiness gate."
       }
     ],
-    "sidecars": [],
+    "sidecars": [
+      {
+        "id": "career-search-channel-readiness-gate-01-full-pint-existing-eq-style",
+        "source_pr": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01",
+        "repo": "fap-api",
+        "branch": "codex/career-search-channel-readiness-gate-01",
+        "command_or_check": "cd backend && vendor/bin/pint --test",
+        "evidence": "Full Pint reports existing new_with_parentheses style issues in backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and backend/tests/Unit/Report/EqIntegratedReportComposerTest.php.",
+        "failure_summary": "Out-of-scope EQ unit test style failures in files not changed by this PR.",
+        "why_external_to_current_pr": "Current PR changes only career Search Channel readiness docs/generated artifact/focused SeoIntel test/train metadata; it does not touch EQ test files.",
+        "impact_on_current_pr": "Scoped Pint for the PR test file passes and scope validation is clean.",
+        "owner": "fap-api EQ test owner",
+        "follow_up_recommendation": "Run a separate scoped EQ Pint cleanup PR or fold the formatting cleanup into the owning EQ task.",
+        "required_checks_status": "pending GitHub checks",
+        "scope_validation_status": "passed",
+        "continue_train_decision": "continue if GitHub required checks are green"
+      }
+    ],
     "next_task": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01"
   },
   "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01": {

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19412,7 +19412,7 @@ prs:
     base: main
     title: "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 career Search Channel readiness gate"
     train_scope: career_10k_scale
-    status: planned
+    status: in_progress
     scope:
       - Add a read-only Search Channel readiness gate for the 2092 career detail URLs.
       - Produce GO/HOLD decision and staged rollout proposal without enqueueing or submitting URLs.


### PR DESCRIPTION
## What changed
- Added the `CAREER-SEARCH-CHANNEL-READINESS-GATE-01` read-only Search Channel readiness report for the 1046 public career detail rollout.
- Added generated JSON with 2092 EN/ZH URL readiness inputs, held slug exclusion state, staged rollout proposal, stop conditions, and explicit HOLD decision.
- Added a focused SeoIntel test validating the readiness artifact and no-mutation/no-submission boundaries.
- Updated the career 10k PR train manifest/state for the current PR only.

## Why
The 1046 career detail rollout is discoverable through sitemap/llms surfaces, but Search Channel remains intentionally closed. This PR records a safe readiness gate and staged future plan without enqueueing or submitting URLs.

## Validation
- `cd backend && php artisan test --filter=CareerSearchChannelReadinessGate01 --no-ansi` PASS
- `cd backend && php artisan route:list --no-ansi` PASS
- `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/CareerSearchChannelReadinessGate01Test.php` PASS
- `cd backend && composer validate --strict` PASS
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` PASS
- `python3 -m json.tool backend/docs/seo/generated/career-search-channel-readiness-gate-01.v1.json >/dev/null` PASS
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` PASS
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"` PASS
- `git diff --check` PASS
- `git diff --cached --check` PASS

## Sidecar
- Full `vendor/bin/pint --test` still reports existing out-of-scope EQ style issues in:
  - `backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php`
  - `backend/tests/Unit/Report/EqIntegratedReportComposerTest.php`
- Current PR scoped Pint passes and this PR does not touch those files.

## Intentionally deferred
- No Search Channel enqueue or URL submission.
- No external search API calls.
- No runtime promotion, CMS/DB mutation, deploy, frontend change, or held slug release.
