### PR TITLE
fix(cms): support canary article hreflang and CMS CTA surfaces

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -228,7 +228,7 @@ class ArticleResource extends Resource
                                     ->helperText(__('ops.resources.articles.helpers.is_public')),
                                 Forms\Components\Toggle::make('is_indexable')
                                     ->label(__('ops.resources.articles.fields.search_indexable'))
-                                    ->default(true)
+                                    ->default(false)
                                     ->helperText(__('ops.resources.articles.helpers.is_indexable')),
                                 Forms\Components\DateTimePicker::make('published_at')
                                     ->label(__('ops.resources.articles.fields.published'))

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -319,6 +319,12 @@ class ArticleController extends Controller
     {
         $segment = $this->frontendLocaleSegment($locale);
         $slug = trim((string) $article->slug);
+        $cmsCtas = $this->publicArticleCtaBundle($article, $locale);
+        $ctaBundle = $cmsCtas !== []
+            ? $cmsCtas
+            : $this->fallbackArticleCtaBundle($article, $locale);
+        $startTestTarget = $this->firstStartTestTarget($ctaBundle)
+            ?? $this->articleTestTarget($article, $locale);
 
         return $this->landingSurfaceContractService->build([
             'landing_scope' => 'public_indexable_detail',
@@ -334,28 +340,9 @@ class ArticleController extends Controller
             ],
             'discoverability_keys' => ['article_index', 'topic_hub', 'personality_hub', 'career_recommendations'],
             'continue_reading_keys' => ['article_index', 'topic_hub'],
-            'start_test_target' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+            'start_test_target' => $startTestTarget,
             'content_continue_target' => '/'.$segment.'/articles',
-            'cta_bundle' => [
-                [
-                    'key' => 'back_to_articles',
-                    'label' => $locale === 'zh-CN' ? '返回文章列表' : 'Back to articles',
-                    'href' => '/'.$segment.'/articles',
-                    'kind' => 'content_continue',
-                ],
-                [
-                    'key' => 'topic_hub',
-                    'label' => $locale === 'zh-CN' ? '查看主题聚合' : 'Browse topic hubs',
-                    'href' => '/'.$segment.'/topics',
-                    'kind' => 'discover',
-                ],
-                [
-                    'key' => 'start_test',
-                    'label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
-                    'href' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
-                    'kind' => 'start_test',
-                ],
-            ],
+            'cta_bundle' => $ctaBundle,
             'indexability_state' => $article->is_indexable ? 'indexable' : 'noindex',
             'attribution_scope' => 'public_article_detail',
             'surface_family' => 'article',
@@ -383,7 +370,8 @@ class ArticleController extends Controller
                 $article->tags->all()
             )))
             : [];
-        $faqBlocks = [
+        $cmsFaqBlocks = $this->publicArticleFaqBlocks($article);
+        $faqBlocks = $cmsFaqBlocks !== [] ? $cmsFaqBlocks : [
             [
                 'key' => 'article_use',
                 'question' => $locale === 'zh-CN' ? '什么时候适合阅读这篇文章？' : 'When should I use this article?',
@@ -419,7 +407,10 @@ class ArticleController extends Controller
                 : null,
         ]));
 
-        $nextStepBlocks = [
+        $cmsNextStepBlocks = $this->answerSurfaceContractService->buildNextStepBlocksFromCtas(
+            $this->publicArticleCtaBundle($article, $locale)
+        );
+        $nextStepBlocks = $cmsNextStepBlocks !== [] ? $cmsNextStepBlocks : [
             [
                 'key' => 'articles_index',
                 'title' => $locale === 'zh-CN' ? '继续浏览文章' : 'Continue with articles',
@@ -438,7 +429,7 @@ class ArticleController extends Controller
                 'key' => 'start_test',
                 'title' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
                 'body' => $locale === 'zh-CN' ? '如果你想把阅读转成自我测量，可以从测试入口开始。' : 'If you want to turn reading into self-measurement, continue into an assessment.',
-                'href' => '/'.$segment.'/tests/mbti-personality-test-16-personality-types',
+                'href' => $this->articleTestTarget($article, $locale),
                 'kind' => 'start_test',
             ],
         ];
@@ -473,6 +464,213 @@ class ArticleController extends Controller
                 'tag_count' => count($tagNames),
             ],
         ]);
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function publicArticleCtaBundle(Article $article, string $locale): array
+    {
+        $metadata = $this->editorialPackageMetadata($article);
+        $slots = is_array($metadata['cta_slots'] ?? null) ? $metadata['cta_slots'] : [];
+        $ctas = [];
+
+        foreach ($slots as $slot) {
+            if (! is_array($slot)) {
+                continue;
+            }
+
+            $label = $this->normalizeString($slot['label'] ?? $slot['title'] ?? null);
+            $href = $this->normalizePublicTestHref($slot['href'] ?? $slot['url'] ?? null);
+            if ($label === null || $href === null) {
+                continue;
+            }
+
+            $key = $this->normalizeString($slot['key'] ?? $slot['slot_id'] ?? $slot['id'] ?? null)
+                ?? 'article_cta_'.(count($ctas) + 1);
+            $kind = $this->normalizeString($slot['kind'] ?? null) ?? 'start_test';
+
+            $ctas[] = [
+                'key' => $key,
+                'label' => $label,
+                'href' => $href,
+                'kind' => $kind,
+            ];
+
+            if (count($ctas) >= 3) {
+                break;
+            }
+        }
+
+        return $ctas;
+    }
+
+    /**
+     * @return list<array<string,string|null>>
+     */
+    private function publicArticleFaqBlocks(Article $article): array
+    {
+        $metadata = $this->editorialPackageMetadata($article);
+        $policy = $this->normalizeString($metadata['answer_surface_policy'] ?? null);
+        $visibility = $this->normalizeString($metadata['answer_surface_visibility'] ?? null);
+        if ($policy !== 'editor_supplied' || $visibility === null || $visibility === 'disabled') {
+            return [];
+        }
+
+        $answerSurface = is_array($metadata['answer_surface_v1'] ?? null) ? $metadata['answer_surface_v1'] : [];
+        $faqItems = is_array($answerSurface['faq_items'] ?? null) ? $answerSurface['faq_items'] : [];
+        $blocks = [];
+
+        foreach ($faqItems as $index => $item) {
+            if (! is_array($item) || $this->isHiddenFaqItem($item)) {
+                continue;
+            }
+
+            $question = $this->normalizeString($item['question'] ?? $item['q'] ?? null);
+            $answer = $this->normalizeString($item['answer'] ?? $item['a'] ?? null);
+            if ($question === null || $answer === null) {
+                continue;
+            }
+
+            $blocks[] = [
+                'key' => $this->normalizeString($item['key'] ?? $item['id'] ?? null) ?? 'article_faq_'.$index,
+                'question' => $question,
+                'answer' => $answer,
+            ];
+
+            if (count($blocks) >= 6) {
+                break;
+            }
+        }
+
+        return $blocks;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function editorialPackageMetadata(Article $article): array
+    {
+        $seoMeta = $article->relationLoaded('seoMeta') ? $article->seoMeta : null;
+        if (is_array($seoMeta?->schema_json) && is_array($seoMeta->schema_json['editorial_package_v1'] ?? null)) {
+            return $seoMeta->schema_json['editorial_package_v1'];
+        }
+
+        $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
+
+        return is_array($variants['editorial_package_v1'] ?? null)
+            ? $variants['editorial_package_v1']
+            : [];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function fallbackArticleCtaBundle(Article $article, string $locale): array
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+
+        return [
+            [
+                'key' => 'back_to_articles',
+                'label' => $locale === 'zh-CN' ? '返回文章列表' : 'Back to articles',
+                'href' => '/'.$segment.'/articles',
+                'kind' => 'content_continue',
+            ],
+            [
+                'key' => 'topic_hub',
+                'label' => $locale === 'zh-CN' ? '查看主题聚合' : 'Browse topic hubs',
+                'href' => '/'.$segment.'/topics',
+                'kind' => 'discover',
+            ],
+            [
+                'key' => 'start_test',
+                'label' => $locale === 'zh-CN' ? '开始测试' : 'Take the test',
+                'href' => $this->articleTestTarget($article, $locale),
+                'kind' => 'start_test',
+            ],
+        ];
+    }
+
+    private function articleTestTarget(Article $article, string $locale): string
+    {
+        $segment = $this->frontendLocaleSegment($locale);
+        foreach ($this->publicRelatedTestSlugs($article) as $slug) {
+            $href = $this->normalizePublicTestHref('/'.$segment.'/tests/'.$slug);
+            if ($href !== null) {
+                return $href;
+            }
+        }
+
+        return '/'.$segment.'/tests/mbti-personality-test-16-personality-types';
+    }
+
+    /**
+     * @param  list<array<string,string>>  $ctas
+     */
+    private function firstStartTestTarget(array $ctas): ?string
+    {
+        foreach ($ctas as $cta) {
+            $href = $this->normalizePublicTestHref($cta['href'] ?? null);
+            if ($href !== null) {
+                return $href;
+            }
+        }
+
+        return null;
+    }
+
+    private function normalizePublicTestHref(mixed $href): ?string
+    {
+        if (! is_scalar($href)) {
+            return null;
+        }
+
+        $value = trim((string) $href);
+        if ($value === '' || ! str_starts_with($value, '/')) {
+            return null;
+        }
+
+        $parts = parse_url($value);
+        if (! is_array($parts) || isset($parts['query']) || isset($parts['fragment'])) {
+            return null;
+        }
+
+        $path = (string) ($parts['path'] ?? '');
+        if (preg_match('#/(result|orders?|share|pay|payment|history|take)(/|$)#i', $path) === 1) {
+            return null;
+        }
+
+        if (preg_match('#^/(en|zh)/tests/[a-z0-9][a-z0-9-]*$#i', $path) !== 1) {
+            return null;
+        }
+
+        return $path;
+    }
+
+    private function normalizeString(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     */
+    private function isHiddenFaqItem(array $item): bool
+    {
+        if (($item['hidden'] ?? false) === true || ($item['is_visible'] ?? true) === false) {
+            return true;
+        }
+
+        $visibility = strtolower((string) ($item['visibility'] ?? 'visible'));
+
+        return in_array($visibility, ['hidden', 'disabled', 'private'], true);
     }
 
     /**
@@ -860,7 +1058,7 @@ class ArticleController extends Controller
             'cover_image_alt' => $article->cover_image_alt,
             'cover_image_width' => $article->cover_image_width !== null ? (int) $article->cover_image_width : null,
             'cover_image_height' => $article->cover_image_height !== null ? (int) $article->cover_image_height : null,
-            'cover_image_variants' => PublicMediaUrlGuard::sanitizeArrayFields($article->cover_image_variants, ['url']),
+            'cover_image_variants' => $this->publicCoverImageVariants($article),
             'related_test_slug' => $article->related_test_slug,
             'related_test_slugs' => $this->publicRelatedTestSlugs($article),
             'test_edges' => $this->publicTestEdges($article),
@@ -904,9 +1102,25 @@ class ArticleController extends Controller
             $seoMeta['schema_json'] = PublicMediaUrlGuard::sanitizeJsonLdImageFields(
                 CanonicalFrontendUrl::normalizeNestedUrls($seoMeta['schema_json'])
             );
+            unset($seoMeta['schema_json']['editorial_package_v1']);
         }
 
         return $seoMeta;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function publicCoverImageVariants(Article $article): ?array
+    {
+        $variants = PublicMediaUrlGuard::sanitizeArrayFields($article->cover_image_variants, ['url']);
+        if (! is_array($variants)) {
+            return null;
+        }
+
+        unset($variants['editorial_package_v1']);
+
+        return $variants;
     }
 
     /**

--- a/backend/app/Models/Article.php
+++ b/backend/app/Models/Article.php
@@ -187,6 +187,13 @@ class Article extends Model
             });
     }
 
+    public function scopePubliclyIndexable($query)
+    {
+        return $query
+            ->publiclyReadable()
+            ->where('is_indexable', true);
+    }
+
     public function revisions(): HasMany
     {
         return $this->hasMany(ArticleRevision::class, 'article_id', 'id');

--- a/backend/app/Services/Cms/ArticleSeoService.php
+++ b/backend/app/Services/Cms/ArticleSeoService.php
@@ -151,6 +151,14 @@ final class ArticleSeoService
 
         if ($seo instanceof ArticleSeoMeta && is_array($seo->schema_json)) {
             $jsonLd = array_replace_recursive($jsonLd, $seo->schema_json);
+            unset($jsonLd['editorial_package_v1']);
+        }
+
+        $faqPage = $this->buildVisibleFaqPage($article, $seo, $canonical);
+        if ($faqPage !== null) {
+            $hasPart = is_array($jsonLd['hasPart'] ?? null) ? $jsonLd['hasPart'] : [];
+            $hasPart[] = $faqPage;
+            $jsonLd['hasPart'] = array_values($hasPart);
         }
 
         return PublicMediaUrlGuard::sanitizeJsonLdImageFields(
@@ -256,22 +264,137 @@ final class ArticleSeoService
     }
 
     /**
+     * @return array<string,mixed>|null
+     */
+    private function buildVisibleFaqPage(Article $article, ?ArticleSeoMeta $seo, ?string $canonical): ?array
+    {
+        $metadata = $this->editorialPackageMetadata($article, $seo);
+        if ($metadata === []) {
+            return null;
+        }
+
+        $policy = $this->normalizeString($metadata['answer_surface_policy'] ?? null);
+        $visibility = $this->normalizeString($metadata['answer_surface_visibility'] ?? null);
+        if ($policy !== 'editor_supplied' || $visibility === null || $visibility === 'disabled') {
+            return null;
+        }
+
+        $answerSurface = is_array($metadata['answer_surface_v1'] ?? null) ? $metadata['answer_surface_v1'] : [];
+        $faqItems = is_array($answerSurface['faq_items'] ?? null) ? $answerSurface['faq_items'] : [];
+
+        $mainEntity = [];
+        foreach ($faqItems as $index => $item) {
+            if (! is_array($item) || $this->isHiddenFaqItem($item)) {
+                continue;
+            }
+
+            $question = $this->normalizeString($item['question'] ?? $item['q'] ?? null);
+            $answer = $this->normalizeString($item['answer'] ?? $item['a'] ?? null);
+            if ($question === null || $answer === null) {
+                continue;
+            }
+
+            $mainEntity[] = [
+                '@type' => 'Question',
+                'name' => $question,
+                'acceptedAnswer' => [
+                    '@type' => 'Answer',
+                    'text' => $answer,
+                ],
+            ];
+
+            if (count($mainEntity) >= 8) {
+                break;
+            }
+        }
+
+        if ($mainEntity === []) {
+            return null;
+        }
+
+        return array_filter([
+            '@type' => 'FAQPage',
+            '@id' => $canonical !== null ? $canonical.'#faq' : null,
+            'mainEntity' => $mainEntity,
+        ], static fn (mixed $value): bool => $value !== null);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function editorialPackageMetadata(Article $article, ?ArticleSeoMeta $seo): array
+    {
+        $schemaPackage = is_array($seo?->schema_json)
+            && is_array($seo->schema_json['editorial_package_v1'] ?? null)
+                ? $seo->schema_json['editorial_package_v1']
+                : [];
+
+        if ($schemaPackage !== []) {
+            return $schemaPackage;
+        }
+
+        $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
+
+        return is_array($variants['editorial_package_v1'] ?? null)
+            ? $variants['editorial_package_v1']
+            : [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     */
+    private function isHiddenFaqItem(array $item): bool
+    {
+        if (($item['hidden'] ?? false) === true || ($item['is_visible'] ?? true) === false) {
+            return true;
+        }
+
+        $visibility = strtolower((string) ($item['visibility'] ?? 'visible'));
+
+        return in_array($visibility, ['hidden', 'disabled', 'private'], true);
+    }
+
+    /**
      * @return array<string, string>
      */
     private function buildAlternates(Article $article): array
     {
-        $variants = Article::query()
+        $variants = [];
+        $translationGroupId = trim((string) ($article->translation_group_id ?? ''));
+
+        if ($translationGroupId !== '') {
+            $variants = Article::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', (int) $article->org_id)
+                ->where('translation_group_id', $translationGroupId)
+                ->publiclyIndexable()
+                ->whereIn('locale', self::SUPPORTED_LOCALES)
+                ->get(['slug', 'locale'])
+                ->all();
+        }
+
+        $legacySameSlugVariants = Article::query()
             ->withoutGlobalScopes()
             ->where('org_id', (int) $article->org_id)
             ->where('slug', (string) $article->slug)
-            ->publiclyReadable()
+            ->publiclyIndexable()
             ->whereIn('locale', self::SUPPORTED_LOCALES)
-            ->pluck('locale')
+            ->get(['slug', 'locale'])
             ->all();
 
         $availableLocales = [];
-        foreach ($variants as $variantLocale) {
-            $availableLocales[$this->normalizeLocale((string) $variantLocale)] = true;
+        foreach (array_merge($variants, $legacySameSlugVariants) as $variant) {
+            if (! $variant instanceof Article) {
+                continue;
+            }
+
+            $locale = $this->normalizeLocale((string) $variant->locale);
+            $slug = trim((string) $variant->slug);
+            if ($slug === '') {
+                continue;
+            }
+
+            $availableLocales[$locale] = $slug;
         }
 
         $alternates = [];
@@ -280,7 +403,7 @@ final class ArticleSeoService
                 continue;
             }
 
-            $canonical = $this->buildCanonicalUrl((string) $article->slug, $supportedLocale);
+            $canonical = $this->buildCanonicalUrl((string) $availableLocales[$supportedLocale], $supportedLocale);
             if ($canonical === null) {
                 continue;
             }

--- a/backend/app/Services/Cms/ArticleService.php
+++ b/backend/app/Services/Cms/ArticleService.php
@@ -68,7 +68,7 @@ final class ArticleService
                 'content_md' => $normalizedContentMd,
                 'status' => 'draft',
                 'is_public' => false,
-                'is_indexable' => true,
+                'is_indexable' => false,
             ]);
 
             $this->syncArticleTags($article, $tagIds, $normalizedOrgId);

--- a/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
+++ b/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
@@ -204,6 +204,7 @@ final class EditorialPackageDraftImporter
             $tags = $this->resolveTags($package['tags']);
             $article = $this->existingArticle($package);
             $primaryTestSlug = $this->primaryTestSlug($package);
+            $translationGroupId = $this->nullableString($package['translation_group_id']);
 
             if ($article instanceof Article && $this->isPublishedOrPublic($article)) {
                 throw new RuntimeException('Existing published/public articles cannot be mutated by editorial package draft import.');
@@ -218,6 +219,7 @@ final class EditorialPackageDraftImporter
                     'reading_minutes' => $this->readingMinutes((string) $package['body_markdown']),
                     'slug' => (string) $package['slug'],
                     'locale' => (string) $package['locale'],
+                    ...($translationGroupId !== null ? ['translation_group_id' => $translationGroupId] : []),
                     'title' => (string) $package['title'],
                     'excerpt' => (string) $package['excerpt'],
                     'content_md' => (string) $package['body_markdown'],
@@ -230,7 +232,7 @@ final class EditorialPackageDraftImporter
                     'related_test_slug' => $primaryTestSlug,
                     'status' => 'draft',
                     'is_public' => false,
-                    'is_indexable' => (bool) $package['indexability'],
+                    'is_indexable' => false,
                     'published_at' => null,
                     'scheduled_at' => null,
                     'published_revision_id' => null,
@@ -242,6 +244,7 @@ final class EditorialPackageDraftImporter
                     'reading_minutes' => $this->readingMinutes((string) $package['body_markdown']),
                     'slug' => (string) $package['slug'],
                     'locale' => (string) $package['locale'],
+                    ...($translationGroupId !== null ? ['translation_group_id' => $translationGroupId] : []),
                     'title' => (string) $package['title'],
                     'excerpt' => (string) $package['excerpt'],
                     'content_md' => (string) $package['body_markdown'],
@@ -252,7 +255,7 @@ final class EditorialPackageDraftImporter
                     'related_test_slug' => $primaryTestSlug,
                     'status' => 'draft',
                     'is_public' => false,
-                    'is_indexable' => (bool) $package['indexability'],
+                    'is_indexable' => false,
                     'published_at' => null,
                     'scheduled_at' => null,
                     'published_revision_id' => null,
@@ -285,11 +288,11 @@ final class EditorialPackageDraftImporter
                     'og_title' => (string) $package['seo_title'],
                     'og_description' => (string) $package['meta_description'],
                     'og_image_url' => (string) $package['cover_image'],
-                    'robots' => (bool) $package['indexability'] ? 'index,follow' : 'noindex,nofollow',
+                    'robots' => 'noindex,nofollow',
                     'schema_json' => [
                         'editorial_package_v1' => $this->editorialMetadata($package, $plan)['editorial_package_v1'],
                     ],
-                    'is_indexable' => (bool) $package['indexability'],
+                    'is_indexable' => false,
                 ],
             );
 
@@ -347,6 +350,7 @@ final class EditorialPackageDraftImporter
             'title' => trim((string) ($package['title'] ?? '')),
             'slug' => Str::slug(trim((string) ($package['slug'] ?? ''))),
             'locale' => trim((string) ($localeOverride ?: ($package['locale'] ?? 'en'))),
+            'translation_group_id' => trim((string) ($package['translation_group_id'] ?? '')),
             'author' => trim((string) ($package['author'] ?? 'Fermat Institute')),
             'intended_status' => trim((string) ($package['intended_status'] ?? 'draft')),
             'body_markdown' => trim($body),
@@ -468,6 +472,10 @@ final class EditorialPackageDraftImporter
 
         $this->trackSpecificValidation($package, $errors);
         $this->answerSurfaceBoundaryValidation($package, $errors);
+
+        if (mb_strlen((string) $package['translation_group_id']) > 64) {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_too_long', 'translation_group_id must be 64 characters or fewer.');
+        }
 
         $claimMatches = $this->claimMatches($package);
         foreach ($claimMatches as $match) {
@@ -1047,6 +1055,7 @@ final class EditorialPackageDraftImporter
             'hero' => (string) $package['cover_image'],
             'editorial_package_v1' => [
                 'package_version' => $package['package_version'],
+                'translation_group_id' => $package['translation_group_id'],
                 'content_track' => $package['content_track'],
                 'topic_cluster' => $package['topic_cluster'],
                 'content_series' => $package['content_series'],
@@ -1120,6 +1129,13 @@ final class EditorialPackageDraftImporter
         if (! in_array($package[$field] ?? null, $allowed, true)) {
             $errors[] = $this->issue($field, 'invalid_enum', $field.' is invalid.');
         }
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $normalized = trim((string) $value);
+
+        return $normalized === '' ? null : $normalized;
     }
 
     /**

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -184,16 +184,10 @@ class SitemapGenerator
         $rows = Article::query()
             ->withoutGlobalScopes()
             ->where('org_id', 0)
-            ->where('status', 'published')
-            ->where('is_public', true)
-            ->where('is_indexable', true)
+            ->publiclyIndexable()
             ->whereIn('locale', ArticleSeoService::SUPPORTED_LOCALES)
             ->whereNotNull('slug')
             ->where('slug', '<>', '')
-            ->where(static function ($query): void {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            })
             ->select(['slug', 'locale', 'updated_at', 'published_at'])
             ->orderBy('locale')
             ->orderBy('slug')

--- a/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
@@ -97,6 +97,7 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $package = $this->editorialPackage([
             'slug' => 'ai-personality-editorial-draft',
             'intended_status' => 'review_pending',
+            'translation_group_id' => 'article_mbti_vs_holland_career_choice_v1',
         ]);
         $path = $this->writePackage($package);
         $sensitiveCounts = $this->sensitiveTableCounts();
@@ -121,7 +122,9 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
 
         $this->assertSame('draft', (string) $article->status);
         $this->assertFalse((bool) $article->is_public);
+        $this->assertFalse((bool) $article->is_indexable);
         $this->assertNull($article->published_revision_id);
+        $this->assertSame('article_mbti_vs_holland_career_choice_v1', (string) $article->translation_group_id);
         $this->assertSame($package['title'], (string) $article->title);
         $this->assertSame($package['body_markdown'], (string) $article->content_md);
         $this->assertSame($package['cover_image'], (string) $article->cover_image_url);
@@ -142,9 +145,11 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $this->assertSame($package['seo_title'], (string) $article->seoMeta?->seo_title);
         $this->assertSame($package['meta_description'], (string) $article->seoMeta?->seo_description);
         $this->assertSame($package['canonical'], (string) $article->seoMeta?->canonical_url);
-        $this->assertSame('index,follow', (string) $article->seoMeta?->robots);
+        $this->assertSame('noindex,nofollow', (string) $article->seoMeta?->robots);
+        $this->assertFalse((bool) $article->seoMeta?->is_indexable);
 
         $metadata = $article->cover_image_variants['editorial_package_v1'] ?? [];
+        $this->assertSame('article_mbti_vs_holland_career_choice_v1', $metadata['translation_group_id'] ?? null);
         $this->assertSame('editorial_journal', $metadata['content_track'] ?? null);
         $this->assertSame($package['references'], $metadata['references'] ?? []);
         $this->assertSame($package['answer_surface_v1']['quick_answer'], data_get($metadata, 'answer_surface_v1.quick_answer'));

--- a/backend/tests/Feature/Ops/ArticleTranslationContractTest.php
+++ b/backend/tests/Feature/Ops/ArticleTranslationContractTest.php
@@ -118,8 +118,8 @@ final class ArticleTranslationContractTest extends TestCase
         $org = $this->createOrganization();
         app(OrgContext::class)->set((int) $org->id, (int) $admin->id, 'admin');
 
-        $zhArticle = $this->createArticle((int) $org->id, 'zh-CN', '中文源文');
-        $enArticle = $this->createArticle((int) $org->id, 'en', 'English source');
+        $zhArticle = $this->createArticle(0, 'zh-CN', '中文源文');
+        $enArticle = $this->createArticle(0, 'en', 'English source');
 
         session($this->opsSession($admin, $org, 'en'));
         $this->actingAs($admin, (string) config('admin.guard', 'admin'));

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -3,6 +3,7 @@
 namespace Tests\Feature\SEO;
 
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\CareerJobSeoMeta;
@@ -782,7 +783,7 @@ class SitemapGeneratorTest extends TestCase
     private function createArticle(array $overrides = []): Article
     {
         /** @var Article */
-        return Article::query()->create(array_merge([
+        $article = Article::query()->create(array_merge([
             'org_id' => 0,
             'category_id' => null,
             'author_admin_user_id' => null,
@@ -801,6 +802,31 @@ class SitemapGeneratorTest extends TestCase
             'created_at' => Carbon::create(2026, 3, 6, 8, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 3, 6, 8, 0, 0, 'UTC'),
         ], $overrides));
+
+        /** @var ArticleTranslationRevision */
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+            'supersedes_revision_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => null,
+            'seo_description' => null,
+            'published_at' => $article->published_at,
+        ]);
+
+        $article->forceFill(['published_revision_id' => $revision->id])->save();
+
+        return $article->fresh(['publishedRevision']) ?? $article;
     }
 
     /**

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -4,6 +4,7 @@ namespace Tests\Feature\SEO;
 
 use App\Domain\Career\Publish\CareerRuntimePublishProjectionVisibility;
 use App\Models\Article;
+use App\Models\ArticleTranslationRevision;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\CareerJobDisplayAsset;
@@ -256,7 +257,7 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
-        Article::query()->create([
+        $this->createPublishedArticle([
             'org_id' => 0,
             'slug' => 'mbti-basics',
             'locale' => 'en',
@@ -274,7 +275,7 @@ class SitemapXmlTest extends TestCase
             'updated_at' => $nowB,
         ]);
 
-        Article::query()->create([
+        $this->createPublishedArticle([
             'org_id' => 0,
             'slug' => 'mbti-basics',
             'locale' => 'zh-CN',
@@ -789,6 +790,54 @@ class SitemapXmlTest extends TestCase
         );
 
         Cache::flush();
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function createPublishedArticle(array $overrides = []): Article
+    {
+        /** @var Article */
+        $article = Article::query()->create(array_merge([
+            'org_id' => 0,
+            'slug' => 'article-slug',
+            'locale' => 'en',
+            'title' => 'Article Title',
+            'excerpt' => 'Article excerpt.',
+            'content_md' => '# Article body',
+            'content_html' => null,
+            'cover_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 1, 31, 11, 35, 0),
+            'scheduled_at' => null,
+        ], $overrides));
+
+        /** @var ArticleTranslationRevision */
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => (int) $article->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) ($article->source_article_id ?: $article->id),
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => (string) $article->locale,
+            'source_locale' => (string) ($article->source_locale ?: $article->locale),
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => $article->source_version_hash,
+            'translated_from_version_hash' => $article->translated_from_version_hash ?: $article->source_version_hash,
+            'supersedes_revision_id' => null,
+            'title' => (string) $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => null,
+            'seo_description' => null,
+            'published_at' => $article->published_at,
+        ]);
+
+        $article->forceFill(['published_revision_id' => $revision->id])->save();
+
+        return $article->fresh(['publishedRevision']) ?? $article;
     }
 
     /**

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -9,6 +9,7 @@ use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
 final class ArticlePublicApiTest extends TestCase
@@ -151,6 +152,83 @@ final class ArticlePublicApiTest extends TestCase
         $this->assertStringNotContainsString($legacyCanonical, (string) $response->getContent());
     }
 
+    public function test_article_seo_alternates_use_translation_group_id_for_different_slugs(): void
+    {
+        config([
+            'app.url' => 'https://api.staging.fermatmind.com',
+            'app.frontend_url' => 'https://staging.fermatmind.com',
+        ]);
+
+        $groupId = 'article_mbti_vs_holland_career_choice_v1';
+        $this->createArticle([
+            'slug' => 'mbti-vs-holland-code-career-choice',
+            'locale' => 'en',
+            'title' => 'MBTI vs Holland Code career choice',
+            'translation_group_id' => $groupId,
+        ]);
+        $this->createArticle([
+            'slug' => 'mbti-vs-holland-career-choice',
+            'locale' => 'zh-CN',
+            'title' => 'MBTI vs Holland career choice',
+            'translation_group_id' => $groupId,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/articles/mbti-vs-holland-code-career-choice')
+            ->assertJsonPath('meta.alternates.zh', 'https://staging.fermatmind.com/zh/articles/mbti-vs-holland-career-choice')
+            ->assertJsonPath('meta.alternates.zh-CN', 'https://staging.fermatmind.com/zh/articles/mbti-vs-holland-career-choice');
+
+        $this->assertNull(data_get($response->json(), 'meta.alternates.x-default'));
+    }
+
+    public function test_article_seo_alternates_exclude_draft_and_noindex_siblings(): void
+    {
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $draftGroup = 'article_draft_sibling_exclusion_v1';
+        $this->createArticle([
+            'slug' => 'draft-sibling-source',
+            'locale' => 'en',
+            'translation_group_id' => $draftGroup,
+        ]);
+        $this->createArticle([
+            'slug' => 'draft-sibling-zh',
+            'locale' => 'zh-CN',
+            'translation_group_id' => $draftGroup,
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+            'published_at' => null,
+        ], [], false);
+
+        $draftResponse = $this->getJson('/api/v0.5/articles/draft-sibling-source/seo?locale=en');
+        $draftResponse->assertOk()
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/articles/draft-sibling-source');
+        $this->assertNull(data_get($draftResponse->json(), 'meta.alternates.zh'));
+        $this->assertNull(data_get($draftResponse->json(), 'meta.alternates.zh-CN'));
+
+        $noindexGroup = 'article_noindex_sibling_exclusion_v1';
+        $this->createArticle([
+            'slug' => 'noindex-sibling-source',
+            'locale' => 'en',
+            'translation_group_id' => $noindexGroup,
+        ]);
+        $this->createArticle([
+            'slug' => 'noindex-sibling-zh',
+            'locale' => 'zh-CN',
+            'translation_group_id' => $noindexGroup,
+            'is_indexable' => false,
+        ]);
+
+        $noindexResponse = $this->getJson('/api/v0.5/articles/noindex-sibling-source/seo?locale=en');
+        $noindexResponse->assertOk()
+            ->assertJsonPath('meta.alternates.en', 'https://staging.fermatmind.com/en/articles/noindex-sibling-source');
+        $this->assertNull(data_get($noindexResponse->json(), 'meta.alternates.zh'));
+        $this->assertNull(data_get($noindexResponse->json(), 'meta.alternates.zh-CN'));
+    }
+
     public function test_article_detail_includes_landing_and_answer_surfaces(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);
@@ -197,6 +275,142 @@ final class ArticlePublicApiTest extends TestCase
             ->assertJsonPath('answer_surface_v1.next_step_blocks.0.href', '/en/articles');
 
         $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
+    }
+
+    public function test_article_detail_projects_cms_cta_slots_and_visible_faq_without_private_targets(): void
+    {
+        config(['app.frontend_url' => 'https://www.fermatmind.com']);
+
+        $editorialPackage = [
+            'answer_surface_policy' => 'editor_supplied',
+            'answer_surface_visibility' => 'below_intro',
+            'answer_surface_v1' => [
+                'faq_items' => [
+                    ['key' => 'visible_faq', 'question' => 'Visible FAQ?', 'answer' => 'Visible answer.'],
+                    ['key' => 'hidden_faq', 'question' => 'Hidden FAQ?', 'answer' => 'Hidden answer.', 'visibility' => 'hidden'],
+                ],
+            ],
+            'cta_slots' => [
+                ['slot_id' => 'primary_riasec', 'label' => 'Start RIASEC', 'href' => '/en/tests/holland-career-interest-test-riasec'],
+                ['slot_id' => 'secondary_mbti', 'label' => 'Start MBTI', 'href' => '/en/tests/mbti-personality-test-16-personality-types'],
+                ['slot_id' => 'tertiary_big_five', 'label' => 'Start Big Five', 'href' => '/en/tests/big-five-personality-test'],
+                ['slot_id' => 'private_result', 'label' => 'Private result', 'href' => '/en/result/private-attempt'],
+            ],
+        ];
+
+        $article = $this->createArticle([
+            'slug' => 'cms-cta-faq-article',
+            'locale' => 'en',
+            'title' => 'CMS CTA FAQ Article',
+            'cover_image_variants' => ['editorial_package_v1' => $editorialPackage],
+            'related_test_slug' => 'mbti-personality-test-16-personality-types',
+        ]);
+        $this->createSeoMeta($article, [
+            'schema_json' => ['editorial_package_v1' => $editorialPackage],
+        ]);
+
+        $detail = $this->getJson('/api/v0.5/articles/cms-cta-faq-article?locale=en');
+
+        $detail->assertOk()
+            ->assertJsonPath('landing_surface_v1.start_test_target', '/en/tests/holland-career-interest-test-riasec')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.0.key', 'primary_riasec')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.0.href', '/en/tests/holland-career-interest-test-riasec')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.1.key', 'secondary_mbti')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.2.key', 'tertiary_big_five')
+            ->assertJsonPath('answer_surface_v1.faq_blocks.0.key', 'visible_faq')
+            ->assertJsonPath('answer_surface_v1.faq_blocks.0.question', 'Visible FAQ?')
+            ->assertJsonPath('answer_surface_v1.next_step_blocks.0.href', '/en/tests/holland-career-interest-test-riasec');
+
+        $this->assertContains('FAQPage', $detail->json('seo_surface_v1.structured_data_keys'));
+
+        $this->assertStringNotContainsString('private-attempt', (string) $detail->getContent());
+        $this->assertStringNotContainsString('Hidden FAQ?', (string) $detail->getContent());
+
+        $seo = $this->getJson('/api/v0.5/articles/cms-cta-faq-article/seo?locale=en');
+        $seo->assertOk()
+            ->assertJsonPath('jsonld.hasPart.0.@type', 'FAQPage')
+            ->assertJsonPath('jsonld.hasPart.0.mainEntity.0.name', 'Visible FAQ?');
+
+        $this->assertStringNotContainsString('Hidden FAQ?', (string) $seo->getContent());
+    }
+
+    public function test_article_detail_uses_locale_specific_cms_faq_blocks(): void
+    {
+        $groupId = 'article_locale_specific_faq_v1';
+        $enPackage = [
+            'answer_surface_policy' => 'editor_supplied',
+            'answer_surface_visibility' => 'below_intro',
+            'answer_surface_v1' => [
+                'faq_items' => [
+                    ['key' => 'en_visible_faq', 'question' => 'English visible FAQ?', 'answer' => 'English visible answer.'],
+                ],
+            ],
+        ];
+        $zhPackage = [
+            'answer_surface_policy' => 'editor_supplied',
+            'answer_surface_visibility' => 'below_intro',
+            'answer_surface_v1' => [
+                'faq_items' => [
+                    ['key' => 'zh_visible_faq', 'question' => 'Chinese visible FAQ?', 'answer' => 'Chinese visible answer.'],
+                ],
+            ],
+        ];
+
+        $enArticle = $this->createArticle([
+            'slug' => 'locale-specific-faq-en',
+            'locale' => 'en',
+            'translation_group_id' => $groupId,
+            'cover_image_variants' => ['editorial_package_v1' => $enPackage],
+        ]);
+        $this->createSeoMeta($enArticle, [
+            'schema_json' => ['editorial_package_v1' => $enPackage],
+        ]);
+
+        $zhArticle = $this->createArticle([
+            'slug' => 'locale-specific-faq-zh',
+            'locale' => 'zh-CN',
+            'translation_group_id' => $groupId,
+            'cover_image_variants' => ['editorial_package_v1' => $zhPackage],
+        ]);
+        $this->createSeoMeta($zhArticle, [
+            'schema_json' => ['editorial_package_v1' => $zhPackage],
+        ]);
+
+        $enDetail = $this->getJson('/api/v0.5/articles/locale-specific-faq-en?locale=en');
+        $enDetail->assertOk()
+            ->assertJsonPath('answer_surface_v1.faq_blocks.0.question', 'English visible FAQ?');
+        $this->assertStringNotContainsString('Chinese visible FAQ?', (string) $enDetail->getContent());
+
+        $zhDetail = $this->getJson('/api/v0.5/articles/locale-specific-faq-zh?locale=zh-CN');
+        $zhDetail->assertOk()
+            ->assertJsonPath('answer_surface_v1.faq_blocks.0.question', 'Chinese visible FAQ?');
+        $this->assertStringNotContainsString('English visible FAQ?', (string) $zhDetail->getContent());
+
+        $enSeo = $this->getJson('/api/v0.5/articles/locale-specific-faq-en/seo?locale=en');
+        $enSeo->assertOk()
+            ->assertJsonPath('jsonld.hasPart.0.mainEntity.0.name', 'English visible FAQ?');
+        $this->assertStringNotContainsString('Chinese visible FAQ?', (string) $enSeo->getContent());
+
+        $zhSeo = $this->getJson('/api/v0.5/articles/locale-specific-faq-zh/seo?locale=zh-CN');
+        $zhSeo->assertOk()
+            ->assertJsonPath('jsonld.hasPart.0.mainEntity.0.name', 'Chinese visible FAQ?');
+        $this->assertStringNotContainsString('English visible FAQ?', (string) $zhSeo->getContent());
+    }
+
+    public function test_article_detail_fallback_uses_related_public_test_before_mbti_default(): void
+    {
+        $this->createArticle([
+            'slug' => 'riasec-fallback-article',
+            'locale' => 'en',
+            'related_test_slug' => 'holland-career-interest-test-riasec',
+        ]);
+
+        $response = $this->getJson('/api/v0.5/articles/riasec-fallback-article?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('landing_surface_v1.start_test_target', '/en/tests/holland-career-interest-test-riasec')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.2.href', '/en/tests/holland-career-interest-test-riasec')
+            ->assertJsonPath('answer_surface_v1.next_step_blocks.2.href', '/en/tests/holland-career-interest-test-riasec');
     }
 
     public function test_public_reads_require_published_revision_and_hide_human_review(): void
@@ -392,6 +606,38 @@ final class ArticlePublicApiTest extends TestCase
             $this->getJson('/api/v0.5/articles/'.$slug.'?locale=zh-CN')->assertNotFound();
             $this->getJson('/api/v0.5/articles/'.$slug.'?locale=en')->assertNotFound();
         }
+    }
+
+    public function test_sitemap_source_uses_public_readable_and_indexable_article_gate(): void
+    {
+        Cache::flush();
+        config(['app.frontend_url' => 'https://staging.fermatmind.com']);
+
+        $this->createArticle([
+            'slug' => 'sitemap-visible-article',
+            'locale' => 'en',
+        ]);
+        $this->createArticle([
+            'slug' => 'sitemap-draft-article',
+            'locale' => 'en',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+            'published_at' => null,
+        ], [], false);
+        $this->createArticle([
+            'slug' => 'sitemap-noindex-article',
+            'locale' => 'en',
+            'is_indexable' => false,
+        ]);
+
+        $response = $this->getJson('/api/v0.5/seo/sitemap-source');
+
+        $response->assertOk();
+        $locations = collect($response->json('items'))->pluck('loc')->all();
+        $this->assertContains('https://staging.fermatmind.com/en/articles/sitemap-visible-article', $locations);
+        $this->assertNotContains('https://staging.fermatmind.com/en/articles/sitemap-draft-article', $locations);
+        $this->assertNotContains('https://staging.fermatmind.com/en/articles/sitemap-noindex-article', $locations);
     }
 
     public function test_article_seo_does_not_fake_missing_locale_alternates(): void

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,14 +1,14 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-02T11:20:10Z",
+  "updated_at": "2026-06-02T11:21:50Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
       "branch": "codex/seo-cms-canary-be-01-hreflang-cta-surfaces",
-      "status": "local_checks_passed",
+      "status": "pr_open",
       "depends_on": [],
-      "commit_sha": null,
-      "pr_url": null,
+      "commit_sha": "686c2799487b48d0b75f9de983f87c61884f9391",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1852",
       "checks": {
         "local": {
           "status": "passed",
@@ -47,6 +47,12 @@
           "from": "in_progress",
           "to": "local_checks_passed",
           "note": "Composer/phpunit config inspected; targeted Article public API, editorial package import, controlled publish dry-run, translation contract, scoped Pint, and git diff checks passed."
+        },
+        {
+          "at": "2026-06-02T11:21:50Z",
+          "from": "local_checks_passed",
+          "to": "pr_open",
+          "note": "Opened https://github.com/fermatmind/fap-api/pull/1852 for GitHub checks and merge review."
         }
       ],
       "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,13 +1,13 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-02T11:26:10Z",
+  "updated_at": "2026-06-02T11:39:52Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
       "branch": "codex/seo-cms-canary-be-01-hreflang-cta-surfaces",
-      "status": "github_checks_failed",
+      "status": "local_checks_passed_after_ci_fix",
       "depends_on": [],
-      "commit_sha": "94c3133853cbadda740da4478d5efbb909bfaa03",
+      "commit_sha": "0bccc4b3a9febc9c2fcb9c19715ff63845fa4561",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1852",
       "checks": {
         "local": {
@@ -50,16 +50,27 @@
             "Semgrep OSS",
             "semgrep sarif non-blocking upload"
           ]
+        },
+        "local_ci_fix": {
+          "status": "passed",
+          "commands": [
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapXmlTest.php --no-ansi",
+            "cd backend && vendor/bin/pint --test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php vendor/phpunit/phpunit/phpunit --configuration phpunit.xml tests/Feature/V0_5/CareerRecommendationPublicApiTest.php tests/Feature/PersonalityCms/PersonalityBaselineImportTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php tests/Unit/Services/Mbti/MbtiPublicProjectionServiceTest.php tests/Feature/V0_5/PersonalityPublicApiTest.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/V0_3/MbtiReportHttpContractRegressionTest.php tests/Feature/V0_3/ShareSummaryContractTest.php tests/Feature/V0_3/MbtiCompareInviteContractTest.php",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --no-ansi",
+            "git diff --check"
+          ],
+          "notes": "GitHub verify-mbti failures were caused by sitemap test fixtures that did not create published article revisions after the production sitemap source began using the public article readable/indexable gate. Updated SitemapGeneratorTest and SitemapXmlTest fixtures to create published revisions for public article URLs."
         }
       },
-      "failure_reason": "GitHub checks failed on 2026-06-02: verify-mbti-legacy and verify-mbti-v2 failed on the current PR check run; verify-bigfive was still pending when execution stopped per PR-train failure policy.",
+      "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": false,
+        "github_checks_green": null,
         "post_merge_revalidated": null
       },
       "transitions": [
@@ -86,6 +97,12 @@
           "from": "pr_open",
           "to": "github_checks_failed",
           "note": "Stopped after GitHub checks failed: verify-mbti-legacy and verify-mbti-v2. No merge, cleanup, WEB-01, CMS draft, or publish action was executed."
+        },
+        {
+          "at": "2026-06-02T11:39:52Z",
+          "from": "github_checks_failed",
+          "to": "local_checks_passed_after_ci_fix",
+          "note": "Fixed CI sitemap fixtures to create published revisions under the new article sitemap gate; targeted SitemapXmlTest, CI personality authority gate, ArticlePublicApiTest, scoped Pint, and git diff checks passed locally."
         }
       ],
       "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,13 +1,13 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-02T11:21:50Z",
+  "updated_at": "2026-06-02T11:26:10Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
       "branch": "codex/seo-cms-canary-be-01-hreflang-cta-surfaces",
-      "status": "pr_open",
+      "status": "github_checks_failed",
       "depends_on": [],
-      "commit_sha": "686c2799487b48d0b75f9de983f87c61884f9391",
+      "commit_sha": "94c3133853cbadda740da4478d5efbb909bfaa03",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1852",
       "checks": {
         "local": {
@@ -23,16 +23,43 @@
           ],
           "scope_validation": "passed",
           "notes": "All targeted checks exited 0. PHPUnit emitted existing file_get_contents warnings. ArticleTranslationContractTest failed on origin/main with the same public-org fixture issue before this branch aligned the scoped fixture to ArticleResource's public content org."
+        },
+        "github": {
+          "status": "failed",
+          "failed_checks": [
+            {
+              "name": "verify-mbti-legacy",
+              "url": "https://github.com/fermatmind/fap-api/actions/runs/26816454211/job/79059557105"
+            },
+            {
+              "name": "verify-mbti-v2",
+              "url": "https://github.com/fermatmind/fap-api/actions/runs/26816454211/job/79059557191"
+            }
+          ],
+          "pending_checks": [
+            {
+              "name": "verify-bigfive",
+              "url": "https://github.com/fermatmind/fap-api/actions/runs/26816454211/job/79059557228"
+            }
+          ],
+          "passed_checks": [
+            "hygiene",
+            "supply-chain",
+            "content-pack-build-validate",
+            "Semgrep blocking secrets",
+            "Semgrep OSS",
+            "semgrep sarif non-blocking upload"
+          ]
         }
       },
-      "failure_reason": null,
+      "failure_reason": "GitHub checks failed on 2026-06-02: verify-mbti-legacy and verify-mbti-v2 failed on the current PR check run; verify-bigfive was still pending when execution stopped per PR-train failure policy.",
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "scope_validation": {
         "allowed_paths_only": true,
         "local_validation_passed": true,
-        "github_checks_green": null,
+        "github_checks_green": false,
         "post_merge_revalidated": null
       },
       "transitions": [
@@ -53,6 +80,12 @@
           "from": "local_checks_passed",
           "to": "pr_open",
           "note": "Opened https://github.com/fermatmind/fap-api/pull/1852 for GitHub checks and merge review."
+        },
+        {
+          "at": "2026-06-02T11:26:10Z",
+          "from": "pr_open",
+          "to": "github_checks_failed",
+          "note": "Stopped after GitHub checks failed: verify-mbti-legacy and verify-mbti-v2. No merge, cleanup, WEB-01, CMS draft, or publish action was executed."
         }
       ],
       "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,7 +1,57 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-01T13:33:00Z",
+  "updated_at": "2026-06-02T11:20:10Z",
   "items": {
+    "SEO-CMS-CANARY-BE-01": {
+      "repo": "fap-api",
+      "branch": "codex/seo-cms-canary-be-01-hreflang-cta-surfaces",
+      "status": "local_checks_passed",
+      "depends_on": [],
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "local": {
+          "status": "passed",
+          "commands": [
+            "cd backend && rg -n \"phpunit|artisan test|scripts|require\" composer.json phpunit.xml",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi",
+            "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Ops/ArticleTranslationContractTest.php --no-ansi",
+            "cd backend && vendor/bin/pint --test app/Models/Article.php app/Services/Cms/ArticleSeoService.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Services/Cms/ArticleService.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php app/Services/SEO/SitemapGenerator.php app/Filament/Ops/Resources/ArticleResource.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Ops/ArticleTranslationContractTest.php",
+            "git diff --check"
+          ],
+          "scope_validation": "passed",
+          "notes": "All targeted checks exited 0. PHPUnit emitted existing file_get_contents warnings. ArticleTranslationContractTest failed on origin/main with the same public-org fixture issue before this branch aligned the scoped fixture to ArticleResource's public content org."
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "scope_validation": {
+        "allowed_paths_only": true,
+        "local_validation_passed": true,
+        "github_checks_green": null,
+        "post_merge_revalidated": null
+      },
+      "transitions": [
+        {
+          "at": "2026-06-02T11:00:00Z",
+          "from": "planned_external_manifest",
+          "to": "in_progress",
+          "note": "Started after fap-web SEO-CMS-CANARY-TRAIN-00 merged and cleanup completed."
+        },
+        {
+          "at": "2026-06-02T11:20:10Z",
+          "from": "in_progress",
+          "to": "local_checks_passed",
+          "note": "Composer/phpunit config inspected; targeted Article public API, editorial package import, controlled publish dry-run, translation contract, scoped Pint, and git diff checks passed."
+        }
+      ],
+      "sidecars": [],
+      "next_task": "SEO-CMS-CANARY-WEB-01"
+    },
     "PR-EQ-PER-01": {
       "repo": "fap-api",
       "branch": "codex/pr-eq-per-01-all-free-copy-contract-cleanup",


### PR DESCRIPTION
## What changed
- Added public article alternates by `translation_group_id`, preserving same-slug legacy alternates while excluding draft/noindex siblings.
- Projected CMS/editorial package `cta_slots` and visible FAQ items into article landing/answer surfaces and FAQPage JSON-LD without exposing private CTA targets or hidden FAQ payloads.
- Changed article draft creation/import defaults to fail closed: draft, non-public, no published revision, noindex/nofollow.
- Reused the public article readable/indexable gate for article sitemap source rows.
- Added the fap-api train state entry for `SEO-CMS-CANARY-BE-01` with local validation evidence.

## Why
The SEO CMS canary preflight was NO-GO because the backend could not safely support different-slug bilingual article hreflang, CMS-owned CTA/FAQ projection, draft fail-closed defaults, and sitemap parity with the public article gate. This PR fixes only those backend platform blockers.

## Validation
- `cd backend && rg -n "phpunit|artisan test|scripts|require" composer.json phpunit.xml`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticlePublishControlledCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Ops/ArticleTranslationContractTest.php --no-ansi`
- `cd backend && vendor/bin/pint --test app/Models/Article.php app/Services/Cms/ArticleSeoService.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Services/Cms/ArticleService.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php app/Services/SEO/SitemapGenerator.php app/Filament/Ops/Resources/ArticleResource.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Ops/ArticleTranslationContractTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --check`
- `git diff --cached --check`

PHPUnit emitted existing `file_get_contents(...)` warnings in the targeted suites; all commands exited 0.

## Intentionally deferred
- No `SEO-CMS-CANARY-PREFLIGHT` run.
- No CMS draft creation and no publish action.
- No GPT-5.5 Pro content package changes, no content/copy/asset generation, and no frontend/analytics runtime changes.
- Preview remains a blocker for `SEO-CMS-CANARY-PREFLIGHT` unless a token-gated/noindex/not-in-sitemap preview path is implemented later.
- `SEO-CMS-CANARY-WEB-01` and `SEO-CONTENT-P1-08` are not executed in this PR.

## Repository rule impact
Backend/CMS remains the content authority. This PR changes product platform projection and safety gates only; it does not introduce frontend editorial fallback content or new runtime content assets.
