### PR TITLE
CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec

### DIFF
--- a/backend/docs/career/README.md
+++ b/backend/docs/career/README.md
@@ -100,6 +100,13 @@ the public Career system spans both repositories.
 | 2026-06-01 | fap-web | [#967](https://github.com/fermatmind/fap-web/pull/967) | `a218ace5b76f` | Convert Career jobs index to paginated directory shell. |
 | 2026-06-01 | fap-web | [#970](https://github.com/fermatmind/fap-web/pull/970) | `2ea27cae88af` | Align Career LLM surfaces to directory/sitemap authority. |
 | 2026-06-01 | fap-api | [#1835](https://github.com/fermatmind/fap-api/pull/1835) | `9257a57f6dd9` | Add 10k directory warm/validate ops gate. |
+| 2026-06-01 | fap-web | [#982](https://github.com/fermatmind/fap-web/pull/982) | `3907e7aaa09a` | Add Career detail P95/P99 latency scan artifact. |
+| 2026-06-01 | fap-web | [#984](https://github.com/fermatmind/fap-web/pull/984) | `bf6bc6d42664` | Repair Career detail cache/render budget. |
+| 2026-06-01 | fap-api | [#1845](https://github.com/fermatmind/fap-api/pull/1845) | `1716749dc17d` | Audit legacy full jobs index consumers. |
+| 2026-06-01 | fap-api | [#1846](https://github.com/fermatmind/fap-api/pull/1846) | `aa5b54b395ff` | Add directory/detail/sitemap/LLM drift gate. |
+| 2026-06-01 | fap-web | [#986](https://github.com/fermatmind/fap-web/pull/986) | `a237fa67e1cf` | Add `llms-full` 10k budget gate. |
+| 2026-06-01 | fap-web | [#987](https://github.com/fermatmind/fap-web/pull/987) | `7f1c0de41f2f` | Improve Career directory UX facet parity. |
+| 2026-06-01 | fap-api | [#1847](https://github.com/fermatmind/fap-api/pull/1847) | `5ef46feea558` | Add read-only Search Channel readiness gate with HOLD decision. |
 
 ### Related fap-web Technical Notes
 
@@ -386,6 +393,60 @@ Current expected Career discoverability counts:
 
 `llms-full.txt` must be artifact/cache-first. Request-time full fanout across
 thousands of Career details is not acceptable at 10k scale.
+
+### 10k Target Architecture Contract
+
+The 10k Career architecture is a scale posture, not a permission to publish
+10,000 new occupations. Runtime expansion still requires separate authority
+manifests, dry-runs, controlled apply approval, and post-deploy smoke.
+
+Target data flow:
+
+```text
+Occupation authority / content assets
+  -> runtime projection and release gates
+  -> Career directory authority service
+  -> public directory API, detail API, sitemap source, LLM source
+  -> fap-web paginated directory shell and detail rendering
+```
+
+Hard invariants:
+
+- one backend directory authority source feeds public directory, detail
+  eligibility, sitemap Career URLs, and LLM Career URLs;
+- `/api/v0.5/career/jobs` may remain as legacy compatibility, but new
+  directory surfaces must consume `/api/v0.5/career/directory`;
+- `/career/jobs` renders a bounded first page and facets, never the complete
+  occupation database;
+- query and filter URLs remain noindex/canonicalized unless a future SEO
+  authority decision explicitly promotes a facet page;
+- sitemap owns full URL discovery for public detail pages;
+- `llms.txt` may enumerate public URL/title/type records, but must not fetch
+  every detail bundle at request time;
+- `llms-full.txt` must be artifact-first, cache-first, and bounded on request;
+- held, conflict, draft, private, noindex, fallback-only, and not-runtime-ready
+  slugs stay absent from public APIs and discoverability surfaces.
+
+Scale budgets:
+
+| Surface | 1046 state | 10k posture |
+| --- | --- | --- |
+| Directory API first page | 50 items | 50 to 100 bounded items |
+| Directory API payload | card/list fields only | no detail bundle, FAQ, snapshots, or markdown |
+| Frontend SSR | first page + facets | first page + facets only |
+| Sitemap | 2092 Career detail URLs | full public detail URL coverage from authority artifact |
+| `llms.txt` | 2092 Career detail URLs | URL/title/type records from sitemap/directory authority |
+| `llms-full.txt` | 2092 when complete artifact warm | precomputed artifact or last-known-good, degraded 200 if needed |
+| Search Channel | HOLD | staged only after explicit approval and readiness gate |
+
+Rollback posture:
+
+- every rollout apply needs a batch id, rollback group, and exact slug manifest;
+- rollback reverses only the approved runtime promotion batch;
+- rollback must not alter held slugs, conflict slugs, content imports, or Search
+  Channel state;
+- after rollback, rerun directory count, sitemap/LLM count, sample detail,
+  claim-boundary, and staging containment checks.
 
 ## 1046 Rollout Policy
 

--- a/backend/docs/seo/career-10k-rollout-architecture-spec-01.md
+++ b/backend/docs/seo/career-10k-rollout-architecture-spec-01.md
@@ -1,0 +1,174 @@
+# CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01
+
+Date: 2026-06-01
+
+## Executive Summary
+
+FermatMind Career is production-stable at the current 1046 public detail
+cohort, with 2092 EN/ZH detail URLs exposed through sitemap and LLM surfaces.
+The next scale target is 10k occupations, but the architecture must preserve a
+strict separation between authority, directory rendering, discoverability, and
+Search Channel operations.
+
+This specification is documentation-only. It does not publish occupations,
+change runtime APIs, mutate CMS/DB state, deploy code, enqueue Search Channel,
+submit URLs, or release held slugs.
+
+## Current Authority Baseline
+
+- Public career detail slugs: 1046.
+- Public localized career detail URLs: 2092.
+- Directory endpoint exists and supports bounded pagination.
+- `/career/jobs` is a paginated directory shell, not a full database render.
+- Sitemap, `llms.txt`, and `llms-full.txt` consume authority/artifacts instead
+  of request-time fanout across all detail pages.
+- Search Channel remains HOLD.
+
+Held slugs remain excluded:
+
+- `software-developers`
+- `digital-forensics-analysts`
+- `computer-occupations-all-other`
+
+## Target Architecture
+
+```text
+Career authority source
+  -> content/display readiness
+  -> runtime projection and release ledger
+  -> directory authority service
+  -> public directory API
+  -> detail API and SEO contract
+  -> sitemap source and LLM source
+  -> fap-web paginated directory shell and detail renderer
+```
+
+The backend remains source of truth. fap-web consumes public contracts and must
+not create fallback Career content.
+
+## Rollout Gates
+
+Every future cohort expansion must pass:
+
+1. Authority manifest parse and schema validation.
+2. Held/conflict/manual-review slug exclusion.
+3. Display/content readiness.
+4. Runtime projection dry-run.
+5. Candidate-prep dry-run, if candidate state is needed.
+6. Runtime promotion dry-run.
+7. Explicit apply approval.
+8. Post-apply cache warm.
+9. Post-deploy smoke for API, details, sitemap, LLM, robots, canonical, and
+   claim boundaries.
+
+No ad hoc SQL, tinker write, production migration, Search Channel action, or
+URL submission is part of the rollout apply path.
+
+## Directory API Budget
+
+The directory API must remain lightweight at 10k scale:
+
+- first page default: 50 items;
+- maximum page size: 100 unless a future benchmark proves otherwise;
+- fields: slug, localized title, family, canonical path, robots/indexability,
+  detail readiness, updated timestamp;
+- forbidden fields: full sections, long markdown, FAQ bodies, report snapshots,
+  personalized recommendation text, private provenance, and structured-data
+  blobs.
+
+## Frontend Contract
+
+fap-web `/career/jobs` must:
+
+- SSR only the first bounded page plus count and facets;
+- keep query/filter/search pages noindex with canonical back to the directory
+  root unless separately promoted;
+- fetch additional pages through the directory API;
+- render empty/error states without frontend editorial fallback content;
+- preserve held slug absence.
+
+## Sitemap and LLM Policy
+
+- Sitemap enumerates all public indexable detail URLs from backend authority.
+- `llms.txt` can list public URL/title/type records from sitemap or directory
+  authority.
+- `llms-full.txt` must be precomputed/artifact-first and cache-first.
+- Request-time fanout across 10k detail APIs is disallowed.
+- A degraded `llms-full.txt` response should return HTTP 200 with bounded
+  content and explicit degraded metadata instead of timing out.
+
+## Search Channel Policy
+
+Search Channel remains closed until a separate explicit approval. A future
+Search Channel PR may only use the readiness gate output as an input and must
+perform no submission unless the user provides exact confirmation.
+
+Recommended future staged plan:
+
+1. Canary: 10 EN + 10 ZH paired detail URLs.
+2. Observe 24 hours.
+3. Expand to a 100 paired URL batch if no stop condition fires.
+4. Continue bounded batches with sidecar logging.
+
+Stop conditions include held slug exposure, noindex/canonical drift, staging
+contamination, claim-boundary regression, queue anomaly, and external search
+API failure.
+
+## Observability and SLO
+
+Track at minimum:
+
+- directory EN/ZH count parity;
+- public detail indexable count;
+- sitemap Career URL count;
+- `llms.txt` Career URL count;
+- `llms-full.txt` complete/degraded state and response time;
+- held slug absence;
+- sampled detail HTTP/canonical/robots/H1 state;
+- cache warm duration and payload size;
+- legacy `/api/v0.5/career/jobs` consumer usage;
+- Search Channel gate state.
+
+Recommended latency posture:
+
+- directory API first page p95 under 800ms after warm cache;
+- sampled detail page p95 under 2500ms before edge/CDN optimizations;
+- `llms-full.txt` repeated reads should return 200 without gateway timeout.
+
+## Rollback
+
+Each rollout apply must record:
+
+- batch id;
+- slug manifest;
+- rollback group;
+- apply artifact;
+- cache warm artifact;
+- post-apply smoke artifact.
+
+Rollback must only reverse the approved runtime promotion batch. It must not
+alter held slugs, content imports, Search Channel queue state, or fap-web
+fallback behavior.
+
+## Future PR Boundaries
+
+Keep future work small and reversible:
+
+- authority source import and review packages;
+- candidate-prep runtime support;
+- rollout dry-run artifacts;
+- rollout apply with explicit approval;
+- directory API performance/caching;
+- fap-web directory UX;
+- sitemap/LLM artifact budgets;
+- Search Channel readiness and staged submission.
+
+Do not combine runtime promotion, frontend UX, LLM generation, and Search
+Channel actions in one PR.
+
+## Final Decision
+
+`career_10k_rollout_architecture_spec_completed_ready_for_future_scoped_prs`
+
+Next task: none for this train. Future 10k work needs a new scoped train and
+explicit manifest/state authorization.

--- a/backend/docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json
+++ b/backend/docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json
@@ -1,0 +1,123 @@
+{
+  "schema_version": "career_10k_rollout_architecture_spec.v1",
+  "task": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01",
+  "final_decision": "career_10k_rollout_architecture_spec_completed_ready_for_future_scoped_prs",
+  "current_public_detail_count": 1046,
+  "current_localized_detail_url_count": 2092,
+  "target_scale": 10000,
+  "authority_source": {
+    "owner": "fap-api",
+    "truth_boundary": "backend_runtime_projection_release_gate_directory_authority",
+    "frontend_fallback_allowed": false
+  },
+  "held_slug_policy": {
+    "held_slugs": [
+      "software-developers",
+      "digital-forensics-analysts",
+      "computer-occupations-all-other"
+    ],
+    "release_allowed_in_this_task": false,
+    "must_remain_absent_from_public_runtime": true,
+    "must_remain_absent_from_sitemap_llms_search_channel": true
+  },
+  "rollout_gates": [
+    "authority_manifest_schema_validation",
+    "held_conflict_manual_review_exclusion",
+    "display_content_readiness",
+    "runtime_projection_dry_run",
+    "candidate_prep_dry_run_if_needed",
+    "runtime_promotion_dry_run",
+    "explicit_apply_approval",
+    "post_apply_cache_warm",
+    "post_deploy_smoke"
+  ],
+  "directory_api_budget": {
+    "default_first_page_size": 50,
+    "maximum_page_size_without_future_benchmark": 100,
+    "allowed_item_fields": [
+      "slug",
+      "localized_title",
+      "family",
+      "canonical_path",
+      "robots_policy",
+      "indexable",
+      "detail_ready",
+      "updated_at"
+    ],
+    "forbidden_item_fields": [
+      "full_sections",
+      "long_markdown",
+      "faq_bodies",
+      "recommendation_snapshots",
+      "personalized_recommendation_text",
+      "private_provenance",
+      "structured_data_blobs"
+    ]
+  },
+  "frontend_directory_policy": {
+    "ssr_full_database_allowed": false,
+    "ssr_first_page_and_facets_only": true,
+    "query_filter_pages_noindex": true,
+    "query_filter_pages_canonical_to_directory_root": true,
+    "frontend_editorial_fallback_allowed": false
+  },
+  "sitemap_llms_policy": {
+    "sitemap_source": "backend_public_directory_or_sitemap_authority",
+    "sitemap_full_public_detail_coverage_required": true,
+    "llms_txt_allowed_shape": "url_title_type_records",
+    "llms_full_generation": "precomputed_artifact_or_last_known_good_cache",
+    "runtime_detail_fanout_allowed": false,
+    "degraded_200_preferred_over_504": true
+  },
+  "observability_slo": {
+    "track_directory_count_parity": true,
+    "track_public_detail_indexable_count": true,
+    "track_sitemap_career_url_count": true,
+    "track_llms_career_url_count": true,
+    "track_llms_full_complete_or_degraded_state": true,
+    "track_held_slug_absence": true,
+    "track_sampled_detail_status_canonical_robots": true,
+    "track_cache_warm_duration_and_payload_size": true,
+    "track_legacy_full_jobs_index_consumers": true,
+    "track_search_channel_gate_state": true,
+    "recommended_directory_first_page_p95_ms_after_warm": 800,
+    "recommended_detail_page_p95_ms_before_edge_optimization": 2500
+  },
+  "search_channel_policy": {
+    "current_decision": "HOLD",
+    "future_explicit_approval_required": true,
+    "recommended_canary_pair_count": 10,
+    "recommended_observation_window_hours": 24,
+    "search_channel_action_performed": false,
+    "url_submission_performed": false,
+    "external_search_api_call_performed": false
+  },
+  "rollback_policy": {
+    "requires_batch_id": true,
+    "requires_slug_manifest": true,
+    "requires_rollback_group": true,
+    "rollback_scope": "approved_runtime_promotion_batch_only",
+    "must_not_alter_held_slugs": true,
+    "must_not_alter_search_channel_queue": true
+  },
+  "future_pr_boundaries": [
+    "authority_source_import_and_review_package",
+    "candidate_prep_runtime_support",
+    "rollout_dry_run_artifact",
+    "rollout_apply_with_explicit_approval",
+    "directory_api_performance_cache",
+    "frontend_directory_ux",
+    "sitemap_llms_artifact_budget",
+    "search_channel_readiness_or_staged_submission"
+  ],
+  "no_runtime_change": true,
+  "no_cms_mutation": true,
+  "no_database_mutation": true,
+  "no_deploy": true,
+  "no_fap_web_change": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_external_search_api_call": true,
+  "held_slug_release_performed": false,
+  "next_task": "none"
+}

--- a/backend/tests/Feature/SeoIntel/Career10kRolloutArchitectureSpec01Test.php
+++ b/backend/tests/Feature/SeoIntel/Career10kRolloutArchitectureSpec01Test.php
@@ -1,0 +1,100 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use Tests\TestCase;
+
+final class Career10kRolloutArchitectureSpec01Test extends TestCase
+{
+    public function test_career_10k_rollout_architecture_spec_preserves_authority_and_no_write_boundaries(): void
+    {
+        $reportPath = base_path('docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json');
+        $handbookPath = base_path('docs/career/README.md');
+        $markdownPath = base_path('docs/seo/career-10k-rollout-architecture-spec-01.md');
+
+        $this->assertFileExists($reportPath);
+        $this->assertFileExists($handbookPath);
+        $this->assertFileExists($markdownPath);
+
+        $report = json_decode((string) file_get_contents($reportPath), true, 512, JSON_THROW_ON_ERROR);
+        $handbook = (string) file_get_contents($handbookPath);
+        $markdown = (string) file_get_contents($markdownPath);
+
+        $this->assertSame('career_10k_rollout_architecture_spec.v1', $report['schema_version'] ?? null);
+        $this->assertSame('CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01', $report['task'] ?? null);
+        $this->assertSame(
+            'career_10k_rollout_architecture_spec_completed_ready_for_future_scoped_prs',
+            $report['final_decision'] ?? null,
+        );
+        $this->assertSame(1046, $report['current_public_detail_count'] ?? null);
+        $this->assertSame(2092, $report['current_localized_detail_url_count'] ?? null);
+        $this->assertSame(10000, $report['target_scale'] ?? null);
+
+        $this->assertSame('fap-api', $report['authority_source']['owner'] ?? null);
+        $this->assertFalse($report['authority_source']['frontend_fallback_allowed'] ?? true);
+
+        foreach ([
+            'software-developers',
+            'digital-forensics-analysts',
+            'computer-occupations-all-other',
+        ] as $heldSlug) {
+            $this->assertContains($heldSlug, $report['held_slug_policy']['held_slugs'] ?? []);
+            $this->assertStringContainsString($heldSlug, $handbook);
+            $this->assertStringContainsString($heldSlug, $markdown);
+        }
+
+        foreach ([
+            'authority_manifest_schema_validation',
+            'runtime_projection_dry_run',
+            'explicit_apply_approval',
+            'post_deploy_smoke',
+        ] as $gate) {
+            $this->assertContains($gate, $report['rollout_gates'] ?? []);
+        }
+
+        $this->assertSame(50, $report['directory_api_budget']['default_first_page_size'] ?? null);
+        $this->assertSame(100, $report['directory_api_budget']['maximum_page_size_without_future_benchmark'] ?? null);
+        $this->assertFalse($report['frontend_directory_policy']['ssr_full_database_allowed'] ?? true);
+        $this->assertTrue($report['frontend_directory_policy']['ssr_first_page_and_facets_only'] ?? false);
+        $this->assertFalse($report['sitemap_llms_policy']['runtime_detail_fanout_allowed'] ?? true);
+        $this->assertTrue($report['sitemap_llms_policy']['degraded_200_preferred_over_504'] ?? false);
+        $this->assertSame('HOLD', $report['search_channel_policy']['current_decision'] ?? null);
+        $this->assertTrue($report['search_channel_policy']['future_explicit_approval_required'] ?? false);
+
+        foreach ([
+            'track_directory_count_parity',
+            'track_public_detail_indexable_count',
+            'track_sitemap_career_url_count',
+            'track_llms_career_url_count',
+            'track_llms_full_complete_or_degraded_state',
+            'track_held_slug_absence',
+            'track_sampled_detail_status_canonical_robots',
+            'track_cache_warm_duration_and_payload_size',
+            'track_legacy_full_jobs_index_consumers',
+            'track_search_channel_gate_state',
+        ] as $field) {
+            $this->assertTrue($report['observability_slo'][$field] ?? false, $field);
+        }
+
+        foreach ([
+            'no_runtime_change',
+            'no_cms_mutation',
+            'no_database_mutation',
+            'no_deploy',
+            'no_fap_web_change',
+            'no_search_channel_action',
+            'no_url_submission',
+            'no_external_search_api_call',
+        ] as $field) {
+            $this->assertTrue($report[$field] ?? false, $field);
+        }
+
+        $this->assertFalse($report['held_slug_release_performed'] ?? true);
+        $this->assertSame('none', $report['next_task'] ?? null);
+        $this->assertStringContainsString('10k Target Architecture Contract', $handbook);
+        $this->assertStringContainsString('Runtime expansion still requires separate authority', $handbook);
+        $this->assertStringContainsString('manifests, dry-runs, controlled apply approval', $handbook);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -25884,7 +25884,7 @@
   "GSC-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/gsc-live-00-readiness-contract",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "SEARCH-CHANNEL-LIVE-00"
     ],
@@ -39562,7 +39562,7 @@
     "depends_on": [
       "CAREER-DIRECTORY-AUTHORITY-DRIFT-GATE-01"
     ],
-    "commit_sha": "a948adc520215d52d51cfc63ee0728c9e4642903",
+    "commit_sha": "5ef46feea558a488744ea2139eb30c3b56e02979",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1847",
     "checks": {
       "manifest_registration": {
@@ -39609,14 +39609,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-01T18:13:57Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -39636,6 +39636,12 @@
         "from": "implementation_in_progress",
         "to": "pr_open",
         "note": "Opened PR #1847 with scoped report, generated artifact, test, and ledger update."
+      },
+      {
+        "at": "2026-06-01T18:13:57Z",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "PR #1847 merged with squash commit 5ef46feea558a488744ea2139eb30c3b56e02979; remote branch deleted; post-merge focused test passed."
       }
     ],
     "sidecars": [
@@ -39651,9 +39657,9 @@
         "impact_on_current_pr": "Scoped Pint for the PR test file passes and scope validation is clean.",
         "owner": "fap-api EQ test owner",
         "follow_up_recommendation": "Run a separate scoped EQ Pint cleanup PR or fold the formatting cleanup into the owning EQ task.",
-        "required_checks_status": "pending GitHub checks",
+        "required_checks_status": "green",
         "scope_validation_status": "passed",
-        "continue_train_decision": "continue if GitHub required checks are green"
+        "continue_train_decision": "continued to CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 after required checks passed"
       }
     ],
     "next_task": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01"
@@ -39663,21 +39669,64 @@
     "repo": "fap-api",
     "branch": "codex/career-10k-rollout-architecture-spec-01",
     "base": "main",
-    "status": "planned",
+    "status": "implementation_in_progress",
     "title": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec",
     "depends_on": [
       "CAREER-SEARCH-CHANNEL-READINESS-GATE-01"
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User authorized all eight career 10k scale train entries; this fap-api entry exists in manifest/state."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "CAREER-SEARCH-CHANNEL-READINESS-GATE-01 merged as PR #1847 with squash commit 5ef46feea558a488744ea2139eb30c3b56e02979."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to backend Career handbook update, 10k rollout architecture report, generated JSON, focused SeoIntel test, and train metadata."
+      },
+      "focused_phpunit": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=Career10kRolloutArchitectureSpec01 --no-ansi",
+        "evidence": "PASS, 1 test / 55 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS, 210 routes."
+      },
+      "scoped_pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/Career10kRolloutArchitectureSpec01Test.php",
+        "evidence": "PASS, focused PR test file is formatted."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS, no security vulnerability advisories found."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "command": "python3 -m json.tool backend/docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check",
+        "evidence": "PASS."
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
-      "local_validation_passed": null,
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null
     },
@@ -39687,9 +39736,32 @@
         "from": "missing",
         "to": "planned",
         "note": "Initialized by user authorization for the career 10k scale train."
+      },
+      {
+        "at": "2026-06-01T18:16:00Z",
+        "from": "planned",
+        "to": "implementation_in_progress",
+        "note": "Started backend-owned Career 10k rollout architecture specification PR."
       }
     ],
-    "sidecars": [],
+    "sidecars": [
+      {
+        "id": "career-10k-rollout-architecture-spec-01-full-pint-existing-eq-style",
+        "source_pr": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01",
+        "repo": "fap-api",
+        "branch": "codex/career-10k-rollout-architecture-spec-01",
+        "command_or_check": "cd backend && vendor/bin/pint --test",
+        "evidence": "Full Pint reports existing new_with_parentheses style issues in backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php and backend/tests/Unit/Report/EqIntegratedReportComposerTest.php.",
+        "failure_summary": "Out-of-scope EQ unit test style failures in files not changed by this PR.",
+        "why_external_to_current_pr": "Current PR changes only Career docs, generated architecture artifact, focused SeoIntel test, and train metadata; it does not touch EQ test files.",
+        "impact_on_current_pr": "Scoped Pint for the PR test file passes and scope validation is clean.",
+        "owner": "fap-api EQ test owner",
+        "follow_up_recommendation": "Run a separate scoped EQ Pint cleanup PR or fold the formatting cleanup into the owning EQ task.",
+        "required_checks_status": "pending GitHub checks",
+        "scope_validation_status": "passed",
+        "continue_train_decision": "continue if GitHub required checks are green"
+      }
+    ],
     "next_task": "none"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -39669,13 +39669,13 @@
     "repo": "fap-api",
     "branch": "codex/career-10k-rollout-architecture-spec-01",
     "base": "main",
-    "status": "implementation_in_progress",
+    "status": "pr_open",
     "title": "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec",
     "depends_on": [
       "CAREER-SEARCH-CHANNEL-READINESS-GATE-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "8662cf8e92fce12fcc0095534472054252e6ec55",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1848",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -39742,6 +39742,12 @@
         "from": "planned",
         "to": "implementation_in_progress",
         "note": "Started backend-owned Career 10k rollout architecture specification PR."
+      },
+      {
+        "at": "2026-06-01T18:24:15Z",
+        "from": "implementation_in_progress",
+        "to": "pr_open",
+        "note": "Opened PR #1848 with Career 10k rollout architecture spec, generated artifact, focused test, handbook update, and ledger reconciliation."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18044,7 +18044,7 @@ prs:
     branch: ops/career-warm-cache-perf-01
     title: "OPS-CAREER-WARM-CACHE-PERF-01 reduce career warm cache authority rebuilds"
     train_scope: career_warm_cache_authority_performance
-    status: in_progress
+    status: merged
     allowed_paths:
       - backend/app/Domain/Career/Publish/**
       - backend/app/Services/Career/Dataset/CareerFullDatasetAuthorityBuilder.php
@@ -19447,7 +19447,7 @@ prs:
     base: main
     title: "CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01 career 10k rollout architecture spec"
     train_scope: career_10k_scale
-    status: planned
+    status: in_progress
     scope:
       - Produce the backend-owned 10k career rollout architecture specification.
       - Cover authority source, rollout gates, held slug policy, directory API budget, sitemap/llms policy, smoke/SLO, rollback, and future PR boundaries.


### PR DESCRIPTION
## What changed
- Added `CAREER-10K-ROLLOUT-ARCHITECTURE-SPEC-01`, a backend-owned 10k Career rollout architecture spec.
- Updated the Career backend handbook with current 10k target architecture, directory budgets, sitemap/LLM policy, rollback posture, and recent Career PR timeline entries.
- Added generated JSON defining authority boundaries, rollout gates, held slug policy, directory API budget, sitemap/LLM policy, observability/SLO fields, Search Channel HOLD state, and rollback boundaries.
- Added a focused SeoIntel test that validates the architecture artifact and no-write/no-submission boundaries.
- Reconciled PR #1847 ledger state after merge and started this final train item.

## Why
The current 1046 Career rollout is stable, but future 10k scale requires a fixed authority and performance contract so new occupation publication, directory rendering, sitemap, LLM, and Search Channel work stay decoupled and reversible.

## Validation
- `cd backend && php artisan test --filter=Career10kRolloutArchitectureSpec01 --no-ansi` PASS
- `cd backend && php artisan route:list --no-ansi` PASS
- `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/Career10kRolloutArchitectureSpec01Test.php` PASS
- `cd backend && composer validate --strict` PASS
- `cd backend && composer audit --locked --no-interaction --ignore-unreachable` PASS
- `python3 -m json.tool backend/docs/seo/generated/career-10k-rollout-architecture-spec-01.v1.json >/dev/null` PASS
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` PASS
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"` PASS
- `git diff --check` PASS
- `git diff --cached --check` PASS

## Sidecar
- Full `vendor/bin/pint --test` still reports existing out-of-scope EQ style issues in:
  - `backend/tests/Unit/Eq/EqSjtValidationTelemetryContractTest.php`
  - `backend/tests/Unit/Report/EqIntegratedReportComposerTest.php`
- Current PR scoped Pint passes and this PR does not touch those files.

## Intentionally deferred
- No runtime implementation changes.
- No CMS/DB mutation, deploy, fap-web change, Search Channel enqueue, URL submission, external search API call, or held slug release.
- Future 10k rollout work needs a new scoped train and explicit manifest/state authorization.
