### PR TITLE
ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 freeze purchase report truth bridge

### DIFF
--- a/backend/docs/seo/analytics-funnel-purchase-report-truth-bridge-03.md
+++ b/backend/docs/seo/analytics-funnel-purchase-report-truth-bridge-03.md
@@ -1,0 +1,122 @@
+# ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03
+
+## Executive Summary
+
+This PR freezes the purchase and paid-report analytics truth policy after the backend payment unlock repairs.
+
+The decision is conservative: backend Ops remains the source of truth for `payment_success`, `report_unlock`, and `report_ready`. GA4 is used only as a public funnel reporting auxiliary unless a separate privacy-safe server-side bridge is explicitly approved later. Baidu Tongji remains limited to public traffic and page observation.
+
+Final decision:
+
+`analytics_funnel_purchase_report_truth_bridge_completed_backend_ops_truth_ga4_public_auxiliary`
+
+## Current Gap
+
+The repaired backend funnel can now represent paid report access correctly through:
+
+- orders/payment event/provider reconciliation for payment truth.
+- active benefit grants for unlock truth.
+- unified access projections plus attempt receipts/results for report-ready truth.
+- `analytics_funnel_daily` as the Ops read model after controlled refresh.
+
+GA4 and Baidu can observe parts of the public journey, but neither surface can safely decide whether a user paid, was granted access, or can enter a full paid result. Browser-only analytics can be blocked by consent, route suppression, client failure, duplicate tabs, or network behavior.
+
+## Truth Boundary
+
+| Stage | Backend authority | GA4 role | Baidu role |
+| --- | --- | --- | --- |
+| `payment_success` | orders/payment events/provider reconciliation | not truth; optional future server-side reporting only | not truth |
+| `report_unlock` | active benefit grants | not truth; optional future server-side reporting only | not truth |
+| `report_ready` | ready unified access projection with receipt/result | not truth; optional future server-side reporting only | not truth |
+| public funnel steps | public runtime and backend events | reporting auxiliary | public traffic/page observation |
+
+Backend `analytics_funnel_daily` remains the Ops reporting truth for paid, unlocked, and report-ready counts.
+
+## GA4 Strategy
+
+GA4 key events should remain focused on public, privacy-safe funnel events:
+
+- `test_start`
+- `test_submit`
+- `result_view`
+- `checkout_start`
+- `order_created`
+
+`payment_success`, `report_unlock`, and `report_ready` are conditional only. They must not be treated as browser event truth. If the business later wants these visible in GA4, the next step is a separate server-side Measurement Protocol design and implementation with:
+
+- explicit user approval.
+- dry-run and smoke validation.
+- privacy-safe payloads only.
+- no raw order numbers, result IDs, attempt IDs, user IDs, email, phone, or provider payloads.
+- deterministic dedupe event IDs.
+- environment gates and rollback instructions.
+
+This PR does not implement Measurement Protocol export.
+
+## Baidu Strategy
+
+Baidu Tongji can observe:
+
+- public page PV/UV/IP.
+- public source and entrance pages.
+- public landing or test-page element observation where no private identifier is exposed.
+
+Baidu Tongji must not be used for:
+
+- payment truth.
+- unlock truth.
+- report-ready truth.
+- email lookup success truth.
+- result access token truth.
+- private result/order/pay/share/history route conversion tracking.
+
+## Read Model Policy
+
+`analytics_funnel_daily` remains backend-owned and should continue to map:
+
+- `payment_success` from backend payment truth.
+- `report_unlock` from active grant truth.
+- `report_ready` from projection-ready report access truth.
+
+No production analytics refresh is run by this PR.
+
+## What Was Not Done
+
+- No production DB mutation.
+- No analytics refresh.
+- No payment repair.
+- No benefit grant creation.
+- No payment provider call.
+- No CMS mutation.
+- No GA4 admin change.
+- No Baidu admin change.
+- No Measurement Protocol export.
+- No Search Channel action.
+- No URL submission.
+- No deploy.
+- No fap-web change.
+
+## Validation
+
+Required focused validation:
+
+```bash
+cd backend && php artisan test --filter=AnalyticsFunnelPurchaseReportTruthBridge03 --no-ansi
+cd backend && php artisan route:list --no-ansi
+cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php
+cd backend && composer validate --strict
+cd backend && composer audit --locked --no-interaction --ignore-unreachable
+python3 -m json.tool backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check
+git diff --cached --check
+```
+
+## Final Decision
+
+`analytics_funnel_purchase_report_truth_bridge_completed_backend_ops_truth_ga4_public_auxiliary`
+
+## Next Task
+
+`ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01`

--- a/backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json
+++ b/backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json
@@ -1,0 +1,117 @@
+{
+  "schema_version": "1.0",
+  "task": "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03",
+  "final_decision": "analytics_funnel_purchase_report_truth_bridge_completed_backend_ops_truth_ga4_public_auxiliary",
+  "source_of_truth": {
+    "payment_success": "backend_orders_payment_events_provider_reconciliation",
+    "report_unlock": "active_backend_benefit_grants",
+    "report_ready": "ready_unified_access_projection_with_attempt_receipt_and_result",
+    "ops_read_model": "analytics_funnel_daily",
+    "ga4_role": "public_funnel_reporting_auxiliary_only",
+    "baidu_role": "public_traffic_and_page_observation_only",
+    "frontend_role": "ux_and_public_interaction_observation_only"
+  },
+  "backend_truth_events": [
+    {
+      "event": "payment_success",
+      "authority": "orders.payment_state plus provider reconciliation or payment event authority",
+      "ga4_strategy": "do_not_use_browser_ga4_as_truth",
+      "baidu_strategy": "not_supported_as_truth"
+    },
+    {
+      "event": "report_unlock",
+      "authority": "active benefit_grants for the target attempt/result",
+      "ga4_strategy": "do_not_use_browser_ga4_as_truth",
+      "baidu_strategy": "not_supported_as_truth"
+    },
+    {
+      "event": "report_ready",
+      "authority": "unified_access_projections access_state=ready and report_state=ready with required attempt receipt/result",
+      "ga4_strategy": "do_not_use_browser_ga4_as_truth",
+      "baidu_strategy": "not_supported_as_truth"
+    }
+  ],
+  "ga4_public_auxiliary_events": [
+    "test_start",
+    "test_submit",
+    "result_view",
+    "checkout_start",
+    "order_created"
+  ],
+  "ga4_conditional_server_side_events": [
+    "payment_success",
+    "report_unlock",
+    "report_ready"
+  ],
+  "ga4_conditional_server_side_requirements": {
+    "separate_pr_required": true,
+    "measurement_protocol_not_enabled_in_this_pr": true,
+    "server_side_only": true,
+    "privacy_safe_payload_only": true,
+    "no_raw_order_no": true,
+    "no_raw_user_id": true,
+    "no_raw_email": true,
+    "no_provider_payload": true,
+    "dedupe_event_id_required": true,
+    "dry_run_and_smoke_required": true,
+    "explicit_admin_and_env_approval_required": true
+  },
+  "baidu_allowed_scope": [
+    "public_page_pv_uv_ip",
+    "public_source_entrance_page_observation",
+    "public_landing_or_test_page_element_observation"
+  ],
+  "baidu_forbidden_truth_scope": [
+    "payment_success",
+    "report_unlock",
+    "report_ready",
+    "email_lookup_success",
+    "result_access_token",
+    "private_result_or_order_route_conversion"
+  ],
+  "analytics_funnel_daily_policy": {
+    "remains_backend_truth_for_ops": true,
+    "refresh_not_run_in_this_pr": true,
+    "payment_success_source": "backend payment truth",
+    "report_unlock_source": "active benefit grant truth",
+    "report_ready_source": "projection-ready report access truth"
+  },
+  "implementation_actions": {
+    "production_db_mutation": false,
+    "analytics_refresh": false,
+    "payment_repair": false,
+    "benefit_grant_creation": false,
+    "payment_provider_call": false,
+    "cms_mutation": false,
+    "ga4_admin_change": false,
+    "baidu_admin_change": false,
+    "measurement_protocol_export": false,
+    "search_channel_action": false,
+    "url_submission": false,
+    "deploy": false,
+    "fap_web_change": false
+  },
+  "recommended_next_steps": [
+    {
+      "task": "ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01",
+      "scope": "Read-only browser and GA4 DebugView smoke for public auxiliary events only."
+    },
+    {
+      "task": "ANALYTICS-FUNNEL-SERVER-SIDE-GA4-BRIDGE-SPEC-04",
+      "scope": "Optional future spec for privacy-safe server-side Measurement Protocol export of payment/report truth; requires explicit approval before implementation."
+    }
+  ],
+  "no_production_db_mutation": true,
+  "no_analytics_refresh": true,
+  "no_payment_repair": true,
+  "no_benefit_grant_creation": true,
+  "no_payment_provider_call": true,
+  "no_cms_mutation": true,
+  "no_ga4_admin_change": true,
+  "no_baidu_admin_change": true,
+  "no_measurement_protocol_export": true,
+  "no_search_channel_action": true,
+  "no_url_submission": true,
+  "no_deploy": true,
+  "next_task": "ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01"
+}

--- a/backend/tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php
+++ b/backend/tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php
@@ -1,0 +1,68 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class AnalyticsFunnelPurchaseReportTruthBridge03Test extends TestCase
+{
+    #[Test]
+    public function purchase_report_truth_bridge_artifact_freezes_backend_ops_truth_policy(): void
+    {
+        $path = base_path('docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json');
+
+        $this->assertFileExists($path);
+
+        $payload = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03', $payload['task'] ?? null);
+        $this->assertSame(
+            'analytics_funnel_purchase_report_truth_bridge_completed_backend_ops_truth_ga4_public_auxiliary',
+            $payload['final_decision'] ?? null
+        );
+
+        $sourceOfTruth = $payload['source_of_truth'] ?? [];
+        $this->assertSame('backend_orders_payment_events_provider_reconciliation', $sourceOfTruth['payment_success'] ?? null);
+        $this->assertSame('active_backend_benefit_grants', $sourceOfTruth['report_unlock'] ?? null);
+        $this->assertSame('ready_unified_access_projection_with_attempt_receipt_and_result', $sourceOfTruth['report_ready'] ?? null);
+        $this->assertSame('analytics_funnel_daily', $sourceOfTruth['ops_read_model'] ?? null);
+        $this->assertSame('public_funnel_reporting_auxiliary_only', $sourceOfTruth['ga4_role'] ?? null);
+        $this->assertSame('public_traffic_and_page_observation_only', $sourceOfTruth['baidu_role'] ?? null);
+
+        $this->assertContains('test_start', $payload['ga4_public_auxiliary_events'] ?? []);
+        $this->assertContains('order_created', $payload['ga4_public_auxiliary_events'] ?? []);
+        $this->assertContains('payment_success', $payload['ga4_conditional_server_side_events'] ?? []);
+        $this->assertContains('report_unlock', $payload['ga4_conditional_server_side_events'] ?? []);
+        $this->assertContains('report_ready', $payload['ga4_conditional_server_side_events'] ?? []);
+
+        $serverSideRequirements = $payload['ga4_conditional_server_side_requirements'] ?? [];
+        $this->assertTrue((bool) ($serverSideRequirements['separate_pr_required'] ?? false));
+        $this->assertTrue((bool) ($serverSideRequirements['measurement_protocol_not_enabled_in_this_pr'] ?? false));
+        $this->assertTrue((bool) ($serverSideRequirements['server_side_only'] ?? false));
+        $this->assertTrue((bool) ($serverSideRequirements['privacy_safe_payload_only'] ?? false));
+        $this->assertTrue((bool) ($serverSideRequirements['dedupe_event_id_required'] ?? false));
+
+        $this->assertContains('payment_success', $payload['baidu_forbidden_truth_scope'] ?? []);
+        $this->assertContains('report_unlock', $payload['baidu_forbidden_truth_scope'] ?? []);
+        $this->assertContains('report_ready', $payload['baidu_forbidden_truth_scope'] ?? []);
+
+        $this->assertTrue((bool) ($payload['analytics_funnel_daily_policy']['remains_backend_truth_for_ops'] ?? false));
+        $this->assertTrue((bool) ($payload['no_production_db_mutation'] ?? false));
+        $this->assertTrue((bool) ($payload['no_analytics_refresh'] ?? false));
+        $this->assertTrue((bool) ($payload['no_payment_repair'] ?? false));
+        $this->assertTrue((bool) ($payload['no_benefit_grant_creation'] ?? false));
+        $this->assertTrue((bool) ($payload['no_payment_provider_call'] ?? false));
+        $this->assertTrue((bool) ($payload['no_cms_mutation'] ?? false));
+        $this->assertTrue((bool) ($payload['no_ga4_admin_change'] ?? false));
+        $this->assertTrue((bool) ($payload['no_baidu_admin_change'] ?? false));
+        $this->assertTrue((bool) ($payload['no_measurement_protocol_export'] ?? false));
+        $this->assertTrue((bool) ($payload['no_search_channel_action'] ?? false));
+        $this->assertTrue((bool) ($payload['no_url_submission'] ?? false));
+        $this->assertTrue((bool) ($payload['no_deploy'] ?? false));
+        $this->assertSame('ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01', $payload['next_task'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21195,8 +21195,8 @@
         "GLOBAL-EN-ZH-MEDIA-ALT-VISUAL-REVIEW-BATCH-07"
       ],
       "title": "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08 global UI i18n parity review and frontend consumer follow-up",
-      "commit_sha": null,
-      "pr_url": null,
+  "commit_sha": "ca0c77ca",
+  "pr_url": "https://github.com/fermatmind/fap-api/pull/1851",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -24294,7 +24294,7 @@
       },
       {
         "at": "2026-05-19T03:38:09.440Z",
-        "status": "local_checks_passed",
+  "status": "open",
         "summary": "Added fap-api CodeQL workflow and train metadata. YAML/JSON validation, git diff checks, and scope validation passed."
       },
       {
@@ -39935,13 +39935,19 @@
         "to": "implementation_in_progress",
         "note": "Initialized by user authorization for purchase/report truth bridge policy."
       },
-      {
-        "at": "2026-06-02T05:28:00Z",
-        "from": "implementation_in_progress",
-        "to": "local_checks_passed",
-        "note": "Focused PHPUnit, route list, scoped Pint, composer validate/audit, JSON/YAML parse, and diff checks passed."
-      }
-    ],
+    {
+      "at": "2026-06-02T05:28:00Z",
+      "from": "implementation_in_progress",
+      "to": "local_checks_passed",
+      "note": "Focused PHPUnit, route list, scoped Pint, composer validate/audit, JSON/YAML parse, and diff checks passed."
+    },
+    {
+      "at": "2026-06-02T05:34:00Z",
+      "from": "local_checks_passed",
+      "to": "open",
+      "note": "Opened https://github.com/fermatmind/fap-api/pull/1851 for GitHub checks and merge review."
+    }
+  ],
     "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01"
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -38094,7 +38094,7 @@
     "branch": "codex/analytics-funnel-ops-global-scope-entry-01",
     "base": "main",
     "title": "ANALYTICS-FUNNEL-OPS-GLOBAL-SCOPE-ENTRY-01 allow global org0 funnel scope entry",
-    "status": "local_checks_passed",
+    "status": "merged",
     "depends_on": [
       "ANALYTICS-FUNNEL-OPS-ORG0-VISIBILITY-REPAIR-01"
     ],
@@ -39780,8 +39780,8 @@
     "depends_on": [
       "ANALYTICS-FUNNEL-REPORT-READY-MERGE-TIMESTAMP-03"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d176ddc4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1850",
     "checks": {
       "manifest_registration": {
         "status": "pass",
@@ -39827,9 +39827,9 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-02T00:52:00Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
@@ -39854,9 +39854,95 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened PR #1850 for GA4/Baidu funnel mapping scan."
+      },
+      {
+        "at": "2026-06-02T05:18:00Z",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Ledger reconciled: PR #1850 is merged, origin/main contains merge commit d176ddc4, remote branch is deleted, and post-merge focused test passed."
       }
     ],
     "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-WEB-EVENT-NAME-ALIGNMENT-02"
+  },
+  "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03": {
+    "id": "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03",
+    "repo": "fap-api",
+    "branch": "codex/analytics-funnel-purchase-report-truth-bridge-03",
+    "base": "main",
+    "status": "local_checks_passed",
+    "title": "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 freeze purchase report truth bridge",
+    "depends_on": [
+      "ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01",
+      "ANALYTICS-FUNNEL-WEB-EVENT-NAME-ALIGNMENT-02"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "manifest_registration": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 to fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json."
+      },
+      "scope_boundaries": {
+        "status": "pass",
+        "evidence": "Scope is limited to backend-owned purchase/report truth bridge docs, generated JSON, focused SeoIntel test, and PR train metadata. No production DB mutation, analytics refresh, payment repair, benefit grant creation, payment provider call, CMS mutation, GA4/Baidu admin change, Measurement Protocol export, Search Channel action, URL submission, deploy, or fap-web runtime change is allowed."
+      },
+      "focused_phpunit": {
+        "status": "pass",
+        "command": "cd backend && php artisan test --filter=AnalyticsFunnelPurchaseReportTruthBridge03 --no-ansi",
+        "evidence": "PASS, 1 test / 37 assertions."
+      },
+      "route_list": {
+        "status": "pass",
+        "command": "cd backend && php artisan route:list --no-ansi",
+        "evidence": "PASS, route list rendered successfully with 210 routes."
+      },
+      "scoped_pint": {
+        "status": "pass",
+        "command": "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php",
+        "evidence": "PASS, focused PR test file is formatted."
+      },
+      "composer_validate": {
+        "status": "pass",
+        "command": "cd backend && composer validate --strict",
+        "evidence": "PASS, composer.json is valid."
+      },
+      "composer_audit": {
+        "status": "pass",
+        "command": "cd backend && composer audit --locked --no-interaction --ignore-unreachable",
+        "evidence": "PASS, no security vulnerability advisories found."
+      },
+      "json_yaml_diff": {
+        "status": "pass",
+        "command": "python3 -m json.tool backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json >/dev/null && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null && python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\" && git diff --check && git diff --cached --check",
+        "evidence": "PASS."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-02T05:18:00Z",
+        "from": "missing",
+        "to": "implementation_in_progress",
+        "note": "Initialized by user authorization for purchase/report truth bridge policy."
+      },
+      {
+        "at": "2026-06-02T05:28:00Z",
+        "from": "implementation_in_progress",
+        "to": "local_checks_passed",
+        "note": "Focused PHPUnit, route list, scoped Pint, composer validate/audit, JSON/YAML parse, and diff checks passed."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01"
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19523,3 +19523,56 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: ANALYTICS-FUNNEL-WEB-EVENT-NAME-ALIGNMENT-02
+
+  - id: ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03
+    repo: fap-api
+    branch: codex/analytics-funnel-purchase-report-truth-bridge-03
+    base: main
+    title: "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 freeze purchase report truth bridge"
+    train_scope: analytics_funnel_ga4_baidu_alignment
+    risk_level: p1_analytics_funnel_truth_boundary
+    depends_on:
+      - ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01
+      - ANALYTICS-FUNNEL-WEB-EVENT-NAME-ALIGNMENT-02
+    scope:
+      - Freeze the paid/report analytics truth bridge policy after backend payment unlock repair.
+      - Document that backend Ops/analytics_funnel_daily remains truth for payment_success, report_unlock, and report_ready.
+      - Document that GA4 is public-funnel auxiliary unless a separate privacy-safe server-side bridge is explicitly approved.
+      - Document that Baidu remains public traffic/page observation only and cannot be paid/report truth.
+      - Do not implement Measurement Protocol export, analytics refresh, payment repair, provider call, CMS mutation, Search Channel action, URL submission, deploy, or fap-web runtime change.
+    allowed_paths:
+      - backend/docs/seo/analytics-funnel-purchase-report-truth-bridge-03.md
+      - backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json
+      - backend/tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=AnalyticsFunnelPurchaseReportTruthBridge03 --no-ansi
+      - cd backend && php artisan route:list --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php
+      - cd backend && composer validate --strict
+      - cd backend && composer audit --locked --no-interaction --ignore-unreachable
+      - python3 -m json.tool backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_repair_allowed: false
+    benefit_grant_creation_allowed: false
+    payment_provider_call: false
+    analytics_refresh_allowed: false
+    measurement_protocol_export: false
+    ga_admin_change: false
+    baidu_admin_change: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01


### PR DESCRIPTION
## What changed
- Added the `ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03` backend truth bridge report and generated JSON artifact.
- Added a focused SeoIntel test that asserts backend Ops remains the payment/report truth boundary while GA4/Baidu remain public auxiliary observability surfaces.
- Updated the PR train manifest/state for this scoped item and reconciled the previously merged mapping scan item.

## Why
The payment/report funnel now has backend repair and projection-backed truth. This PR freezes how that truth should relate to GA4 and Baidu so future analytics work does not accidentally treat frontend/public analytics as payment or report-access authority.

## Validation
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03/backend && php artisan test --filter=AnalyticsFunnelPurchaseReportTruthBridge03 --no-ansi`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03/backend && php artisan route:list --no-ansi`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03/backend && vendor/bin/pint --test tests/Feature/SeoIntel/AnalyticsFunnelPurchaseReportTruthBridge03Test.php`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03/backend && composer validate --strict`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03/backend && composer audit --locked --no-interaction --ignore-unreachable`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03 && python3 -m json.tool backend/docs/seo/generated/analytics-funnel-purchase-report-truth-bridge-03.v1.json >/dev/null`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03 && python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03 && python3 - <<'PY'\nimport yaml, pathlib\nyaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\nprint('metadata ok')\nPY`
- `cd /private/tmp/fap-api-analytics-funnel-purchase-report-truth-bridge-03 && git diff --check && git diff --cached --check`

## Intentionally deferred
- No production DB mutation or analytics refresh.
- No payment repair, grant creation, provider call, CMS mutation, Search Channel action, URL submission, or deploy.
- No GA4/Baidu admin configuration changes and no Measurement Protocol export implementation.
- No fap-web runtime changes.

## Repository rule impact
This is a docs/generated/test truth-boundary PR. It does not change content authority, public runtime rendering, payment execution, or external analytics configuration.
