### PR TITLE
IQ-BANK-50-01 define beta50 bank manifest spec

### DIFF
--- a/backend/docs/iq/iq-beta-50-bank-spec.md
+++ b/backend/docs/iq/iq-beta-50-bank-spec.md
@@ -1,0 +1,69 @@
+# IQ_BETA_50_ORIGINAL Bank Specification
+
+Date: 2026-06-02
+
+Scope: backend-authoritative planning contract for the future 50-item FermatMind IQ beta bank. This PR defines the manifest/spec only. It does not import final questions, answer keys, scoring norms, runtime binding, CMS copy, frontend take behavior, or commerce unlock.
+
+## 1. Bank identity
+
+| Field | Value |
+| --- | --- |
+| Bank id | `IQ_BETA_50_ORIGINAL` |
+| Scale code | `IQ_INTELLIGENCE_QUOTIENT` |
+| Legacy compatibility | `IQ_RAVEN` remains an input alias only; it is not user-facing copy. |
+| Frontend display key | `beta_50` |
+| Relationship to beta30 | `IQ_BETA_30_ORIGINAL` remains the current available free beta form. |
+| Item count target | `50` |
+| Option count target | `6` options per item, `A` through `F` |
+| Runtime status | `future_placeholder_spec_only` |
+| Public take enabled | `false` |
+| Commerce requirement | None in this PR; commerce unlock remains deferred until backend authority exists. |
+
+## 2. Target dimension distribution
+
+| Dimension | Count | Purpose |
+| --- | --- | --- |
+| `VSPR` | `22` | Visual-spatial pattern reasoning, including progressive matrices and visual sequences. |
+| `VSI` | `16` | Visual-spatial insight, rotation, overlay, symmetry, and grouping. |
+| `NPR` | `12` | Numerical pattern reasoning using language-light count, recurrence, and symbolic rules. |
+
+## 3. Target item-family distribution
+
+| Family | Count | Notes |
+| --- | --- | --- |
+| `matrix_3x3` | `16` | Main progressive matrix signal. |
+| `matrix_2x2` | `6` | Warm-up and analogy items. |
+| `series` | `8` | Figure sequence continuation. |
+| `odd_one_out` | `6` | Shared-rule exception detection. |
+| `rotation` | `5` | Rotation and mirror-rejection tasks. |
+| `overlay` | `5` | Union, intersection, subtraction, or XOR-style composition. |
+| `numeric_pattern` | `4` | Count-based or symbolic recurrence. |
+
+## 4. Launch gates
+
+Beta50 must stay unavailable until all gates pass:
+
+- final item import
+- backend-only answer key
+- scoring spec
+- norm authority and calibration policy
+- copyright gate
+- ambiguity gate
+- provenance gate
+- public payload redaction gate
+- frontend renderer contract gate
+
+## 5. Explicit non-goals for this PR
+
+- no `items.json`
+- no `answer_key.json`
+- no `scoring_spec.json`
+- no runtime binding
+- no public take entry
+- no sitemap, llms, or JSON-LD expansion
+- no CMS editorial copy
+- no payment or entitlement change
+
+## 6. Frontend handoff
+
+Frontend may render `beta_50` as a coming-soon or future validation placeholder only. It must not expose a start/take CTA until backend imports the final bank and marks the form take-enabled through an explicit follow-up PR.

--- a/backend/tests/Feature/Content/IqBeta50BankSpecTest.php
+++ b/backend/tests/Feature/Content/IqBeta50BankSpecTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Content;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class IqBeta50BankSpecTest extends TestCase
+{
+    private function bankDir(): string
+    {
+        return base_path('../content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL');
+    }
+
+    private function readManifest(): array
+    {
+        $payload = json_decode((string) file_get_contents($this->bankDir().'/manifest.json'), true);
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+
+    #[Test]
+    public function manifest_defines_beta50_as_future_placeholder_only(): void
+    {
+        $manifest = $this->readManifest();
+
+        $this->assertSame('IQ_BETA_50_ORIGINAL', $manifest['bank_id']);
+        $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', $manifest['scale_code']);
+        $this->assertSame('future_placeholder_spec_only', $manifest['status']);
+        $this->assertFalse($manifest['runtime_bound']);
+        $this->assertFalse($manifest['public_take_enabled']);
+        $this->assertSame(50, $manifest['item_count_target']);
+        $this->assertSame(0, $manifest['item_count_imported']);
+        $this->assertSame(['VSPR' => 22, 'VSI' => 16, 'NPR' => 12], $manifest['dimension_targets']);
+    }
+
+    #[Test]
+    public function launch_gates_block_runtime_use_until_items_scoring_and_norms_exist(): void
+    {
+        $manifest = $this->readManifest();
+
+        foreach ([
+            'items_import_required',
+            'answer_key_required',
+            'scoring_spec_required',
+            'norm_authority_required',
+            'copyright_gate_required',
+            'ambiguity_gate_required',
+            'provenance_gate_required',
+        ] as $gate) {
+            $this->assertTrue((bool) $manifest['launch_gates'][$gate], $gate.' should remain required');
+        }
+
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_items']);
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_answer_key']);
+        $this->assertFalse($manifest['norm_policy']['iq_claims_enabled']);
+        $this->assertFalse($manifest['norm_policy']['percentile_claims_enabled']);
+    }
+
+    #[Test]
+    public function beta50_pr_does_not_import_runtime_items_answer_key_or_scoring_spec(): void
+    {
+        $this->assertFileExists($this->bankDir().'/manifest.json');
+        $this->assertFileDoesNotExist($this->bankDir().'/items.json');
+        $this->assertFileDoesNotExist($this->bankDir().'/answer_key.json');
+        $this->assertFileDoesNotExist($this->bankDir().'/scoring_spec.json');
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json
@@ -1,0 +1,55 @@
+{
+  "schema_version": "fm.iq.item_bank_manifest.v1",
+  "bank_id": "IQ_BETA_50_ORIGINAL",
+  "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+  "legacy_compatibility": {
+    "accepts_legacy_scale_code_alias": "IQ_RAVEN",
+    "legacy_alias_user_facing": false
+  },
+  "status": "future_placeholder_spec_only",
+  "runtime_bound": false,
+  "public_take_enabled": false,
+  "item_count_target": 50,
+  "item_count_imported": 0,
+  "option_count": 6,
+  "option_codes": ["A", "B", "C", "D", "E", "F"],
+  "dimension_targets": {
+    "VSPR": 22,
+    "VSI": 16,
+    "NPR": 12
+  },
+  "item_family_targets": {
+    "matrix_3x3": 16,
+    "matrix_2x2": 6,
+    "series": 8,
+    "odd_one_out": 6,
+    "rotation": 5,
+    "overlay": 5,
+    "numeric_pattern": 4
+  },
+  "launch_gates": {
+    "items_import_required": true,
+    "answer_key_required": true,
+    "scoring_spec_required": true,
+    "norm_authority_required": true,
+    "copyright_gate_required": true,
+    "ambiguity_gate_required": true,
+    "provenance_gate_required": true
+  },
+  "public_payload_policy": {
+    "may_emit_items": false,
+    "may_emit_answer_key": false,
+    "may_emit_solution_rule": false,
+    "may_emit_generator_metadata": false
+  },
+  "norm_policy": {
+    "iq_claims_enabled": false,
+    "percentile_claims_enabled": false,
+    "population_norm_table_required_before_production": true
+  },
+  "notes": {
+    "frontend_display_key": "beta_50",
+    "beta_30_current_bank_id": "IQ_BETA_30_ORIGINAL",
+    "reason": "future beta50 placeholder only; no runtime item import in IQ-BANK-50-01"
+  }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -21195,8 +21195,8 @@
         "GLOBAL-EN-ZH-MEDIA-ALT-VISUAL-REVIEW-BATCH-07"
       ],
       "title": "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08 global UI i18n parity review and frontend consumer follow-up",
-  "commit_sha": "ca0c77ca",
-  "pr_url": "https://github.com/fermatmind/fap-api/pull/1851",
+      "commit_sha": "ca0c77ca",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1851",
       "checks": {
         "manifest_registration": {
           "status": "pass",
@@ -24294,7 +24294,7 @@
       },
       {
         "at": "2026-05-19T03:38:09.440Z",
-  "status": "open",
+        "status": "open",
         "summary": "Added fap-api CodeQL workflow and train metadata. YAML/JSON validation, git diff checks, and scope validation passed."
       },
       {
@@ -31297,6 +31297,62 @@
         }
       ],
       "next_task": "PAYMENT-WAIT-PAID-REDIRECT-CONTRACT-06"
+    },
+    "IQ-BANK-50-01": {
+      "id": "IQ-BANK-50-01",
+      "repo": "fap-api",
+      "branch": "codex/iq-bank-50-01",
+      "base": "main",
+      "title": "IQ-BANK-50-01 define beta50 bank manifest spec",
+      "status": "local_checks_passed",
+      "commit_sha": null,
+      "pr_url": null,
+      "checks": {
+        "cd backend && php artisan test --filter=IqBeta50BankSpec --no-ansi": {
+          "status": "passed"
+        },
+        "cd backend && vendor/bin/pint --test tests/Feature/Content/IqBeta50BankSpecTest.php": {
+          "status": "passed"
+        },
+        "python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json >/dev/null": {
+          "status": "passed"
+        },
+        "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null": {
+          "status": "passed"
+        },
+        "python3 -c yaml.safe_load docs/codex/pr-train.yaml": {
+          "status": "passed"
+        },
+        "git diff --check": {
+          "status": "passed"
+        }
+      },
+      "failure_reason": null,
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "events": [
+        {
+          "at": "2026-06-02T19:49:40+08:00",
+          "status": "started",
+          "summary": "Started backend beta50 placeholder bank manifest/spec PR with no runtime item import."
+        },
+        {
+          "at": "2026-06-02T19:50:02+08:00",
+          "status": "local_check_failed",
+          "summary": "Stopped before PR creation because backend Composer dependencies are missing in the isolated worktree."
+        },
+        {
+          "at": "2026-06-02T19:50:57+08:00",
+          "status": "retry_authorized",
+          "summary": "User authorized Composer dependency install and local check retry for IQ-BANK-50-01."
+        },
+        {
+          "at": "2026-06-02T19:52:27+08:00",
+          "status": "local_checks_passed",
+          "summary": "Composer dependencies installed in ignored vendor directory; backend beta50 manifest/spec checks passed."
+        }
+      ]
     }
   },
   "RESULT-EN-PARITY-04": {
@@ -39935,19 +39991,19 @@
         "to": "implementation_in_progress",
         "note": "Initialized by user authorization for purchase/report truth bridge policy."
       },
-    {
-      "at": "2026-06-02T05:28:00Z",
-      "from": "implementation_in_progress",
-      "to": "local_checks_passed",
-      "note": "Focused PHPUnit, route list, scoped Pint, composer validate/audit, JSON/YAML parse, and diff checks passed."
-    },
-    {
-      "at": "2026-06-02T05:34:00Z",
-      "from": "local_checks_passed",
-      "to": "open",
-      "note": "Opened https://github.com/fermatmind/fap-api/pull/1851 for GitHub checks and merge review."
-    }
-  ],
+      {
+        "at": "2026-06-02T05:28:00Z",
+        "from": "implementation_in_progress",
+        "to": "local_checks_passed",
+        "note": "Focused PHPUnit, route list, scoped Pint, composer validate/audit, JSON/YAML parse, and diff checks passed."
+      },
+      {
+        "at": "2026-06-02T05:34:00Z",
+        "from": "local_checks_passed",
+        "to": "open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1851 for GitHub checks and merge review."
+      }
+    ],
     "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01"
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31304,9 +31304,9 @@
       "branch": "codex/iq-bank-50-01",
       "base": "main",
       "title": "IQ-BANK-50-01 define beta50 bank manifest spec",
-      "status": "committed",
-      "commit_sha": "50948b17c22c66e07a40534d4a86f4fc0b3ec75b",
-      "pr_url": null,
+      "status": "pr_open",
+      "commit_sha": "c02723c6102ce0d1422979e90eb745788cb628fe",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1853",
       "checks": {
         "cd backend && php artisan test --filter=IqBeta50BankSpec --no-ansi": {
           "status": "passed"
@@ -31356,6 +31356,11 @@
           "at": "2026-06-02T19:52:49+08:00",
           "status": "committed",
           "summary": "Committed backend beta50 placeholder bank manifest/spec implementation."
+        },
+        {
+          "at": "2026-06-02T19:53:12+08:00",
+          "status": "pr_open",
+          "summary": "Opened fap-api PR #1853 for IQ-BANK-50-01."
         }
       ]
     }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31304,8 +31304,8 @@
       "branch": "codex/iq-bank-50-01",
       "base": "main",
       "title": "IQ-BANK-50-01 define beta50 bank manifest spec",
-      "status": "local_checks_passed",
-      "commit_sha": null,
+      "status": "committed",
+      "commit_sha": "50948b17c22c66e07a40534d4a86f4fc0b3ec75b",
       "pr_url": null,
       "checks": {
         "cd backend && php artisan test --filter=IqBeta50BankSpec --no-ansi": {
@@ -31351,6 +31351,11 @@
           "at": "2026-06-02T19:52:27+08:00",
           "status": "local_checks_passed",
           "summary": "Composer dependencies installed in ignored vendor directory; backend beta50 manifest/spec checks passed."
+        },
+        {
+          "at": "2026-06-02T19:52:49+08:00",
+          "status": "committed",
+          "summary": "Committed backend beta50 placeholder bank manifest/spec implementation."
         }
       ]
     }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19576,3 +19576,46 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01
+  - id: IQ-BANK-50-01
+    repo: fap-api
+    branch: codex/iq-bank-50-01
+    base: main
+    title: "IQ-BANK-50-01 define beta50 bank manifest spec"
+    train_scope: iq_beta_bank_display_model
+    risk_level: p2_iq_beta50_placeholder_spec
+    depends_on:
+      - IQ-FE-BANK-SWITCH-01
+    scope:
+      - Define IQ_BETA_50_ORIGINAL future placeholder manifest/spec.
+      - Keep runtime_bound=false and public_take_enabled=false.
+      - Add a focused contract test proving no items, answer key, or scoring spec are imported.
+    allowed_paths:
+      - backend/docs/iq/iq-beta-50-bank-spec.md
+      - backend/tests/Feature/Content/IqBeta50BankSpecTest.php
+      - content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    validation:
+      - cd backend && php artisan test --filter=IqBeta50BankSpec --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/Content/IqBeta50BankSpecTest.php
+      - python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: IQ-FE-BETA50-TEASER-01


### PR DESCRIPTION
## What changed
- Added `IQ_BETA_50_ORIGINAL` as a backend future-placeholder bank manifest/spec.
- Documented beta50 launch gates and explicit non-goals: no item import, answer key, scoring spec, runtime binding, public take entry, norm/IQ claims, or paid-report enablement.
- Added a focused backend feature test proving beta50 is spec-only and does not import runtime question/scoring assets.
- Added PR-train manifest/state entries for `IQ-BANK-50-01`.

## Why
- The frontend now has a beta30/beta50 bank display model; backend needs a source-of-truth placeholder spec for the future 50-item bank without accidentally making it runnable.

## Validation commands
- `cd backend && php artisan test --filter=IqBeta50BankSpec --no-ansi`
- `cd backend && vendor/bin/pint --test tests/Feature/Content/IqBeta50BankSpecTest.php`
- `python3 -m json.tool content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No beta50 formal items are imported.
- No beta50 answer key, scoring spec, calibration, norm authority, public result claims, or paid report unlock is enabled.
- No frontend entry behavior is changed in this backend PR.

## Repository rule impact
- IQ beta50 remains backend-authoritative as a spec-only future bank.
- No CMS authority, SEO/GEO enumeration, payment, production write, deploy, or frontend fallback authority changes.
