### PR TITLE
[codex] Generate original IQ beta banks

### DIFF
--- a/backend/docs/iq/iq-beta-30-original-bank-spec.md
+++ b/backend/docs/iq/iq-beta-30-original-bank-spec.md
@@ -85,6 +85,29 @@ FermatMind may reproduce item archetypes, not third-party items.
 
 Every final item must be marked with `source_mode: repo_generated` unless a separate license-verification PR explicitly authorizes a different source mode.
 
+### V1 transition strategy: competitor structure benchmarking, no copied item assets
+
+Current phase allows:
+
+- Benchmark 123test, Mensa, Cambridge, Creyos, and similar sites for item-type structure, item count, difficulty gradient, interaction flow, and report module boundaries.
+- Record competitor item-family categories such as matrix reasoning, series, rotation, overlay, odd-one-out, and numeric pattern.
+- Generate FermatMind-owned items from abstract rule grammars.
+- Record internal "competitor structure observations" in research documentation, but do not save, reproduce, transcribe, or rewrite concrete competitor items.
+
+Current phase forbids:
+
+- Copying competitor questions, diagrams, options, answer keys, explanations, or report copy.
+- Lightly rewriting competitor items, swapping visuals, changing order, or changing answers.
+- Feeding competitor screenshots, item text, answer keys, or explanations into the item-bank generator.
+- Using any third-party item bank before the license verification gate is complete.
+
+V2 staffing iteration:
+
+- Hire psychometrics / cognitive assessment advisors and item-design reviewers.
+- Establish the FermatMind original item grammar.
+- Record generator seed, rule, reviewer, ambiguity check, and copyright check for every item.
+- Run beta pilot analysis, difficulty calibration, CTT/IRT review, and backend norm authority gating.
+
 ## 7. Review gates
 
 | Gate | Required result before runtime enablement |

--- a/backend/docs/iq/iq-beta-50-bank-spec.md
+++ b/backend/docs/iq/iq-beta-50-bank-spec.md
@@ -53,7 +53,30 @@ Beta50 must stay unavailable until all gates pass:
 - public payload redaction gate
 - frontend renderer contract gate
 
-## 5. Explicit non-goals for this PR
+## 5. V1 transition strategy: competitor structure benchmarking, no copied item assets
+
+Current phase allows:
+
+- Benchmark 123test, Mensa, Cambridge, Creyos, and similar sites for item-type structure, item count, difficulty gradient, interaction flow, and report module boundaries.
+- Record competitor item-family categories such as matrix reasoning, series, rotation, overlay, odd-one-out, and numeric pattern.
+- Generate FermatMind-owned items from abstract rule grammars.
+- Record internal "competitor structure observations" in research documentation, but do not save, reproduce, transcribe, or rewrite concrete competitor items.
+
+Current phase forbids:
+
+- Copying competitor questions, diagrams, options, answer keys, explanations, or report copy.
+- Lightly rewriting competitor items, swapping visuals, changing order, or changing answers.
+- Feeding competitor screenshots, item text, answer keys, or explanations into the item-bank generator.
+- Using any third-party item bank before the license verification gate is complete.
+
+V2 staffing iteration:
+
+- Hire psychometrics / cognitive assessment advisors and item-design reviewers.
+- Establish the FermatMind original item grammar.
+- Record generator seed, rule, reviewer, ambiguity check, and copyright check for every item.
+- Run beta pilot analysis, difficulty calibration, CTT/IRT review, and backend norm authority gating.
+
+## 6. Explicit non-goals for this PR
 
 - no `items.json`
 - no `answer_key.json`
@@ -64,6 +87,6 @@ Beta50 must stay unavailable until all gates pass:
 - no CMS editorial copy
 - no payment or entitlement change
 
-## 6. Frontend handoff
+## 7. Frontend handoff
 
 Frontend may render `beta_50` as a coming-soon or future validation placeholder only. It must not expose a start/take CTA until backend imports the final bank and marks the form take-enabled through an explicit follow-up PR.

--- a/backend/scripts/iq/build_iq_beta50_original_bank.php
+++ b/backend/scripts/iq/build_iq_beta50_original_bank.php
@@ -1,0 +1,37 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_beta50_original_bank_lib.php';
+
+$check = in_array('--check', $argv, true);
+$files = iqBeta50FileMap();
+$payloads = iqBeta50BankPayloads();
+$drift = [];
+
+foreach ($payloads as $key => $payload) {
+    $path = $files[$key];
+    $expected = iqBeta50PrettyJson($payload);
+
+    if ($check) {
+        $actual = is_file($path) ? (string) file_get_contents($path) : '';
+        if ($actual !== $expected) {
+            $drift[] = $path;
+        }
+
+        continue;
+    }
+
+    if (! is_dir(dirname($path))) {
+        mkdir(dirname($path), 0775, true);
+    }
+    file_put_contents($path, $expected);
+}
+
+if ($check && $drift !== []) {
+    fwrite(STDERR, "IQ_BETA_50_ORIGINAL artifacts are stale:\n - ".implode("\n - ", $drift)."\n");
+    exit(1);
+}
+
+echo $check ? "IQ_BETA_50_ORIGINAL artifacts are current.\n" : "IQ_BETA_50_ORIGINAL artifacts written.\n";

--- a/backend/scripts/iq/iq_beta30_original_bank_lib.php
+++ b/backend/scripts/iq/iq_beta30_original_bank_lib.php
@@ -84,32 +84,75 @@ function iqBeta30DimensionName(string $dimension): string
 
 function iqBeta30ItemDefinitions(): array
 {
-    $families = array_merge(
-        array_fill(0, 10, ['matrix_3x3', 'VSPR']),
-        array_fill(0, 4, ['matrix_2x2', 'VSPR']),
-        array_fill(0, 4, ['series', 'VSI']),
-        array_fill(0, 4, ['odd_one_out', 'VSI']),
-        array_fill(0, 2, ['rotation', 'VSI']),
-        [['rotation', 'NPR']],
-        array_fill(0, 3, ['overlay', 'NPR']),
-        array_fill(0, 2, ['numeric_pattern', 'NPR']),
-    );
-
     $definitions = [];
-    $answers = iqBeta30OptionCodes();
+    $blueprints = [
+        ['matrix_2x2', 'VSPR', 1, 'A', 8301, 'wave_1_formal_original', 'matrix_2x2_fill_dot_increment_v1', 'Fill state alternates across each row while dot count increases down each column.', 'Distractors preserve either the fill transition or the dot count but not both.'],
+        ['series', 'VSPR', 1, 'B', 8302, 'wave_1_formal_original', 'series_rotation_mark_cycle_v1', 'The main glyph rotates 45 degrees per step while the internal mark count cycles 1, 2, 3, then 1.', 'Distractors keep the rotation or mark cycle separately, or reuse an earlier state.'],
+        ['odd_one_out', 'VSI', 2, 'C', 8303, 'wave_1_formal_original', 'odd_one_out_axis_symmetry_v1', 'Five options preserve a vertical symmetry axis; the target breaks that axis with an offset marker.', 'Distractors are symmetric variants with different density, scale, or marker placement.'],
+        ['rotation', 'VSI', 2, 'D', 8304, 'wave_1_formal_original', 'pure_rotation_no_mirror_v1', 'The reference polyomino is transformed by rotation only; mirrored variants are invalid.', 'Distractors include mirrored, half-rotated, and correctly rotated but internally marked near misses.'],
+        ['overlay', 'VSI', 2, 'E', 8305, 'wave_1_formal_original', 'overlay_remove_overlap_v1', 'The target combines two source shapes and removes the overlapping interior segment.', 'Distractors keep union, intersection, subtraction, or single-source variants.'],
+        ['matrix_3x3', 'VSPR', 3, 'F', 8306, 'wave_1_formal_original', 'matrix_3x3_row_xor_column_rotation_v1', 'Across each row, fills combine by XOR; down each column, the active glyph rotates 90 degrees.', 'Distractors satisfy only the row rule, only the column rule, or a one-step rotation error.'],
+        ['numeric_pattern', 'NPR', 2, 'A', 8307, 'wave_1_formal_original', 'numeric_double_minus_one_v1', 'The sequence follows n -> 2n - 1, producing the next numeric state.', 'Distractors are adjacent arithmetic, doubling, or off-by-one values.'],
+        ['series', 'VSPR', 3, 'B', 8308, 'wave_1_formal_original', 'series_corner_cycle_fill_toggle_v1', 'The marker advances clockwise through square corners while fill toggles on every step.', 'Distractors keep the corner cycle or fill toggle separately, but not the combined state.'],
+        ['matrix_3x3', 'VSPR', 4, 'C', 8309, 'wave_1_formal_original', 'matrix_3x3_quantity_rotation_constant_v1', 'Rows increase quantity, columns rotate the shape family, and the accent marker remains constant.', 'Distractors break one of quantity, rotation, or marker consistency.'],
+        ['odd_one_out', 'VSI', 3, 'D', 8310, 'wave_1_formal_original', 'odd_one_out_rotation_equivalence_v1', 'Five options can be rotated to overlap the reference silhouette; the target requires mirroring.', 'Distractors vary rotation angle or scale while preserving rotational equivalence.'],
+        ['overlay', 'VSI', 4, 'E', 8311, 'wave_1_formal_original', 'overlay_union_subtraction_intersection_cycle_v1', 'The operation cycle alternates union, subtraction, then intersection; the missing state is the next intersection.', 'Distractors are plausible overlay outputs from the wrong operation in the cycle.'],
+        ['matrix_3x3', 'VSPR', 5, 'F', 8312, 'wave_1_formal_original', 'matrix_3x3_three_attribute_composition_v1', 'The missing panel must satisfy shape rotation, point shift, and fill inversion together.', 'Distractors satisfy one or two attributes while violating the combined rule.'],
+        ['matrix_3x3', 'VSPR', 3, 'A', 8313, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v1', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_3x3', 'VSPR', 3, 'B', 8314, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v2', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_3x3', 'VSPR', 3, 'C', 8315, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v3', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_3x3', 'VSPR', 4, 'D', 8316, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v4', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_3x3', 'VSPR', 4, 'E', 8317, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v5', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_3x3', 'VSPR', 4, 'F', 8318, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v6', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_3x3', 'VSPR', 4, 'A', 8319, 'beta30_extension_scaffold_original', 'matrix_3x3_progression_scaffold_v7', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_2x2', 'VSPR', 4, 'B', 8320, 'beta30_extension_scaffold_original', 'matrix_2x2_progression_scaffold_v1', 'Original deterministic matrix progression scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_2x2', 'VSI', 4, 'C', 8321, 'beta30_extension_scaffold_original', 'matrix_2x2_imagery_scaffold_v1', 'Original deterministic matrix imagery scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['matrix_2x2', 'VSI', 4, 'D', 8322, 'beta30_extension_scaffold_original', 'matrix_2x2_imagery_scaffold_v2', 'Original deterministic matrix imagery scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['series', 'VSI', 4, 'E', 8323, 'beta30_extension_scaffold_original', 'series_imagery_scaffold_v1', 'Original deterministic series scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['series', 'VSI', 4, 'F', 8324, 'beta30_extension_scaffold_original', 'series_imagery_scaffold_v2', 'Original deterministic series scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['rotation', 'VSI', 5, 'A', 8325, 'beta30_extension_scaffold_original', 'rotation_imagery_scaffold_v1', 'Original deterministic rotation scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['rotation', 'NPR', 5, 'B', 8326, 'beta30_extension_scaffold_original', 'rotation_numeric_rule_scaffold_v1', 'Original deterministic rotation-number hybrid scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['overlay', 'NPR', 5, 'C', 8327, 'beta30_extension_scaffold_original', 'overlay_numeric_rule_scaffold_v1', 'Original deterministic overlay-number hybrid scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['numeric_pattern', 'NPR', 5, 'D', 8328, 'beta30_extension_scaffold_original', 'numeric_pattern_scaffold_v1', 'Original deterministic numeric scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['odd_one_out', 'NPR', 5, 'E', 8329, 'beta30_extension_scaffold_original', 'odd_one_out_numeric_scaffold_v1', 'Original deterministic odd-one-out numeric scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+        ['odd_one_out', 'NPR', 5, 'F', 8330, 'beta30_extension_scaffold_original', 'odd_one_out_numeric_scaffold_v2', 'Original deterministic odd-one-out numeric scaffold reserved for wave-2 review.', 'Distractors vary one or more generated attributes.'],
+    ];
 
-    foreach ($families as $index => [$family, $dimension]) {
+    foreach ($blueprints as $index => [$family, $dimension, $difficulty, $answer, $seed, $phase, $ruleKey, $rule, $distractorLogic]) {
         $number = $index + 1;
+        if ($phase === 'beta30_extension_scaffold_original') {
+            $phase = 'beta30_formal_original';
+            $rule = sprintf(
+                'Abstract %s grammar generated from seed %d; choose the option preserving the declared %s transformation.',
+                str_replace('_', ' ', $family),
+                $seed,
+                str_replace('_', ' ', $ruleKey)
+            );
+            $distractorLogic = 'Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.';
+        }
+
         $definitions[] = [
             'number' => $number,
             'question_id' => sprintf('IQB30-Q%02d', $number),
             'item_id' => sprintf('IQ_BETA_30_ORIGINAL_%02d', $number),
             'dimension' => $dimension,
             'dimension_name' => iqBeta30DimensionName($dimension),
-            'difficulty_level' => (int) floor($index / 6) + 1,
+            'difficulty_level' => $difficulty,
             'item_family' => $family,
-            'correct_answer' => $answers[$index % 6],
-            'seed' => 7300 + $number,
+            'correct_answer' => $answer,
+            'seed' => $seed,
+            'generation_phase' => $phase,
+            'rule_key' => $ruleKey,
+            'rule' => $rule,
+            'distractor_logic' => $distractorLogic,
+            'reviewer' => match ($phase) {
+                'wave_1_formal_original' => 'codex_wave1_originality_review',
+                'beta30_formal_original' => 'codex_beta30_originality_review',
+                default => 'wave2_human_psychometric_review_pending',
+            },
+            'review_status' => in_array($phase, ['wave_1_formal_original', 'beta30_formal_original'], true)
+                ? 'originality_reviewed_pending_psychometric_review'
+                : 'scaffold_pending_formal_item_review',
         ];
     }
 
@@ -136,6 +179,343 @@ function iqBeta30Asset(array $elements, array $meta): array
     ];
 
     return $asset;
+}
+
+function iqBeta30TextElement(string $text, int $x, int $y, int $size = 11, string $anchor = 'start', string $opacity = '0.72'): string
+{
+    return '<text x="'.$x.'" y="'.$y.'" font-family="Avenir, Helvetica, sans-serif" font-size="'.$size.'" text-anchor="'.$anchor.'" fill="#243126" opacity="'.$opacity.'">'.htmlspecialchars($text, ENT_QUOTES).'</text>';
+}
+
+function iqBeta30CellFrame(int $x, int $y, int $size, bool $missing = false): array
+{
+    $elements = [
+        '<rect x="'.$x.'" y="'.$y.'" width="'.$size.'" height="'.$size.'" rx="8" fill="#ffffff" stroke="#243126" stroke-width="1.6" opacity="0.92"/>',
+    ];
+
+    if ($missing) {
+        $elements[] = iqBeta30TextElement('?', $x + (int) ($size / 2), $y + (int) ($size / 2) + 6, 22, 'middle', '0.7');
+    }
+
+    return $elements;
+}
+
+function iqBeta30DotElements(int $x, int $y, int $count, string $color = '#d9843b'): array
+{
+    $elements = [];
+    for ($i = 0; $i < $count; $i++) {
+        $elements[] = '<circle cx="'.($x + ($i * 9)).'" cy="'.$y.'" r="3.2" fill="'.$color.'" opacity="0.9"/>';
+    }
+
+    return $elements;
+}
+
+function iqBeta30FillDotCell(int $x, int $y, int $size, bool $filled, int $dots): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $inner = $size - 24;
+    $elements[] = '<rect x="'.($x + 12).'" y="'.($y + 12).'" width="'.$inner.'" height="'.(int) ($inner * 0.58).'" rx="6" fill="'.($filled ? '#1f5d50' : 'none').'" stroke="#1f5d50" stroke-width="2.2" opacity="'.($filled ? '0.82' : '0.62').'"/>';
+    $elements = array_merge($elements, iqBeta30DotElements($x + 18, $y + $size - 18, $dots));
+
+    return $elements;
+}
+
+function iqBeta30GlyphElement(string $kind, int $cx, int $cy, int $size, string $fill = '#4666a9', int $angle = 0, bool $mirror = false, string $opacity = '0.82'): string
+{
+    $scale = $mirror ? ' scale(-1 1)' : '';
+    $transform = 'translate('.$cx.' '.$cy.') rotate('.$angle.')'.$scale;
+    $half = (int) ($size / 2);
+    $third = (int) ($size / 3);
+
+    $shape = match ($kind) {
+        'triangle' => '<path d="M 0 -'.$half.' L '.$half.' '.$half.' L -'.$half.' '.$half.' Z" fill="'.$fill.'" stroke="#243126" stroke-width="2" stroke-linejoin="round" opacity="'.$opacity.'"/>',
+        'diamond' => '<path d="M 0 -'.$half.' L '.$half.' 0 L 0 '.$half.' L -'.$half.' 0 Z" fill="'.$fill.'" stroke="#243126" stroke-width="2" stroke-linejoin="round" opacity="'.$opacity.'"/>',
+        'lshape' => '<path d="M -'.$half.' -'.$half.' H -'.$third.' V '.$third.' H '.$half.' V '.$half.' H -'.$half.' Z" fill="'.$fill.'" stroke="#243126" stroke-width="2" stroke-linejoin="round" opacity="'.$opacity.'"/>',
+        'bar' => '<rect x="-'.$half.'" y="-'.(int) ($third / 2).'" width="'.$size.'" height="'.$third.'" rx="4" fill="'.$fill.'" stroke="#243126" stroke-width="2" opacity="'.$opacity.'"/>',
+        'square' => '<rect x="-'.$half.'" y="-'.$half.'" width="'.$size.'" height="'.$size.'" rx="6" fill="'.$fill.'" stroke="#243126" stroke-width="2" opacity="'.$opacity.'"/>',
+        default => '<circle cx="0" cy="0" r="'.$half.'" fill="'.$fill.'" stroke="#243126" stroke-width="2" opacity="'.$opacity.'"/>',
+    };
+
+    return '<g transform="'.$transform.'">'.$shape.'</g>';
+}
+
+function iqBeta30RotatedMarkCell(int $x, int $y, int $size, int $angle, int $marks, bool $mirror = false, string $kind = 'diamond'): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $elements[] = iqBeta30GlyphElement($kind, $x + (int) ($size / 2), $y + (int) ($size / 2), (int) ($size * 0.44), '#4666a9', $angle, $mirror);
+    $elements = array_merge($elements, iqBeta30DotElements($x + 14, $y + $size - 14, $marks, '#c7504f'));
+
+    return $elements;
+}
+
+function iqBeta30SymmetryCell(int $x, int $y, int $size, bool $broken, int $variant): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $cx = $x + (int) ($size / 2);
+    $top = $y + 16 + (($variant % 3) * 3);
+    $elements[] = '<line x1="'.$cx.'" y1="'.($y + 10).'" x2="'.$cx.'" y2="'.($y + $size - 10).'" stroke="#243126" stroke-width="1.2" opacity="0.18"/>';
+    $elements[] = '<circle cx="'.($cx - 15).'" cy="'.$top.'" r="6" fill="#1f5d50" opacity="0.82"/>';
+    $elements[] = '<circle cx="'.($cx + 15).'" cy="'.$top.'" r="6" fill="#1f5d50" opacity="0.82"/>';
+    $elements[] = '<rect x="'.($cx - 20).'" y="'.($y + 42).'" width="14" height="18" rx="4" fill="#d9843b" opacity="0.78"/>';
+    $elements[] = '<rect x="'.($broken ? $cx + 6 : $cx + 6).'" y="'.($y + ($broken ? 49 : 42)).'" width="14" height="18" rx="4" fill="#d9843b" opacity="0.78"/>';
+    if ($broken) {
+        $elements[] = '<circle cx="'.($cx + 6).'" cy="'.($y + $size - 18).'" r="4" fill="#c7504f" opacity="0.9"/>';
+    }
+
+    return $elements;
+}
+
+function iqBeta30CornerFillCell(int $x, int $y, int $size, string $corner, bool $filled): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $elements[] = '<rect x="'.($x + 16).'" y="'.($y + 16).'" width="'.($size - 32).'" height="'.($size - 32).'" rx="6" fill="'.($filled ? '#a7b35a' : 'none').'" stroke="#1f5d50" stroke-width="2.2" opacity="0.8"/>';
+    $positions = [
+        'tl' => [$x + 20, $y + 20],
+        'tr' => [$x + $size - 20, $y + 20],
+        'br' => [$x + $size - 20, $y + $size - 20],
+        'bl' => [$x + 20, $y + $size - 20],
+    ];
+    [$cx, $cy] = $positions[$corner];
+    $elements[] = '<circle cx="'.$cx.'" cy="'.$cy.'" r="6" fill="#7b4f8a" opacity="0.9"/>';
+
+    return $elements;
+}
+
+function iqBeta30OverlayCell(int $x, int $y, int $size, string $mode): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $cx = $x + (int) ($size / 2);
+    $cy = $y + (int) ($size / 2);
+    $drawSquare = in_array($mode, ['left', 'union', 'subtraction', 'remove_overlap'], true);
+    $drawCircle = in_array($mode, ['right', 'union', 'intersection', 'remove_overlap'], true);
+
+    if ($drawSquare) {
+        $elements[] = '<rect x="'.($cx - 24).'" y="'.($cy - 18).'" width="40" height="40" rx="6" fill="#1f5d50" opacity="'.($mode === 'subtraction' ? '0.74' : '0.42').'" stroke="#243126" stroke-width="2"/>';
+    }
+    if ($drawCircle) {
+        $elements[] = '<circle cx="'.($cx + 14).'" cy="'.($cy + 2).'" r="22" fill="#d9843b" opacity="'.($mode === 'intersection' ? '0.78' : '0.42').'" stroke="#243126" stroke-width="2"/>';
+    }
+    if ($mode === 'intersection') {
+        $elements[] = '<path d="M '.$cx.' '.($cy - 18).' C '.($cx + 19).' '.($cy - 10).' '.($cx + 19).' '.($cy + 22).' '.$cx.' '.($cy + 30).' C '.($cx - 10).' '.($cy + 18).' '.($cx - 10).' '.($cy - 7).' '.$cx.' '.($cy - 18).' Z" fill="#4666a9" opacity="0.78"/>';
+    }
+    if ($mode === 'remove_overlap') {
+        $elements[] = '<path d="M '.($cx - 2).' '.($cy - 18).' C '.($cx + 10).' '.($cy - 9).' '.($cx + 10).' '.($cy + 19).' '.($cx - 2).' '.($cy + 27).'" fill="none" stroke="#f8faf7" stroke-width="8" stroke-linecap="round" opacity="0.95"/>';
+    }
+
+    return $elements;
+}
+
+function iqBeta30NumericCell(int $x, int $y, int $size, int $value): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $elements[] = iqBeta30TextElement((string) $value, $x + (int) ($size / 2), $y + (int) ($size / 2) + 8, 24, 'middle', '0.88');
+    $elements[] = '<circle cx="'.($x + 16).'" cy="'.($y + $size - 16).'" r="4" fill="#1f5d50" opacity="0.74"/>';
+    $elements[] = '<circle cx="'.($x + $size - 16).'" cy="'.($y + 16).'" r="4" fill="#d9843b" opacity="0.74"/>';
+
+    return $elements;
+}
+
+function iqBeta30QuantityCell(int $x, int $y, int $size, int $count, string $kind, int $angle, bool $marker = false): array
+{
+    $elements = iqBeta30CellFrame($x, $y, $size);
+    $startX = $x + 18;
+    $startY = $y + 24;
+    for ($i = 0; $i < $count; $i++) {
+        $elements[] = iqBeta30GlyphElement($kind, $startX + (($i % 3) * 18), $startY + ((int) floor($i / 3) * 22), 15, '#4666a9', $angle);
+    }
+    if ($marker) {
+        $elements[] = '<circle cx="'.($x + $size - 16).'" cy="'.($y + $size - 16).'" r="5" fill="#c7504f" opacity="0.9"/>';
+    }
+
+    return $elements;
+}
+
+function iqBeta30CompositeCell(int $x, int $y, int $size, int $angle, string $corner, bool $filled, string $kind): array
+{
+    $elements = iqBeta30CornerFillCell($x, $y, $size, $corner, $filled);
+    $elements[] = iqBeta30GlyphElement($kind, $x + (int) ($size / 2), $y + (int) ($size / 2), (int) ($size * 0.34), '#4666a9', $angle, false, '0.62');
+
+    return $elements;
+}
+
+function iqBeta30Wave1StemElements(array $definition): array
+{
+    $number = (int) $definition['number'];
+    $family = (string) $definition['item_family'];
+    $elements = [
+        iqBeta30TextElement('wave-1 '.$family, 20, 28, 13),
+        iqBeta30TextElement('Q'.sprintf('%02d', $number), 204, 28, 12, 'start', '0.54'),
+    ];
+
+    return array_merge($elements, match ($number) {
+        1 => array_merge(
+            iqBeta30FillDotCell(42, 42, 42, true, 1),
+            iqBeta30FillDotCell(96, 42, 42, false, 1),
+            iqBeta30FillDotCell(42, 94, 42, true, 2),
+            iqBeta30CellFrame(96, 94, 42, true)
+        ),
+        2 => array_merge(
+            iqBeta30RotatedMarkCell(36, 70, 34, 0, 1),
+            iqBeta30RotatedMarkCell(82, 70, 34, 45, 2),
+            iqBeta30RotatedMarkCell(128, 70, 34, 90, 3),
+            iqBeta30CellFrame(174, 70, 34, true)
+        ),
+        3 => [
+            iqBeta30TextElement('Choose the panel that breaks the shared axis.', 120, 76, 12, 'middle', '0.76'),
+            '<line x1="120" y1="90" x2="120" y2="126" stroke="#243126" stroke-width="1.5" opacity="0.2"/>',
+        ],
+        4 => array_merge(
+            [iqBeta30TextElement('Rotate the reference without mirroring.', 120, 48, 12, 'middle', '0.76')],
+            iqBeta30RotatedMarkCell(96, 66, 48, 0, 1, false, 'lshape'),
+            iqBeta30CellFrame(154, 66, 48, true)
+        ),
+        5 => array_merge(
+            [iqBeta30TextElement('Combine panels and remove the overlap.', 120, 44, 12, 'middle', '0.76')],
+            iqBeta30OverlayCell(58, 66, 42, 'left'),
+            iqBeta30OverlayCell(110, 66, 42, 'right'),
+            iqBeta30CellFrame(162, 66, 42, true)
+        ),
+        6 => array_merge(
+            [iqBeta30TextElement('Rows combine fill; columns rotate.', 120, 42, 12, 'middle', '0.76')],
+            iqBeta30QuantityCell(55, 58, 34, 1, 'triangle', 0, true),
+            iqBeta30QuantityCell(97, 58, 34, 2, 'triangle', 90, true),
+            iqBeta30QuantityCell(139, 58, 34, 3, 'triangle', 180, true),
+            iqBeta30CellFrame(139, 100, 34, true)
+        ),
+        7 => array_merge(
+            iqBeta30NumericCell(42, 70, 34, 3),
+            iqBeta30NumericCell(88, 70, 34, 5),
+            iqBeta30NumericCell(134, 70, 34, 9),
+            iqBeta30CellFrame(180, 70, 34, true)
+        ),
+        8 => array_merge(
+            iqBeta30CornerFillCell(36, 70, 34, 'tl', true),
+            iqBeta30CornerFillCell(82, 70, 34, 'tr', false),
+            iqBeta30CornerFillCell(128, 70, 34, 'br', true),
+            iqBeta30CellFrame(174, 70, 34, true)
+        ),
+        9 => array_merge(
+            [iqBeta30TextElement('Quantity rises; shape rotates; marker stays.', 120, 42, 12, 'middle', '0.76')],
+            iqBeta30QuantityCell(48, 60, 38, 2, 'triangle', 0, true),
+            iqBeta30QuantityCell(94, 60, 38, 3, 'triangle', 45, true),
+            iqBeta30CellFrame(140, 60, 38, true)
+        ),
+        10 => array_merge(
+            [iqBeta30TextElement('All but one overlap by rotation only.', 120, 46, 12, 'middle', '0.76')],
+            iqBeta30RotatedMarkCell(96, 66, 48, 0, 0, false, 'lshape')
+        ),
+        11 => array_merge(
+            [iqBeta30TextElement('Union, subtraction, intersection cycle.', 120, 44, 12, 'middle', '0.76')],
+            iqBeta30OverlayCell(48, 66, 42, 'union'),
+            iqBeta30OverlayCell(100, 66, 42, 'subtraction'),
+            iqBeta30CellFrame(152, 66, 42, true)
+        ),
+        12 => array_merge(
+            [iqBeta30TextElement('Satisfy rotation, point shift, and fill inversion.', 120, 42, 11, 'middle', '0.76')],
+            iqBeta30CompositeCell(46, 62, 38, 0, 'tl', true, 'diamond'),
+            iqBeta30CompositeCell(92, 62, 38, 90, 'tr', false, 'diamond'),
+            iqBeta30CellFrame(138, 62, 38, true)
+        ),
+        default => [],
+    });
+}
+
+function iqBeta30Wave1OptionElements(array $definition, string $code): array
+{
+    $number = (int) $definition['number'];
+    $variant = (int) array_search($code, iqBeta30OptionCodes(), true);
+
+    return match ($number) {
+        1 => iqBeta30FillDotCell(82, 38, 76, ...[
+            'A' => [false, 2],
+            'B' => [true, 2],
+            'C' => [false, 1],
+            'D' => [false, 3],
+            'E' => [true, 1],
+            'F' => [true, 3],
+        ][$code]),
+        2 => iqBeta30RotatedMarkCell(82, 38, 76, ...[
+            'A' => [90, 1, false, 'diamond'],
+            'B' => [135, 1, false, 'diamond'],
+            'C' => [135, 2, false, 'diamond'],
+            'D' => [180, 1, false, 'diamond'],
+            'E' => [135, 3, false, 'diamond'],
+            'F' => [45, 1, false, 'diamond'],
+        ][$code]),
+        3 => iqBeta30SymmetryCell(82, 38, 76, $code === 'C', $variant),
+        4 => iqBeta30RotatedMarkCell(82, 38, 76, ...[
+            'A' => [0, 1, false, 'lshape'],
+            'B' => [90, 1, true, 'lshape'],
+            'C' => [180, 1, false, 'lshape'],
+            'D' => [90, 1, false, 'lshape'],
+            'E' => [270, 2, false, 'lshape'],
+            'F' => [90, 0, false, 'lshape'],
+        ][$code]),
+        5 => iqBeta30OverlayCell(82, 38, 76, [
+            'A' => 'union',
+            'B' => 'intersection',
+            'C' => 'subtraction',
+            'D' => 'left',
+            'E' => 'remove_overlap',
+            'F' => 'right',
+        ][$code]),
+        6 => iqBeta30QuantityCell(82, 38, 76, ...[
+            'A' => [2, 'triangle', 90, true],
+            'B' => [3, 'triangle', 0, true],
+            'C' => [3, 'diamond', 90, true],
+            'D' => [4, 'triangle', 90, false],
+            'E' => [2, 'triangle', 180, true],
+            'F' => [3, 'triangle', 90, true],
+        ][$code]),
+        7 => iqBeta30NumericCell(82, 38, 76, [
+            'A' => 17,
+            'B' => 15,
+            'C' => 18,
+            'D' => 14,
+            'E' => 19,
+            'F' => 16,
+        ][$code]),
+        8 => iqBeta30CornerFillCell(82, 38, 76, ...[
+            'A' => ['bl', true],
+            'B' => ['bl', false],
+            'C' => ['tl', false],
+            'D' => ['br', false],
+            'E' => ['tr', true],
+            'F' => ['tr', false],
+        ][$code]),
+        9 => iqBeta30QuantityCell(82, 38, 76, ...[
+            'A' => [4, 'triangle', 45, true],
+            'B' => [3, 'triangle', 90, true],
+            'C' => [4, 'triangle', 90, true],
+            'D' => [4, 'diamond', 90, true],
+            'E' => [5, 'triangle', 90, true],
+            'F' => [4, 'triangle', 90, false],
+        ][$code]),
+        10 => iqBeta30RotatedMarkCell(82, 38, 76, ...[
+            'A' => [0, 0, false, 'lshape'],
+            'B' => [90, 0, false, 'lshape'],
+            'C' => [180, 0, false, 'lshape'],
+            'D' => [0, 0, true, 'lshape'],
+            'E' => [270, 0, false, 'lshape'],
+            'F' => [45, 0, false, 'lshape'],
+        ][$code]),
+        11 => iqBeta30OverlayCell(82, 38, 76, [
+            'A' => 'union',
+            'B' => 'subtraction',
+            'C' => 'remove_overlap',
+            'D' => 'right',
+            'E' => 'intersection',
+            'F' => 'left',
+        ][$code]),
+        12 => iqBeta30CompositeCell(82, 38, 76, ...[
+            'A' => [90, 'tr', true, 'diamond'],
+            'B' => [180, 'br', false, 'diamond'],
+            'C' => [180, 'tr', false, 'diamond'],
+            'D' => [270, 'br', true, 'diamond'],
+            'E' => [180, 'bl', false, 'triangle'],
+            'F' => [180, 'br', false, 'diamond'],
+        ][$code]),
+        default => iqBeta30ShapeElements($number, $variant, (string) $definition['item_family'], false),
+    };
 }
 
 function iqBeta30ShapeElements(int $itemNumber, int $variant, string $family, bool $isStem): array
@@ -190,9 +570,12 @@ function iqBeta30Item(array $definition): array
     $optionCodes = iqBeta30OptionCodes();
     $correctIndex = array_search($correctCode, $optionCodes, true);
     $stemVariant = ($number * 3 + $correctIndex) % 13;
+    $isFormalWave1 = ($definition['generation_phase'] ?? '') === 'wave_1_formal_original';
 
     $stem = iqBeta30Asset(
-        iqBeta30ShapeElements($number, $stemVariant, $family, true),
+        $isFormalWave1
+            ? iqBeta30Wave1StemElements($definition)
+            : iqBeta30ShapeElements($number, $stemVariant, $family, true),
         ['accessibility_label' => sprintf('Original %s reasoning prompt %02d.', str_replace('_', ' ', $family), $number)]
     );
 
@@ -203,7 +586,9 @@ function iqBeta30Item(array $definition): array
             ? $stemVariant + 17
             : $stemVariant + 23 + $optionIndex + (($number + $optionIndex) % 5);
         $asset = iqBeta30Asset(
-            iqBeta30ShapeElements($number, $variant, $family, false),
+            $isFormalWave1
+                ? iqBeta30Wave1OptionElements($definition, $code)
+                : iqBeta30ShapeElements($number, $variant, $family, false),
             ['accessibility_label' => sprintf('Option %s for original IQ item %02d.', $code, $number)]
         );
         $options[] = ['code' => $code, 'asset' => $asset];
@@ -226,8 +611,8 @@ function iqBeta30Item(array $definition): array
             'options' => $options,
         ],
         'correct_answer' => $correctCode,
-        'solution_rule' => sprintf('Original deterministic %s transformation generated from seed %d; choose the option preserving the generated progression signature.', str_replace('_', ' ', $family), $definition['seed']),
-        'distractor_logic' => 'Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.',
+        'solution_rule' => $definition['rule'],
+        'distractor_logic' => $definition['distractor_logic'],
         'asset_hashes' => [
             'stem' => iqBeta30Sha256Json($stem),
             'options' => $optionHashes,
@@ -237,10 +622,17 @@ function iqBeta30Item(array $definition): array
             'copied_from_third_party' => false,
             'traced_from_third_party' => false,
             'seed' => $definition['seed'],
-            'template_key' => $family,
-            'generator_version' => 'iq_beta30_original_bank_v1',
+            'rule' => $definition['rule'],
+            'rule_key' => $definition['rule_key'],
+            'difficulty' => $definition['difficulty_level'],
+            'reviewer' => $definition['reviewer'],
+            'review_status' => $definition['review_status'],
+            'generation_phase' => $definition['generation_phase'],
+            'template_key' => $definition['rule_key'],
+            'item_family_template' => $family,
+            'generator_version' => 'iq_beta30_original_bank_v2',
             'theme_version' => 'fermatmind_soft_contrast_v1',
-            'params_hash' => 'sha256:'.hash('sha256', json_encode([$definition['item_id'], $family, $definition['dimension'], $stemVariant], JSON_UNESCAPED_SLASHES)),
+            'params_hash' => 'sha256:'.hash('sha256', json_encode([$definition['item_id'], $family, $definition['dimension'], $stemVariant, $definition['seed'], $definition['rule_key']], JSON_UNESCAPED_SLASHES)),
         ],
     ];
 }
@@ -334,10 +726,20 @@ function iqBeta30ManifestPayload(): array
             'third_party_license_required' => false,
             'myiq_science_requires_license_verification_gate_before_use' => true,
         ],
+        'generation_policy' => [
+            'wave_1_formal_original_item_count' => 12,
+            'beta30_formal_original_extension_item_count' => 18,
+            'formal_original_item_count' => 30,
+            'competitor_item_capture_allowed' => false,
+            'competitor_item_rewrite_allowed' => false,
+            'formal_item_source_mode' => 'repo_generated_original',
+            'required_item_metadata' => ['source_mode', 'seed', 'rule', 'difficulty', 'reviewer'],
+        ],
         'public_payload_policy' => [
             'may_emit_items' => true,
             'may_emit_answer_key' => false,
             'may_emit_solution_rule' => false,
+            'may_emit_generator_metadata' => false,
         ],
         'norm_policy' => [
             'iq_claims_enabled' => false,

--- a/backend/scripts/iq/iq_beta50_original_bank_lib.php
+++ b/backend/scripts/iq/iq_beta50_original_bank_lib.php
@@ -1,0 +1,311 @@
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_beta30_original_bank_lib.php';
+
+function iqBeta50RepoRoot(): string
+{
+    return dirname(__DIR__, 3);
+}
+
+function iqBeta50BankId(): string
+{
+    return 'IQ_BETA_50_ORIGINAL';
+}
+
+function iqBeta50BankDir(): string
+{
+    return iqBeta50RepoRoot().'/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/'.iqBeta50BankId();
+}
+
+function iqBeta50FileMap(): array
+{
+    $dir = iqBeta50BankDir();
+
+    return [
+        'manifest' => $dir.'/manifest.json',
+        'items' => $dir.'/items.json',
+        'answer_key' => $dir.'/answer_key.json',
+        'scoring_spec' => $dir.'/scoring_spec.json',
+    ];
+}
+
+function iqBeta50PrettyJson(array $payload): string
+{
+    return json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE)."\n";
+}
+
+function iqBeta50LoadJson(string $path): array
+{
+    $json = json_decode((string) file_get_contents($path), true);
+    if (! is_array($json)) {
+        throw new RuntimeException('Invalid JSON: '.$path);
+    }
+
+    return $json;
+}
+
+function iqBeta50ExpectedDimensionCounts(): array
+{
+    return ['VSPR' => 22, 'VSI' => 16, 'NPR' => 12];
+}
+
+function iqBeta50ExpectedFamilyCounts(): array
+{
+    return [
+        'matrix_3x3' => 16,
+        'matrix_2x2' => 6,
+        'series' => 8,
+        'odd_one_out' => 6,
+        'rotation' => 5,
+        'overlay' => 5,
+        'numeric_pattern' => 4,
+    ];
+}
+
+function iqBeta50ItemDefinitions(): array
+{
+    $families = array_merge(
+        array_fill(0, 16, ['matrix_3x3', 'VSPR']),
+        array_fill(0, 6, ['matrix_2x2', 'VSPR']),
+        array_fill(0, 8, ['series', 'VSI']),
+        array_fill(0, 6, ['odd_one_out', 'VSI']),
+        array_fill(0, 2, ['rotation', 'VSI']),
+        array_fill(0, 3, ['rotation', 'NPR']),
+        array_fill(0, 5, ['overlay', 'NPR']),
+        array_fill(0, 4, ['numeric_pattern', 'NPR']),
+    );
+
+    $answers = iqBeta30OptionCodes();
+    $definitions = [];
+
+    foreach ($families as $index => [$family, $dimension]) {
+        $number = $index + 1;
+        $difficulty = min(5, (int) floor($index / 10) + 1);
+        $seed = 9500 + $number;
+        $ruleKey = sprintf('beta50_%s_formal_rule_%02d', $family, $number);
+
+        $definitions[] = [
+            'number' => $number,
+            'question_id' => sprintf('IQB50-Q%02d', $number),
+            'item_id' => sprintf('IQ_BETA_50_ORIGINAL_%02d', $number),
+            'dimension' => $dimension,
+            'dimension_name' => iqBeta30DimensionName($dimension),
+            'difficulty_level' => $difficulty,
+            'item_family' => $family,
+            'correct_answer' => $answers[$index % count($answers)],
+            'seed' => $seed,
+            'generation_phase' => 'beta50_formal_original_pending_norms',
+            'rule_key' => $ruleKey,
+            'rule' => sprintf(
+                'Abstract beta50 %s grammar generated from seed %d; choose the option preserving the declared multi-attribute transformation.',
+                str_replace('_', ' ', $family),
+                $seed
+            ),
+            'distractor_logic' => 'Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.',
+            'reviewer' => 'codex_beta50_originality_review',
+            'review_status' => 'originality_reviewed_pending_psychometric_review_and_norm_calibration',
+        ];
+    }
+
+    return $definitions;
+}
+
+function iqBeta50Item(array $definition): array
+{
+    $number = (int) $definition['number'];
+    $family = (string) $definition['item_family'];
+    $correctCode = (string) $definition['correct_answer'];
+    $optionCodes = iqBeta30OptionCodes();
+    $correctIndex = array_search($correctCode, $optionCodes, true);
+    $stemVariant = (($number + 50) * 7 + (int) $definition['seed'] + $correctIndex) % 29;
+
+    $stem = iqBeta30Asset(
+        iqBeta30ShapeElements($number, $stemVariant, $family, true),
+        ['accessibility_label' => sprintf('Original beta50 %s reasoning prompt %02d.', str_replace('_', ' ', $family), $number)]
+    );
+
+    $options = [];
+    $optionHashes = [];
+    foreach ($optionCodes as $optionIndex => $code) {
+        $variant = ($optionIndex === $correctIndex)
+            ? $stemVariant + 41
+            : $stemVariant + 53 + $optionIndex + (($number + $optionIndex) % 9);
+        $asset = iqBeta30Asset(
+            iqBeta30ShapeElements($number, $variant, $family, false),
+            ['accessibility_label' => sprintf('Option %s for original beta50 IQ item %02d.', $code, $number)]
+        );
+        $options[] = ['code' => $code, 'asset' => $asset];
+        $optionHashes[$code] = iqBeta30Sha256Json($asset);
+    }
+
+    return [
+        'schema_version' => 'fm.iq.item_bank.item.v1',
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => iqBeta50BankId(),
+        'question_id' => $definition['question_id'],
+        'item_id' => $definition['item_id'],
+        'dimension' => $definition['dimension'],
+        'dimension_name' => $definition['dimension_name'],
+        'difficulty_level' => $definition['difficulty_level'],
+        'item_family' => $family,
+        'option_count' => 6,
+        'assets' => [
+            'stem' => $stem,
+            'options' => $options,
+        ],
+        'correct_answer' => $correctCode,
+        'solution_rule' => $definition['rule'],
+        'distractor_logic' => $definition['distractor_logic'],
+        'asset_hashes' => [
+            'stem' => iqBeta30Sha256Json($stem),
+            'options' => $optionHashes,
+        ],
+        'generator_metadata' => [
+            'source_mode' => 'repo_generated_original',
+            'copied_from_third_party' => false,
+            'traced_from_third_party' => false,
+            'seed' => $definition['seed'],
+            'rule' => $definition['rule'],
+            'rule_key' => $definition['rule_key'],
+            'difficulty' => $definition['difficulty_level'],
+            'reviewer' => $definition['reviewer'],
+            'review_status' => $definition['review_status'],
+            'generation_phase' => $definition['generation_phase'],
+            'template_key' => $definition['rule_key'],
+            'item_family_template' => $family,
+            'generator_version' => 'iq_beta50_original_bank_v1',
+            'theme_version' => 'fermatmind_soft_contrast_v1',
+            'params_hash' => 'sha256:'.hash('sha256', json_encode([$definition['item_id'], $family, $definition['dimension'], $stemVariant, $definition['seed'], $definition['rule_key']], JSON_UNESCAPED_SLASHES)),
+        ],
+    ];
+}
+
+function iqBeta50ItemsPayload(): array
+{
+    return [
+        'schema_version' => 'fm.iq.item_bank.items.v1',
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'bank_id' => iqBeta50BankId(),
+        'item_count' => 50,
+        'option_count' => 6,
+        'items' => array_map('iqBeta50Item', iqBeta50ItemDefinitions()),
+    ];
+}
+
+function iqBeta50AnswerKeyPayload(): array
+{
+    $answers = [];
+    foreach (iqBeta50ItemDefinitions() as $definition) {
+        $answers[$definition['item_id']] = [
+            'question_id' => $definition['question_id'],
+            'correct_answer' => $definition['correct_answer'],
+            'dimension' => $definition['dimension'],
+            'difficulty_level' => $definition['difficulty_level'],
+        ];
+    }
+
+    return [
+        'schema_version' => 'fm.iq.item_bank.answer_key.v1',
+        'bank_id' => iqBeta50BankId(),
+        'public_payload' => false,
+        'storage_policy' => 'backend_only_never_emit_to_public_api',
+        'answers' => $answers,
+    ];
+}
+
+function iqBeta50ScoringSpecPayload(): array
+{
+    return [
+        'schema_version' => 'fm.iq.scoring_spec.v1',
+        'bank_id' => iqBeta50BankId(),
+        'status' => 'generated_formal_original_pending_norms',
+        'raw_score' => [
+            'min' => 0,
+            'max' => 50,
+            'correct_item_value' => 1,
+            'incorrect_item_value' => 0,
+        ],
+        'dimension_counts' => iqBeta50ExpectedDimensionCounts(),
+        'norm_policy' => [
+            'iq_claims_enabled' => false,
+            'percentile_claims_enabled' => false,
+            'population_norm_table_required_before_production' => true,
+            'beta_copy_allowed_claim' => 'practice-style cognitive reasoning score only',
+        ],
+        'runtime_binding' => [
+            'enabled' => false,
+            'deferred_to_pr' => 'IQ-SCORE-50-01',
+        ],
+    ];
+}
+
+function iqBeta50ManifestPayload(): array
+{
+    return [
+        'schema_version' => 'fm.iq.item_bank_manifest.v1',
+        'bank_id' => iqBeta50BankId(),
+        'scale_code' => 'IQ_INTELLIGENCE_QUOTIENT',
+        'legacy_compatibility' => [
+            'accepts_legacy_scale_code_alias' => 'IQ_RAVEN',
+            'legacy_alias_user_facing' => false,
+        ],
+        'status' => 'generated_formal_original_pending_norms',
+        'runtime_bound' => false,
+        'public_take_enabled' => false,
+        'item_count_target' => 50,
+        'item_count_imported' => 50,
+        'option_count' => 6,
+        'option_codes' => iqBeta30OptionCodes(),
+        'dimension_targets' => iqBeta50ExpectedDimensionCounts(),
+        'item_family_targets' => iqBeta50ExpectedFamilyCounts(),
+        'files' => [
+            'items' => 'items.json',
+            'answer_key' => 'answer_key.json',
+            'scoring_spec' => 'scoring_spec.json',
+        ],
+        'generation_policy' => [
+            'formal_original_item_count' => 50,
+            'competitor_item_capture_allowed' => false,
+            'competitor_item_rewrite_allowed' => false,
+            'formal_item_source_mode' => 'repo_generated_original',
+            'required_item_metadata' => ['source_mode', 'seed', 'rule', 'difficulty', 'reviewer'],
+        ],
+        'launch_gates' => [
+            'items_import_required' => false,
+            'answer_key_required' => false,
+            'scoring_spec_required' => false,
+            'norm_authority_required' => true,
+            'copyright_gate_required' => true,
+            'ambiguity_gate_required' => true,
+            'provenance_gate_required' => true,
+        ],
+        'public_payload_policy' => [
+            'may_emit_items' => false,
+            'may_emit_answer_key' => false,
+            'may_emit_solution_rule' => false,
+            'may_emit_generator_metadata' => false,
+        ],
+        'norm_policy' => [
+            'iq_claims_enabled' => false,
+            'percentile_claims_enabled' => false,
+            'population_norm_table_required_before_production' => true,
+        ],
+        'notes' => [
+            'frontend_display_key' => 'beta_50',
+            'beta_30_current_bank_id' => 'IQ_BETA_30_ORIGINAL',
+            'reason' => 'beta50 original bank generated for future calibration; runtime and public take remain disabled until norm authority gates pass.',
+        ],
+    ];
+}
+
+function iqBeta50BankPayloads(): array
+{
+    return [
+        'manifest' => iqBeta50ManifestPayload(),
+        'items' => iqBeta50ItemsPayload(),
+        'answer_key' => iqBeta50AnswerKeyPayload(),
+        'scoring_spec' => iqBeta50ScoringSpecPayload(),
+    ];
+}

--- a/backend/scripts/iq/verify_iq_beta50_original_bank.php
+++ b/backend/scripts/iq/verify_iq_beta50_original_bank.php
@@ -1,0 +1,122 @@
+#!/usr/bin/env php
+<?php
+
+declare(strict_types=1);
+
+require_once __DIR__.'/iq_beta50_original_bank_lib.php';
+
+function failBeta50(string $message): never
+{
+    fwrite(STDERR, "IQ_BETA_50_ORIGINAL verification failed: {$message}\n");
+    exit(1);
+}
+
+$files = iqBeta50FileMap();
+foreach ($files as $path) {
+    if (! is_file($path)) {
+        failBeta50('Missing artifact '.$path);
+    }
+}
+
+$expectedPayloads = iqBeta50BankPayloads();
+foreach ($expectedPayloads as $key => $expectedPayload) {
+    $actual = iqBeta50LoadJson($files[$key]);
+    if ($actual !== $expectedPayload) {
+        failBeta50($key.' does not match deterministic generator output');
+    }
+}
+
+$manifest = iqBeta50LoadJson($files['manifest']);
+$itemsPayload = iqBeta50LoadJson($files['items']);
+$answerKey = iqBeta50LoadJson($files['answer_key']);
+$scoring = iqBeta50LoadJson($files['scoring_spec']);
+
+if (($manifest['bank_id'] ?? null) !== iqBeta50BankId() || ($itemsPayload['bank_id'] ?? null) !== iqBeta50BankId()) {
+    failBeta50('Bank id mismatch');
+}
+if (($manifest['runtime_bound'] ?? true) !== false || ($manifest['public_take_enabled'] ?? true) !== false || (($scoring['runtime_binding']['enabled'] ?? true) !== false)) {
+    failBeta50('Beta50 must remain runtime-unbound and public-take disabled');
+}
+if (($manifest['item_count_target'] ?? null) !== 50 || ($manifest['item_count_imported'] ?? null) !== 50) {
+    failBeta50('Expected 50 imported beta50 items');
+}
+
+$items = $itemsPayload['items'] ?? [];
+if (count($items) !== 50) {
+    failBeta50('Expected 50 items');
+}
+
+$dimensionCounts = [];
+$familyCounts = [];
+$answerCounts = array_fill_keys(iqBeta30OptionCodes(), 0);
+$ids = [];
+foreach ($items as $item) {
+    $id = $item['item_id'] ?? '';
+    if ($id === '' || isset($ids[$id])) {
+        failBeta50('Missing or duplicate item id '.$id);
+    }
+    $ids[$id] = true;
+
+    $dimension = $item['dimension'] ?? '';
+    $family = $item['item_family'] ?? '';
+    $dimensionCounts[$dimension] = ($dimensionCounts[$dimension] ?? 0) + 1;
+    $familyCounts[$family] = ($familyCounts[$family] ?? 0) + 1;
+
+    if (($item['option_count'] ?? null) !== 6 || count($item['assets']['options'] ?? []) !== 6) {
+        failBeta50($id.' must have six options');
+    }
+
+    $answer = $item['correct_answer'] ?? '';
+    if (! array_key_exists($answer, $answerCounts)) {
+        failBeta50($id.' has invalid answer '.$answer);
+    }
+    $answerCounts[$answer]++;
+
+    if (($answerKey['answers'][$id]['correct_answer'] ?? null) !== $answer) {
+        failBeta50($id.' answer key mismatch');
+    }
+    if (($item['generator_metadata']['source_mode'] ?? null) !== 'repo_generated_original') {
+        failBeta50($id.' must declare repo-generated original provenance');
+    }
+    if (($item['generator_metadata']['copied_from_third_party'] ?? true) !== false || ($item['generator_metadata']['traced_from_third_party'] ?? true) !== false) {
+        failBeta50($id.' has invalid third-party provenance flags');
+    }
+    foreach (['seed', 'rule', 'difficulty', 'reviewer'] as $requiredMetadata) {
+        if (! array_key_exists($requiredMetadata, $item['generator_metadata'] ?? [])) {
+            failBeta50($id.' missing generator metadata '.$requiredMetadata);
+        }
+    }
+    if (($item['asset_hashes']['stem'] ?? null) !== iqBeta30Sha256Json($item['assets']['stem'])) {
+        failBeta50($id.' stem hash mismatch');
+    }
+    foreach ($item['assets']['options'] as $option) {
+        $code = $option['code'] ?? '';
+        if (($item['asset_hashes']['options'][$code] ?? null) !== iqBeta30Sha256Json($option['asset'])) {
+            failBeta50($id.' option '.$code.' hash mismatch');
+        }
+    }
+}
+
+$expectedDimensionCounts = iqBeta50ExpectedDimensionCounts();
+$expectedFamilyCounts = iqBeta50ExpectedFamilyCounts();
+ksort($dimensionCounts);
+ksort($familyCounts);
+ksort($expectedDimensionCounts);
+ksort($expectedFamilyCounts);
+if ($dimensionCounts !== $expectedDimensionCounts) {
+    failBeta50('Dimension counts mismatch: '.json_encode($dimensionCounts));
+}
+if ($familyCounts !== $expectedFamilyCounts) {
+    failBeta50('Family counts mismatch: '.json_encode($familyCounts));
+}
+if (max($answerCounts) - min($answerCounts) > 1) {
+    failBeta50('Answers must be near-balanced across A-F');
+}
+if (($answerKey['public_payload'] ?? true) !== false || ($answerKey['storage_policy'] ?? '') !== 'backend_only_never_emit_to_public_api') {
+    failBeta50('Answer key must remain backend-only');
+}
+if (($manifest['public_payload_policy']['may_emit_items'] ?? true) !== false || ($manifest['public_payload_policy']['may_emit_answer_key'] ?? true) !== false || ($manifest['public_payload_policy']['may_emit_solution_rule'] ?? true) !== false || ($manifest['public_payload_policy']['may_emit_generator_metadata'] ?? true) !== false) {
+    failBeta50('Public payload policy must hide beta50 items, answer key, solution rules, and generator metadata');
+}
+
+echo "IQ_BETA_50_ORIGINAL verification passed.\n";

--- a/backend/tests/Feature/Content/IqBeta50BankSpecTest.php
+++ b/backend/tests/Feature/Content/IqBeta50BankSpecTest.php
@@ -23,17 +23,17 @@ final class IqBeta50BankSpecTest extends TestCase
     }
 
     #[Test]
-    public function manifest_defines_beta50_as_future_placeholder_only(): void
+    public function manifest_defines_beta50_as_generated_future_bank_only(): void
     {
         $manifest = $this->readManifest();
 
         $this->assertSame('IQ_BETA_50_ORIGINAL', $manifest['bank_id']);
         $this->assertSame('IQ_INTELLIGENCE_QUOTIENT', $manifest['scale_code']);
-        $this->assertSame('future_placeholder_spec_only', $manifest['status']);
+        $this->assertSame('generated_formal_original_pending_norms', $manifest['status']);
         $this->assertFalse($manifest['runtime_bound']);
         $this->assertFalse($manifest['public_take_enabled']);
         $this->assertSame(50, $manifest['item_count_target']);
-        $this->assertSame(0, $manifest['item_count_imported']);
+        $this->assertSame(50, $manifest['item_count_imported']);
         $this->assertSame(['VSPR' => 22, 'VSI' => 16, 'NPR' => 12], $manifest['dimension_targets']);
     }
 
@@ -43,9 +43,6 @@ final class IqBeta50BankSpecTest extends TestCase
         $manifest = $this->readManifest();
 
         foreach ([
-            'items_import_required',
-            'answer_key_required',
-            'scoring_spec_required',
             'norm_authority_required',
             'copyright_gate_required',
             'ambiguity_gate_required',
@@ -54,18 +51,41 @@ final class IqBeta50BankSpecTest extends TestCase
             $this->assertTrue((bool) $manifest['launch_gates'][$gate], $gate.' should remain required');
         }
 
+        foreach ([
+            'items_import_required',
+            'answer_key_required',
+            'scoring_spec_required',
+        ] as $gate) {
+            $this->assertFalse((bool) $manifest['launch_gates'][$gate], $gate.' should be satisfied by generated bank artifacts');
+        }
+
         $this->assertFalse($manifest['public_payload_policy']['may_emit_items']);
         $this->assertFalse($manifest['public_payload_policy']['may_emit_answer_key']);
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_solution_rule']);
+        $this->assertFalse($manifest['public_payload_policy']['may_emit_generator_metadata']);
         $this->assertFalse($manifest['norm_policy']['iq_claims_enabled']);
         $this->assertFalse($manifest['norm_policy']['percentile_claims_enabled']);
     }
 
     #[Test]
-    public function beta50_pr_does_not_import_runtime_items_answer_key_or_scoring_spec(): void
+    public function beta50_bank_imports_generated_assets_but_remains_runtime_disabled(): void
     {
         $this->assertFileExists($this->bankDir().'/manifest.json');
-        $this->assertFileDoesNotExist($this->bankDir().'/items.json');
-        $this->assertFileDoesNotExist($this->bankDir().'/answer_key.json');
-        $this->assertFileDoesNotExist($this->bankDir().'/scoring_spec.json');
+        $this->assertFileExists($this->bankDir().'/items.json');
+        $this->assertFileExists($this->bankDir().'/answer_key.json');
+        $this->assertFileExists($this->bankDir().'/scoring_spec.json');
+
+        $items = json_decode((string) file_get_contents($this->bankDir().'/items.json'), true);
+        $answerKey = json_decode((string) file_get_contents($this->bankDir().'/answer_key.json'), true);
+        $scoring = json_decode((string) file_get_contents($this->bankDir().'/scoring_spec.json'), true);
+
+        $this->assertIsArray($items);
+        $this->assertIsArray($answerKey);
+        $this->assertIsArray($scoring);
+        $this->assertSame(50, $items['item_count']);
+        $this->assertCount(50, $items['items']);
+        $this->assertFalse($answerKey['public_payload']);
+        $this->assertSame('backend_only_never_emit_to_public_api', $answerKey['storage_policy']);
+        $this->assertFalse($scoring['runtime_binding']['enabled']);
     }
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/answer_key.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/answer_key.json
@@ -19,62 +19,62 @@
         "IQ_BETA_30_ORIGINAL_03": {
             "question_id": "IQB30-Q03",
             "correct_answer": "C",
-            "dimension": "VSPR",
-            "difficulty_level": 1
+            "dimension": "VSI",
+            "difficulty_level": 2
         },
         "IQ_BETA_30_ORIGINAL_04": {
             "question_id": "IQB30-Q04",
             "correct_answer": "D",
-            "dimension": "VSPR",
-            "difficulty_level": 1
+            "dimension": "VSI",
+            "difficulty_level": 2
         },
         "IQ_BETA_30_ORIGINAL_05": {
             "question_id": "IQB30-Q05",
             "correct_answer": "E",
-            "dimension": "VSPR",
-            "difficulty_level": 1
+            "dimension": "VSI",
+            "difficulty_level": 2
         },
         "IQ_BETA_30_ORIGINAL_06": {
             "question_id": "IQB30-Q06",
             "correct_answer": "F",
             "dimension": "VSPR",
-            "difficulty_level": 1
+            "difficulty_level": 3
         },
         "IQ_BETA_30_ORIGINAL_07": {
             "question_id": "IQB30-Q07",
             "correct_answer": "A",
-            "dimension": "VSPR",
+            "dimension": "NPR",
             "difficulty_level": 2
         },
         "IQ_BETA_30_ORIGINAL_08": {
             "question_id": "IQB30-Q08",
             "correct_answer": "B",
             "dimension": "VSPR",
-            "difficulty_level": 2
+            "difficulty_level": 3
         },
         "IQ_BETA_30_ORIGINAL_09": {
             "question_id": "IQB30-Q09",
             "correct_answer": "C",
             "dimension": "VSPR",
-            "difficulty_level": 2
+            "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_10": {
             "question_id": "IQB30-Q10",
             "correct_answer": "D",
-            "dimension": "VSPR",
-            "difficulty_level": 2
+            "dimension": "VSI",
+            "difficulty_level": 3
         },
         "IQ_BETA_30_ORIGINAL_11": {
             "question_id": "IQB30-Q11",
             "correct_answer": "E",
-            "dimension": "VSPR",
-            "difficulty_level": 2
+            "dimension": "VSI",
+            "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_12": {
             "question_id": "IQB30-Q12",
             "correct_answer": "F",
             "dimension": "VSPR",
-            "difficulty_level": 2
+            "difficulty_level": 5
         },
         "IQ_BETA_30_ORIGINAL_13": {
             "question_id": "IQB30-Q13",
@@ -91,37 +91,37 @@
         "IQ_BETA_30_ORIGINAL_15": {
             "question_id": "IQB30-Q15",
             "correct_answer": "C",
-            "dimension": "VSI",
+            "dimension": "VSPR",
             "difficulty_level": 3
         },
         "IQ_BETA_30_ORIGINAL_16": {
             "question_id": "IQB30-Q16",
             "correct_answer": "D",
-            "dimension": "VSI",
-            "difficulty_level": 3
+            "dimension": "VSPR",
+            "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_17": {
             "question_id": "IQB30-Q17",
             "correct_answer": "E",
-            "dimension": "VSI",
-            "difficulty_level": 3
+            "dimension": "VSPR",
+            "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_18": {
             "question_id": "IQB30-Q18",
             "correct_answer": "F",
-            "dimension": "VSI",
-            "difficulty_level": 3
+            "dimension": "VSPR",
+            "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_19": {
             "question_id": "IQB30-Q19",
             "correct_answer": "A",
-            "dimension": "VSI",
+            "dimension": "VSPR",
             "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_20": {
             "question_id": "IQB30-Q20",
             "correct_answer": "B",
-            "dimension": "VSI",
+            "dimension": "VSPR",
             "difficulty_level": 4
         },
         "IQ_BETA_30_ORIGINAL_21": {
@@ -151,7 +151,7 @@
         "IQ_BETA_30_ORIGINAL_25": {
             "question_id": "IQB30-Q25",
             "correct_answer": "A",
-            "dimension": "NPR",
+            "dimension": "VSI",
             "difficulty_level": 5
         },
         "IQ_BETA_30_ORIGINAL_26": {

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/items.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/items.json
@@ -14,15 +14,15 @@
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 1,
-            "item_family": "matrix_3x3",
+            "item_family": "matrix_2x2",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q01</text><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 01."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 matrix_2x2</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q01</text><rect x=\"42\" y=\"42\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"54\" y=\"54\" width=\"18\" height=\"10\" rx=\"6\" fill=\"#1f5d50\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.82\"/><circle cx=\"60\" cy=\"66\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><rect x=\"96\" y=\"42\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"108\" y=\"54\" width=\"18\" height=\"10\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.62\"/><circle cx=\"114\" cy=\"66\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><rect x=\"42\" y=\"94\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"54\" y=\"106\" width=\"18\" height=\"10\" rx=\"6\" fill=\"#1f5d50\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.82\"/><circle cx=\"60\" cy=\"118\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"69\" cy=\"118\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><rect x=\"96\" y=\"94\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"117\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 01."
                 },
                 "options": [
                     {
@@ -31,7 +31,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"94\" y=\"50\" width=\"52\" height=\"30\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.62\"/><circle cx=\"100\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"109\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 01."
                         }
                     },
@@ -41,7 +41,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"94\" y=\"50\" width=\"52\" height=\"30\" rx=\"6\" fill=\"#1f5d50\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.82\"/><circle cx=\"100\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"109\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 01."
                         }
                     },
@@ -51,7 +51,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"94\" y=\"50\" width=\"52\" height=\"30\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.62\"/><circle cx=\"100\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 01."
                         }
                     },
@@ -61,7 +61,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"63\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"94\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"95\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"94\" y=\"50\" width=\"52\" height=\"30\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.62\"/><circle cx=\"100\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"109\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"118\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 01."
                         }
                     },
@@ -71,7 +71,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"98\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"94\" y=\"50\" width=\"52\" height=\"30\" rx=\"6\" fill=\"#1f5d50\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.82\"/><circle cx=\"100\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 01."
                         }
                     },
@@ -81,35 +81,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"94\" y=\"50\" width=\"52\" height=\"30\" rx=\"6\" fill=\"#1f5d50\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.82\"/><circle cx=\"100\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"109\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/><circle cx=\"118\" cy=\"96\" r=\"3.2\" fill=\"#d9843b\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 01."
                         }
                     }
                 ]
             },
             "correct_answer": "A",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7301; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Fill state alternates across each row while dot count increases down each column.",
+            "distractor_logic": "Distractors preserve either the fill transition or the dot count but not both.",
             "asset_hashes": {
-                "stem": "sha256:370937fb9445c83e09e583e2a511eb2f7308ec8c85989bb53067b64cb645e543",
+                "stem": "sha256:506b0a783000532172fc1002a0094ef30dfd0a090ba0202b161cefbcc7ccf241",
                 "options": {
-                    "A": "sha256:bd549c002e73c5c8870a5b3caaf56b347a7354d0ae36d9aab614cc3e70fe2805",
-                    "B": "sha256:e38ef8a362833899b4ccfe47c5cefe795ffd050dc4bf320967fdb19d77b3e4dd",
-                    "C": "sha256:3e500c83d44913efaf85466f5c3d8b4871f284b3ac66ca11ade327fccf0a58d9",
-                    "D": "sha256:f39640cffab5ebd1bfef9cb6e17875d1d1a6a89cc90a90f6896c6d89358175f9",
-                    "E": "sha256:8df40ff76c7b688a6f2790348782b87df613c6d7a5b61b6cd4e30f8ca72497db",
-                    "F": "sha256:4b5f74bd333c4fc2359f5559c97baa26f02a63a0c6babd3afe97980d3b2ae26b"
+                    "A": "sha256:05363d4f3c441d84bab4524e98944af063cfa05fe1c68b9f0f8c6820065ef8b0",
+                    "B": "sha256:bd4aae94200c1620a31fe6e1d382a48d040c21b9632c659ae2d09589c67e5824",
+                    "C": "sha256:b1dc3f2a45af69ed28adaf614997a46d60809c95396f2878e062fc6c3c6415af",
+                    "D": "sha256:3565e13a25f630cab57da3899d3c42e2f1c59884602cdf484cfc8b7b68fa360d",
+                    "E": "sha256:ecfc905bc0e0ec6b8ac0d7bddbb65f1a6efccdc6b3c1e1c294d28f82b30c4502",
+                    "F": "sha256:2ce30f2e67d58332e1c89d49e83374d44244e6b5eb63d19f5166dc4dd6b43d70"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7301,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8301,
+                "rule": "Fill state alternates across each row while dot count increases down each column.",
+                "rule_key": "matrix_2x2_fill_dot_increment_v1",
+                "difficulty": 1,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "matrix_2x2_fill_dot_increment_v1",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:6d812569d65d9ab04d776360be3d692a56af64146882ca5acd1478d4f2bb99dd"
+                "params_hash": "sha256:00e8124c6c2db4325bbc910bfeec14a628c0bea3ad196d9850c7f80ab0a8cff2"
             }
         },
         {
@@ -121,15 +128,15 @@
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 1,
-            "item_family": "matrix_3x3",
+            "item_family": "series",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q02</text><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 02."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 series</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q02</text><rect x=\"36\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(53 87) rotate(0)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"50\" cy=\"90\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"82\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(99 87) rotate(45)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"90\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"105\" cy=\"90\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"128\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(145 87) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"90\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"151\" cy=\"90\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"160\" cy=\"90\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"174\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"191\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original series reasoning prompt 02."
                 },
                 "options": [
                     {
@@ -138,7 +145,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(90)\"><path d=\"M 0 -16 L 16 0 L 0 16 L -16 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 02."
                         }
                     },
@@ -148,7 +155,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(135)\"><path d=\"M 0 -16 L 16 0 L 0 16 L -16 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 02."
                         }
                     },
@@ -158,7 +165,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(135)\"><path d=\"M 0 -16 L 16 0 L 0 16 L -16 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"105\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 02."
                         }
                     },
@@ -168,7 +175,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M 0 -16 L 16 0 L 0 16 L -16 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 02."
                         }
                     },
@@ -178,7 +185,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(135)\"><path d=\"M 0 -16 L 16 0 L 0 16 L -16 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"105\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"114\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 02."
                         }
                     },
@@ -188,35 +195,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"99\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"94\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(45)\"><path d=\"M 0 -16 L 16 0 L 0 16 L -16 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 02."
                         }
                     }
                 ]
             },
             "correct_answer": "B",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7302; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The main glyph rotates 45 degrees per step while the internal mark count cycles 1, 2, 3, then 1.",
+            "distractor_logic": "Distractors keep the rotation or mark cycle separately, or reuse an earlier state.",
             "asset_hashes": {
-                "stem": "sha256:c6f56c3f0464772d3d97bc7b0f5dee326d82f6e08292153f44db027a4b8fb419",
+                "stem": "sha256:3517f1adad5cacf8360460f43f3a8e2ddb572fa792e7e1342b926b91f9dbc924",
                 "options": {
-                    "A": "sha256:9e7867876f880475a5ed9d61588c101997aed0a4e96a0c7819c7279f38522421",
-                    "B": "sha256:640a338a82e5c07f7b0111b3c7d7336bb839a2b3911b4d682f8b355cbf6fc827",
-                    "C": "sha256:01885e1a59569a430341266ee351ec5cc1ed99ece196a7fe1e533aefdd51e217",
-                    "D": "sha256:e825df2271ca2a918cae20351cce294aa6b0b4f59e6d7f8421e2505066badea5",
-                    "E": "sha256:f9e7e1314bb48008817596bb5d11d73951f31e49250a438204e5ebd057838f45",
-                    "F": "sha256:e0c9ace5fed6547721316bdb7f85c2ebe3d88341beadfe1b0a77599c04908d13"
+                    "A": "sha256:caa8120f32de9816445c72d9d8249d637287a496946692cfe214df931074b930",
+                    "B": "sha256:d93e68d7d136185f72bede896e962b207bccf92e8170ccdbaff8a36c160ac280",
+                    "C": "sha256:c023322aea22dc65eb24b62ce46f046955e723a7e8f64d33dbb58c1530a48211",
+                    "D": "sha256:d7dd11fbdc33cfcba2254f43260e0240b92b3358ca555ac59454251681811d59",
+                    "E": "sha256:f50958d8bd5b408aec816bf11724c12b5914a4e98727fcaad716a567d41be76e",
+                    "F": "sha256:efd313444aefa5e6dbb9ae1201f17138de02c12738330532c3175afc1ea5d53e"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7302,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8302,
+                "rule": "The main glyph rotates 45 degrees per step while the internal mark count cycles 1, 2, 3, then 1.",
+                "rule_key": "series_rotation_mark_cycle_v1",
+                "difficulty": 1,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "series_rotation_mark_cycle_v1",
+                "item_family_template": "series",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:1103c5162ff3307649beafc828ac1c3b40b232623673469f7631dd9d9c81baf0"
+                "params_hash": "sha256:37b399c7b93136528d1969127645241f747f32d7b228cf5ce723fa53a42c4ca7"
             }
         },
         {
@@ -225,18 +239,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q03",
             "item_id": "IQ_BETA_30_ORIGINAL_03",
-            "dimension": "VSPR",
-            "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 1,
-            "item_family": "matrix_3x3",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 2,
+            "item_family": "odd_one_out",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q03</text><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 03."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 odd_one_out</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q03</text><text x=\"120\" y=\"76\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Choose the panel that breaks the shared axis.</text><line x1=\"120\" y1=\"90\" x2=\"120\" y2=\"126\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.2\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 03."
                 },
                 "options": [
                     {
@@ -245,7 +259,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><line x1=\"120\" y1=\"48\" x2=\"120\" y2=\"104\" stroke=\"#243126\" stroke-width=\"1.2\" opacity=\"0.18\"/><circle cx=\"105\" cy=\"54\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><circle cx=\"135\" cy=\"54\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><rect x=\"100\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"126\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 03."
                         }
                     },
@@ -255,7 +269,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><line x1=\"120\" y1=\"48\" x2=\"120\" y2=\"104\" stroke=\"#243126\" stroke-width=\"1.2\" opacity=\"0.18\"/><circle cx=\"105\" cy=\"57\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><circle cx=\"135\" cy=\"57\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><rect x=\"100\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"126\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 03."
                         }
                     },
@@ -265,7 +279,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"95\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"96\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"97\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><line x1=\"120\" y1=\"48\" x2=\"120\" y2=\"104\" stroke=\"#243126\" stroke-width=\"1.2\" opacity=\"0.18\"/><circle cx=\"105\" cy=\"60\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><circle cx=\"135\" cy=\"60\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><rect x=\"100\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"126\" y=\"87\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><circle cx=\"126\" cy=\"96\" r=\"4\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 03."
                         }
                     },
@@ -275,7 +289,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><line x1=\"120\" y1=\"48\" x2=\"120\" y2=\"104\" stroke=\"#243126\" stroke-width=\"1.2\" opacity=\"0.18\"/><circle cx=\"105\" cy=\"54\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><circle cx=\"135\" cy=\"54\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><rect x=\"100\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"126\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 03."
                         }
                     },
@@ -285,7 +299,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"96\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"97\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><line x1=\"120\" y1=\"48\" x2=\"120\" y2=\"104\" stroke=\"#243126\" stroke-width=\"1.2\" opacity=\"0.18\"/><circle cx=\"105\" cy=\"57\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><circle cx=\"135\" cy=\"57\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><rect x=\"100\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"126\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 03."
                         }
                     },
@@ -295,35 +309,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><line x1=\"120\" y1=\"48\" x2=\"120\" y2=\"104\" stroke=\"#243126\" stroke-width=\"1.2\" opacity=\"0.18\"/><circle cx=\"105\" cy=\"60\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><circle cx=\"135\" cy=\"60\" r=\"6\" fill=\"#1f5d50\" opacity=\"0.82\"/><rect x=\"100\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"126\" y=\"80\" width=\"14\" height=\"18\" rx=\"4\" fill=\"#d9843b\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 03."
                         }
                     }
                 ]
             },
             "correct_answer": "C",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7303; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Five options preserve a vertical symmetry axis; the target breaks that axis with an offset marker.",
+            "distractor_logic": "Distractors are symmetric variants with different density, scale, or marker placement.",
             "asset_hashes": {
-                "stem": "sha256:7bf45553bfaad4662a7a67b9529fa93fc8caafbba4522574b92e1d29998ccc8d",
+                "stem": "sha256:11797abc1d4e34214c4e803c0cb13b6ad200a5b167e3d4a6bb1f4495688843f6",
                 "options": {
-                    "A": "sha256:20035f383c4728a21b641933319a1bee1866cf34bfa696db922005fa28adfc36",
-                    "B": "sha256:d89ed6e7da3179d0c7af4c8f857942250e8136f246e5188fbe132df571a95113",
-                    "C": "sha256:0f355da700440c767f2f8084eb112376daa31193aa4d69851410f2495d19c8d7",
-                    "D": "sha256:e9dc84f1965aa9e97976a31f011ded4e6702d2680cba3aa1be5bbff213d90999",
-                    "E": "sha256:d5528674d1028f7baffc9927922504b1e20e441315b1b07ef1c99701ec19beb8",
-                    "F": "sha256:f97739f173e6a74a7231c101a59b13095d796773b93488a885ed24128b73910d"
+                    "A": "sha256:9fec247e3fe2a4ad7c9c59442679a014bbeb3c64adc54b1786239050754a539c",
+                    "B": "sha256:a780af8bda68da8b2d5babd44d01f7ded9077f400f863892d1316e6875f9b310",
+                    "C": "sha256:70b25aebe3e1908d94691a0b9314f950e55a7e95fcd92d7ce3e0042fdbd2e594",
+                    "D": "sha256:66f085a8d5e95318299087f3ca3ce1cfa44c63015e9642a846b0cbc9f0a27797",
+                    "E": "sha256:9a9f7f2174c05933b52bb27779e438519e71652fdff4896e5a231c4c059245c4",
+                    "F": "sha256:7fd20f483387d95f2df62c0ede038fc32ead504ccdb98f5ea0f709d3a9e5a4f4"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7303,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8303,
+                "rule": "Five options preserve a vertical symmetry axis; the target breaks that axis with an offset marker.",
+                "rule_key": "odd_one_out_axis_symmetry_v1",
+                "difficulty": 2,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "odd_one_out_axis_symmetry_v1",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:e3104d3af03b3559ec858bfd4139ae5eacc0bffcd79c82d5af03afa6e904cd9c"
+                "params_hash": "sha256:6118eb7c03632d2ee1c792e7f5b6ab7e1061cfc4bdc05543d8674093712fb2db"
             }
         },
         {
@@ -332,18 +353,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q04",
             "item_id": "IQ_BETA_30_ORIGINAL_04",
-            "dimension": "VSPR",
-            "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 1,
-            "item_family": "matrix_3x3",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 2,
+            "item_family": "rotation",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q04</text><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 04."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 rotation</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q04</text><text x=\"120\" y=\"48\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Rotate the reference without mirroring.</text><rect x=\"96\" y=\"66\" width=\"48\" height=\"48\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 90) rotate(0)\"><path d=\"M -10 -10 H -7 V 7 H 10 V 10 H -10 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"110\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"154\" y=\"66\" width=\"48\" height=\"48\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"178\" y=\"96\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original rotation reasoning prompt 04."
                 },
                 "options": [
                     {
@@ -352,7 +373,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(0)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 04."
                         }
                     },
@@ -362,7 +383,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"99\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(90) scale(-1 1)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 04."
                         }
                     },
@@ -372,7 +393,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 04."
                         }
                     },
@@ -382,7 +403,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"94\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(90)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 04."
                         }
                     },
@@ -392,7 +413,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(270)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"96\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/><circle cx=\"105\" cy=\"100\" r=\"3.2\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 04."
                         }
                     },
@@ -402,35 +423,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"95\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(90)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option F for original IQ item 04."
                         }
                     }
                 ]
             },
             "correct_answer": "D",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7304; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The reference polyomino is transformed by rotation only; mirrored variants are invalid.",
+            "distractor_logic": "Distractors include mirrored, half-rotated, and correctly rotated but internally marked near misses.",
             "asset_hashes": {
-                "stem": "sha256:b66cd0dad196935d1927e455ffb580667b0c220f498ab0cdce0db74bf2186ade",
+                "stem": "sha256:4c4467dc0475614797391ffd39d090a3d0ca1235bd7a79444352d83fc7ea3ee2",
                 "options": {
-                    "A": "sha256:0a991028943ebc0cbc7f4275dbd74f9ba427ecba7a97e0b61acc862a7f85ff44",
-                    "B": "sha256:d976c7eb85b098d60590a2ae9f02f115bbe9399b6d3bfc2528a55c98e677a843",
-                    "C": "sha256:9f8b13aa928c609ffc810c70aa32433ed4e07d8652bfd5b93d67f4dbfd06dd2e",
-                    "D": "sha256:d188999cb0c2c6c7be8a46dedd14d21599e6b9aea5b722d47e2700db54542c6b",
-                    "E": "sha256:d877993aa5abbc109306d4ed6456d85200fd98feee0fa1e152fa6b1cbdecec1b",
-                    "F": "sha256:2c0772bcffb5f4ea8866708bd41ce86124ea6eb669befbbeb54a7654865027ce"
+                    "A": "sha256:22d5953cbc2ed2b9ffe41a8816f29ba95fe5a9928108365db7f95fd454c3f0e4",
+                    "B": "sha256:8697c99f16d12fe19b36e24fab21516904271b035c596a731d03d9b0b5f3295b",
+                    "C": "sha256:af3788d7ae5557fa46aebb80cdf3a0767b2eb3a966f54474617c1e513262c8c5",
+                    "D": "sha256:807aae21f35e6b20cd15fa3ca2fc429cb7cd97a33e0c79eb3a845084bda1e76f",
+                    "E": "sha256:788cd8c9bb593e676c0f08d44f2734457ef67dffe52dfe91ad56ae9e163c6257",
+                    "F": "sha256:aa654af62cc7b3dc5409dd294e0e3de3ab1c1987e7ee38f6d7e4c358a878642e"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7304,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8304,
+                "rule": "The reference polyomino is transformed by rotation only; mirrored variants are invalid.",
+                "rule_key": "pure_rotation_no_mirror_v1",
+                "difficulty": 2,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "pure_rotation_no_mirror_v1",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:ace921ed3a1d7fa95a836ecc5e6a66932c14508bdac1b9dfe947346728521c8c"
+                "params_hash": "sha256:5ad13fb6d423c1624c12c94a46bfbf1009b65287599942cbce0d652bca1350dc"
             }
         },
         {
@@ -439,18 +467,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q05",
             "item_id": "IQ_BETA_30_ORIGINAL_05",
-            "dimension": "VSPR",
-            "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 1,
-            "item_family": "matrix_3x3",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 2,
+            "item_family": "overlay",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q05</text><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"99\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 05."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 overlay</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q05</text><text x=\"120\" y=\"44\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Combine panels and remove the overlap.</text><rect x=\"58\" y=\"66\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"55\" y=\"69\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><rect x=\"110\" y=\"66\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><circle cx=\"145\" cy=\"89\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><rect x=\"162\" y=\"66\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"183\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original overlay reasoning prompt 05."
                 },
                 "options": [
                     {
@@ -459,7 +487,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"58\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"96\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"97\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 05."
                         }
                     },
@@ -469,7 +497,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.78\" stroke=\"#243126\" stroke-width=\"2\"/><path d=\"M 120 58 C 139 66 139 98 120 106 C 110 94 110 69 120 58 Z\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 05."
                         }
                     },
@@ -479,7 +507,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"61\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"62\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"63\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"94\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"95\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.74\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 05."
                         }
                     },
@@ -489,7 +517,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"58\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"59\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 05."
                         }
                     },
@@ -499,7 +527,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><path d=\"M 118 58 C 130 67 130 95 118 103\" fill=\"none\" stroke=\"#f8faf7\" stroke-width=\"8\" stroke-linecap=\"round\" opacity=\"0.95\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 05."
                         }
                     },
@@ -509,35 +537,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"95\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"96\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"97\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 05."
                         }
                     }
                 ]
             },
             "correct_answer": "E",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7305; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The target combines two source shapes and removes the overlapping interior segment.",
+            "distractor_logic": "Distractors keep union, intersection, subtraction, or single-source variants.",
             "asset_hashes": {
-                "stem": "sha256:9325c540b0c010cc7ba9ce5231ecbe7001320a8b36c71bb054742f2364974c89",
+                "stem": "sha256:a4f3f2bee4db987bd4359d8d406b2e43489d530d417cd5f1ee7d7769d84fe050",
                 "options": {
-                    "A": "sha256:94da768597b27a5077124bf8a564ef98b1206212badb6340eb7ab89726afadc7",
-                    "B": "sha256:7b08d49d0f6e25d3f158060026ef3e367b8bb6626adf48ff68ded1e3cef6215d",
-                    "C": "sha256:18a969c25a2762e8581e510dc2af42e6fbc4d57977fb7d066b7fa2b0f84ec458",
-                    "D": "sha256:4737c47efa1529840f91e49c5b5fb5124782a455dfd2d57bb913769aa486e0d1",
-                    "E": "sha256:af33aa03399b76d239df873ff1b741f169aa13903f1f7566f287142cb69a4d34",
-                    "F": "sha256:0e48ee51d9bcb0e6d8f9d90c24533f925c5b401bfecce9cb52c2af8b011e4e6d"
+                    "A": "sha256:cdd39827c7b1d1ff8111776c3cc13af933b6818c5b68d5ed03ec682fe7fb30dd",
+                    "B": "sha256:a37965dfa115e8a851ecd77fdf18ab918b7dd948a3c1f2d9f5e8ba0fdf1e651b",
+                    "C": "sha256:d5e9702aa26fe0004802ae7799900ef8b1703654ea82d74de278be2635a07179",
+                    "D": "sha256:a14a86aafb900516cdbec8eb22b18a8588e84f4ca69a89f62a52bd75833a24af",
+                    "E": "sha256:3fbfae36ca66599a0c6315666ddca4e84d76ac174a4e96b7010b98fdb1da506a",
+                    "F": "sha256:0f9b90f4521e1d30ec64e41ccec2161f5abf9165ac3d1ce1050d4daaa0cb524a"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7305,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8305,
+                "rule": "The target combines two source shapes and removes the overlapping interior segment.",
+                "rule_key": "overlay_remove_overlap_v1",
+                "difficulty": 2,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "overlay_remove_overlap_v1",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:a3bdde3ad5af7d8499da7edac2b75bcabfb16c52708c26cf2c6b9d15a52a77bd"
+                "params_hash": "sha256:df2265378bc44cb107551e0d1143afad09e9c86f20bb04053194aafe5a67b94d"
             }
         },
         {
@@ -548,7 +583,7 @@
             "item_id": "IQ_BETA_30_ORIGINAL_06",
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 1,
+            "difficulty_level": 3,
             "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
@@ -556,7 +591,7 @@
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q06</text><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 matrix_3x3</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q06</text><text x=\"120\" y=\"42\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Rows combine fill; columns rotate.</text><rect x=\"55\" y=\"58\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(73 82) rotate(0)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"73\" cy=\"76\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"97\" y=\"58\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(115 82) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(133 82) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"115\" cy=\"76\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"139\" y=\"58\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(157 82) rotate(180)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(175 82) rotate(180)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(193 82) rotate(180)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"157\" cy=\"76\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"139\" y=\"100\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"156\" y=\"123\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
                     "accessibility_label": "Original matrix 3x3 reasoning prompt 06."
                 },
                 "options": [
@@ -566,7 +601,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"63\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 06."
                         }
                     },
@@ -576,7 +611,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"59\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"97\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"98\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(0)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(0)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(0)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 06."
                         }
                     },
@@ -586,7 +621,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 06."
                         }
                     },
@@ -596,7 +631,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"95\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"96\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(100 84) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option D for original IQ item 06."
                         }
                     },
@@ -606,7 +641,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"98\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"99\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"94\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(180)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(180)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 06."
                         }
                     },
@@ -616,35 +651,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"94\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 06."
                         }
                     }
                 ]
             },
             "correct_answer": "F",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7306; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Across each row, fills combine by XOR; down each column, the active glyph rotates 90 degrees.",
+            "distractor_logic": "Distractors satisfy only the row rule, only the column rule, or a one-step rotation error.",
             "asset_hashes": {
-                "stem": "sha256:8704992fe93b0eb3086bcf2826796ce6e5b3972bc6856ed464277ea3b95abf0e",
+                "stem": "sha256:f3bddd6c18fcdac2e02fc7ca08230cc7a39451b5791ab523d4057904647381d3",
                 "options": {
-                    "A": "sha256:ba08a30c43bb79b22096a71127012f48b4fb0a8501ffc5bfec8924324d2d4242",
-                    "B": "sha256:0c59452928464abcd785a1766783bcc1547ed44eb27db5a91876e47c05790b45",
-                    "C": "sha256:5ec5a5f03a4a2be428168da9074a6b65fe80ece52a9ce9d5de2329864e7a6f2b",
-                    "D": "sha256:87a7fd953079f381130183e06647ff1efa3fde9c1b4fa018cd260ffae0abf763",
-                    "E": "sha256:598910dc79a9dafe8f6778d3f065ed1eed515fbc66b5700332bad485a1cfd9e9",
-                    "F": "sha256:29aea864163f75c712def15fca9692071bb737a1d2c038ab658323928e2bfe2d"
+                    "A": "sha256:3d59b2f1add0c95a68c3fe3cecf6e70d84f749bdbb1b4316ab2aed540f21c024",
+                    "B": "sha256:c009865ce52bb8c99c12ad1c3eab65176fed903e39e4d26190208bb04dd06e78",
+                    "C": "sha256:4a18f8c8c988ddd53c7ad130ac7b9323f49b897d8c596c7fb077aeb3c5c43b28",
+                    "D": "sha256:7f6cde8fbe083738ded29fdcec99ebf91f2c5fde5d68298c1dd7ccab7b008e66",
+                    "E": "sha256:2c429da954f5e2f291e3c1e8bead78ea45d67b39236583c8710159ea3d8bc18a",
+                    "F": "sha256:763806e646922369a87b300ebd34983ac3f98d1da9fd19c357c3368a5efac56a"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7306,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8306,
+                "rule": "Across each row, fills combine by XOR; down each column, the active glyph rotates 90 degrees.",
+                "rule_key": "matrix_3x3_row_xor_column_rotation_v1",
+                "difficulty": 3,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "matrix_3x3_row_xor_column_rotation_v1",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:71ec61fe492ca42b723d1914281a7dce6fb016a3734b3fb93494357e51acc1dc"
+                "params_hash": "sha256:44cd8f09a88cb2b14bfbe89a787890709f616a3907fe5c4c1ba750f96a6566c2"
             }
         },
         {
@@ -653,18 +695,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q07",
             "item_id": "IQ_BETA_30_ORIGINAL_07",
-            "dimension": "VSPR",
-            "dimension_name": "Visual-spatial pattern reasoning",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
             "difficulty_level": 2,
-            "item_family": "matrix_3x3",
+            "item_family": "numeric_pattern",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q07</text><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"94\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 07."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 numeric_pattern</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q07</text><rect x=\"42\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"59\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">3</text><circle cx=\"58\" cy=\"88\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"60\" cy=\"86\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/><rect x=\"88\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"105\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">5</text><circle cx=\"104\" cy=\"88\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"106\" cy=\"86\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/><rect x=\"134\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"151\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">9</text><circle cx=\"150\" cy=\"88\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"152\" cy=\"86\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/><rect x=\"180\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"197\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original numeric pattern reasoning prompt 07."
                 },
                 "options": [
                     {
@@ -673,7 +715,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"120\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">17</text><circle cx=\"98\" cy=\"98\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"142\" cy=\"54\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 07."
                         }
                     },
@@ -683,7 +725,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"120\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">15</text><circle cx=\"98\" cy=\"98\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"142\" cy=\"54\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 07."
                         }
                     },
@@ -693,7 +735,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"120\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">18</text><circle cx=\"98\" cy=\"98\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"142\" cy=\"54\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 07."
                         }
                     },
@@ -703,7 +745,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"120\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">14</text><circle cx=\"98\" cy=\"98\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"142\" cy=\"54\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 07."
                         }
                     },
@@ -713,7 +755,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"120\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">19</text><circle cx=\"98\" cy=\"98\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"142\" cy=\"54\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 07."
                         }
                     },
@@ -723,35 +765,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"120\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"24\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.88\">16</text><circle cx=\"98\" cy=\"98\" r=\"4\" fill=\"#1f5d50\" opacity=\"0.74\"/><circle cx=\"142\" cy=\"54\" r=\"4\" fill=\"#d9843b\" opacity=\"0.74\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 07."
                         }
                     }
                 ]
             },
             "correct_answer": "A",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7307; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The sequence follows n -> 2n - 1, producing the next numeric state.",
+            "distractor_logic": "Distractors are adjacent arithmetic, doubling, or off-by-one values.",
             "asset_hashes": {
-                "stem": "sha256:776ba2adee04404a80dc2361996cabc03e2b10da0830c59d6c70e3ec1a530278",
+                "stem": "sha256:789901fa877d1649e9848b92745e5d413c6857a3ed8a226cc33e98688a853e54",
                 "options": {
-                    "A": "sha256:56dcd0e15434c0400c40b7327ce3238a21d7068cc8b89b9dcde140025015cb10",
-                    "B": "sha256:58f02a61eaaab5ed8762c3baf269adcee6d13c3f32b23786d7d83dbe6c2c982a",
-                    "C": "sha256:971939b3d78c2201bb0dc2a49891f4b0991fe5412ab4144043d7a61c9b7820cc",
-                    "D": "sha256:4e2a05c6fc724215a71d714c388edc49ebb4dec6d540caab8484ddf37300c706",
-                    "E": "sha256:540b4247a3095849fd954210a6ff7ca1d1ae4b139df6e0758c01868bec3898f1",
-                    "F": "sha256:802f21f8b98f779726ebf0bf5182f4b511927e37c2bd9325fb5097903df5ab67"
+                    "A": "sha256:8a2328b8d807cb5f8c03f99a9c638e5d143a7f7c56f33b744209aabfafb11ce0",
+                    "B": "sha256:0b70481c046d6bef17ec88b83ebe516079c7e4df04745a946ed3f97f8ff5bd9f",
+                    "C": "sha256:1f8913a154122f074a413658ede23b5049917d63ab010989b158d86a9d22d126",
+                    "D": "sha256:92558703aef113f35f2eb3ea94039596aa96dded48faf8b9e23b878bfb52c2c7",
+                    "E": "sha256:808c07f2247e6476b6a848dd1fdf45fa4774141907274574444dfeb7fad74c27",
+                    "F": "sha256:cd7600897936c5cd2be7e426fc6ed41bd79b42810fa881d40c02e83183ae8ed2"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7307,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8307,
+                "rule": "The sequence follows n -> 2n - 1, producing the next numeric state.",
+                "rule_key": "numeric_double_minus_one_v1",
+                "difficulty": 2,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "numeric_double_minus_one_v1",
+                "item_family_template": "numeric_pattern",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:dee9b7b245f92fdb5da2792f10247f172c1d97cd62298c1b21790db6c71ba506"
+                "params_hash": "sha256:3938810ffcb16ec713e7ac8650277edc804763bbabef6b634f99c810868e948c"
             }
         },
         {
@@ -762,16 +811,16 @@
             "item_id": "IQ_BETA_30_ORIGINAL_08",
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 2,
-            "item_family": "matrix_3x3",
+            "difficulty_level": 3,
+            "item_family": "series",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q08</text><rect x=\"58\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 08."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 series</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q08</text><rect x=\"36\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"52\" y=\"86\" width=\"2\" height=\"2\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"56\" cy=\"90\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><rect x=\"82\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"86\" width=\"2\" height=\"2\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"96\" cy=\"90\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><rect x=\"128\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"144\" y=\"86\" width=\"2\" height=\"2\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"142\" cy=\"84\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><rect x=\"174\" y=\"70\" width=\"34\" height=\"34\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"191\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original series reasoning prompt 08."
                 },
                 "options": [
                     {
@@ -780,7 +829,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"102\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 08."
                         }
                     },
@@ -790,7 +839,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"102\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 08."
                         }
                     },
@@ -800,7 +849,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"102\" cy=\"58\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 08."
                         }
                     },
@@ -810,7 +859,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"95\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"96\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 08."
                         }
                     },
@@ -820,7 +869,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"58\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 08."
                         }
                     },
@@ -830,35 +879,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"94\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"58\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 08."
                         }
                     }
                 ]
             },
             "correct_answer": "B",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7308; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The marker advances clockwise through square corners while fill toggles on every step.",
+            "distractor_logic": "Distractors keep the corner cycle or fill toggle separately, but not the combined state.",
             "asset_hashes": {
-                "stem": "sha256:d10790064002adb1afd486ffe59a93507aec3b2fb63c7e223361b0313b63ee12",
+                "stem": "sha256:e12b3df88a324973223c57df00b3d543c7507748e834918f19be78bd4e104c4b",
                 "options": {
-                    "A": "sha256:d0dd5a256e04cf31c35810c6aa61a99cdfa9c0ee10ed79d551d65be1f39bc310",
-                    "B": "sha256:3817bb9d4d8cc5505969624e93856d8546f4b5c5613e97bf2f136f733ce91017",
-                    "C": "sha256:e65a53062e62f6af6823661a1e64ecc52b4df60702191f872235d416c11e4476",
-                    "D": "sha256:e9d807c37f1d6d71b836adcf1738df36ace56bf01fb62fbabc1348f6a245cc05",
-                    "E": "sha256:0f7ec9da4c15f088fadf3355ac1fcbd8ed8424d7548ccbc2d536d86ceb2710a3",
-                    "F": "sha256:9c0cf41992d642c2daae00ac949bfd2b88e78a1c01412713c17a88279f41446d"
+                    "A": "sha256:f52a10340118b0042108c3adfcaee8b1f0c65ef3110e04aa4d0b2f9376aac8e9",
+                    "B": "sha256:f39f867b5ecf3c4a7af16dcfb17ab222b93a8b22bd7a113b4004756c055ef44e",
+                    "C": "sha256:e4da3bcf272ac4b4c141d027b2a68b64c91f9b88b0e96f2230f2cd33b53c128d",
+                    "D": "sha256:851b5f1c53ece8183bfd40db05d2552ec46119ce446bbc5d65b465c4366cf216",
+                    "E": "sha256:2a546fd36642b68d8b7cbbe658f6d7f75bbb5d567ee57a830137e4004db3a9da",
+                    "F": "sha256:b7aac1ed01bb885021eadbb4bc6dfe61b0a20d09067c58fb42626cafb00ec3c8"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7308,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8308,
+                "rule": "The marker advances clockwise through square corners while fill toggles on every step.",
+                "rule_key": "series_corner_cycle_fill_toggle_v1",
+                "difficulty": 3,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "series_corner_cycle_fill_toggle_v1",
+                "item_family_template": "series",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:41a1e8c7f74579ce8537e5429c1140e959368b7b9adcc5d4475fa1b951b9ff27"
+                "params_hash": "sha256:b652f41501c0448e22c69b698e5481a558777a1ee31b43bfd5b95e3dc9e35f4d"
             }
         },
         {
@@ -869,7 +925,7 @@
             "item_id": "IQ_BETA_30_ORIGINAL_09",
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 2,
+            "difficulty_level": 4,
             "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
@@ -877,7 +933,7 @@
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q09</text><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 matrix_3x3</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q09</text><text x=\"120\" y=\"42\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Quantity rises; shape rotates; marker stays.</text><rect x=\"48\" y=\"60\" width=\"38\" height=\"38\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(66 84) rotate(0)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(84 84) rotate(0)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"70\" cy=\"82\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"94\" y=\"60\" width=\"38\" height=\"38\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(112 84) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(130 84) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(148 84) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"116\" cy=\"82\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/><rect x=\"140\" y=\"60\" width=\"38\" height=\"38\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"159\" y=\"85\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
                     "accessibility_label": "Original matrix 3x3 reasoning prompt 09."
                 },
                 "options": [
@@ -887,7 +943,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(100 84) rotate(45)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 09."
                         }
                     },
@@ -897,7 +953,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 09."
                         }
                     },
@@ -907,7 +963,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(100 84) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 09."
                         }
                     },
@@ -917,7 +973,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(100 84) rotate(90)\"><path d=\"M 0 -7 L 7 0 L 0 7 L -7 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 09."
                         }
                     },
@@ -927,7 +983,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(100 84) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 84) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><circle cx=\"142\" cy=\"98\" r=\"5\" fill=\"#c7504f\" opacity=\"0.9\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 09."
                         }
                     },
@@ -937,35 +993,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(100 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(118 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(136 62) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g><g transform=\"translate(100 84) rotate(90)\"><path d=\"M 0 -7 L 7 7 L -7 7 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option F for original IQ item 09."
                         }
                     }
                 ]
             },
             "correct_answer": "C",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7309; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Rows increase quantity, columns rotate the shape family, and the accent marker remains constant.",
+            "distractor_logic": "Distractors break one of quantity, rotation, or marker consistency.",
             "asset_hashes": {
-                "stem": "sha256:c44393dc408f0f225b7b221b949af3065a232bdbdb83c56317e2f2b6bd98b8c9",
+                "stem": "sha256:5d3d22bdb4671d05337f765de02f8f4fefbb0eaa20ebdb09559d0ec6bb921eea",
                 "options": {
-                    "A": "sha256:f6e1e07a7b64c19ebd331f3d8d9fe50fbbce8a007083eb029bc14e3e87c9fd63",
-                    "B": "sha256:de55521608ac47b257dc6d6f3ceb090dd4931d801db4d2d2043415436931a257",
-                    "C": "sha256:548032cbfa38ec4bbf1c8eb2c05dc73da1f6b45039dae9b3c441bce2ddff966e",
-                    "D": "sha256:6b306d471cfbcf910eb5f8a325741abf30be025131abe5c4e6895965f26d2306",
-                    "E": "sha256:0d2a98863e1a471c7700d3594c130dc0cc2dca55a49a3ce13c2b7560e97547c5",
-                    "F": "sha256:771a3a43ffbeae22bf0ed40c05e05dea8270c0dead5909a9cdd2324a9e15b25a"
+                    "A": "sha256:8f554800c66401598d046e30bce4d54cf735265dfe719a2834efe8b02eb0d912",
+                    "B": "sha256:fd0aecfd11ac93097b6abd8bb3562041f35d0210f0ed7818bd49601e9e0566f3",
+                    "C": "sha256:f42d46ce7f301354f2f8799ba63591a6d3e371cd9207de230972d8d467132a1b",
+                    "D": "sha256:293068e07c2c8f374f47e764f5906a47de475a92bfee6d4bd6beb9d31b9effb3",
+                    "E": "sha256:40ec54ce2ac81b1c7bef6a3535b6463c1004779537df18f6e4a0ce2f3ba8ae32",
+                    "F": "sha256:64c7b4676c116396592bcb6ad0075525268b46884b8d91e94743108b581ea9e8"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7309,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8309,
+                "rule": "Rows increase quantity, columns rotate the shape family, and the accent marker remains constant.",
+                "rule_key": "matrix_3x3_quantity_rotation_constant_v1",
+                "difficulty": 4,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "matrix_3x3_quantity_rotation_constant_v1",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:3a1b7ea27acb47328c0a8bc7fa992745fbf5da928d21b642db6aa1cfcf6a58b0"
+                "params_hash": "sha256:c45c9bb15743861c97dd6b87181d6a358edd0bb7325dcca43886fcbcc7e170c3"
             }
         },
         {
@@ -974,18 +1037,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q10",
             "item_id": "IQ_BETA_30_ORIGINAL_10",
-            "dimension": "VSPR",
-            "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 2,
-            "item_family": "matrix_3x3",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "odd_one_out",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q10</text><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 3x3 reasoning prompt 10."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 odd_one_out</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q10</text><text x=\"120\" y=\"46\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">All but one overlap by rotation only.</text><rect x=\"96\" y=\"66\" width=\"48\" height=\"48\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 90) rotate(0)\"><path d=\"M -10 -10 H -7 V 7 H 10 V 10 H -10 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 10."
                 },
                 "options": [
                     {
@@ -994,7 +1057,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(0)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option A for original IQ item 10."
                         }
                     },
@@ -1004,7 +1067,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"94\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(90)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option B for original IQ item 10."
                         }
                     },
@@ -1014,7 +1077,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option C for original IQ item 10."
                         }
                     },
@@ -1024,7 +1087,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"97\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(0) scale(-1 1)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option D for original IQ item 10."
                         }
                     },
@@ -1034,7 +1097,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(270)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option E for original IQ item 10."
                         }
                     },
@@ -1044,35 +1107,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><g transform=\"translate(120 76) rotate(45)\"><path d=\"M -16 -16 H -11 V 11 H 16 V 16 H -16 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.82\"/></g></svg>",
                             "accessibility_label": "Option F for original IQ item 10."
                         }
                     }
                 ]
             },
             "correct_answer": "D",
-            "solution_rule": "Original deterministic matrix 3x3 transformation generated from seed 7310; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Five options can be rotated to overlap the reference silhouette; the target requires mirroring.",
+            "distractor_logic": "Distractors vary rotation angle or scale while preserving rotational equivalence.",
             "asset_hashes": {
-                "stem": "sha256:058ee7199f7cdef061e88ec13114e031c93b7015ca6b17f5729e10ff86f46a04",
+                "stem": "sha256:e36abe4575d6fba936a81016e20945e90ffe9b1a9eb1b72a388ebe5592eba4d1",
                 "options": {
-                    "A": "sha256:d26cb10a98e47742630bf9a238a87a237f5416add935418a66598e7cdc9242dd",
-                    "B": "sha256:9619cfaedc1994e286af24a4079fd118e19099a90e6c478be68c6985b4343096",
-                    "C": "sha256:18132c6112cdd578e6e62e69b0cd22a726e89d395f0c1c23b137905260c878ef",
-                    "D": "sha256:efa096ff26626de261ab881d22b95e284e5b9c6e0eb2d7c4738ef4549f5b070e",
-                    "E": "sha256:b1a4941ba00c20364952a52299d574a5140f8a52945bba669d7329384c7265b2",
-                    "F": "sha256:42e035111c558dac8640b9e225a42d8947db95410363e3fe5cb243c3996ce277"
+                    "A": "sha256:67524792c6935fdda4dcf81184926cd1867a58422a1e7ed6e20ae15826456d37",
+                    "B": "sha256:430eb7128264955c5d52aa6cfe567d3da003697b5afaa6c916522ed1af680e9f",
+                    "C": "sha256:f2bf3a38c98066ba7efed372a297a87932b899160e24552720f41e27c96cb5c8",
+                    "D": "sha256:5ede724dff2d0c4d841ed43f619e0eb3a914c9adc660246e8accae1c2ac480fe",
+                    "E": "sha256:5a8eb1176e32821bd3dc4902ca7a71543b91991308e9921f7ce5e93f3ff2ca19",
+                    "F": "sha256:7df6bbc914b8ebd79aa63edb892ff093e56c9b81aae716a499bb46c1b7d66418"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7310,
-                "template_key": "matrix_3x3",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8310,
+                "rule": "Five options can be rotated to overlap the reference silhouette; the target requires mirroring.",
+                "rule_key": "odd_one_out_rotation_equivalence_v1",
+                "difficulty": 3,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "odd_one_out_rotation_equivalence_v1",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:ed54e74b960582866d87e4ee20ee80aaff6b71887813e7fef47192faa7502294"
+                "params_hash": "sha256:b4ef118643034eba123ba27551456930702732d7916095bdd31b165a3aabba15"
             }
         },
         {
@@ -1081,18 +1151,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q11",
             "item_id": "IQ_BETA_30_ORIGINAL_11",
-            "dimension": "VSPR",
-            "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 2,
-            "item_family": "matrix_2x2",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "overlay",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q11</text><rect x=\"53\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"67\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"100\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"137\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 2x2 reasoning prompt 11."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 overlay</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q11</text><text x=\"120\" y=\"44\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Union, subtraction, intersection cycle.</text><rect x=\"48\" y=\"66\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"45\" y=\"69\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><circle cx=\"83\" cy=\"89\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><rect x=\"100\" y=\"66\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"97\" y=\"69\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.74\" stroke=\"#243126\" stroke-width=\"2\"/><rect x=\"152\" y=\"66\" width=\"42\" height=\"42\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"173\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original overlay reasoning prompt 11."
                 },
                 "options": [
                     {
@@ -1101,7 +1171,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"67\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"100\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"137\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 11."
                         }
                     },
@@ -1111,7 +1181,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"63\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"64\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"101\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.74\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 11."
                         }
                     },
@@ -1121,7 +1191,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"65\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"66\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"103\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"135\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/><path d=\"M 118 58 C 130 67 130 95 118 103\" fill=\"none\" stroke=\"#f8faf7\" stroke-width=\"8\" stroke-linecap=\"round\" opacity=\"0.95\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 11."
                         }
                     },
@@ -1131,7 +1201,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"67\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"62\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"99\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 11."
                         }
                     },
@@ -1141,7 +1211,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"66\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"67\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"98\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"136\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"137\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><circle cx=\"134\" cy=\"78\" r=\"22\" fill=\"#d9843b\" opacity=\"0.78\" stroke=\"#243126\" stroke-width=\"2\"/><path d=\"M 120 58 C 139 66 139 98 120 106 C 110 94 110 69 120 58 Z\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 11."
                         }
                     },
@@ -1151,35 +1221,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"66\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"67\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"54\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"136\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"137\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"96\" y=\"58\" width=\"40\" height=\"40\" rx=\"6\" fill=\"#1f5d50\" opacity=\"0.42\" stroke=\"#243126\" stroke-width=\"2\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 11."
                         }
                     }
                 ]
             },
             "correct_answer": "E",
-            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7311; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The operation cycle alternates union, subtraction, then intersection; the missing state is the next intersection.",
+            "distractor_logic": "Distractors are plausible overlay outputs from the wrong operation in the cycle.",
             "asset_hashes": {
-                "stem": "sha256:747a42e4a84f70e1133abdcb45802f50b3a66ef148aae9eef2ccb5311e57261e",
+                "stem": "sha256:bc7e277d6d8fa4e34d18cdc3db61a9b95ed8c41253ea77dfd56022f575a3099c",
                 "options": {
-                    "A": "sha256:b4353b70422c98d4ad017765c22242b046691543aeca4c54c8ab657737ae1983",
-                    "B": "sha256:9e5a1738f61f1232a0000ea6c5a29078f8cfa2d684e6e070ac0de6c7a2ceb9f8",
-                    "C": "sha256:b8eed0d7bac347d0bc6b5f9d1bec571679bd1d6d7bc5d341c1ce0bd95c7f1b97",
-                    "D": "sha256:e2e6544df5a4651eaaf7e6502f27d7c091e93fbdddbd55d3c09f2fd2c917e006",
-                    "E": "sha256:1d3d49a7f4396a1d0863cf87c0dc40827aba71a544b1570da19ffc5685047187",
-                    "F": "sha256:03499b01319c48f1da525bb391d03a127710eb37889a40b6486dbcf87cf4bcaf"
+                    "A": "sha256:74f6bd1ba95e75e50a246c308ba2f1796426fc9c6eef94476365fb8f1ab4e874",
+                    "B": "sha256:c92d7103e9a0376860220e4174bb4a4c11a9fe574bcb46b54ec3135802f6f0fe",
+                    "C": "sha256:208e00a16833ac9caea78240efd7b8276fd97d2f4e3c2370dd105600c288f7c7",
+                    "D": "sha256:fbcf4cf262754e1e87e5c0a77a44c6ec3ba2dbbae1926f0a7d9d8bf83bb516f4",
+                    "E": "sha256:d23ef663be07e9cd8fbcb268350bcb24f5cb5f25f7c355da405b88f09b40f40d",
+                    "F": "sha256:ff11c62f50955cf469e1b8441a75291865dca2da10f31a42386c304f17ea8db3"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7311,
-                "template_key": "matrix_2x2",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8311,
+                "rule": "The operation cycle alternates union, subtraction, then intersection; the missing state is the next intersection.",
+                "rule_key": "overlay_union_subtraction_intersection_cycle_v1",
+                "difficulty": 4,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "overlay_union_subtraction_intersection_cycle_v1",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:456acce7974150fc178f359ee4cc9d53ea5a9b10db78d47c9bb593575137541a"
+                "params_hash": "sha256:2067e87cb273fa87a3ad4dacbd3810ad5f8d5d9acca660042b3cfa13c378bda6"
             }
         },
         {
@@ -1190,16 +1267,16 @@
             "item_id": "IQ_BETA_30_ORIGINAL_12",
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
-            "difficulty_level": 2,
-            "item_family": "matrix_2x2",
+            "difficulty_level": 5,
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q12</text><rect x=\"52\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"64\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"65\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"102\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"103\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"134\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 2x2 reasoning prompt 12."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.72\">wave-1 matrix_3x3</text><text x=\"204\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" text-anchor=\"start\" fill=\"#243126\" opacity=\"0.54\">Q12</text><text x=\"120\" y=\"42\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"11\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.76\">Satisfy rotation, point shift, and fill inversion.</text><rect x=\"46\" y=\"62\" width=\"38\" height=\"38\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"62\" y=\"78\" width=\"6\" height=\"6\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"66\" cy=\"82\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(65 81) rotate(0)\"><path d=\"M 0 -6 L 6 0 L 0 6 L -6 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g><rect x=\"92\" y=\"62\" width=\"38\" height=\"38\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"108\" y=\"78\" width=\"6\" height=\"6\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"110\" cy=\"82\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(111 81) rotate(90)\"><path d=\"M 0 -6 L 6 0 L 0 6 L -6 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g><rect x=\"138\" y=\"62\" width=\"38\" height=\"38\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><text x=\"157\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"22\" text-anchor=\"middle\" fill=\"#243126\" opacity=\"0.7\">?</text></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 12."
                 },
                 "options": [
                     {
@@ -1208,7 +1285,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"65\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"66\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"103\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"135\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"136\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"58\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(120 76) rotate(90)\"><path d=\"M 0 -12 L 12 0 L 0 12 L -12 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g></svg>",
                             "accessibility_label": "Option A for original IQ item 12."
                         }
                     },
@@ -1218,7 +1295,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"67\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"99\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"100\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M 0 -12 L 12 0 L 0 12 L -12 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g></svg>",
                             "accessibility_label": "Option B for original IQ item 12."
                         }
                     },
@@ -1228,7 +1305,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"64\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"101\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"102\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"139\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"134\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"58\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M 0 -12 L 12 0 L 0 12 L -12 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g></svg>",
                             "accessibility_label": "Option C for original IQ item 12."
                         }
                     },
@@ -1238,7 +1315,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"66\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"67\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"#a7b35a\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(120 76) rotate(270)\"><path d=\"M 0 -12 L 12 0 L 0 12 L -12 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g></svg>",
                             "accessibility_label": "Option D for original IQ item 12."
                         }
                     },
@@ -1248,7 +1325,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"100\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"101\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"138\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"102\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M 0 -12 L 12 12 L -12 12 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g></svg>",
                             "accessibility_label": "Option E for original IQ item 12."
                         }
                     },
@@ -1258,35 +1335,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"139\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"134\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"82\" y=\"38\" width=\"76\" height=\"76\" rx=\"8\" fill=\"#ffffff\" stroke=\"#243126\" stroke-width=\"1.6\" opacity=\"0.92\"/><rect x=\"98\" y=\"54\" width=\"44\" height=\"44\" rx=\"6\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"2.2\" opacity=\"0.8\"/><circle cx=\"138\" cy=\"94\" r=\"6\" fill=\"#7b4f8a\" opacity=\"0.9\"/><g transform=\"translate(120 76) rotate(180)\"><path d=\"M 0 -12 L 12 0 L 0 12 L -12 0 Z\" fill=\"#4666a9\" stroke=\"#243126\" stroke-width=\"2\" stroke-linejoin=\"round\" opacity=\"0.62\"/></g></svg>",
                             "accessibility_label": "Option F for original IQ item 12."
                         }
                     }
                 ]
             },
             "correct_answer": "F",
-            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7312; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "The missing panel must satisfy shape rotation, point shift, and fill inversion together.",
+            "distractor_logic": "Distractors satisfy one or two attributes while violating the combined rule.",
             "asset_hashes": {
-                "stem": "sha256:b9587716ff0bd3bd55ab8e947d9a2b1f752737270c5511734d0cc517fedf46c5",
+                "stem": "sha256:667ae188b6bfd1c70e555d44a7776be02a7bcdb1070e28c7c15646c557c6cca3",
                 "options": {
-                    "A": "sha256:ae52dacd002044ae8fd953cffa645c4d4f9681ad54293e094a4eb2b6ef87e70b",
-                    "B": "sha256:3fc5f9fdb79b5f81bf1961f8d17143f608ef11df4d0f04f0c1aa89d02d9e1af6",
-                    "C": "sha256:a79ade4fde38ceda5eb791c92fc03db2497afe685e5bdbbb90e42d5543b44fbc",
-                    "D": "sha256:af10406e85e66b9843d15fd0aabb2efa11b9e2f674e993c68fabeba307eb5473",
-                    "E": "sha256:16de2e5b081df6094e3092a23ad5cca514b64e24449eb9efc4b31fa0a62c011d",
-                    "F": "sha256:95eb0c779168cdfe11ee1e42b37c9440bcf265f664f8aa412e6bdaa2c9e2491b"
+                    "A": "sha256:ae88593c18a95078083cd0373dba52106e23fdc34bb28482cca33d47cbb3108b",
+                    "B": "sha256:c41f9d6fdff7fd34dacabd3e651ecb07b8d9873d145f6ab62002903a7080c7fd",
+                    "C": "sha256:01970a2a60fb4c119ca40cb9e25ee071daa6e4a8c1ee287a1bc90528054c70e8",
+                    "D": "sha256:bf13c56b3c72912c6566da6f29e36e28c28715a8bdb7827f518f6750ee14275b",
+                    "E": "sha256:b33fa1710afe2089b6d5546c5667c858a8518bc35451c3819a8c7195e5a505ae",
+                    "F": "sha256:4f9f8f923dc213c28ea6e8c63f73e6ccf609089ac9b765058f12e544f7a82680"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7312,
-                "template_key": "matrix_2x2",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8312,
+                "rule": "The missing panel must satisfy shape rotation, point shift, and fill inversion together.",
+                "rule_key": "matrix_3x3_three_attribute_composition_v1",
+                "difficulty": 5,
+                "reviewer": "codex_wave1_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "wave_1_formal_original",
+                "template_key": "matrix_3x3_three_attribute_composition_v1",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:ce9b4be40587ccd960fea303b930631f39708ec1a3f7ebdb56802d22e926ef0e"
+                "params_hash": "sha256:e6fde71b188dc51d240f62d311105fd565315891ea6b500dac6d56144df46a17"
             }
         },
         {
@@ -1298,15 +1382,15 @@
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 3,
-            "item_family": "matrix_2x2",
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q13</text><rect x=\"58\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"100\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"101\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 2x2 reasoning prompt 13."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q13</text><rect x=\"58\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"150\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"58\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"97\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 13."
                 },
                 "options": [
                     {
@@ -1315,7 +1399,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"67\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"100\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"137\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"96\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 13."
                         }
                     },
@@ -1325,7 +1409,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"66\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"67\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"98\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 13."
                         }
                     },
@@ -1335,7 +1419,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"139\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 13."
                         }
                     },
@@ -1345,7 +1429,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"65\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"66\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"103\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 13."
                         }
                     },
@@ -1355,7 +1439,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"67\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"100\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"137\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 13."
                         }
                     },
@@ -1365,35 +1449,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"64\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"101\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 13."
                         }
                     }
                 ]
             },
             "correct_answer": "A",
-            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7313; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8313; choose the option preserving the declared matrix 3x3 progression scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:688a4d6f78c9962eca09553876dc9a913d970ac5628233bdd74f04912ff32294",
+                "stem": "sha256:f4f416dbdcc15938a607d74d4d7bf656d16d2c55cfb9c49fc1f202fa9c16ca73",
                 "options": {
-                    "A": "sha256:692495581a9e5ca97d127adb57c396bdf2bcfb29bf65be07584a91975e30245e",
-                    "B": "sha256:290c272d368b4a9144a8f27560b4ab296c9601c838658bf87949aafceaa47f4c",
-                    "C": "sha256:1b95e3e5780e552a94b16a4f05c9a94b152caff011c8402637a19c476df5ee72",
-                    "D": "sha256:3b77d9e3705c95c666b24472efbeb46ae2ec5c897992030b1f95758a7e60ef78",
-                    "E": "sha256:0778d11f8337f57d1614e483fb7d87ce5894b727e29760ec1997c5f12c5adb07",
-                    "F": "sha256:f30aebcca26205278dcc0981e5da5e30be3a7c3cb83b384075a40ebae6cc2ff8"
+                    "A": "sha256:8d87f42a23d09c3f9337fcd9239f435a4970af3ceb9846597ca479da5f615d02",
+                    "B": "sha256:fc7d6e9006232b7373c065502a3d93854e97cf92307552dc75d3a1a19ebdb5e0",
+                    "C": "sha256:71f2f1eaae18940d9a8b994e9c3af23180ce0a20ed24d6e76e12fe14ae1f803c",
+                    "D": "sha256:9a43612dd2dcc4031d3b48ae79359173de642940a24d53ac50ddc3bad62f4856",
+                    "E": "sha256:7e457ef609927364b01dcbbffef64c887a3a0214f7cebe46e4e4ac9ced9a1566",
+                    "F": "sha256:b5c8045cba1e2d5a58821c463165100af29936ea8a32249748671a30dbe2a08e"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7313,
-                "template_key": "matrix_2x2",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8313,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8313; choose the option preserving the declared matrix 3x3 progression scaffold v1 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v1",
+                "difficulty": 3,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v1",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:829eb078a5a6a75f19a3f54f8dd6533b2708450f8fe716dd578d2186e6ed6302"
+                "params_hash": "sha256:1d0fed28966efff7b337c206a85b2f3c1cdf5e0e4bb76c999c3f93e39b36aa07"
             }
         },
         {
@@ -1405,15 +1496,15 @@
             "dimension": "VSPR",
             "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 3,
-            "item_family": "matrix_2x2",
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q14</text><rect x=\"56\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"66\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"67\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"56\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"136\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
-                    "accessibility_label": "Original matrix 2x2 reasoning prompt 14."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q14</text><rect x=\"56\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"95\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"96\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 14."
                 },
                 "options": [
                     {
@@ -1422,7 +1513,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 14."
                         }
                     },
@@ -1432,7 +1523,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"65\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"66\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"103\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"135\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"136\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"94\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"95\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"96\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 14."
                         }
                     },
@@ -1442,7 +1533,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"100\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 14."
                         }
                     },
@@ -1452,7 +1543,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"64\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"65\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"102\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"103\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"134\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 14."
                         }
                     },
@@ -1462,7 +1553,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"66\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"67\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"98\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 14."
                         }
                     },
@@ -1472,35 +1563,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"62\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"63\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"100\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"101\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"138\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 14."
                         }
                     }
                 ]
             },
             "correct_answer": "B",
-            "solution_rule": "Original deterministic matrix 2x2 transformation generated from seed 7314; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8314; choose the option preserving the declared matrix 3x3 progression scaffold v2 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:69ed416fc392ac6bed8fbccd380b8332c2b224db54e69102a45e1d1f85c7b2d3",
+                "stem": "sha256:eec26d211a0368115c1cdda22b5fafbe3d49c4616908a7aecd974aa4f40d699a",
                 "options": {
-                    "A": "sha256:d33252a66df1cac1caec11b3a86dd0bd1c65c867d2b4b4ad2e4273ec1dda23ca",
-                    "B": "sha256:6b5eadf4313f88cec70d7d5987f9acddfe9de8f37a2618db3f720cb6a92b9162",
-                    "C": "sha256:2c1f0546ddb27c317d1f3b8678e468917226d6a02910abdc3674ea97eae2d40e",
-                    "D": "sha256:bb1c7332eb0c56f24f424308c28cc3510858d418eafade390b354ab5d91381a2",
-                    "E": "sha256:ae685a14ef0b28ef301beda952f04bb8590bc1e03ec6630848e06791c0f8cb0d",
-                    "F": "sha256:4d081a04aec1e41179c49b2c9a7d9d5dc53d3902005e3e55597ed2612a8640e6"
+                    "A": "sha256:4f8d19970e5ea1e86ee71e92ca7cea8217ac443b6682a4a87ff4dafb9dfd1370",
+                    "B": "sha256:ce55dc79b9c22c97ce3ddeafd59d93fb64b7ff272b00caf672ba10e3dcb95466",
+                    "C": "sha256:5b03fa4f0a96bf41d8909885fabbcf940f68deca984a95bc621285cb1c78c418",
+                    "D": "sha256:689239e2ebe53fa5379d453d327e6288076f7252ed38bd6ac08fc4e57dad51da",
+                    "E": "sha256:409b72d8d253ad6b384cbbfb87a5ade026eeea82452989ccd6d65d7e6d1d0b5d",
+                    "F": "sha256:2a8328e4949155dbce7e866d74ca31ed8baa84f42d42f14fc617e02d40056c81"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7314,
-                "template_key": "matrix_2x2",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8314,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8314; choose the option preserving the declared matrix 3x3 progression scaffold v2 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v2",
+                "difficulty": 3,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v2",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:caebbc7666134c9ab551d5367e7f5c5b4fc392a6c2e51e4655f2af5d0e61a495"
+                "params_hash": "sha256:68df1d5d9321f689328032b3e675fbfb9f05cfe1f10fd9b08cce98739d907fb0"
             }
         },
         {
@@ -1509,18 +1607,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q15",
             "item_id": "IQ_BETA_30_ORIGINAL_15",
-            "dimension": "VSI",
-            "dimension_name": "Visual-spatial imagery",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 3,
-            "item_family": "series",
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q15</text><circle cx=\"60\" cy=\"105\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 39 126 Q 60 84 81 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"99\" cy=\"52\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 77 74 Q 99 30 121 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"138\" cy=\"75\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 115 98 Q 138 52 161 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"177\" cy=\"98\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 153 122 Q 177 74 201 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"51\" cy=\"121\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 26 146 Q 51 96 76 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"90\" cy=\"68\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 64 94 Q 90 42 116 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original series reasoning prompt 15."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q15</text><rect x=\"54\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"60\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"61\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"146\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"62\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"99\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"94\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"95\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 15."
                 },
                 "options": [
                     {
@@ -1529,7 +1627,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"148\" cy=\"116\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 120 144 Q 148 88 176 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"187\" cy=\"63\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 158 92 Q 187 34 216 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"61\" cy=\"86\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 47 100 Q 61 72 75 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"100\" cy=\"109\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 85 124 Q 100 94 115 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"56\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 123 72 Q 139 40 155 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"98\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"99\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 15."
                         }
                     },
@@ -1539,7 +1637,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"170\" cy=\"74\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 156 88 Q 170 60 184 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"97\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 29 112 Q 44 82 59 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"120\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 67 136 Q 83 104 99 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"61\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"63\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 15."
                         }
                     },
@@ -1549,7 +1647,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"82\" cy=\"90\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 60 112 Q 82 68 104 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"113\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 98 136 Q 121 90 144 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"160\" cy=\"60\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 136 84 Q 160 36 184 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 15."
                         }
                     },
@@ -1559,7 +1657,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"49\" cy=\"66\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 31 84 Q 49 48 67 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"88\" cy=\"89\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 69 108 Q 88 70 107 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"112\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 107 132 Q 127 92 147 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 15."
                         }
                     },
@@ -1569,7 +1667,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"71\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 120 Q 71 80 91 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"47\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 89 68 Q 110 26 131 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"70\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 127 92 Q 149 48 171 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"93\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 165 116 Q 188 70 211 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"116\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 38 140 Q 62 92 86 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"94\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"95\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 15."
                         }
                     },
@@ -1579,35 +1677,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"38\" cy=\"49\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 21 66 Q 38 32 55 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"77\" cy=\"72\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 59 90 Q 77 54 95 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"116\" cy=\"95\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 97 114 Q 116 76 135 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"118\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 135 138 Q 155 98 175 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"194\" cy=\"65\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 173 86 Q 194 44 215 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"68\" cy=\"88\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 46 110 Q 68 66 90 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"58\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"97\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"98\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 15."
                         }
                     }
                 ]
             },
             "correct_answer": "C",
-            "solution_rule": "Original deterministic series transformation generated from seed 7315; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8315; choose the option preserving the declared matrix 3x3 progression scaffold v3 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:8ed3a6a60f4080b4fb573d0e9fc5f89e6b696e774fab03b1b7d74201c24b2ae5",
+                "stem": "sha256:cf5dc6def041001c7ccc105fc2a025a65d85b8f697d55fcf5c0a02f1463fbbfe",
                 "options": {
-                    "A": "sha256:fb641706cf5c3a03d779ca8f3d2cb254ba19b6430b7e9a9266eda5ea90a6dd5c",
-                    "B": "sha256:f18e50002d0a95dd97f428a3ac9dd3ad782d442b050995a1ea244e27c0e329b1",
-                    "C": "sha256:2f641fb0a6d9337fbf5ac0b635175d3ec26ea415b8bec169a0d54f6a075cdd21",
-                    "D": "sha256:10e899387762c89745230e22911a6a9a8edd7f188f457c3df6f9471fb8f9c549",
-                    "E": "sha256:c083ff1b73924d11c0d013d528360c0381bcc6259ee43301b562096368eaf467",
-                    "F": "sha256:f6f83532d6e1d68bf9af6d644db0a817caf344c4893a836502111f6e926816d7"
+                    "A": "sha256:540bc895821de7231566add2c11c33b9fbe60ef3280b351ea35ed73e63137ac2",
+                    "B": "sha256:3e849c89e1cb7cb7830db0e21f4f9ae75734bd3bb405321e4044e777f9bab744",
+                    "C": "sha256:a711d3bef3b4e889724544e6ad4d97b2b3210bd8b619026a11c56bfe63349409",
+                    "D": "sha256:d8d68441a801cdd500457588667446bc84fd3cf3e86209f9e29d8dcbf7c2b9bd",
+                    "E": "sha256:0b31890853799accb5fc1821010842f5dbdc64729c748bbf75cd6a70c73588bf",
+                    "F": "sha256:2a559b4a5f9e0dfb6cb582c2d3d833b2ffd86d0bd4a297266b54766c3f45cb72"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7315,
-                "template_key": "series",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8315,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8315; choose the option preserving the declared matrix 3x3 progression scaffold v3 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v3",
+                "difficulty": 3,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v3",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:d3bc1b647ef1404c6a37c33475f228bfcaaaff2d1a6acc5af54e79254f30122b"
+                "params_hash": "sha256:7d5adb4d6b5f53be95847b52865b1fbbc6b57aad50f2e02ac48491300f086136"
             }
         },
         {
@@ -1616,18 +1721,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q16",
             "item_id": "IQ_BETA_30_ORIGINAL_16",
-            "dimension": "VSI",
-            "dimension_name": "Visual-spatial imagery",
-            "difficulty_level": 3,
-            "item_family": "series",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 4,
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q16</text><circle cx=\"111\" cy=\"102\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 85 128 Q 111 76 137 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"49\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 123 76 Q 150 22 177 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"72\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 161 100 Q 189 44 217 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original series reasoning prompt 16."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q16</text><rect x=\"52\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"58\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"59\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 16."
                 },
                 "options": [
                     {
@@ -1636,7 +1741,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"45\" cy=\"54\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 27 72 Q 45 36 63 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"77\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 65 96 Q 84 58 103 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"123\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 103 120 Q 123 80 143 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 16."
                         }
                     },
@@ -1646,7 +1751,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"67\" cy=\"88\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 47 108 Q 67 68 87 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"106\" cy=\"111\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 85 132 Q 106 90 127 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"58\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 123 80 Q 145 36 167 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"81\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 161 104 Q 184 58 207 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"104\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 34 128 Q 58 80 82 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 16."
                         }
                     },
@@ -1656,7 +1761,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"89\" cy=\"46\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 67 68 Q 89 24 111 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"128\" cy=\"69\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 105 92 Q 128 46 151 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"92\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 143 116 Q 167 68 191 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 16."
                         }
                     },
@@ -1666,7 +1771,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"133\" cy=\"87\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 106 114 Q 133 60 160 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"110\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 144 138 Q 172 82 200 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"57\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 17 86 Q 46 28 75 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"85\" cy=\"80\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 71 94 Q 85 66 99 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 16."
                         }
                     },
@@ -1676,7 +1781,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"78\" cy=\"105\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 57 126 Q 78 84 99 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"117\" cy=\"52\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 95 74 Q 117 30 139 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"156\" cy=\"75\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 133 98 Q 156 52 179 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"195\" cy=\"98\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 171 122 Q 195 74 219 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"69\" cy=\"121\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 44 146 Q 69 96 94 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"108\" cy=\"68\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 82 94 Q 108 42 134 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"150\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"95\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 16."
                         }
                     },
@@ -1686,35 +1791,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"100\" cy=\"63\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 77 86 Q 100 40 123 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"86\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 115 110 Q 139 62 163 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"178\" cy=\"109\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 153 134 Q 178 84 203 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"52\" cy=\"56\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 26 82 Q 52 30 78 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"145\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 16."
                         }
                     }
                 ]
             },
             "correct_answer": "D",
-            "solution_rule": "Original deterministic series transformation generated from seed 7316; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8316; choose the option preserving the declared matrix 3x3 progression scaffold v4 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:ff292e0449e923efbbeb4da183716f7fad6117edad3cb175e568d240854a75ec",
+                "stem": "sha256:690d12d4f38ac1f05d2142e3cf8be79a0b5c0366a17c680c4e9313911c152fd0",
                 "options": {
-                    "A": "sha256:2d27e74ffbf5d93dd6e7256171d837fb81e0a5145757f985916d81ce00e19f26",
-                    "B": "sha256:05cc449cda375a5a75562ea69984dd26dc318a06e5cd60387e5a5d67387b46c4",
-                    "C": "sha256:89fe574688fd411a090f83ea3d03a8473095bfa3da58c8755dd841c3d67115fe",
-                    "D": "sha256:b02bc241b34cd4470ab31a5cbf0e15fcc599934793b7c3a0efde133489ba9d74",
-                    "E": "sha256:2d2eb334d2f054abc1b7233ef1a0ae3a51c28d7b306b6d66b3d1c3b2d35b177c",
-                    "F": "sha256:054777e8a5bc3785df9110506d204020be0613caab9e8cdf970452b13ecc5c2d"
+                    "A": "sha256:5ff5e90c4f1e0955ab150eddd16e1a247a24c7627661eb9c88ede0f7718f15ba",
+                    "B": "sha256:1b1772818433fb55a632d073d63aac61e52ff2a955f1f4f0feb4b231568f0839",
+                    "C": "sha256:29575e30102e1876da281c365590e1827531651bd3a0d63387d0eedae13f8cff",
+                    "D": "sha256:5a0678fd13fc1b965a05f4a2d698afda70dc9ed266edf2206f78c9df0100a2c3",
+                    "E": "sha256:85ae7530f69f3fe91e031f8160f6361be0d3508c3eb9a8f6605ca7cfb93ba644",
+                    "F": "sha256:69b91d8ed2ced1357adea5ed85d8117b9d0a7fa322f65b32a0f70cfad6c15ca0"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7316,
-                "template_key": "series",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8316,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8316; choose the option preserving the declared matrix 3x3 progression scaffold v4 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v4",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v4",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:fb94c678bb6ec720c67847c073503b3759cc5ff60e4f62ff513e893be0756c0e"
+                "params_hash": "sha256:aca667731a6ea87771099c7221f74bbba02dc957d9c88a3216886f0b7c337ace"
             }
         },
         {
@@ -1723,18 +1835,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q17",
             "item_id": "IQ_BETA_30_ORIGINAL_17",
-            "dimension": "VSI",
-            "dimension_name": "Visual-spatial imagery",
-            "difficulty_level": 3,
-            "item_family": "series",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 4,
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q17</text><circle cx=\"184\" cy=\"106\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 166 124 Q 184 88 202 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"53\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 39 72 Q 58 34 77 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"97\" cy=\"76\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 77 96 Q 97 56 117 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original series reasoning prompt 17."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q17</text><rect x=\"58\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"61\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 17."
                 },
                 "options": [
                     {
@@ -1743,7 +1855,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"129\" cy=\"75\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 102 102 Q 129 48 156 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"168\" cy=\"98\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 140 126 Q 168 70 196 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"42\" cy=\"121\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 13 150 Q 42 92 71 150\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"81\" cy=\"68\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 67 82 Q 81 54 95 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"95\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 17."
                         }
                     },
@@ -1753,7 +1865,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"151\" cy=\"109\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 122 138 Q 151 80 180 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"190\" cy=\"56\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 176 70 Q 190 42 204 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"64\" cy=\"79\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 49 94 Q 64 64 79 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"103\" cy=\"102\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 87 118 Q 103 86 119 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"142\" cy=\"49\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 125 66 Q 142 32 159 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"181\" cy=\"72\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 163 90 Q 181 54 199 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"99\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 17."
                         }
                     },
@@ -1763,7 +1875,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"173\" cy=\"67\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 158 82 Q 173 52 188 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"90\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 31 106 Q 47 74 63 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"113\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 69 130 Q 86 96 103 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 107 78 Q 125 42 143 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 17."
                         }
                     },
@@ -1773,7 +1885,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"140\" cy=\"92\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 112 120 Q 140 64 168 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"179\" cy=\"115\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 150 144 Q 179 86 208 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 39 76 Q 53 48 67 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"85\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 77 100 Q 92 70 107 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"108\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 115 124 Q 131 92 147 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"58\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"59\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"96\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"97\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 17."
                         }
                     },
@@ -1783,7 +1895,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"41\" cy=\"91\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 22 110 Q 41 72 60 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"114\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 60 134 Q 80 94 100 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 98 82 Q 119 40 140 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"158\" cy=\"84\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 136 106 Q 158 62 180 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"60\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"61\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"62\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"99\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 17."
                         }
                     },
@@ -1793,35 +1905,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"184\" cy=\"84\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 168 100 Q 184 68 200 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"107\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 41 124 Q 58 90 75 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"97\" cy=\"54\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 79 72 Q 97 36 115 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"136\" cy=\"77\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 117 96 Q 136 58 155 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"175\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 155 120 Q 175 80 195 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"94\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"95\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 17."
                         }
                     }
                 ]
             },
             "correct_answer": "E",
-            "solution_rule": "Original deterministic series transformation generated from seed 7317; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8317; choose the option preserving the declared matrix 3x3 progression scaffold v5 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:c52a9680f883c217eb0151ef9a6d66578e8f65a0752677c4458d60c4dfa35c32",
+                "stem": "sha256:0cd05e44d0be1ca59af087771a01f0313d88e61114a1fa768382b1544ca9c2ae",
                 "options": {
-                    "A": "sha256:d2fad7c81f69570707bbeaa6c5f98112bdbda1522d8386285719493e62339da2",
-                    "B": "sha256:72f79f9bb6f56f148447030358624245ba59bbeea2305ce8c59eba623b577d20",
-                    "C": "sha256:67e30c6733f68054fc9b4c7f2d710d872e138df47525d0eda5766f4034fe3040",
-                    "D": "sha256:c7e06bd4494a8116574e511b0a7d01f6802f6cb5c920f914ca8fded3a273f521",
-                    "E": "sha256:dfc2acb210b2f6a3e6b20dd62fa30c661a86fd9e1007cb6b8693980eb973b200",
-                    "F": "sha256:979152c0bc86cc78c16d3968f0f2239b3e4fd51a94300d02a4aa68a69f760238"
+                    "A": "sha256:77e963bb90808ceec5c142443d32cab13689c09ba7cfba0b5e6da81aba3ae9a7",
+                    "B": "sha256:2ceaf28e15ff958cff35f0c039bb4bea422b4727e1eed414359696712a5ee991",
+                    "C": "sha256:226108b0446c6bf6aa1da9e181a0fdd23341f7cdb60878cf580b6321aefb42b2",
+                    "D": "sha256:68a053972280afd155585e7b862e6473749509ce50eee0a234853c127e427101",
+                    "E": "sha256:9759cea94d13f109cdf2399d012fc5f0d1e45f5a314aa30c8b996a83be25eff6",
+                    "F": "sha256:935cd2ab41fc972df5f595f12b36bb2a8c31abca71057c1e26d7520053c12e91"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7317,
-                "template_key": "series",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8317,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8317; choose the option preserving the declared matrix 3x3 progression scaffold v5 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v5",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v5",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:d3eaf38099c13b29e89dd29bc4cb1fa5d2cec7e8a03a8eb21b877d38dc190996"
+                "params_hash": "sha256:a4dd81be591bd0a22649191caf06b2f8fc41ddbfab4b234e5ea1ddd566dc33cd"
             }
         },
         {
@@ -1830,18 +1949,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q18",
             "item_id": "IQ_BETA_30_ORIGINAL_18",
-            "dimension": "VSI",
-            "dimension_name": "Visual-spatial imagery",
-            "difficulty_level": 3,
-            "item_family": "series",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 4,
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q18</text><circle cx=\"70\" cy=\"103\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 47 126 Q 70 80 93 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"109\" cy=\"50\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 85 74 Q 109 26 133 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"148\" cy=\"73\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 123 98 Q 148 48 173 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"187\" cy=\"96\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 161 122 Q 187 70 213 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original series reasoning prompt 18."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q18</text><rect x=\"56\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"59\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"60\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"148\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"61\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"98\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 18."
                 },
                 "options": [
                     {
@@ -1850,7 +1969,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"191\" cy=\"89\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 174 106 Q 191 72 208 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"112\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 47 130 Q 65 94 83 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"59\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 85 78 Q 104 40 123 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"82\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 123 102 Q 143 62 163 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"105\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 161 126 Q 182 84 203 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"56\" cy=\"52\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 34 74 Q 56 30 78 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"61\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"63\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"94\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"95\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"96\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 18."
                         }
                     },
@@ -1860,7 +1979,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"48\" cy=\"47\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 29 66 Q 48 28 67 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"70\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 67 90 Q 87 50 107 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"93\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 105 114 Q 126 72 147 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"116\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 143 138 Q 165 94 187 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"63\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"148\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"59\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"96\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 18."
                         }
                     },
@@ -1870,7 +1989,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"180\" cy=\"72\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 164 88 Q 180 56 196 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"54\" cy=\"95\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 37 112 Q 54 78 71 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"93\" cy=\"118\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 75 136 Q 93 100 111 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"132\" cy=\"65\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 113 84 Q 132 46 151 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"171\" cy=\"88\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 151 108 Q 171 68 191 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"99\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"94\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 18."
                         }
                     },
@@ -1880,7 +1999,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"37\" cy=\"106\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 19 124 Q 37 88 55 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"76\" cy=\"53\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 57 72 Q 76 34 95 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"115\" cy=\"76\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 95 96 Q 115 56 135 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 18."
                         }
                     },
@@ -1890,7 +2009,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"59\" cy=\"64\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 39 84 Q 59 44 79 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"98\" cy=\"87\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 77 108 Q 98 66 119 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"137\" cy=\"110\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 115 132 Q 137 88 159 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"176\" cy=\"57\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 153 80 Q 176 34 199 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"50\" cy=\"80\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 26 104 Q 50 56 74 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 18."
                         }
                     },
@@ -1900,35 +2019,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"88\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 68 112 Q 92 64 116 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"111\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 106 136 Q 131 86 156 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"58\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 144 84 Q 170 32 196 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"81\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 17 108 Q 44 54 71 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"104\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 55 132 Q 83 76 111 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"59\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"97\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"98\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 18."
                         }
                     }
                 ]
             },
             "correct_answer": "F",
-            "solution_rule": "Original deterministic series transformation generated from seed 7318; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8318; choose the option preserving the declared matrix 3x3 progression scaffold v6 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:485c2f77d4effb9a0f207aee85ef442fc868b4053dfa60050335bf0c7868fb95",
+                "stem": "sha256:3db6b7f0b9a624dbca5fa75ff92af5c443e46ce0f83d06e1310ce8f3ab474d5e",
                 "options": {
-                    "A": "sha256:25c3dddbdde06c19841ac6d16a8eab5ebd48ffd11b4803633803010371476563",
-                    "B": "sha256:7ee4a10ebcf55c3e51fb33e3fe91c362e01226f2f60952ef0f2f55a6e3c25fec",
-                    "C": "sha256:b832914423917ef2fca3f9f25540f3f0ee320fb0c4b5229d979b3b0c9bcab1c0",
-                    "D": "sha256:f73fa8b1c812321b879e878a6e58f15447a5cf2f335120424d8fffefb9941ec6",
-                    "E": "sha256:40635cafe7ef90506e10c918ab2f3b9612836eb876a43a4d1b8c4ea32c7f60d9",
-                    "F": "sha256:9c985d494550a1ba8c257bae099e00e68a9c302b7fbc0e5108ae390220749f21"
+                    "A": "sha256:3e897d85175468f5bc7425854ff4f2f6e41a44f1f59350d82ae4c551b27018df",
+                    "B": "sha256:540ff666d4619adaca0b3ce688c0ea33998194c2cc84adeab869266b0a8d1c89",
+                    "C": "sha256:324ad62b81feb4ef017090b06af4aeb1b76bffd1d473e1cbd33ca1b66abda261",
+                    "D": "sha256:e8dad3334bee469d628a4f020d755136943a3eec27d90487c2163b013b9d2864",
+                    "E": "sha256:6c5caae44b6e731adc0e465a97773e5eb83924a04c95d4e17a000134701f585b",
+                    "F": "sha256:c4daf258fad188259dac755da015231b9e33a25a976ed5ce037e1907ec20d9ae"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7318,
-                "template_key": "series",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8318,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8318; choose the option preserving the declared matrix 3x3 progression scaffold v6 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v6",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v6",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:0b6a5eaf87d52b17cae445cfba64fa8bb361d43b2432ea1d9783c8ab675b82d6"
+                "params_hash": "sha256:cb726596776e811a85a84a93614637e8b5f307384d329a0bb91ca9ae6a66be53"
             }
         },
         {
@@ -1937,18 +2063,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q19",
             "item_id": "IQ_BETA_30_ORIGINAL_19",
-            "dimension": "VSI",
-            "dimension_name": "Visual-spatial imagery",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 4,
-            "item_family": "odd_one_out",
+            "item_family": "matrix_3x3",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q19</text><circle cx=\"55\" cy=\"74\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 33 96 Q 55 52 77 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"94\" cy=\"97\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 71 120 Q 94 74 117 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"120\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 109 144 Q 133 96 157 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original odd one out reasoning prompt 19."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q19</text><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 3x3 reasoning prompt 19."
                 },
                 "options": [
                     {
@@ -1957,7 +2083,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"77\" cy=\"59\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 54 82 Q 77 36 100 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"116\" cy=\"82\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 92 106 Q 116 58 140 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"105\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 130 130 Q 155 80 180 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"194\" cy=\"52\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 168 78 Q 194 26 220 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 19."
                         }
                     },
@@ -1967,7 +2093,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"154\" cy=\"102\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 140 116 Q 154 88 168 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"193\" cy=\"49\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 178 64 Q 193 34 208 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"67\" cy=\"72\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 51 88 Q 67 56 83 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"58\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"59\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 19."
                         }
                     },
@@ -1977,7 +2103,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"176\" cy=\"60\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 160 76 Q 176 44 192 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"50\" cy=\"83\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 33 100 Q 50 66 67 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"89\" cy=\"106\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 71 124 Q 89 88 107 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"128\" cy=\"53\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 109 72 Q 128 34 147 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"76\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 147 96 Q 167 56 187 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"98\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"99\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 19."
                         }
                     },
@@ -1987,7 +2113,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"33\" cy=\"94\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 15 112 Q 33 76 51 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"72\" cy=\"117\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 53 136 Q 72 98 91 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"64\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 91 84 Q 111 44 131 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"61\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"62\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 19."
                         }
                     },
@@ -1997,7 +2123,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"55\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 35 72 Q 55 32 75 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"94\" cy=\"75\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 73 96 Q 94 54 115 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 111 120 Q 133 76 155 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"121\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 149 144 Q 172 98 195 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"68\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 22 92 Q 46 44 70 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"96\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 19."
                         }
                     },
@@ -2007,35 +2133,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"77\" cy=\"86\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 55 108 Q 77 64 99 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"116\" cy=\"109\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 93 132 Q 116 86 139 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"56\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 131 80 Q 155 32 179 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 19."
                         }
                     }
                 ]
             },
             "correct_answer": "A",
-            "solution_rule": "Original deterministic odd one out transformation generated from seed 7319; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 3x3 grammar generated from seed 8319; choose the option preserving the declared matrix 3x3 progression scaffold v7 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:0168cec602d900606336c43c4641068eca98cfa10a30e86ed62e6316260029fa",
+                "stem": "sha256:f321a0adde4d182a5aec66a874587277dfa4f66040165be6ba25cf040694bb69",
                 "options": {
-                    "A": "sha256:c291ef4e607449c1442527eda27fbe91804e4f3c33a047bbdc366380e8fa4931",
-                    "B": "sha256:5f150340b198c811e68f26f33836f1395be135666c4c9734dde491d5adfdf0a3",
-                    "C": "sha256:bde23f4e0ab0fa1b66c099599291ba085e7e1c88021e4b108b62a1b8fc746e7a",
-                    "D": "sha256:2b4c152f167bf2383f8c965aac7230e03116b659adf3b2177c09a9bab8c48df1",
-                    "E": "sha256:d53dee82ecf24f60e722b84a50cc854077859058e494884b49245a768b011611",
-                    "F": "sha256:1790ba08d6d48db648d262854dbab1446f9260d73c0b8cffff7a01763bf97014"
+                    "A": "sha256:da5d896adc8cf9d68d0c8b4e8042371a5ffd947aea7421bafa106558378974c4",
+                    "B": "sha256:57d8efc796ee09b8739131b8a13b5782f26557e9c7c5ec5903138ec64d8915b3",
+                    "C": "sha256:945369cdbc576f81a8e107a7f159f473b12f94d3245eedb8d1aec6fe70eaecdf",
+                    "D": "sha256:862917b533491a4aea2991ba8a94735cb978e778a4a3400bb4b8c6b395d39f97",
+                    "E": "sha256:81db71680878a3f94091266361c4318e98946c33e388f2246186a6e2986c0040",
+                    "F": "sha256:3398cd8c89beb661c3d078a2b428d1d18dbfebcd962f280a9d98694dbaca3f5c"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7319,
-                "template_key": "odd_one_out",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8319,
+                "rule": "Abstract matrix 3x3 grammar generated from seed 8319; choose the option preserving the declared matrix 3x3 progression scaffold v7 transformation.",
+                "rule_key": "matrix_3x3_progression_scaffold_v7",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_3x3_progression_scaffold_v7",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:82662df3875a39bb709e2db5599e91eea037dba4956e8d969c6d8006cf04c115"
+                "params_hash": "sha256:d916d3ed53c9bbfb7fbe29ffbd3eb3110cf4874bb0f6927e07d37811bda8413d"
             }
         },
         {
@@ -2044,18 +2177,18 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q20",
             "item_id": "IQ_BETA_30_ORIGINAL_20",
-            "dimension": "VSI",
-            "dimension_name": "Visual-spatial imagery",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
             "difficulty_level": 4,
-            "item_family": "odd_one_out",
+            "item_family": "matrix_2x2",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q20</text><circle cx=\"106\" cy=\"71\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 79 98 Q 106 44 133 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"94\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 117 122 Q 145 66 173 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"117\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 155 146 Q 184 88 213 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"64\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 44 78 Q 58 50 72 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original odd one out reasoning prompt 20."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q20</text><rect x=\"53\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"65\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"66\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"103\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 20."
                 },
                 "options": [
                     {
@@ -2064,7 +2197,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"194\" cy=\"82\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 176 100 Q 194 64 212 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"68\" cy=\"105\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 49 124 Q 68 86 87 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"107\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 87 72 Q 107 32 127 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"64\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"65\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"102\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 20."
                         }
                     },
@@ -2074,7 +2207,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"128\" cy=\"56\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 100 84 Q 128 28 156 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"79\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 138 108 Q 167 50 196 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"41\" cy=\"102\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 27 116 Q 41 88 55 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"49\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 65 64 Q 80 34 95 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"72\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 103 88 Q 119 56 135 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"64\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"65\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"102\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"103\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"134\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 20."
                         }
                     },
@@ -2084,7 +2217,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"73\" cy=\"74\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 51 96 Q 73 52 95 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"112\" cy=\"97\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 89 120 Q 112 74 135 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"151\" cy=\"120\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 127 144 Q 151 96 175 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"100\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 20."
                         }
                     },
@@ -2094,7 +2227,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"95\" cy=\"108\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 71 132 Q 95 84 119 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"134\" cy=\"55\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 109 80 Q 134 30 159 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"78\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 147 104 Q 173 52 199 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"101\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 20 128 Q 47 74 74 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"48\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 58 76 Q 86 20 114 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"64\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"65\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"102\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"103\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"134\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 20."
                         }
                     },
@@ -2104,7 +2237,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"117\" cy=\"66\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 91 92 Q 117 40 143 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"156\" cy=\"89\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 129 116 Q 156 62 183 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"195\" cy=\"112\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 167 140 Q 195 84 223 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"66\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"67\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 20."
                         }
                     },
@@ -2114,35 +2247,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"84\" cy=\"91\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 61 114 Q 84 68 107 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"123\" cy=\"114\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 99 138 Q 123 90 147 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"162\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 137 86 Q 162 36 187 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"36\" cy=\"84\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 10 110 Q 36 58 62 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"64\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"101\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"102\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 20."
                         }
                     }
                 ]
             },
             "correct_answer": "B",
-            "solution_rule": "Original deterministic odd one out transformation generated from seed 7320; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 2x2 grammar generated from seed 8320; choose the option preserving the declared matrix 2x2 progression scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:e1853736f198f2a66e2077e7b3b3fc73113bf93f1b2b17dc5e42a46c6b0605d3",
+                "stem": "sha256:eb04eb20552b85df62da345b6f54de96fb7318349ad16a0b407409d5d11fe207",
                 "options": {
-                    "A": "sha256:88e3b04bb8099290bb103435f8aa9d22b6e31bcd624b6961041c32ffdd2b969c",
-                    "B": "sha256:20569201a6a84f97f33e6c40d8f4b14579a1703baca2eec021e7621d4841b24b",
-                    "C": "sha256:b8de5c47f450a6c57dad853a503cf19fafb1b466fdc22ff5752bb5b0a00ef526",
-                    "D": "sha256:7bd76a1f7b8e9b0354a43b1b7379ceab7639a62ff6d9b887b75a3f984e4df8cb",
-                    "E": "sha256:c5a1bb72e0c5d7c2eaa135660e4947c8da8e26192d17a1808b44be54d05a6d0a",
-                    "F": "sha256:4b7f75f330698c8bc3182399109215cd7ae264917866bce1c1acc273ea6db3b3"
+                    "A": "sha256:d6e3c6c2f4adb5e482e7b0b863355e4fb9f9d2015e7ed546c3c171b3c8489364",
+                    "B": "sha256:416c7975d40d561dd685c72aa684f7258a3947795cee55fbe0c8434e063ad5d0",
+                    "C": "sha256:f6421d82b1a4da48a2e920c3407f37937dea58b79547347cba914e8d52ddc668",
+                    "D": "sha256:ba08e49cbb4a9c61ddb485e1804432fedbabd6901b17e3a76361b4ba57312eb6",
+                    "E": "sha256:66a0d0550ea0773cdbe033846f4a20179669e3edb41c690891865284ee46a1f8",
+                    "F": "sha256:e3a388ed16f7da25491e576a852f63ffbc3775d1f57912ff8aedacb75055a5b8"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7320,
-                "template_key": "odd_one_out",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8320,
+                "rule": "Abstract matrix 2x2 grammar generated from seed 8320; choose the option preserving the declared matrix 2x2 progression scaffold v1 transformation.",
+                "rule_key": "matrix_2x2_progression_scaffold_v1",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_2x2_progression_scaffold_v1",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:542bee0accfa3c2b2b07e75f158fc7c0e8827d0f2f56e4ff7c8ece7708ae4699"
+                "params_hash": "sha256:ae895411ab065e279da45dc88bdec75d79077e9bc171f8cf72af73099cf3beec"
             }
         },
         {
@@ -2154,15 +2294,15 @@
             "dimension": "VSI",
             "dimension_name": "Visual-spatial imagery",
             "difficulty_level": 4,
-            "item_family": "odd_one_out",
+            "item_family": "matrix_2x2",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q21</text><circle cx=\"179\" cy=\"75\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 160 94 Q 179 56 198 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"98\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 33 118 Q 53 78 73 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"121\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 71 142 Q 92 100 113 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"68\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 109 90 Q 131 46 153 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original odd one out reasoning prompt 21."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q21</text><rect x=\"52\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"100\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"101\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 21."
                 },
                 "options": [
                     {
@@ -2171,7 +2311,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"113\" cy=\"103\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 86 130 Q 113 76 140 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"152\" cy=\"50\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 124 78 Q 152 22 180 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"191\" cy=\"73\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 162 102 Q 191 44 220 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 110 Q 65 82 79 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"100\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"101\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 21."
                         }
                     },
@@ -2181,7 +2321,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"135\" cy=\"61\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 106 90 Q 135 32 164 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"174\" cy=\"84\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 160 98 Q 174 70 188 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"48\" cy=\"107\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 33 122 Q 48 92 63 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"54\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 71 70 Q 87 38 103 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"77\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 109 94 Q 126 60 143 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"100\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 147 118 Q 165 82 183 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"64\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"65\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"57\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"102\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"103\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"134\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"135\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 21."
                         }
                     },
@@ -2191,7 +2331,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"36\" cy=\"60\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 16 80 Q 36 40 56 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"75\" cy=\"83\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 54 104 Q 75 62 96 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"114\" cy=\"106\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 92 128 Q 114 84 136 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"153\" cy=\"53\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 130 76 Q 153 30 176 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"192\" cy=\"76\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 168 100 Q 192 52 216 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"67\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"62\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"99\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"100\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"137\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 21."
                         }
                     },
@@ -2201,7 +2341,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"179\" cy=\"53\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 162 70 Q 179 36 196 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"76\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 35 94 Q 53 58 71 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"99\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 73 118 Q 92 80 111 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"46\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 111 66 Q 131 26 151 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"69\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 149 90 Q 170 48 191 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"92\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 22 114 Q 44 70 66 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"100\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"101\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"54\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"138\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"139\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 21."
                         }
                     },
@@ -2211,7 +2351,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"146\" cy=\"78\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 132 92 Q 146 64 160 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"185\" cy=\"101\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 170 116 Q 185 86 200 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"59\" cy=\"48\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 43 64 Q 59 32 75 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"65\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"66\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"103\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 21."
                         }
                     },
@@ -2221,35 +2361,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"168\" cy=\"112\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 152 128 Q 168 96 184 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"42\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 25 76 Q 42 42 59 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"81\" cy=\"82\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 63 100 Q 81 64 99 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"120\" cy=\"105\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 101 124 Q 120 86 139 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"159\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 139 72 Q 159 32 179 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"67\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"100\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"137\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 21."
                         }
                     }
                 ]
             },
             "correct_answer": "C",
-            "solution_rule": "Original deterministic odd one out transformation generated from seed 7321; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 2x2 grammar generated from seed 8321; choose the option preserving the declared matrix 2x2 imagery scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:a51e2f7938948c582fa68fde640074c7764a7b97cea41d5146a701de80e233c3",
+                "stem": "sha256:c43c3fc71ed2c361992514b6b226f2d7de2a036d23b1ba1749958f144382453d",
                 "options": {
-                    "A": "sha256:92d8ebd8cd763b91401565f183771db830bfe0e1fd7ee4791ceb4916e00f298d",
-                    "B": "sha256:ec7f67760a7a5cb2a91bd0e42dc06ab2dd3b20eb3d0ce5f4cf4cb3915ebf7260",
-                    "C": "sha256:b5fd99e77462552fefb84e57f740193e5a3bef5dd8f687d45b43048c6ddf9b0c",
-                    "D": "sha256:e45f236cf2db75a89d5c807ecebdafe1ba459691c2b3fa06bdc0fb60df1064cc",
-                    "E": "sha256:11e334abeab4d810f7f3b76450a34dc42376308bd378f66b9312a053ea8f149c",
-                    "F": "sha256:a46824664f5dfa7c2abb2af18a5f6d788602c12488c2e6d2215e1655d2ef3b17"
+                    "A": "sha256:f452f8beba3e3a2154c57e6d739be68fbaadd5192ad1d615c20c09ecdad9dfa5",
+                    "B": "sha256:53d04e996c1f5ee515bf317519376978fc46fd9cb93575a5f8d6df389f1f5dda",
+                    "C": "sha256:16d63718983dccd6574c27788526fd3c691c4cd3a65a659545d4d0b6e69f6ad0",
+                    "D": "sha256:467045a12c8dd5dce00ed52fe3d4fe482b6c829dd5c8017bbaca778f04ef6e8d",
+                    "E": "sha256:5dd3fc92fe127c8a835d11be89266ee16470ee2bb69533df298428c2e5c90e39",
+                    "F": "sha256:654f8c1e5d7c4eb5144d4f83567fa640fe3cd16c19166e38ed3b82ab961b82b4"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7321,
-                "template_key": "odd_one_out",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8321,
+                "rule": "Abstract matrix 2x2 grammar generated from seed 8321; choose the option preserving the declared matrix 2x2 imagery scaffold v1 transformation.",
+                "rule_key": "matrix_2x2_imagery_scaffold_v1",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_2x2_imagery_scaffold_v1",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:3df71d9e992de8e96646ad066d3ccbaa611fdf99383181c3a3a694703891a373"
+                "params_hash": "sha256:c3da2b21870a349eef5a77b32bca8ffe6f4015b7d8f33801a055c11fa565fd22"
             }
         },
         {
@@ -2261,15 +2408,15 @@
             "dimension": "VSI",
             "dimension_name": "Visual-spatial imagery",
             "difficulty_level": 4,
-            "item_family": "odd_one_out",
+            "item_family": "matrix_2x2",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q22</text><circle cx=\"65\" cy=\"72\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 41 96 Q 65 48 89 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"95\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 79 120 Q 104 70 129 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"118\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 117 144 Q 143 92 169 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"65\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 155 92 Q 182 38 209 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"56\" cy=\"88\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 28 116 Q 56 60 84 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
-                    "accessibility_label": "Original odd one out reasoning prompt 22."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q22</text><rect x=\"57\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"66\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"67\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"98\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"99\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"136\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original matrix 2x2 reasoning prompt 22."
                 },
                 "options": [
                     {
@@ -2278,7 +2425,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"175\" cy=\"117\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 158 134 Q 175 100 192 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"49\" cy=\"64\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 31 82 Q 49 46 67 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"88\" cy=\"87\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 69 106 Q 88 68 107 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"110\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 107 130 Q 127 90 147 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"166\" cy=\"57\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 145 78 Q 166 36 187 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"40\" cy=\"80\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 18 102 Q 40 58 62 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"67\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"100\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"54\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"137\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"138\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 22."
                         }
                     },
@@ -2288,7 +2435,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"32\" cy=\"75\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 13 94 Q 32 56 51 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"98\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 118 Q 71 78 91 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"121\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 89 142 Q 110 100 131 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"68\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 127 90 Q 149 46 171 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"63\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"64\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"101\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"102\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 22."
                         }
                     },
@@ -2298,7 +2445,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"54\" cy=\"109\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 33 130 Q 54 88 75 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"93\" cy=\"56\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 71 78 Q 93 34 115 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"132\" cy=\"79\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 109 102 Q 132 56 155 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"171\" cy=\"102\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 147 126 Q 171 78 195 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"45\" cy=\"49\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 20 74 Q 45 24 70 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"72\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 58 98 Q 84 46 110 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"65\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"66\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"103\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"58\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"135\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"136\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 22."
                         }
                     },
@@ -2308,7 +2455,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"87\" cy=\"57\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 62 82 Q 87 32 112 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"80\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 100 106 Q 126 54 152 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"103\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 138 130 Q 165 76 192 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"39\" cy=\"50\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 11 78 Q 39 22 67 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"78\" cy=\"73\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 49 102 Q 78 44 107 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"117\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 103 110 Q 117 82 131 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"65\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"66\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"103\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"135\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"136\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 22."
                         }
                     },
@@ -2318,7 +2465,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"43\" cy=\"92\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 23 112 Q 43 72 63 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"82\" cy=\"115\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 61 136 Q 82 94 103 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 99 84 Q 121 40 143 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"160\" cy=\"85\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 137 108 Q 160 62 183 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"34\" cy=\"108\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 10 132 Q 34 84 58 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"64\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"65\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"102\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"103\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"57\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"134\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 22."
                         }
                     },
@@ -2328,35 +2475,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"65\" cy=\"50\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 43 72 Q 65 28 87 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"73\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 81 96 Q 104 50 127 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"96\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 119 120 Q 143 72 167 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"66\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"67\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 22."
                         }
                     }
                 ]
             },
             "correct_answer": "D",
-            "solution_rule": "Original deterministic odd one out transformation generated from seed 7322; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract matrix 2x2 grammar generated from seed 8322; choose the option preserving the declared matrix 2x2 imagery scaffold v2 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:f22e02f9d47b705544f05b949e4673d615bbc481555d7e109929f42d41875685",
+                "stem": "sha256:1074896a9109a54680157738e07da85a848a646269cb03e4abee9283e088b71b",
                 "options": {
-                    "A": "sha256:0dfb675fb7c4071bdaf804069e88f4d90a1929c6104e92b7b21609b865af6f77",
-                    "B": "sha256:83a93643f0c8b2ab6c43075a7871b336c6adbb4750903f56d4ae5d2a49b9a06a",
-                    "C": "sha256:3dc5f6aa4d8bc230ae7c0a5691da9c64bc2431c3ef571e06dc181e5cca9dd2cc",
-                    "D": "sha256:7cf5b350448e24f69b047c470cfbd1c893060a87d03b8b2ee84fbe1fd625aca8",
-                    "E": "sha256:990a5aea87fa3295b651be5355784daa5861141fbace6beb76c669590e8b3a0a",
-                    "F": "sha256:fc77a0b1bf1c094d6b0ca532736ac24cece829695788ac9d0d7220e44ed4e166"
+                    "A": "sha256:6b5bb7c90b525a92a39f5537e4612b8a83f1225f9499013587e412c2825824b9",
+                    "B": "sha256:63cc2d8834e7b4e9fe68482fd564aa8ea2fec72cb710064a3e9b7be78caf3643",
+                    "C": "sha256:d6080ac64dc45fdb0c101b724e324c6d9176c322f991fd0bd13182dccab44944",
+                    "D": "sha256:1f9fc1d78e24e16474b1f78a2c30bfb14d6b3cdb9af146ea8ea025d0978d720f",
+                    "E": "sha256:ca2721af4800e34c8b19cddfec7529cedadefe409a6188f4f085cbfa66d8a583",
+                    "F": "sha256:236c87891eab45d391925032dbef087af4b6fe320149a7473005b520a440b1e5"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7322,
-                "template_key": "odd_one_out",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8322,
+                "rule": "Abstract matrix 2x2 grammar generated from seed 8322; choose the option preserving the declared matrix 2x2 imagery scaffold v2 transformation.",
+                "rule_key": "matrix_2x2_imagery_scaffold_v2",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "matrix_2x2_imagery_scaffold_v2",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:5a5556b5d6134875c0d99b7c32e45db97cc77aec2c6609d40507511d8c3a982f"
+                "params_hash": "sha256:f978b0b1308758e1c9998f34ada5d3539a127c26df692380f30e091a975001d5"
             }
         },
         {
@@ -2368,15 +2522,15 @@
             "dimension": "VSI",
             "dimension_name": "Visual-spatial imagery",
             "difficulty_level": 4,
-            "item_family": "rotation",
+            "item_family": "series",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q23</text><path d=\"M 116 40 L 145 98 L 87 98 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(325 116 69)\"/><path d=\"M 155 78 L 169 106 L 141 106 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(12 155 92)\"/><path d=\"M 194 100 L 209 130 L 179 130 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(59 194 115)\"/><path d=\"M 68 46 L 84 78 L 52 78 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(106 68 62)\"/><path d=\"M 107 68 L 124 102 L 90 102 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(153 107 85)\"/><path d=\"M 146 90 L 164 126 L 128 126 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(200 146 108)\"/></svg>",
-                    "accessibility_label": "Original rotation reasoning prompt 23."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q23</text><circle cx=\"116\" cy=\"69\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 87 98 Q 116 40 145 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"92\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 141 106 Q 155 78 169 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"194\" cy=\"115\" r=\"7\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 179 130 Q 194 100 209 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"68\" cy=\"62\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 52 78 Q 68 46 84 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"107\" cy=\"85\" r=\"8\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 90 102 Q 107 68 124 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"146\" cy=\"108\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 128 126 Q 146 90 164 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original series reasoning prompt 23."
                 },
                 "options": [
                     {
@@ -2385,7 +2539,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 72 32 L 95 78 L 49 78 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(51 72 55)\"/><path d=\"M 111 54 L 135 102 L 87 102 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(98 111 78)\"/><path d=\"M 150 76 L 175 126 L 125 126 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(145 150 101)\"/><path d=\"M 189 22 L 215 74 L 163 74 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(192 189 48)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"72\" cy=\"55\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 49 78 Q 72 32 95 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"78\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 87 102 Q 111 54 135 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"101\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 125 126 Q 150 76 175 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"48\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 163 74 Q 189 22 215 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 23."
                         }
                     },
@@ -2395,7 +2549,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 94 64 L 119 114 L 69 114 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(113 94 89)\"/><path d=\"M 133 86 L 159 138 L 107 138 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(160 133 112)\"/><path d=\"M 172 32 L 199 86 L 145 86 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(207 172 59)\"/><path d=\"M 46 54 L 74 110 L 18 110 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(254 46 82)\"/><path d=\"M 85 76 L 114 134 L 56 134 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(301 85 105)\"/><path d=\"M 124 38 L 138 66 L 110 66 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(348 124 52)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"94\" cy=\"89\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 69 114 Q 94 64 119 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"112\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 107 138 Q 133 86 159 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"59\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 145 86 Q 172 32 199 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"82\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 18 110 Q 46 54 74 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"85\" cy=\"105\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 56 134 Q 85 76 114 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"124\" cy=\"52\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 110 66 Q 124 38 138 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 23."
                         }
                     },
@@ -2405,7 +2559,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 61 92 L 83 136 L 39 136 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(20 61 114)\"/><path d=\"M 100 38 L 123 84 L 77 84 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(67 100 61)\"/><path d=\"M 139 60 L 163 108 L 115 108 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(114 139 84)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"61\" cy=\"114\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 39 136 Q 61 92 83 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"100\" cy=\"61\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 77 84 Q 100 38 123 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"84\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 115 108 Q 139 60 163 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 23."
                         }
                     },
@@ -2415,7 +2569,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 83 48 L 107 96 L 59 96 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(82 83 72)\"/><path d=\"M 122 70 L 147 120 L 97 120 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(129 122 95)\"/><path d=\"M 161 92 L 187 144 L 135 144 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(176 161 118)\"/><path d=\"M 35 38 L 62 92 L 8 92 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(223 35 65)\"/><path d=\"M 74 60 L 102 116 L 46 116 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(270 74 88)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"83\" cy=\"72\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 59 96 Q 83 48 107 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"122\" cy=\"95\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 97 120 Q 122 70 147 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"161\" cy=\"118\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 135 144 Q 161 92 187 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"35\" cy=\"65\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 8 92 Q 35 38 62 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"74\" cy=\"88\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 46 116 Q 74 60 102 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 23."
                         }
                     },
@@ -2425,7 +2579,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 138 40 L 152 68 L 124 68 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(132 138 54)\"/><path d=\"M 177 62 L 192 92 L 162 92 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(179 177 77)\"/><path d=\"M 51 84 L 67 116 L 35 116 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(226 51 100)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"138\" cy=\"54\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 124 68 Q 138 40 152 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"177\" cy=\"77\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 162 92 Q 177 62 192 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"51\" cy=\"100\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 35 116 Q 51 84 67 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 23."
                         }
                     },
@@ -2435,35 +2589,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 127 36 L 155 92 L 99 92 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(206 127 64)\"/><path d=\"M 166 58 L 195 116 L 137 116 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(253 166 87)\"/><path d=\"M 40 96 L 54 124 L 26 124 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(300 40 110)\"/><path d=\"M 79 42 L 94 72 L 64 72 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(347 79 57)\"/><path d=\"M 118 64 L 134 96 L 102 96 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(34 118 80)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"127\" cy=\"64\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 99 92 Q 127 36 155 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"166\" cy=\"87\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 137 116 Q 166 58 195 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"40\" cy=\"110\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 26 124 Q 40 96 54 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"79\" cy=\"57\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 64 72 Q 79 42 94 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"118\" cy=\"80\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 102 96 Q 118 64 134 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 23."
                         }
                     }
                 ]
             },
             "correct_answer": "E",
-            "solution_rule": "Original deterministic rotation transformation generated from seed 7323; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract series grammar generated from seed 8323; choose the option preserving the declared series imagery scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:7ad5dbb787f065e63fd24b6ebd05cfc8ac8c7c22cbb8bd2db7353be5296c8081",
+                "stem": "sha256:1419bda4f13db3e218553bcdc2862d798f06ead57334447a348227e5085f6c82",
                 "options": {
-                    "A": "sha256:78ff0529a9e368d6b0b0088cca73bc4579d7c80a2e1cc31a379f873968fb3a8a",
-                    "B": "sha256:5ecaeda11423907cf89d7bc691f8cc9ba1bb0a1c60f6c03f1c323e25f99b0f3b",
-                    "C": "sha256:cf8362fec6ccfd4e87159d78a6320d0f02f17b3f90ff8c7a7508c8b08ff88a99",
-                    "D": "sha256:3153bc2fd73a6c31d26540b5229ab069ee7e342d2e7632a0897dc3358fb9d2a6",
-                    "E": "sha256:5c5b91d62905000d38c4c2f8644f92fdf2a72d79bab5b052fe8b771c72b1e954",
-                    "F": "sha256:7c37d773c4cd4cd179a2a3dbf3140b3bdfc8c00ab7420eb137a86d2c7d4f2974"
+                    "A": "sha256:fdf6e0b463a88358752b72f480b3bbaec1474b07ca0a1acf112f04676b47c0ae",
+                    "B": "sha256:8fd3bfc721dc27b299556e54fd018b3e74c9a1b0d1dad007fec909b9fe74a012",
+                    "C": "sha256:970ac2144cfd79f14d64b26200ace5f96a7acec2d888bd61633a5825133ef63b",
+                    "D": "sha256:ad5f2a8f9df4ea93f9b0bd98ee9612e4c3f5e52026eec7d784627de5caf73eb2",
+                    "E": "sha256:a88a48afd1c08be7453d3568c88ce46ef807cb03f77d983eec1476975da748f4",
+                    "F": "sha256:2e6f2af73bf9a138bdf9fd481a68299bc6ebb6fbfa4395e02b7f0455d8fb1d91"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7323,
-                "template_key": "rotation",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8323,
+                "rule": "Abstract series grammar generated from seed 8323; choose the option preserving the declared series imagery scaffold v1 transformation.",
+                "rule_key": "series_imagery_scaffold_v1",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "series_imagery_scaffold_v1",
+                "item_family_template": "series",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:a3b19778b3b97c102036e259f8c4cf7ebf7419e779456e0008ecdaa81d7aaf7e"
+                "params_hash": "sha256:79977bdc9006d2f948de10653039aca2e74a05999ef251ccdcf9fa389276939b"
             }
         },
         {
@@ -2475,15 +2636,15 @@
             "dimension": "VSI",
             "dimension_name": "Visual-spatial imagery",
             "difficulty_level": 4,
-            "item_family": "rotation",
+            "item_family": "series",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q24</text><path d=\"M 167 48 L 185 84 L 149 84 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(108 167 66)\"/><path d=\"M 41 70 L 60 108 L 22 108 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(155 41 89)\"/><path d=\"M 80 92 L 100 132 L 60 132 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(202 80 112)\"/></svg>",
-                    "accessibility_label": "Original rotation reasoning prompt 24."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q24</text><circle cx=\"167\" cy=\"66\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 149 84 Q 167 48 185 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"41\" cy=\"89\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 22 108 Q 41 70 60 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"112\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 60 132 Q 80 92 100 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original series reasoning prompt 24."
                 },
                 "options": [
                     {
@@ -2492,7 +2653,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 134 40 L 163 98 L 105 98 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(225 134 69)\"/><path d=\"M 173 78 L 187 106 L 159 106 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(272 173 92)\"/><path d=\"M 47 100 L 62 130 L 32 130 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(319 47 115)\"/><path d=\"M 86 46 L 102 78 L 70 78 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(6 86 62)\"/><path d=\"M 125 68 L 142 102 L 108 102 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(53 125 85)\"/><path d=\"M 164 90 L 182 126 L 146 126 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(100 164 108)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"134\" cy=\"69\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 105 98 Q 134 40 163 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"92\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 159 106 Q 173 78 187 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"115\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 32 130 Q 47 100 62 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"62\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 70 78 Q 86 46 102 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"85\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 108 102 Q 125 68 142 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"164\" cy=\"108\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 146 126 Q 164 90 182 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 24."
                         }
                     },
@@ -2502,7 +2663,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 101 68 L 127 120 L 75 120 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(132 101 94)\"/><path d=\"M 140 90 L 167 144 L 113 144 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(179 140 117)\"/><path d=\"M 179 36 L 207 92 L 151 92 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(226 179 64)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"101\" cy=\"94\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 75 120 Q 101 68 127 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"140\" cy=\"117\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 113 144 Q 140 90 167 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"179\" cy=\"64\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 151 92 Q 179 36 207 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 24."
                         }
                     },
@@ -2512,7 +2673,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 123 24 L 151 80 L 95 80 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(194 123 52)\"/><path d=\"M 162 46 L 191 104 L 133 104 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(241 162 75)\"/><path d=\"M 36 84 L 50 112 L 22 112 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(288 36 98)\"/><path d=\"M 75 106 L 90 136 L 60 136 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(335 75 121)\"/><path d=\"M 114 52 L 130 84 L 98 84 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(22 114 68)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"123\" cy=\"52\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 95 80 Q 123 24 151 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"162\" cy=\"75\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 133 104 Q 162 46 191 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"36\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 22 112 Q 36 84 50 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"75\" cy=\"121\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 60 136 Q 75 106 90 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"114\" cy=\"68\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 98 84 Q 114 52 130 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 24."
                         }
                     },
@@ -2522,7 +2683,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 145 72 L 159 100 L 131 100 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(256 145 86)\"/><path d=\"M 184 94 L 199 124 L 169 124 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(303 184 109)\"/><path d=\"M 58 40 L 74 72 L 42 72 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(350 58 56)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"145\" cy=\"86\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 131 100 Q 145 72 159 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"109\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 169 124 Q 184 94 199 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"56\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 42 72 Q 58 40 74 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 24."
                         }
                     },
@@ -2532,7 +2693,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 167 104 L 183 136 L 151 136 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(318 167 120)\"/><path d=\"M 41 50 L 58 84 L 24 84 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(5 41 67)\"/><path d=\"M 80 72 L 98 108 L 62 108 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(52 80 90)\"/><path d=\"M 119 94 L 138 132 L 100 132 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(99 119 113)\"/><path d=\"M 158 40 L 178 80 L 138 80 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(146 158 60)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"167\" cy=\"120\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 151 136 Q 167 104 183 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"41\" cy=\"67\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 24 84 Q 41 50 58 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"90\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 62 108 Q 80 72 98 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"113\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 100 132 Q 119 94 138 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"158\" cy=\"60\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 138 80 Q 158 40 178 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 24."
                         }
                     },
@@ -2542,35 +2703,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 189 32 L 208 70 L 170 70 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(275 189 51)\"/><path d=\"M 63 54 L 83 94 L 43 94 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(322 63 74)\"/><path d=\"M 102 76 L 123 118 L 81 118 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(9 102 97)\"/><path d=\"M 141 98 L 163 142 L 119 142 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(56 141 120)\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"189\" cy=\"51\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 170 70 Q 189 32 208 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"63\" cy=\"74\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 43 94 Q 63 54 83 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"102\" cy=\"97\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 81 118 Q 102 76 123 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"141\" cy=\"120\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 119 142 Q 141 98 163 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 24."
                         }
                     }
                 ]
             },
             "correct_answer": "F",
-            "solution_rule": "Original deterministic rotation transformation generated from seed 7324; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract series grammar generated from seed 8324; choose the option preserving the declared series imagery scaffold v2 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:2f746dec717b555e89fffd0aaf5a60a04521148ad1fe8940b099847de99a533f",
+                "stem": "sha256:49762e30f6e181f532321fba8bc408e780b7e6ab2b15fce4f525e011648afc66",
                 "options": {
-                    "A": "sha256:11df7775a2545a8137ff6b008dbcdcdea572c78d67cf8faff26c1fc10046ae2a",
-                    "B": "sha256:ff2c455b4fd700944b8aa1b73fbc6f6e5b87fd68714fee86e1e568cf15ce2ce8",
-                    "C": "sha256:8ca53bd3f9eeb292530dc370993a85fa8f3feab100a0534f5720c63ed9fd41dc",
-                    "D": "sha256:7ad49335c1c310cef74c58058e0f15e3e5a44e03a7da9aa3389e8f8773b006b8",
-                    "E": "sha256:7876a44a0daad3de0c5464a33430b0fe5244fa9c24fb4ac2b6e719cdc627f358",
-                    "F": "sha256:305062e34f76af6566c5714b42369b51ce1ea5a1e01ddc3ce27ea512375b25bb"
+                    "A": "sha256:33e25d3edf540e19e3c1e2589a0722e53020fb1dbbb54ad3a85a08f99ecdccec",
+                    "B": "sha256:d5019255b5d43ce3f355c9d7e29cd9d6f742e64b8eea0e3db70fc6d4e16b1ad6",
+                    "C": "sha256:e1a1e558101750f1e018ffcda3be5eff476a3e59f518ec5e109ecfaa7ead8dfe",
+                    "D": "sha256:1db93abeb58d8d8336c9ed6fd95c9e068f705d21ca50651cf3cd3a0082987fdc",
+                    "E": "sha256:83c8af191754c0a19b1ec0252024fe2694e7b27c8ed4399f671875b03fe7e019",
+                    "F": "sha256:f53c6a6310d2e6773425ad82a4dab695881faf67f7ed1d9e8b754da29d78392f"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7324,
-                "template_key": "rotation",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8324,
+                "rule": "Abstract series grammar generated from seed 8324; choose the option preserving the declared series imagery scaffold v2 transformation.",
+                "rule_key": "series_imagery_scaffold_v2",
+                "difficulty": 4,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "series_imagery_scaffold_v2",
+                "item_family_template": "series",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:183f9a63b11badcfee3a6767591e1a3bfac2647664e6a882a3bb7eba3ec5d357"
+                "params_hash": "sha256:c8b71ffdfce668edf6675eb7e9ae27eb958e460e09b65c9c828b2f6e551a6f89"
             }
         },
         {
@@ -2579,8 +2747,8 @@
             "bank_id": "IQ_BETA_30_ORIGINAL",
             "question_id": "IQB30-Q25",
             "item_id": "IQ_BETA_30_ORIGINAL_25",
-            "dimension": "NPR",
-            "dimension_name": "Numeric pattern reasoning",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
             "difficulty_level": 5,
             "item_family": "rotation",
             "option_count": 6,
@@ -2656,8 +2824,8 @@
                 ]
             },
             "correct_answer": "A",
-            "solution_rule": "Original deterministic rotation transformation generated from seed 7325; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract rotation grammar generated from seed 8325; choose the option preserving the declared rotation imagery scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
                 "stem": "sha256:668718335be0ea2f933e3d47d76761603c327b00aed535d0c270e4391f7e31ef",
                 "options": {
@@ -2673,11 +2841,18 @@
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7325,
-                "template_key": "rotation",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8325,
+                "rule": "Abstract rotation grammar generated from seed 8325; choose the option preserving the declared rotation imagery scaffold v1 transformation.",
+                "rule_key": "rotation_imagery_scaffold_v1",
+                "difficulty": 5,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "rotation_imagery_scaffold_v1",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:6177a4972b7d6088282798293380ac58cb8119940b8212d600c1a2ec40206348"
+                "params_hash": "sha256:fb0de385dbe2a4193a12d6aeb867ceaed5d87c1556ed0982ac35043452948358"
             }
         },
         {
@@ -2689,15 +2864,15 @@
             "dimension": "NPR",
             "dimension_name": "Numeric pattern reasoning",
             "difficulty_level": 5,
-            "item_family": "overlay",
+            "item_family": "rotation",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q26</text><rect x=\"47.5\" y=\"104.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(165 60 117)\"/><circle cx=\"68\" cy=\"112\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"86\" y=\"51\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(212 99 64)\"/><circle cx=\"107\" cy=\"59\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"124.5\" y=\"73.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(259 138 87)\"/><circle cx=\"146\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"163\" y=\"96\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(306 177 110)\"/><circle cx=\"185\" cy=\"105\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"36.5\" y=\"42.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(353 51 57)\"/><circle cx=\"59\" cy=\"52\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"83\" y=\"73\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(40 90 80)\"/><circle cx=\"98\" cy=\"75\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
-                    "accessibility_label": "Original overlay reasoning prompt 26."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q26</text><path d=\"M 60 92 L 85 142 L 35 142 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(165 60 117)\"/><path d=\"M 99 38 L 125 90 L 73 90 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(212 99 64)\"/><path d=\"M 138 60 L 165 114 L 111 114 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(259 138 87)\"/><path d=\"M 177 82 L 205 138 L 149 138 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(306 177 110)\"/><path d=\"M 51 28 L 80 86 L 22 86 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(353 51 57)\"/><path d=\"M 90 66 L 104 94 L 76 94 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(40 90 80)\"/></svg>",
+                    "accessibility_label": "Original rotation reasoning prompt 26."
                 },
                 "options": [
                     {
@@ -2706,7 +2881,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"150.5\" y=\"60.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(189 159 69)\"/><circle cx=\"167\" cy=\"64\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"24\" y=\"83\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(236 33 92)\"/><circle cx=\"41\" cy=\"87\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"62.5\" y=\"105.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(283 72 115)\"/><circle cx=\"80\" cy=\"110\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"101\" y=\"52\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(330 111 62)\"/><circle cx=\"119\" cy=\"57\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"139.5\" y=\"74.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(17 150 85)\"/><circle cx=\"158\" cy=\"80\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"178\" y=\"97\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(64 189 108)\"/><circle cx=\"197\" cy=\"103\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 159 52 L 176 86 L 142 86 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(189 159 69)\"/><path d=\"M 33 74 L 51 110 L 15 110 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(236 33 92)\"/><path d=\"M 72 96 L 91 134 L 53 134 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(283 72 115)\"/><path d=\"M 111 42 L 131 82 L 91 82 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(330 111 62)\"/><path d=\"M 150 64 L 171 106 L 129 106 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(17 150 85)\"/><path d=\"M 189 86 L 211 130 L 167 130 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(64 189 108)\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 26."
                         }
                     },
@@ -2716,7 +2891,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"69\" y=\"89\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(332 82 102)\"/><circle cx=\"90\" cy=\"97\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"107.5\" y=\"35.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(19 121 49)\"/><circle cx=\"129\" cy=\"44\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"146\" y=\"58\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(66 160 72)\"/><circle cx=\"168\" cy=\"67\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 82 76 L 108 128 L 56 128 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(332 82 102)\"/><path d=\"M 121 22 L 148 76 L 94 76 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(19 121 49)\"/><path d=\"M 160 44 L 188 100 L 132 100 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(66 160 72)\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 26."
                         }
                     },
@@ -2726,7 +2901,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"27.5\" y=\"50.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(313 38 61)\"/><circle cx=\"46\" cy=\"56\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"66\" y=\"73\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(0 77 84)\"/><circle cx=\"85\" cy=\"79\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"104.5\" y=\"95.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(47 116 107)\"/><circle cx=\"124\" cy=\"102\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"143\" y=\"42\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(94 155 54)\"/><circle cx=\"163\" cy=\"49\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181.5\" y=\"64.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(141 194 77)\"/><circle cx=\"202\" cy=\"72\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55\" y=\"87\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(188 68 100)\"/><circle cx=\"76\" cy=\"95\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 38 40 L 59 82 L 17 82 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(313 38 61)\"/><path d=\"M 77 62 L 99 106 L 55 106 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(0 77 84)\"/><path d=\"M 116 84 L 139 130 L 93 130 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(47 116 107)\"/><path d=\"M 155 30 L 179 78 L 131 78 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(94 155 54)\"/><path d=\"M 194 52 L 219 102 L 169 102 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(141 194 77)\"/><path d=\"M 68 74 L 94 126 L 42 126 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(188 68 100)\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 26."
                         }
                     },
@@ -2736,7 +2911,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"48.5\" y=\"83.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(15 60 95)\"/><circle cx=\"68\" cy=\"90\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"87\" y=\"106\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(62 99 118)\"/><circle cx=\"107\" cy=\"113\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"125.5\" y=\"52.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(109 138 65)\"/><circle cx=\"146\" cy=\"60\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"164\" y=\"75\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(156 177 88)\"/><circle cx=\"185\" cy=\"83\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 60 72 L 83 118 L 37 118 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(15 60 95)\"/><path d=\"M 99 94 L 123 142 L 75 142 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(62 99 118)\"/><path d=\"M 138 40 L 163 90 L 113 90 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(109 138 65)\"/><path d=\"M 177 62 L 203 114 L 151 114 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(156 177 88)\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 26."
                         }
                     },
@@ -2746,7 +2921,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"182\" y=\"110\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(282 192 120)\"/><circle cx=\"200\" cy=\"115\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55.5\" y=\"56.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(329 66 67)\"/><circle cx=\"74\" cy=\"62\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"94\" y=\"79\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(16 105 90)\"/><circle cx=\"113\" cy=\"85\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"132.5\" y=\"101.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(63 144 113)\"/><circle cx=\"152\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"171\" y=\"48\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(110 183 60)\"/><circle cx=\"191\" cy=\"55\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 192 100 L 212 140 L 172 140 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(282 192 120)\"/><path d=\"M 66 46 L 87 88 L 45 88 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(329 66 67)\"/><path d=\"M 105 68 L 127 112 L 83 112 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(16 105 90)\"/><path d=\"M 144 90 L 167 136 L 121 136 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(63 144 113)\"/><path d=\"M 183 36 L 207 84 L 159 84 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(110 183 60)\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 26."
                         }
                     },
@@ -2756,35 +2931,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"38\" y=\"67\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(344 49 78)\"/><circle cx=\"57\" cy=\"73\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"76.5\" y=\"89.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(31 88 101)\"/><circle cx=\"96\" cy=\"96\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"115\" y=\"36\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(78 127 48)\"/><circle cx=\"135\" cy=\"43\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 49 56 L 71 100 L 27 100 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(344 49 78)\"/><path d=\"M 88 78 L 111 124 L 65 124 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(31 88 101)\"/><path d=\"M 127 24 L 151 72 L 103 72 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(78 127 48)\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 26."
                         }
                     }
                 ]
             },
             "correct_answer": "B",
-            "solution_rule": "Original deterministic overlay transformation generated from seed 7326; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract rotation grammar generated from seed 8326; choose the option preserving the declared rotation numeric rule scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:dc709c597ed667e732a9ebc8f76ded875c8e429e094074e6d78cf5b505a6a9cc",
+                "stem": "sha256:131f0d9479f21c32153eab6339bf918000740d39b7ec523ec15c6325c72723d0",
                 "options": {
-                    "A": "sha256:950def6a8a3a77c268fb3f3ac575856c37c69349271028da7b4efa811ffb109e",
-                    "B": "sha256:c3c26623968f9a592454886d789f99c3acb8120fd3b5a465c6288e550f936aae",
-                    "C": "sha256:26fd5716d59265a96dc3ad8c3897d24c83a589bbc8b720347147902fd67c2351",
-                    "D": "sha256:c38ea09232c374c0fbedcab64f457a3c1bed68a79e7db471f126fb7638b98313",
-                    "E": "sha256:c6028957f2d23feebd5a3f1b8f840a9f197a3531cf98ccc4ebe3fcf61bb739f0",
-                    "F": "sha256:7d2b7b7e28716ac7fbd3ed558f87d4d88bdf7cb45117023a8f1f0c648b651bad"
+                    "A": "sha256:ee186158c6364d444195b33538d915b60d7f7682fe8d3aa9d7a693e7dc375594",
+                    "B": "sha256:9e9697e9579d7a62d6b6e4ef0641dc9baed7fcdd15d1e1136884144b11fe1f81",
+                    "C": "sha256:175d7315c26f36e441db1119929a78779a0b6311eea2f72b7b8956e67caf43b6",
+                    "D": "sha256:f4c43a78398345a50f2cd7e9539684778915bd0eb73f94d303bbc05cf15defb7",
+                    "E": "sha256:29dc76df5085b2d81b3a54f4d8125bb7a50660aae81a27c479ab720ede3c1fe0",
+                    "F": "sha256:f6e96c80d7c70f7783fa07558d4cd6a812a4da03eed65942c4d4a202ffcee864"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7326,
-                "template_key": "overlay",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8326,
+                "rule": "Abstract rotation grammar generated from seed 8326; choose the option preserving the declared rotation numeric rule scaffold v1 transformation.",
+                "rule_key": "rotation_numeric_rule_scaffold_v1",
+                "difficulty": 5,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "rotation_numeric_rule_scaffold_v1",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:50b1a9276ffad59602e1ca72603dafc772118a028fa89a6ba7e7a705e1931a60"
+                "params_hash": "sha256:36e0529a1540a36e225a8f6d56e8fcfaa9874333a0972a0d05db48d34416ef85"
             }
         },
         {
@@ -2870,8 +3052,8 @@
                 ]
             },
             "correct_answer": "C",
-            "solution_rule": "Original deterministic overlay transformation generated from seed 7327; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract overlay grammar generated from seed 8327; choose the option preserving the declared overlay numeric rule scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
                 "stem": "sha256:0f83ec621c0a5aebac17b9d13156bd908d1f615a589eb06f1fd090e8585d2021",
                 "options": {
@@ -2887,11 +3069,18 @@
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7327,
-                "template_key": "overlay",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8327,
+                "rule": "Abstract overlay grammar generated from seed 8327; choose the option preserving the declared overlay numeric rule scaffold v1 transformation.",
+                "rule_key": "overlay_numeric_rule_scaffold_v1",
+                "difficulty": 5,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "overlay_numeric_rule_scaffold_v1",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:4f957980dc2757cd58199ab138b057cc8f526b4c15bfa47b141ca39aac594113"
+                "params_hash": "sha256:42b0bbea4e407f2be2b79cd94e03b62a62ce3d1f0dd6d7df4eb4a772ad70492e"
             }
         },
         {
@@ -2903,15 +3092,15 @@
             "dimension": "NPR",
             "dimension_name": "Numeric pattern reasoning",
             "difficulty_level": 5,
-            "item_family": "overlay",
+            "item_family": "numeric_pattern",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q28</text><rect x=\"152.5\" y=\"101.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(91 162 111)\"/><circle cx=\"170\" cy=\"106\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"26\" y=\"48\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(138 36 58)\"/><circle cx=\"44\" cy=\"53\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"64.5\" y=\"70.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(185 75 81)\"/><circle cx=\"83\" cy=\"76\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"103\" y=\"93\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(232 114 104)\"/><circle cx=\"122\" cy=\"99\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
-                    "accessibility_label": "Original overlay reasoning prompt 28."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q28</text><circle cx=\"162\" cy=\"111\" r=\"9\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"157\" y=\"116\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"36\" cy=\"58\" r=\"10\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"31\" y=\"63\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"75\" cy=\"81\" r=\"10\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"70\" y=\"86\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"114\" cy=\"104\" r=\"11\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"109\" y=\"109\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text></svg>",
+                    "accessibility_label": "Original numeric pattern reasoning prompt 28."
                 },
                 "options": [
                     {
@@ -2920,7 +3109,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"103.5\" y=\"82.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(177 118 97)\"/><circle cx=\"126\" cy=\"92\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"150\" y=\"113\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(224 157 120)\"/><circle cx=\"165\" cy=\"115\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"188.5\" y=\"59.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(271 196 67)\"/><circle cx=\"204\" cy=\"62\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"62\" y=\"82\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(318 70 90)\"/><circle cx=\"78\" cy=\"85\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"100.5\" y=\"104.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(5 109 113)\"/><circle cx=\"117\" cy=\"108\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"139\" y=\"51\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(52 148 60)\"/><circle cx=\"156\" cy=\"55\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"118\" cy=\"97\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"113\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"157\" cy=\"120\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"152\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"196\" cy=\"67\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"191\" y=\"72\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"70\" cy=\"90\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"65\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"109\" cy=\"113\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"104\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"148\" cy=\"60\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"143\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text></svg>",
                             "accessibility_label": "Option A for original IQ item 28."
                         }
                     },
@@ -2930,7 +3119,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"132.5\" y=\"47.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(239 140 55)\"/><circle cx=\"148\" cy=\"50\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"171\" y=\"70\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(286 179 78)\"/><circle cx=\"187\" cy=\"73\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"44.5\" y=\"92.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(333 53 101)\"/><circle cx=\"61\" cy=\"96\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"83\" y=\"39\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(20 92 48)\"/><circle cx=\"100\" cy=\"43\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"140\" cy=\"55\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"135\" y=\"60\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"179\" cy=\"78\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"174\" y=\"83\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"53\" cy=\"101\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"48\" y=\"106\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"92\" cy=\"48\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"87\" y=\"53\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text></svg>",
                             "accessibility_label": "Option B for original IQ item 28."
                         }
                     },
@@ -2940,7 +3129,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"93\" y=\"66\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(146 107 80)\"/><circle cx=\"115\" cy=\"75\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"131.5\" y=\"88.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(193 146 103)\"/><circle cx=\"154\" cy=\"98\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"178\" y=\"43\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(240 185 50)\"/><circle cx=\"193\" cy=\"45\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"51.5\" y=\"65.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(287 59 73)\"/><circle cx=\"67\" cy=\"68\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"90\" y=\"88\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(334 98 96)\"/><circle cx=\"106\" cy=\"91\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"107\" cy=\"80\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"102\" y=\"85\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"146\" cy=\"103\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"141\" y=\"108\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"185\" cy=\"50\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"180\" y=\"55\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"59\" cy=\"73\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"54\" y=\"78\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"98\" cy=\"96\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"93\" y=\"101\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text></svg>",
                             "accessibility_label": "Option C for original IQ item 28."
                         }
                     },
@@ -2950,7 +3139,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"174\" y=\"86\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(258 184 96)\"/><circle cx=\"192\" cy=\"91\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"47.5\" y=\"108.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(305 58 119)\"/><circle cx=\"66\" cy=\"114\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"86\" y=\"55\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(352 97 66)\"/><circle cx=\"105\" cy=\"61\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"124.5\" y=\"77.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(39 136 89)\"/><circle cx=\"144\" cy=\"84\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"163\" y=\"100\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(86 175 112)\"/><circle cx=\"183\" cy=\"107\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"184\" cy=\"96\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"179\" y=\"101\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"58\" cy=\"119\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"53\" y=\"124\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"97\" cy=\"66\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"92\" y=\"71\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"136\" cy=\"89\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"131\" y=\"94\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"175\" cy=\"112\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"170\" y=\"117\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text></svg>",
                             "accessibility_label": "Option D for original IQ item 28."
                         }
                     },
@@ -2960,7 +3149,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"143\" y=\"64\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(270 151 72)\"/><circle cx=\"159\" cy=\"67\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181.5\" y=\"86.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(317 190 95)\"/><circle cx=\"198\" cy=\"90\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55\" y=\"109\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(4 64 118)\"/><circle cx=\"72\" cy=\"113\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"93.5\" y=\"55.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(51 103 65)\"/><circle cx=\"111\" cy=\"60\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"132\" y=\"78\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(98 142 88)\"/><circle cx=\"150\" cy=\"83\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"151\" cy=\"72\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"146\" y=\"77\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"190\" cy=\"95\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"185\" y=\"100\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"64\" cy=\"118\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"59\" y=\"123\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"103\" cy=\"65\" r=\"9\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"98\" y=\"70\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"142\" cy=\"88\" r=\"10\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"137\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text></svg>",
                             "accessibility_label": "Option E for original IQ item 28."
                         }
                     },
@@ -2970,35 +3159,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"164\" y=\"97\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(332 173 106)\"/><circle cx=\"181\" cy=\"101\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"37.5\" y=\"43.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(19 47 53)\"/><circle cx=\"55\" cy=\"48\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"76\" y=\"66\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(66 86 76)\"/><circle cx=\"94\" cy=\"71\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"173\" cy=\"106\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"168\" y=\"111\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"47\" cy=\"53\" r=\"9\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"42\" y=\"58\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"86\" cy=\"76\" r=\"10\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"81\" y=\"81\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text></svg>",
                             "accessibility_label": "Option F for original IQ item 28."
                         }
                     }
                 ]
             },
             "correct_answer": "D",
-            "solution_rule": "Original deterministic overlay transformation generated from seed 7328; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract numeric pattern grammar generated from seed 8328; choose the option preserving the declared numeric pattern scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:4b91e7a6cefd88838c9e914d3f98a86e2ec4f416fa98a55046b9b7e70e0625f0",
+                "stem": "sha256:ca525f72ead408bdcb5176ef2b3a0a06c168ac52dec9d5bbe9784f13f5f66744",
                 "options": {
-                    "A": "sha256:25dd2f31809da9d3e7080f3987e92a4c17e5969332a54771fecb8d6303115fad",
-                    "B": "sha256:8ed991869fc7c837bdb90af2688cc0290d2ee8d9f6dd7687e008d211cd855eb1",
-                    "C": "sha256:21d5db92c5fb6d31f5bff64bfa6b373a02448887e0cab05cbeec2615f4419fbc",
-                    "D": "sha256:ee7a00fdbcf49d3f643e124b202cbf9778621786cc9ca49b9050197b3f4ec426",
-                    "E": "sha256:f2d78feb4e36b5722ffab98fd1804127c6fc461e1d05236ac8b267bd4fcad3d4",
-                    "F": "sha256:03da9b2bcfe5de0ff3d7a14e84291385b037032acd82d2ee2dcabe010a170b3f"
+                    "A": "sha256:de9b0a72d37b85f32be68fe8bcb8984371816b1f0638c27091fac3b2a361b2cb",
+                    "B": "sha256:66137dc3c193c02c23c94a8f4c67464b43f33ba60c5970344f2480fe62f15dfd",
+                    "C": "sha256:3d89af5a5c170c031d125c4c909ea6fd17dc90c015bbb433523459dfba8920e0",
+                    "D": "sha256:8af4bcfcc52f7ca193ad841fe9e163255183eaa6a65f196058be23e9cfd00f4b",
+                    "E": "sha256:3d544ea35edfb01e5ba79e14ea83f8df1f2fccb5e7edb57b2d312746e96b76e7",
+                    "F": "sha256:5c1ad399e0b852bd1f85b10b5583ae3c92d98df1f1ac6c5d3bfc08940c4c493e"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7328,
-                "template_key": "overlay",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8328,
+                "rule": "Abstract numeric pattern grammar generated from seed 8328; choose the option preserving the declared numeric pattern scaffold v1 transformation.",
+                "rule_key": "numeric_pattern_scaffold_v1",
+                "difficulty": 5,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "numeric_pattern_scaffold_v1",
+                "item_family_template": "numeric_pattern",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:1547caaf07a8bc13ddd762890435e96dd02edbda07126ef12138f5618d135fac"
+                "params_hash": "sha256:05be27887cd4b17b6eb155e3646594c63bcd24facfd562449147cc4b9eb20eeb"
             }
         },
         {
@@ -3010,15 +3206,15 @@
             "dimension": "NPR",
             "dimension_name": "Numeric pattern reasoning",
             "difficulty_level": 5,
-            "item_family": "numeric_pattern",
+            "item_family": "odd_one_out",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q29</text><circle cx=\"70\" cy=\"115\" r=\"13\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"65\" y=\"120\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"109\" cy=\"62\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"104\" y=\"67\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"148\" cy=\"85\" r=\"14\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"143\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"187\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"182\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text></svg>",
-                    "accessibility_label": "Original numeric pattern reasoning prompt 29."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q29</text><circle cx=\"70\" cy=\"115\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 43 142 Q 70 88 97 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"109\" cy=\"62\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 81 90 Q 109 34 137 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"148\" cy=\"85\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 119 114 Q 148 56 177 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"187\" cy=\"108\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 173 122 Q 187 94 201 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 29."
                 },
                 "options": [
                     {
@@ -3027,7 +3223,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"37\" cy=\"118\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"32\" y=\"123\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"76\" cy=\"65\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"71\" y=\"70\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"115\" cy=\"88\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"110\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"37\" cy=\"118\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 15 140 Q 37 96 59 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"76\" cy=\"65\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 53 88 Q 76 42 99 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"115\" cy=\"88\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 91 112 Q 115 64 139 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 29."
                         }
                     },
@@ -3037,7 +3233,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"169\" cy=\"67\" r=\"9\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"164\" y=\"72\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"43\" cy=\"90\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"38\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"82\" cy=\"113\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"77\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"121\" cy=\"60\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"116\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"169\" cy=\"67\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 150 86 Q 169 48 188 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"43\" cy=\"90\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 23 110 Q 43 70 63 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"82\" cy=\"113\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 61 134 Q 82 92 103 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"60\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 99 82 Q 121 38 143 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 29."
                         }
                     },
@@ -3047,7 +3243,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"191\" cy=\"101\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"186\" y=\"106\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"65\" cy=\"48\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"60\" y=\"53\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"104\" cy=\"71\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"99\" y=\"76\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"143\" cy=\"94\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"138\" y=\"99\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"182\" cy=\"117\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"177\" y=\"122\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"56\" cy=\"64\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"51\" y=\"69\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"191\" cy=\"101\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 170 122 Q 191 80 212 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"48\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 43 70 Q 65 26 87 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"71\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 81 94 Q 104 48 127 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"94\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 119 118 Q 143 70 167 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"117\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 157 142 Q 182 92 207 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"56\" cy=\"64\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 30 90 Q 56 38 82 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 29."
                         }
                     },
@@ -3057,7 +3253,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"48\" cy=\"59\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"43\" y=\"64\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"87\" cy=\"82\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"82\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"126\" cy=\"105\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"121\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"165\" cy=\"52\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"160\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"48\" cy=\"59\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 25 82 Q 48 36 71 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"82\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 63 106 Q 87 58 111 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"105\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 101 130 Q 126 80 151 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"52\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 139 78 Q 165 26 191 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 29."
                         }
                     },
@@ -3067,7 +3263,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"100\" r=\"14\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"87\" y=\"105\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"131\" cy=\"47\" r=\"14\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"126\" y=\"52\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"170\" cy=\"70\" r=\"7\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"165\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"44\" cy=\"93\" r=\"7\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"39\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"83\" cy=\"116\" r=\"8\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"78\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"100\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 64 128 Q 92 72 120 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"47\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 102 76 Q 131 18 160 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"70\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 156 84 Q 170 56 184 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"93\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 29 108 Q 44 78 59 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"116\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 67 132 Q 83 100 99 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 29."
                         }
                     },
@@ -3077,35 +3273,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"51\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"87\" y=\"56\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"131\" cy=\"74\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"126\" y=\"79\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"170\" cy=\"97\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"165\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"44\" cy=\"120\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"39\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"92\" cy=\"51\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 65 78 Q 92 24 119 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"74\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 103 102 Q 131 46 159 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"97\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 141 126 Q 170 68 199 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"120\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 30 134 Q 44 106 58 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 29."
                         }
                     }
                 ]
             },
             "correct_answer": "E",
-            "solution_rule": "Original deterministic numeric pattern transformation generated from seed 7329; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract odd one out grammar generated from seed 8329; choose the option preserving the declared odd one out numeric scaffold v1 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:66aa91aad2367b80265e6bfbf4b2e5ee9495550c344af66a7fb6f498bd7b5eee",
+                "stem": "sha256:3db92998cc6640dee974c58abf9a7584b4df43da52052a2a740adde2c1661b26",
                 "options": {
-                    "A": "sha256:54ead778100bfb815655eecf41cccf823921a1b678447b05bc836048714b8063",
-                    "B": "sha256:bb0de362a5b0e0cbedaac2d25db1e0a5fb49f3d9c4caaa2d2bbaf59a3a82add4",
-                    "C": "sha256:868e49b5717cf5b9ff17f85b06ae44ebe11afa734692c6c089e9a6e03ae507f5",
-                    "D": "sha256:240deaf0a3ae50f5a88a97afcd9442e5a8f2d21ef41a9bc3f0c0b44776d2219e",
-                    "E": "sha256:1866082abef847ebd2473f60a7ac1bf696cc4f1cd4774d371d19c18e8fcd72ba",
-                    "F": "sha256:52078504ec24a4a2b8c948d9b4d7da8ad8ac017c1ff1e403cc8cfbce12c17328"
+                    "A": "sha256:1afc3e740fd87ca587c28d8fefb4195d3310cccb2f2887d4dfef06dca0ca9a93",
+                    "B": "sha256:4972d570a2c9f992fe07b9a550d78e6fbd1dbcc6f1ec6a26a4d753ead29e2e5a",
+                    "C": "sha256:d747f817c449e3b597a2c09a332be9178d53e3809a1b31fc72b958125f920475",
+                    "D": "sha256:3f2f9437e5dd7d0c811cfbc51c6c0810d7c985e6b82f5a9cf8f90b9dcbef6752",
+                    "E": "sha256:70ed688a7d2555399e455f96211adb4359ce7b54c7a0513bd8e549b43f4afd20",
+                    "F": "sha256:b2c363ac802ccbe1be7c1e6376c5be09669e3278ad2a5db99b74bd3e40289635"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7329,
-                "template_key": "numeric_pattern",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8329,
+                "rule": "Abstract odd one out grammar generated from seed 8329; choose the option preserving the declared odd one out numeric scaffold v1 transformation.",
+                "rule_key": "odd_one_out_numeric_scaffold_v1",
+                "difficulty": 5,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "odd_one_out_numeric_scaffold_v1",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:4387f241faa2f6848dce78a72b6d1daa420db72767551cf651a6b9db30730770"
+                "params_hash": "sha256:a1f84dc88d2ca3873112714c90bb81ecdf2e46bfeeb2c0aacd2af67b21eff3f0"
             }
         },
         {
@@ -3117,15 +3320,15 @@
             "dimension": "NPR",
             "dimension_name": "Numeric pattern reasoning",
             "difficulty_level": 5,
-            "item_family": "numeric_pattern",
+            "item_family": "odd_one_out",
             "option_count": 6,
             "assets": {
                 "stem": {
                     "kind": "inline_svg_markup",
                     "mime_type": "image/svg+xml",
                     "view_box": "0 0 240 160",
-                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q30</text><circle cx=\"121\" cy=\"112\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"116\" y=\"117\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"160\" cy=\"59\" r=\"8\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"155\" y=\"64\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"34\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"29\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"73\" cy=\"105\" r=\"9\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"68\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"112\" cy=\"52\" r=\"10\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"107\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text></svg>",
-                    "accessibility_label": "Original numeric pattern reasoning prompt 30."
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q30</text><circle cx=\"121\" cy=\"112\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 105 128 Q 121 96 137 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"160\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 143 76 Q 160 42 177 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"34\" cy=\"82\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 16 100 Q 34 64 52 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"73\" cy=\"105\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 54 124 Q 73 86 92 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"112\" cy=\"52\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 92 72 Q 112 32 132 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original odd one out reasoning prompt 30."
                 },
                 "options": [
                     {
@@ -3134,7 +3337,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"44\" cy=\"47\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"39\" y=\"52\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"83\" cy=\"70\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"78\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"122\" cy=\"93\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"117\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"161\" cy=\"116\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"156\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"44\" cy=\"47\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 21 70 Q 44 24 67 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"70\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 59 94 Q 83 46 107 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"122\" cy=\"93\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 97 118 Q 122 68 147 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"161\" cy=\"116\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 135 142 Q 161 90 187 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option A for original IQ item 30."
                         }
                     },
@@ -3144,7 +3347,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"66\" cy=\"81\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"61\" y=\"86\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"105\" cy=\"104\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"100\" y=\"109\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"144\" cy=\"51\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"139\" y=\"56\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"183\" cy=\"74\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"178\" y=\"79\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"57\" cy=\"97\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"52\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"96\" cy=\"120\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"91\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"66\" cy=\"81\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 41 106 Q 66 56 91 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"105\" cy=\"104\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 79 130 Q 105 78 131 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"144\" cy=\"51\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 117 78 Q 144 24 171 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"183\" cy=\"74\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 155 102 Q 183 46 211 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"57\" cy=\"97\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 28 126 Q 57 68 86 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"96\" cy=\"120\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 82 134 Q 96 106 110 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option B for original IQ item 30."
                         }
                     },
@@ -3154,7 +3357,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"88\" cy=\"115\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"83\" y=\"120\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"127\" cy=\"62\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"122\" y=\"67\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"166\" cy=\"85\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"161\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"40\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"35\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"88\" cy=\"115\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 61 142 Q 88 88 115 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"62\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 99 90 Q 127 34 155 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"166\" cy=\"85\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 137 114 Q 166 56 195 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"40\" cy=\"108\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 26 122 Q 40 94 54 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option C for original IQ item 30."
                         }
                     },
@@ -3164,7 +3367,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"110\" cy=\"73\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"105\" y=\"78\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"149\" cy=\"96\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"144\" y=\"101\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"188\" cy=\"119\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"183\" y=\"124\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"62\" cy=\"66\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"57\" y=\"71\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"101\" cy=\"89\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"96\" y=\"94\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"140\" cy=\"112\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"135\" y=\"117\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"110\" cy=\"73\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 81 102 Q 110 44 139 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"96\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 135 110 Q 149 82 163 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"119\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 173 134 Q 188 104 203 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"66\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 46 82 Q 62 50 78 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"101\" cy=\"89\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 84 106 Q 101 72 118 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"140\" cy=\"112\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 122 130 Q 140 94 158 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option D for original IQ item 30."
                         }
                     },
@@ -3174,7 +3377,7 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"132\" cy=\"107\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"127\" y=\"112\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"171\" cy=\"54\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"166\" y=\"59\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"45\" cy=\"77\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"40\" y=\"82\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"84\" cy=\"100\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"79\" y=\"105\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"132\" cy=\"107\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 117 122 Q 132 92 147 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"171\" cy=\"54\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 155 70 Q 171 38 187 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"45\" cy=\"77\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 28 94 Q 45 60 62 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"100\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 66 118 Q 84 82 102 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option E for original IQ item 30."
                         }
                     },
@@ -3184,35 +3387,42 @@
                             "kind": "inline_svg_markup",
                             "mime_type": "image/svg+xml",
                             "view_box": "0 0 240 160",
-                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"143\" cy=\"97\" r=\"8\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"138\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"182\" cy=\"120\" r=\"9\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"177\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"56\" cy=\"67\" r=\"9\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"51\" y=\"72\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"95\" cy=\"90\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"90\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"134\" cy=\"113\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"129\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"173\" cy=\"60\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"168\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text></svg>",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"143\" cy=\"97\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 126 114 Q 143 80 160 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"120\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 164 138 Q 182 102 200 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"56\" cy=\"67\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 37 86 Q 56 48 75 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"95\" cy=\"90\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 75 110 Q 95 70 115 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"134\" cy=\"113\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 113 134 Q 134 92 155 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"60\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 151 82 Q 173 38 195 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
                             "accessibility_label": "Option F for original IQ item 30."
                         }
                     }
                 ]
             },
             "correct_answer": "F",
-            "solution_rule": "Original deterministic numeric pattern transformation generated from seed 7330; choose the option preserving the generated progression signature.",
-            "distractor_logic": "Distractors vary one or more generated attributes: count, position, rotation, overlay order, or numeric step. No option is copied from third-party materials.",
+            "solution_rule": "Abstract odd one out grammar generated from seed 8330; choose the option preserving the declared odd one out numeric scaffold v2 transformation.",
+            "distractor_logic": "Distractors are seeded attribute perturbations that break exactly one or more of the generated rule attributes without copying third-party item assets.",
             "asset_hashes": {
-                "stem": "sha256:f6861884016af3bf8ffb612183ecabd5adc170f1224fd0c43d793f02ecfc10ba",
+                "stem": "sha256:41cf40a69577df5aef0ff3a4ab72902c6d93736059fc27a922588af6fc87dc74",
                 "options": {
-                    "A": "sha256:af3f9cb4ee6c198f766ab7c7725570527603b5a0a2b9362edcb0e05e0cd8728c",
-                    "B": "sha256:dcbb2f934e42d92ca9a14cab0908d3ebd197308ecb0d667c657d09959bd3f5e6",
-                    "C": "sha256:6e3f38abce966a54e5c828545c3ee733fc7b14bfd15225b07fe8004eb0eb902a",
-                    "D": "sha256:e03fa25fe5f6212ff6eb2411a0bd3d4a525312c80c0eaf10ec365a17e622c03c",
-                    "E": "sha256:517cd7e63ee1d83d3ef33b38455c5b6912df1ad6ca8d664defb584746e414f7f",
-                    "F": "sha256:17734fa59224ab74848d71e42f182a90397abeaefe0e503b8aad542908740f28"
+                    "A": "sha256:3e7ee57f92348d081e6959f37e8fe7880b634a7259d2ac304d19e164c3e888d5",
+                    "B": "sha256:1d5e13d7a8ffc0a137a0890cc30c57f0311f23a9a89e711eb609a98b29b72d7b",
+                    "C": "sha256:e94f64d8eab84ff2ee61e29356c73abc4b404707ce4d1e1ff8fbaf0c1c21356c",
+                    "D": "sha256:d50018361247dacfbeaede9cd10b2d252ae69378ff15b91e68ba32b898dcf885",
+                    "E": "sha256:9a9b4c32b3c3400affb3e5fab531c4a07271cbb8e08631239ba057601757d2b7",
+                    "F": "sha256:c0dbbd7ea739ad38735c1cad2d61fa277490569789637c650ace8b3aa6e09243"
                 }
             },
             "generator_metadata": {
                 "source_mode": "repo_generated_original",
                 "copied_from_third_party": false,
                 "traced_from_third_party": false,
-                "seed": 7330,
-                "template_key": "numeric_pattern",
-                "generator_version": "iq_beta30_original_bank_v1",
+                "seed": 8330,
+                "rule": "Abstract odd one out grammar generated from seed 8330; choose the option preserving the declared odd one out numeric scaffold v2 transformation.",
+                "rule_key": "odd_one_out_numeric_scaffold_v2",
+                "difficulty": 5,
+                "reviewer": "codex_beta30_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review",
+                "generation_phase": "beta30_formal_original",
+                "template_key": "odd_one_out_numeric_scaffold_v2",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta30_original_bank_v2",
                 "theme_version": "fermatmind_soft_contrast_v1",
-                "params_hash": "sha256:42487a5c9b845e9ead70ae58c5e01d5d730dcd78c8d94ddb5ed4ddc3a2347d1c"
+                "params_hash": "sha256:526099188511a60119ddf7530fd37e116bf0b8c8949775484429eeffe7618720"
             }
         }
     ]

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_30_ORIGINAL/manifest.json
@@ -45,10 +45,26 @@
         "third_party_license_required": false,
         "myiq_science_requires_license_verification_gate_before_use": true
     },
+    "generation_policy": {
+        "wave_1_formal_original_item_count": 12,
+        "beta30_formal_original_extension_item_count": 18,
+        "formal_original_item_count": 30,
+        "competitor_item_capture_allowed": false,
+        "competitor_item_rewrite_allowed": false,
+        "formal_item_source_mode": "repo_generated_original",
+        "required_item_metadata": [
+            "source_mode",
+            "seed",
+            "rule",
+            "difficulty",
+            "reviewer"
+        ]
+    },
     "public_payload_policy": {
         "may_emit_items": true,
         "may_emit_answer_key": false,
-        "may_emit_solution_rule": false
+        "may_emit_solution_rule": false,
+        "may_emit_generator_metadata": false
     },
     "norm_policy": {
         "iq_claims_enabled": false,

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/answer_key.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/answer_key.json
@@ -1,0 +1,308 @@
+{
+    "schema_version": "fm.iq.item_bank.answer_key.v1",
+    "bank_id": "IQ_BETA_50_ORIGINAL",
+    "public_payload": false,
+    "storage_policy": "backend_only_never_emit_to_public_api",
+    "answers": {
+        "IQ_BETA_50_ORIGINAL_01": {
+            "question_id": "IQB50-Q01",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_02": {
+            "question_id": "IQB50-Q02",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_03": {
+            "question_id": "IQB50-Q03",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_04": {
+            "question_id": "IQB50-Q04",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_05": {
+            "question_id": "IQB50-Q05",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_06": {
+            "question_id": "IQB50-Q06",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_07": {
+            "question_id": "IQB50-Q07",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_08": {
+            "question_id": "IQB50-Q08",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_09": {
+            "question_id": "IQB50-Q09",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_10": {
+            "question_id": "IQB50-Q10",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 1
+        },
+        "IQ_BETA_50_ORIGINAL_11": {
+            "question_id": "IQB50-Q11",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_12": {
+            "question_id": "IQB50-Q12",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_13": {
+            "question_id": "IQB50-Q13",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_14": {
+            "question_id": "IQB50-Q14",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_15": {
+            "question_id": "IQB50-Q15",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_16": {
+            "question_id": "IQB50-Q16",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_17": {
+            "question_id": "IQB50-Q17",
+            "correct_answer": "E",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_18": {
+            "question_id": "IQB50-Q18",
+            "correct_answer": "F",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_19": {
+            "question_id": "IQB50-Q19",
+            "correct_answer": "A",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_20": {
+            "question_id": "IQB50-Q20",
+            "correct_answer": "B",
+            "dimension": "VSPR",
+            "difficulty_level": 2
+        },
+        "IQ_BETA_50_ORIGINAL_21": {
+            "question_id": "IQB50-Q21",
+            "correct_answer": "C",
+            "dimension": "VSPR",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_22": {
+            "question_id": "IQB50-Q22",
+            "correct_answer": "D",
+            "dimension": "VSPR",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_23": {
+            "question_id": "IQB50-Q23",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_24": {
+            "question_id": "IQB50-Q24",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_25": {
+            "question_id": "IQB50-Q25",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_26": {
+            "question_id": "IQB50-Q26",
+            "correct_answer": "B",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_27": {
+            "question_id": "IQB50-Q27",
+            "correct_answer": "C",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_28": {
+            "question_id": "IQB50-Q28",
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_29": {
+            "question_id": "IQB50-Q29",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_30": {
+            "question_id": "IQB50-Q30",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 3
+        },
+        "IQ_BETA_50_ORIGINAL_31": {
+            "question_id": "IQB50-Q31",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_32": {
+            "question_id": "IQB50-Q32",
+            "correct_answer": "B",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_33": {
+            "question_id": "IQB50-Q33",
+            "correct_answer": "C",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_34": {
+            "question_id": "IQB50-Q34",
+            "correct_answer": "D",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_35": {
+            "question_id": "IQB50-Q35",
+            "correct_answer": "E",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_36": {
+            "question_id": "IQB50-Q36",
+            "correct_answer": "F",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_37": {
+            "question_id": "IQB50-Q37",
+            "correct_answer": "A",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_38": {
+            "question_id": "IQB50-Q38",
+            "correct_answer": "B",
+            "dimension": "VSI",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_39": {
+            "question_id": "IQB50-Q39",
+            "correct_answer": "C",
+            "dimension": "NPR",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_40": {
+            "question_id": "IQB50-Q40",
+            "correct_answer": "D",
+            "dimension": "NPR",
+            "difficulty_level": 4
+        },
+        "IQ_BETA_50_ORIGINAL_41": {
+            "question_id": "IQB50-Q41",
+            "correct_answer": "E",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_42": {
+            "question_id": "IQB50-Q42",
+            "correct_answer": "F",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_43": {
+            "question_id": "IQB50-Q43",
+            "correct_answer": "A",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_44": {
+            "question_id": "IQB50-Q44",
+            "correct_answer": "B",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_45": {
+            "question_id": "IQB50-Q45",
+            "correct_answer": "C",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_46": {
+            "question_id": "IQB50-Q46",
+            "correct_answer": "D",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_47": {
+            "question_id": "IQB50-Q47",
+            "correct_answer": "E",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_48": {
+            "question_id": "IQB50-Q48",
+            "correct_answer": "F",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_49": {
+            "question_id": "IQB50-Q49",
+            "correct_answer": "A",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        },
+        "IQ_BETA_50_ORIGINAL_50": {
+            "question_id": "IQB50-Q50",
+            "correct_answer": "B",
+            "dimension": "NPR",
+            "difficulty_level": 5
+        }
+    }
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/items.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/items.json
@@ -1,0 +1,5709 @@
+{
+    "schema_version": "fm.iq.item_bank.items.v1",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "bank_id": "IQ_BETA_50_ORIGINAL",
+    "item_count": 50,
+    "option_count": 6,
+    "items": [
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q01",
+            "item_id": "IQ_BETA_50_ORIGINAL_01",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q01</text><rect x=\"52\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"61\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"62\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 01."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"96\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"97\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 01."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 01."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9501; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:57abb24efba98bbe4b64d228ffc7da8f832a3ddb3f966400b0035fc2ec3b942a",
+                "options": {
+                    "A": "sha256:772644275dcc3835ed858fad46a6f2c02b578b88ac29dfb0242a24f2a6b704f5",
+                    "B": "sha256:23fbe18db54bc4001b0a3822dc795a55b6bd65d1c1737d4a40d3efa0a03864d9",
+                    "C": "sha256:7420e746349aff615fc2e075ee06a881e39b32f9bd2faacb78d413840a3fa15f",
+                    "D": "sha256:df98db27a0aa617d24fb6d042c7d9d40707072535f045417fdc4f8c3948cde7d",
+                    "E": "sha256:0e6e1ccb62a2815dfbfb48415d56236905b5d6839d0cd1ce175159a6ec05f985",
+                    "F": "sha256:aa8940aabdf4bde0ba70f436a1dcd5f5eb34ab984d376fae8fd51065ac6e1dce"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9501,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9501; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_01",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_01",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:924570330cfde0937c44333994f1d072f30575bf72605f9105da2897458f5fd0"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q02",
+            "item_id": "IQ_BETA_50_ORIGINAL_02",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q02</text><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 02."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"61\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"145\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 02."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 02."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9502; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:0d3a7f4143391af044c47fbcbbbc4c424ce0d979b33affa63706945ca2de80ee",
+                "options": {
+                    "A": "sha256:45e5bf5d6f34e9d4fc1f5b95ad5d0eddb334114d113e08830db0318a49a915fe",
+                    "B": "sha256:93f3e03a23036b26a248caad87bb356c01cb094ccf60b1b336f6c785692c57e3",
+                    "C": "sha256:48001ec28b62b8404bb69d76baf7e6ce40d1abf817e9742603ae519a94c617f8",
+                    "D": "sha256:6620852e974640a217f8ee968af25d818b97a5618341fec072bab634ff720c70",
+                    "E": "sha256:e42c426587e859d78445cdbf84517285faf7b59ca95e03cdbbc14230ac056723",
+                    "F": "sha256:f1c55a9d723420f1dec8ab09abe2f4e1adde79a8fd31ed2b0bb406fa57f401f5"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9502,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9502; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_02",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_02",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:a0793b535ae315ebdfa9d9d263e419e0837c634f5ae03ff6db698814896330fb"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q03",
+            "item_id": "IQ_BETA_50_ORIGINAL_03",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q03</text><rect x=\"57\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"62\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"149\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"57\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"95\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"96\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"97\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 03."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"144\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"95\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 03."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"58\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"95\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 03."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9503; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:df58be4617163e772350716d5e30aa4ad8cfe81ef2d9e40f888d103ab17cd404",
+                "options": {
+                    "A": "sha256:14dd4f332558f723b261158ed271ad58f67aa63c1078f930fa4cb2bf166290d6",
+                    "B": "sha256:d0e7f0116f9332249c14075c2dbc1d853e4ce7623131ee551194425762b4bdb9",
+                    "C": "sha256:9637041f50062d5d83f9bd4759e8d8f86ffbf101c40c908ee1dbfdd42d494f1c",
+                    "D": "sha256:d8860090b203eff8b4f451886458b06e21207949ba224a254b652d4151492838",
+                    "E": "sha256:b1d173eef4703d794bd2cc62c2cc231e84ed8c902cde69dde2354d4956c60c31",
+                    "F": "sha256:0ebba36cdcb0f7327820b99a6214acb935d2d51a30829f989e48474d2b24f16e"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9503,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9503; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_03",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_03",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:d9e97fb11e6a450d356aec7913d2dd9953de1d1a76436707ec7119cdc73dc18a"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q04",
+            "item_id": "IQ_BETA_50_ORIGINAL_04",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q04</text><rect x=\"53\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"59\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"145\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"98\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 04."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"95\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"60\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"97\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"98\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"60\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"97\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"98\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 04."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"97\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"147\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 04."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9504; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:4099ee38ac951d36cb4955d5f02fb6b0e6eae5169c854024acb9c1fd0f98a1e3",
+                "options": {
+                    "A": "sha256:bf726fc60de22d7f8ab9dd86788466ed9286dae2ebcd69589cb28d31d36b68d7",
+                    "B": "sha256:5a6d5daefa854e4ab54ea6bbaecd800086ba87a54132d948505cf2d723819763",
+                    "C": "sha256:684e65c3bba5a0b32ac1cb956df562a1a9d661c838573ee7c96ccb3b01a299d9",
+                    "D": "sha256:c433de7d3175269a9c2795906ac4001ed104fe033bfc8d1faf4cfa2cba610c1d",
+                    "E": "sha256:980734622fdfba75c8c9d7c804b1c7be0a47f2310e845f0ddcc058cf30f65654",
+                    "F": "sha256:88be07c6ff2018bb8161d821367f1e012d7bbd6649104b1bb6a3cf3787950437"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9504,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9504; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_04",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_04",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:a0af43354551f5b1dc67041b99def02ca8b06314799fa384e4c438f7fe2b53ec"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q05",
+            "item_id": "IQ_BETA_50_ORIGINAL_05",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q05</text><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"97\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 05."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"94\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"95\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"95\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"96\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"97\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 05."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 05."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9505; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:8291f3ad232ea6e22e7db6a5908f138a2c989ba202ac7da4dea5b3999016f10d",
+                "options": {
+                    "A": "sha256:83a20f2945ca4995febda6bd0391c695c98e11855595e41d4e9b6b15bf5e03fc",
+                    "B": "sha256:c2f12bdfdee6ab11aa52b6b2c32a089f734a8f75136f2b398c815322b0b2ebd9",
+                    "C": "sha256:df99f832c76e45c8af06bbc44fcb30215b1383b6743d737b24950d963a8f528f",
+                    "D": "sha256:1f50fde3f07498433841ee881941dc94579716d186d86a8594ff6924e466b2fe",
+                    "E": "sha256:0be4cf9217f5647c6a67e5fac3ec97c21aa62e0101ac48f99b424a030bf9ed21",
+                    "F": "sha256:6d397af025dd738f484996994f909953b653d3b839e61fe6c90c894074c25fb4"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9505,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9505; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_05",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_05",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:44772a9bb600d5811ea27a5be70e25f875968782a13b8f90b386d6f02cd0ca42"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q06",
+            "item_id": "IQ_BETA_50_ORIGINAL_06",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q06</text><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 06."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"94\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"94\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"58\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"59\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"96\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"97\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"98\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 06."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"57\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"98\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 06."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9506; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:ab63e1e6afbc35ebe2590e52fdf6197eff20f64ce9776c4a77747b835a3741bf",
+                "options": {
+                    "A": "sha256:5cd226d9bc9bd1a7589d4049d8eed1f054f8835121195396748a748da42f23d5",
+                    "B": "sha256:3e0c8386c5241c4228e22a3e36df33e5a43b5cc4e8e450b40b952b63e39cb246",
+                    "C": "sha256:b61b83de9c8c403c4dbf9fe2f1d5d1672d32fca5b9e7b73511165cbcc3d53047",
+                    "D": "sha256:90a72126bd06636042ae78a39b69457142812cdb90ea7e2360b2f3c92bef885b",
+                    "E": "sha256:e87200cc6ad15cd7ab7f17c39bdf9f210be227a9164ddd1200bccb457d857d66",
+                    "F": "sha256:5131ede2626f70309b305c462bee741272561dc014de519574eb4182de872659"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9506,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9506; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_06",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_06",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:04111aba30edf707b67f8a05a729f3966f8e462dab0479ed8812ffdec8e4e9d8"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q07",
+            "item_id": "IQ_BETA_50_ORIGINAL_07",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q07</text><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 07."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"95\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"98\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"98\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"96\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"97\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 07."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 07."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9507; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:951392d8d94afa4590d770a8b8c0d76196d0697961cae624cb82ebd5e5f6338c",
+                "options": {
+                    "A": "sha256:13c1ae87d427cba37f3301ead92b240f274e6ebffed1a137fdff4b8662a77b82",
+                    "B": "sha256:ebdc4be683e3c2d1cb23d493b3982c842a4d394868e477546f89c20d4081f81a",
+                    "C": "sha256:3e73261f6af2bfa885bf0afb2a4a0fa945de945b22861ffd86635db5f193facb",
+                    "D": "sha256:4c9f85532ecfad12fa3f62c2bc50379d56db1c673d335c1c1cd0633ecfad0130",
+                    "E": "sha256:cf59df7fe2fe8bd5b235278a5b0a1038de8b9869ee67144045d039ca6702f293",
+                    "F": "sha256:63f06e0b3c1ff56bc0513abf632aa0c922d7f02f22b9689bfb0cc16b22d0c18b"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9507,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9507; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_07",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_07",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:ba7911858418ebfdde511681aba162d65f7f3d4d3d529904a581169b719f9171"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q08",
+            "item_id": "IQ_BETA_50_ORIGINAL_08",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q08</text><rect x=\"58\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"61\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"62\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"99\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"94\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 08."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"95\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"96\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"99\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"94\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"96\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 08."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 08."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9508; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:67effa5308937439c7ed47c0403f7d01b29d0f5f0cafdd7f74e4fb10a34938c3",
+                "options": {
+                    "A": "sha256:ad01bd9960112377a554e25690f75692a454be20bea525eeec435c608cba8253",
+                    "B": "sha256:c601329a1d02c2ae4ec38ce909aa0263cd8c495cdc0209c9a84ac1cfe0915e86",
+                    "C": "sha256:722c1cb9e83a4e638c5b18ec3659928866f74b82d1006f1382a3b32cddafbf19",
+                    "D": "sha256:9b5be0ce6ed4a2f6ce18b1d63c54e23c51286f3eedebf5328a18c96e17adcf33",
+                    "E": "sha256:99db07906695655168785314e376e05414b282d023689c54b516b273e301654b",
+                    "F": "sha256:ac6e5cc7a803aec1bbd239800873bc00730247b1045f761b0f54a4ed250be0b4"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9508,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9508; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_08",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_08",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:db3557a00e6b7dff64c07dc19c51234d3ce6a6159152d1fa63627b499766ef74"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q09",
+            "item_id": "IQ_BETA_50_ORIGINAL_09",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q09</text><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"99\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 09."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"63\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"58\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"149\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"59\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"60\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"144\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"61\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"98\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"99\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"63\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"58\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"96\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"97\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 09."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"94\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"95\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 09."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9509; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:efa5e922745e2081900500e2524179633527f9818fd24cfd105559805c790d07",
+                "options": {
+                    "A": "sha256:254ba4e3135742708d6410f7b1e9234562a8b4ee141529e4bde3fc6ad46fb503",
+                    "B": "sha256:b1d4e51bdb97a944ecd280507d678a23ff49b2e4c57df9522eaf2e6a40abd630",
+                    "C": "sha256:b7825a6fbe8a024821c19ba6ac7b41925bbe05952d05aeec7f0bdfd1478464ab",
+                    "D": "sha256:5c498b6d74b11be5664f78bfa1f4e726315bdcba100cdfdd2abd34def577fe10",
+                    "E": "sha256:c40c83a34d620e6c4f9b5f0363f67636bdc4bc800798fdfcea810f45bb57e4af",
+                    "F": "sha256:41432e168d0ff9e2e49a8b55c3fbee55f7362dd27dd6db72dd06f7d4584094ce"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9509,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9509; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_09",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_09",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:5a40ff09ae93ec1a4416b8a26a62af3aa995f7dd9d65be743ff756a7fb6bc521"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q10",
+            "item_id": "IQ_BETA_50_ORIGINAL_10",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 1,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q10</text><rect x=\"56\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"61\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"148\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"63\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"56\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"94\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 10."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"61\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"94\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"95\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"61\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"94\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"55\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"94\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"97\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"147\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 10."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 10."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9510; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:3737dc5596a3e03bce9b745516cb55975f0e4061a9869061c612ce26963ecf78",
+                "options": {
+                    "A": "sha256:59c38d274c628529e286567e365cbf83fbc627410b810b47398c948c282e6613",
+                    "B": "sha256:9ddd8f07e0bec772c896236ffef15e7823614b5b312b63061fbe6e804db79817",
+                    "C": "sha256:a65f0c26d7b82cfb79f535da5e19fb1c41978659d1106c8cdff25719a1c5340f",
+                    "D": "sha256:52d06a04811bf149eea56804e770df20672af354bf3bcbba281f03db4290ea75",
+                    "E": "sha256:e3972b1c5381aad6bc991672c507af24eb452a2bae74fab2a5b280044eed0b93",
+                    "F": "sha256:87dc6475e42e25a5ea742aab492b1bed701bbdfe8aa377f889cb373e35be48bf"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9510,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9510; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_10",
+                "difficulty": 1,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_10",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:ef61a48fbfe1d647367c5ae16169448b27f00da811b10aa126bbd7f2aa9ec96f"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q11",
+            "item_id": "IQ_BETA_50_ORIGINAL_11",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q11</text><rect x=\"52\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"58\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"59\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"144\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"60\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"52\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"97\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"98\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"99\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 11."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"59\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"60\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"150\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"61\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"58\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"58\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"59\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"96\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"97\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"58\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"59\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 11."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"58\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"59\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 11."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9511; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:a6b690c3fc3c098510ce33d397146fa579db5b1ef568f88f98227dd51278b789",
+                "options": {
+                    "A": "sha256:06ac5dddf6c7b47155a9896d478cdec77c9450d7b796f596dbcaf5be59f33f83",
+                    "B": "sha256:fcaa4f30942bd04317bf6810425d972b792a25da9ebca33345823fdba3553a62",
+                    "C": "sha256:e3b31f51580feaa01f7506077214d668d1394ddfdbb1e43abf89f2fdea2b1e6e",
+                    "D": "sha256:b95b4d5c0077ecba028cf77d47b9e965d8c75d2ec3cd45e1c2985a50a2117941",
+                    "E": "sha256:64f292141d1a214f1373ce59fa3d904ab546eba5402f2d0b8a9a51c0691b927a",
+                    "F": "sha256:ba60082a4ae905196962cfaf582bf1a9f099102bcff32757c5d49a93215523c4"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9511,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9511; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_11",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_11",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:f4f43fbcc7545add1fb980f81b70b0504bf6e138b0a6b8f7711696f2f92f4dbd"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q12",
+            "item_id": "IQ_BETA_50_ORIGINAL_12",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q12</text><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 12."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"58\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"59\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"60\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"94\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 12."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"94\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 12."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9512; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:6e61c60a63d0c7b04566d29c5699d725cf0c00d7779d6b2224264215a7696704",
+                "options": {
+                    "A": "sha256:4dc1dafd83777b1e36bac1da02813444c59da5b1a654b210d012d5a03b19738b",
+                    "B": "sha256:51f10828b000c8e169d75c17d0211495845d08e305d8c13aaaf1ffb63476f7a5",
+                    "C": "sha256:6cc90f02d8695eb87e5c1345512ebde487b49ab1af20a83b931893bb9cafb4dd",
+                    "D": "sha256:88647167bbaab7917354365b98f6ea6ef4286698350d481b923d60e470e79acc",
+                    "E": "sha256:cd02d466dbd7a7cc4bd247197a8eaa78ad1580eea1a5aab512f2b9fcf622d5af",
+                    "F": "sha256:6260d2c372660ffbbe778e34ae7d85197759a0673e515a7064742f434ab844e2"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9512,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9512; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_12",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_12",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:23a6342393e466264664a14a1ce03ab124cda157c686b3b9f2ebc7a66a9a4b4c"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q13",
+            "item_id": "IQ_BETA_50_ORIGINAL_13",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q13</text><rect x=\"58\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"59\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"60\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"61\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 13."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"146\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"98\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"96\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"97\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 13."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"63\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"58\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"59\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"96\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"97\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 13."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9513; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:547e94e97a8078da10bb55c7fcbc00fe7b20bc9e7df973b62192dc382fa54464",
+                "options": {
+                    "A": "sha256:f21e8c44df1c1739d2933ad1f4dcabb68e757475e63614136b654af4cf9b121d",
+                    "B": "sha256:3d722b8e5912b0cd01e20e6b79ce3131258e35e77bce0fc12aa026c1d930b830",
+                    "C": "sha256:226fd987400c976a60bd70cec7b6a04819414ca75462c816b338da3bb7b2a6ea",
+                    "D": "sha256:b716eae9005a10b21c38f03f4cd2e6f764762b53a5a6ec6c5b1a8a3e1e54911e",
+                    "E": "sha256:763211dae4df7528f97a7ddf515930dbd4d933397c14a615f5be7e1771817866",
+                    "F": "sha256:8a4acb64cd9b922dfe31d019c7ed5f52e795f532fc9448f7467ea684e5f16b50"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9513,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9513; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_13",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_13",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:e5ce25534823d5beba7cf92882bcdc55c0f9ea3d7ce5c1347d2d45d8d6323e06"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q14",
+            "item_id": "IQ_BETA_50_ORIGINAL_14",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q14</text><rect x=\"54\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"62\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"63\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"146\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"58\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"95\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"96\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 14."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"61\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"148\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"145\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"95\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"96\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"94\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"59\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"60\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"147\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"61\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"99\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"147\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"94\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 14."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"94\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 14."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9514; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:aa70633bd0a65a0d903895d71df1cb4c12e1f5afa3683cb67ea9a1f2ccc0cd81",
+                "options": {
+                    "A": "sha256:c2bfee3433b49f2a2f4c8ca29da463622e26c7e98a1cc094bdaf4531fbf56407",
+                    "B": "sha256:e96b6253cd5d9dc0b37d49f2dc017ae02411ae6ad79d6aede2e661671705b21b",
+                    "C": "sha256:6175f10b1efd2d6994a45e79ec8fbca9725eec8b144b33aa5555b153047c0cda",
+                    "D": "sha256:29a97c19b4e201f29a6cf293ddc3edbc69533093d2c477b27d8cdda14f6f64a1",
+                    "E": "sha256:c39cb4121c6b5417401dffe9480fb29ed765b6089eab56c83b45b1d5ba6635dd",
+                    "F": "sha256:578c026678112b92727a3b6be7edac2b8af3331bd0c893a92857edafbf73f1a8"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9514,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9514; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_14",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_14",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:091811dfde8e29d140c1cb2b38d75721fa6fd0004702863401f9194a1f0464e6"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q15",
+            "item_id": "IQ_BETA_50_ORIGINAL_15",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q15</text><rect x=\"57\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"59\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"60\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"61\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 15."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"58\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"145\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"53\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"67\" cy=\"97\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"113\" cy=\"98\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"145\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"159\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"147\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"55\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"58\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"59\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"60\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"97\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"61\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"149\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"63\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"97\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 15."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"68\" cy=\"59\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"114\" cy=\"60\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"146\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"160\" cy=\"61\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 15."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9515; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:c78499037813ac8b29eef64bfcc0712a54515b18af4287b92be9f11d3f6124d2",
+                "options": {
+                    "A": "sha256:4fb6772c068f7b9f59355917f5708c59c74ca3feb28041462d47026d0a5b6ee1",
+                    "B": "sha256:af8f10461a165755c711999ebc044ba0ea1cb5652910aac359ca1ce5209a61b7",
+                    "C": "sha256:e6d388a382605c928bd122041ab3ab5eb8f607d860b86e30fe9e706bdc6417e5",
+                    "D": "sha256:7bd441ea2c491fd1a935fa666305572a1bbb33ba270e67becc7d58aaaaae930a",
+                    "E": "sha256:17a93f461f40432eecbfb0fafc4b2d97a22266d366dd94a9b5212e3dbb150ba9",
+                    "F": "sha256:9222a3898e31942fac1f4c441612a24fde8bca9a97d9d75b1b3688ab607e1e76"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9515,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9515; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_15",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_15",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:d0db8d75181cd9f9500baa2883a8876ac614340ad11771ed328d14c3fff6335c"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q16",
+            "item_id": "IQ_BETA_50_ORIGINAL_16",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_3x3",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 3x3</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q16</text><rect x=\"52\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"63\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"112\" cy=\"58\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"144\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"158\" cy=\"59\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"66\" cy=\"96\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 3x3 reasoning prompt 16."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"148\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"162\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"96\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"150\" y=\"47\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"61\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"58\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"85\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"80\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"94\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"58\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"104\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"59\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"150\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"60\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"150\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"164\" cy=\"58\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"95\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"69\" cy=\"62\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"115\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"147\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"161\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 16."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"58\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"59\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"149\" y=\"46\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"163\" cy=\"60\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"57\" y=\"83\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"97\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"84\" width=\"28\" height=\"28\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"98\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 16."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9516; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:ea180b99425678639d7e2420d0d914d0a90384af85e70f7d07f250920dad4f52",
+                "options": {
+                    "A": "sha256:7fd9194b13734df35e5d65657f1e04c9f025407075c1212651e53127f27175da",
+                    "B": "sha256:9dee946682f272ef49f9f30fe1fe7f108933fbc24b700ccb4314eb5909ba19ac",
+                    "C": "sha256:106114ca8ba7f24784a962b3f5bb50da2c6d21c3b12303afe44de28de7830e59",
+                    "D": "sha256:582b3800d2a8800a403fbf7196eac2b99678f7a22bd4a798c4b2c278eb20fb7b",
+                    "E": "sha256:4b896377f0dc32a4cf1052da2aebb28733ef08d32805eb3a7132ba0319f9eabc",
+                    "F": "sha256:5d7d12f987613d986557e83c7b3268f8cb24e209c4d06b3a3cc32228bc760822"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9516,
+                "rule": "Abstract beta50 matrix 3x3 grammar generated from seed 9516; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_3x3_formal_rule_16",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_3x3_formal_rule_16",
+                "item_family_template": "matrix_3x3",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:150464b788f65ab45bc4ebc47ca90f59dfb1d7baace8a42dc16cc59b9f5aa289"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q17",
+            "item_id": "IQ_BETA_50_ORIGINAL_17",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q17</text><rect x=\"55\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"64\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"65\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"102\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"103\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"134\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"135\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 2x2 reasoning prompt 17."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"65\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"66\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"103\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"64\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"65\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"102\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"103\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"66\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"67\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"98\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"99\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"136\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"137\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"62\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"63\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"100\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"101\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"64\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"101\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 17."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"66\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"67\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 17."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9517; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:8a62b6ddb2cb824e4cf947878533a25252ffa33af64952aa08e10ddeac488cc0",
+                "options": {
+                    "A": "sha256:4ce79acc302348bbb749bd81e46a6ea73f4e83d891fba3aeb75109dd6a33e971",
+                    "B": "sha256:256c30fd33d312aedbb2d008ddd6123c043767a1e7531e2ef1fdd732bc61c4f2",
+                    "C": "sha256:63676d4e1b8d1ce7c62650fc0c9a6108a96016763409b9be1d60cd45f6f981f4",
+                    "D": "sha256:2355678220251f13ae15cecf36026135c6e0e62342a4e2cba6806996b3fa716f",
+                    "E": "sha256:5c0608a45b935433fb98b92ee4202db277e02f2dd879b3c73fe0063d80d5fc9a",
+                    "F": "sha256:503bc1c95c3144710dc983b5b3a37f86bf6b22735a3b94fdf55a548075192cd7"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9517,
+                "rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9517; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_2x2_formal_rule_17",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_2x2_formal_rule_17",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:a5b56cb852ea2fe0d7b647ae94fe23d5133e1d6a98853ceef7c90f8a773997e6"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q18",
+            "item_id": "IQ_BETA_50_ORIGINAL_18",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q18</text><rect x=\"58\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"67\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"99\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"100\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 2x2 reasoning prompt 18."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"66\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"67\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"98\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"99\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"55\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"136\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"62\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"63\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"100\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"64\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"65\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"102\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"103\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"134\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"66\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"67\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"62\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"63\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"100\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"101\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"56\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"138\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 18."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"66\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"67\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"98\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"103\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"99\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"57\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"136\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 18."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9518; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:e695ce74da37d911b861d9e1f47e968ec743e59d668189803074c7f8732f233a",
+                "options": {
+                    "A": "sha256:ee94f8e9231847d248f5f5d60eba41482ef3183302ddf7dae54d16fbe539b2c7",
+                    "B": "sha256:6ffefddd93da759c4d09a02891df67ebd521f377fbfc845964d986a80f3ed4b9",
+                    "C": "sha256:837329b7a241cb23404ef1124ea777f9ac75f9721ba355aec1d5fcddfa4c48be",
+                    "D": "sha256:61492f36a73ad7f0c0ed96f6f6debada4728785b4ddfb938cc8af10bd2ae1f1f",
+                    "E": "sha256:d7c6822339f187d29e89deb626aefef7b2d692d4fb3c8d91ed1d3df66358bbdf",
+                    "F": "sha256:c3801630aa359325a237e066694563f5a7fdff480dc962905a1b28d9e9a2a15c"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9518,
+                "rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9518; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_2x2_formal_rule_18",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_2x2_formal_rule_18",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:f95ba629b4d2f4b9141337cbdaf81f49d2e53bc7015f59701336e6d73a7b3750"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q19",
+            "item_id": "IQ_BETA_50_ORIGINAL_19",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q19</text><rect x=\"55\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"64\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"65\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"102\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"103\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 2x2 reasoning prompt 19."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"64\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"101\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"102\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"139\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"66\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"67\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"98\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"99\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"62\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"63\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"100\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"101\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"57\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"138\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"139\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"64\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"65\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"102\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"103\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"66\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"67\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"54\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"98\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"99\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"136\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"137\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 19."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"62\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"63\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"100\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"101\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 19."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9519; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:39fc779eff36a67a35e5a251a7dce6e3ade2bc75e729edb2e67ecd01cdad354b",
+                "options": {
+                    "A": "sha256:49178963a21b00be87e5d05b2f0448a5f5b0d765c5eef7cef4b2b2e05f349f61",
+                    "B": "sha256:2a5525500343e8917461fccc395b7ba0dcbf5cae358c9df624ba8b313d7108a1",
+                    "C": "sha256:86e7b446adfd52dcea4b801d05da35a62df585905c31412b14700dffdc433739",
+                    "D": "sha256:d331a2673e5d21775696eb91adbc5d586bc5a0d2ecb8acd09b74c833c55a15e3",
+                    "E": "sha256:ffcda769c902d0f87a5b7dfdcf449c5214ed89e8e4e081221025c58fcb0f59b9",
+                    "F": "sha256:feb05576a5c1a5fc80325b35a39dde0a682df21ecffbf4d1d8fe7df9cc3f7a32"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9519,
+                "rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9519; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_2x2_formal_rule_19",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_2x2_formal_rule_19",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:b87b1f7f5dfff44866442d59d8d720b7241c0340854d40ed7076861cf5281882"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q20",
+            "item_id": "IQ_BETA_50_ORIGINAL_20",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 2,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q20</text><rect x=\"57\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"62\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"103\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"63\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"57\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"100\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"103\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"101\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"57\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"138\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 2x2 reasoning prompt 20."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"63\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"64\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"101\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"102\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"67\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"102\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"56\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"102\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"100\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"56\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"137\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"102\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"138\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"67\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"99\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"100\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"139\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"134\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"65\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"66\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"103\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"98\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 20."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"67\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"52\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"100\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"137\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"138\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 20."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9520; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:bd74f27c5f871c406330d46e1a4ebe99b9cd97d559e93f8b9225e2362a1460e6",
+                "options": {
+                    "A": "sha256:d274db16f7afb985575bd4b4f8e6ceb612aecb0e9b20d96624bb61ea91cda574",
+                    "B": "sha256:92b7b74106452e6cdfb13ee5334db2af10b3a7ef3030249c0514f38d8923b614",
+                    "C": "sha256:c3eb5078f3e3e7ec9a6ad7817e9a334f7ca93b9c9e2eae3e6041f23a25f5ca50",
+                    "D": "sha256:268cd23eb3674d81610053b11e10fed88a01c8fe969acc8683fd36285356b906",
+                    "E": "sha256:7fcd2f295416c74109fa1aaf25c935073bf8ade0f177d7672ad1ff77134193c0",
+                    "F": "sha256:35650c80e9f7dfdeb2ec33bf41e22148f2cfcf7c777c2f312725467b8d77de74"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9520,
+                "rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9520; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_2x2_formal_rule_20",
+                "difficulty": 2,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_2x2_formal_rule_20",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:d67a02e101fc07f43703f243908558ade9a75af8349f3592b9960808d8faa213"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q21",
+            "item_id": "IQ_BETA_50_ORIGINAL_21",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 3,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q21</text><rect x=\"53\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"65\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"99\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"66\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"53\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"103\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 2x2 reasoning prompt 21."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"53\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"67\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"99\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"117\" cy=\"62\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"53\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"71\" cy=\"99\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"63\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"101\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"64\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"55\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"101\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"101\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"102\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"55\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"139\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"64\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"65\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"52\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"102\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"98\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"103\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"67\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"52\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"98\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"100\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"52\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"137\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"64\" r=\"10\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"101\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 21."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"56\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"65\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"66\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"103\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"102\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"98\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"56\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"135\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 21."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9521; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:190cdc87c929d33ad36f7dbf9a1bd8a1eecded72a5d5be487294e4dc7eeea381",
+                "options": {
+                    "A": "sha256:2b50b96097790484c8a30e5890c34b81a2dbddf6563fb7e18ce8e81c05624428",
+                    "B": "sha256:f06564f7bb338330081ce54ad9a2ba2bfb2261f8e25a4d8eee573a6a41cda3a6",
+                    "C": "sha256:7a4ca8cd7abbdf2b3cfede500032b3d05dce5c4e4d1524e0579323ab72bd272a",
+                    "D": "sha256:36917c69182e6959c7ee14f2133f1ef4f49191a8a7a0eaedd47483ec3e4f9e68",
+                    "E": "sha256:cd6141c310151cd1375fe947efe2dfbc6b1443e2e6f801c6e2d39ccda3fc09bc",
+                    "F": "sha256:c59db10c2ab05ffad1fe4939d863288878305c61cebbd87390a9848016686660"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9521,
+                "rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9521; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_2x2_formal_rule_21",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_2x2_formal_rule_21",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:2548d747f7b64b9c8bc78b208529e8123f0e3daa3b70bfb978d179c0e8c92503"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q22",
+            "item_id": "IQ_BETA_50_ORIGINAL_22",
+            "dimension": "VSPR",
+            "dimension_name": "Visual-spatial pattern reasoning",
+            "difficulty_level": 3,
+            "item_family": "matrix_2x2",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">matrix 2x2</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q22</text><rect x=\"56\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"102\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"63\" r=\"12\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"56\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"100\" r=\"5\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"102\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"120\" cy=\"101\" r=\"6\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"56\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"74\" cy=\"138\" r=\"7\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                    "accessibility_label": "Original beta50 matrix 2x2 reasoning prompt 22."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"57\" y=\"47\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"65\" r=\"12\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"103\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"66\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"57\" y=\"85\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"103\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"103\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"57\" y=\"117\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"75\" cy=\"135\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"103\" y=\"118\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"121\" cy=\"136\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"67\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"98\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"62\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"52\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"70\" cy=\"99\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"98\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"116\" cy=\"100\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"54\" y=\"45\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"63\" r=\"8\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"100\" y=\"46\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"64\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"54\" y=\"83\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"101\" r=\"10\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"100\" y=\"84\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"102\" r=\"11\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"54\" y=\"121\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"72\" cy=\"139\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"100\" y=\"116\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"118\" cy=\"134\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"55\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"67\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"101\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"55\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"99\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"101\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"100\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"55\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"73\" cy=\"137\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"101\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"119\" cy=\"138\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"67\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"104\" y=\"44\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"62\" r=\"5\" fill=\"#7b4f8a\" opacity=\"0.78\"/><rect x=\"58\" y=\"81\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"99\" r=\"6\" fill=\"#c7504f\" opacity=\"0.78\"/><rect x=\"104\" y=\"82\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"100\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.78\"/><rect x=\"58\" y=\"119\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"137\" r=\"8\" fill=\"#d9843b\" opacity=\"0.78\"/><rect x=\"104\" y=\"120\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"138\" r=\"9\" fill=\"#4666a9\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 22."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"48\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"66\" r=\"5\" fill=\"#4666a9\" opacity=\"0.78\"/><rect x=\"104\" y=\"49\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"122\" cy=\"67\" r=\"6\" fill=\"#a7b35a\" opacity=\"0.78\"/><rect x=\"58\" y=\"80\" width=\"36\" height=\"36\" rx=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"1.5\" opacity=\"0.24\"/><circle cx=\"76\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.78\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 22."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9522; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:dc3c90235765636b1ce485a0c45ced98ec4429bbc1e2102c9e847752a823549b",
+                "options": {
+                    "A": "sha256:ebe6b57662f392f9dd007b155224f848d0e27b1637f066499735e1340239bbaf",
+                    "B": "sha256:d849cc175c946dbbd0ad57d16f4ef8977f1d0104969a2da233abcbce790829b4",
+                    "C": "sha256:f50df4b44aec618a24ef9d881319cd4df690ad2e7e591ada121b9a7aa0ca6d2a",
+                    "D": "sha256:81fe89f433bf91eb84efa40f7788ed20b0ccedae6571377964e12cfe0f0c802d",
+                    "E": "sha256:3282eb511beb41919c48215c16c0fdc7e427d0e9e9c11563325c5b1aba4b0a9a",
+                    "F": "sha256:3e57de5a42e09b657fe630230f03d548ffdbf3a862275571f324e484b93a9c77"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9522,
+                "rule": "Abstract beta50 matrix 2x2 grammar generated from seed 9522; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_matrix_2x2_formal_rule_22",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_matrix_2x2_formal_rule_22",
+                "item_family_template": "matrix_2x2",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:8266fc1cabc07afa746928385ae71e7aca531347f2a469ce67d846f40a4181cb"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q23",
+            "item_id": "IQ_BETA_50_ORIGINAL_23",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q23</text><circle cx=\"72\" cy=\"77\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 47 102 Q 72 52 97 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"100\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 85 126 Q 111 74 137 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"47\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 123 74 Q 150 20 177 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"70\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 161 98 Q 189 42 217 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"63\" cy=\"93\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 34 122 Q 63 64 92 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"102\" cy=\"116\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 88 130 Q 102 102 116 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 23."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"50\" cy=\"75\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 31 94 Q 50 56 69 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"89\" cy=\"98\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 69 118 Q 89 78 109 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"128\" cy=\"121\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 107 142 Q 128 100 149 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"68\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 145 90 Q 167 46 189 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"72\" cy=\"109\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 51 130 Q 72 88 93 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"56\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 89 78 Q 111 34 133 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"79\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 127 102 Q 150 56 173 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"102\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 165 126 Q 189 78 213 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"63\" cy=\"49\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 38 74 Q 63 24 88 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"102\" cy=\"72\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 76 98 Q 102 46 128 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"94\" cy=\"67\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 71 90 Q 94 44 117 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"90\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 109 114 Q 133 66 157 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"113\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 147 138 Q 172 88 197 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"60\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 20 86 Q 46 34 72 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"116\" cy=\"101\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 91 126 Q 116 76 141 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"155\" cy=\"48\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 129 74 Q 155 22 181 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"194\" cy=\"71\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 167 98 Q 194 44 221 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"68\" cy=\"94\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 40 122 Q 68 66 96 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"107\" cy=\"117\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 78 146 Q 107 88 136 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"146\" cy=\"64\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 132 78 Q 146 50 160 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"193\" cy=\"90\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 175 108 Q 193 72 211 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"67\" cy=\"113\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 48 132 Q 67 94 86 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"106\" cy=\"60\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 86 80 Q 106 40 126 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 23."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"61\" cy=\"92\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 41 112 Q 61 72 81 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"100\" cy=\"115\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 79 136 Q 100 94 121 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"62\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 117 84 Q 139 40 161 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"178\" cy=\"85\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 155 108 Q 178 62 201 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"52\" cy=\"108\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 28 132 Q 52 84 76 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 23."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9523; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:859ca20c8554761792230e8804e003e706b0b2d6861087815f594f9c9185409d",
+                "options": {
+                    "A": "sha256:489d58430d5418ce570c48767df6eacb8d051bd9f1053498b964509f2621cc34",
+                    "B": "sha256:5d4443f75187ad6583212e361897636314bd7e37bdfe1fecf45e06bb0866094a",
+                    "C": "sha256:daff96598a80ca024f583712fc304ef144fd47601adff6d32faacfae60c74e93",
+                    "D": "sha256:fda0e6185ca00051c106aba618c379721a7d34b5f27b89c43bb3be8e785941c3",
+                    "E": "sha256:e72b7d6dc20619200d7473b633019d4361804074838f712f18d2d0a4e3c6ac6f",
+                    "F": "sha256:a9059f14b7670e2d85f2a1168f01045d2cb145d894cab2f9ae202b7bf2e9f6d0"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9523,
+                "rule": "Abstract beta50 series grammar generated from seed 9523; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_23",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_23",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:13fafa14080d75c65d708b15f8d4c7ba06e20a02f0f8fae37876c5ed535ddfc4"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q24",
+            "item_id": "IQ_BETA_50_ORIGINAL_24",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q24</text><circle cx=\"178\" cy=\"83\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 159 102 Q 178 64 197 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"52\" cy=\"106\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 32 126 Q 52 86 72 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"91\" cy=\"53\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 70 74 Q 91 32 112 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"130\" cy=\"76\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 108 98 Q 130 54 152 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 24."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"167\" cy=\"98\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 153 112 Q 167 84 181 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"41\" cy=\"121\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 26 136 Q 41 106 56 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"68\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 64 84 Q 80 52 96 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"189\" cy=\"56\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 173 72 Q 189 40 205 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"63\" cy=\"79\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 46 96 Q 63 62 80 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"102\" cy=\"102\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 84 120 Q 102 84 120 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"141\" cy=\"49\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 122 68 Q 141 30 160 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"180\" cy=\"72\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 160 92 Q 180 52 200 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"46\" cy=\"90\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 28 108 Q 46 72 64 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"85\" cy=\"113\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 66 132 Q 85 94 104 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"124\" cy=\"60\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 104 80 Q 124 40 144 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"134\" cy=\"47\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 107 74 Q 134 20 161 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"70\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 145 98 Q 173 42 201 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"93\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 18 122 Q 47 64 76 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"116\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 72 130 Q 86 102 100 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"156\" cy=\"81\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 127 110 Q 156 52 185 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"195\" cy=\"104\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 181 118 Q 195 90 209 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"69\" cy=\"51\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 54 66 Q 69 36 84 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"108\" cy=\"74\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 92 90 Q 108 58 124 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"147\" cy=\"97\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 130 114 Q 147 80 164 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"186\" cy=\"120\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 168 138 Q 186 102 204 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 24."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"134\" cy=\"96\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 106 124 Q 134 68 162 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"119\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 144 148 Q 173 90 202 148\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"66\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 33 80 Q 47 52 61 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"89\" r=\"7\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 71 104 Q 86 74 101 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"112\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 109 128 Q 125 96 141 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 24."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9524; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:565ffc81d59ea03b9678be535f0b8f734120fa756af660e1b6e4967287b4a5b9",
+                "options": {
+                    "A": "sha256:86df659ff7f126367a5e3ba7e614c52c2402dc2c5d51e1fe0a774ed7e5fbdbbe",
+                    "B": "sha256:ddec8b135f1d5b4b651fb3724f9a09e0f0e8b5ddef3af9a87f433ba37c4bb5e7",
+                    "C": "sha256:36caf3950f8b23d3b1650484d785d0b4fc193ddf93baf53b301ccfd8a83fe5fd",
+                    "D": "sha256:4a9c8bad53b375cf0aea72f980a09628d18138f1ac698fbc2d8fb577974f7712",
+                    "E": "sha256:7225ce7d230d7f933c6bd6b34c136bcdb46cc849112b4fac889f25cb80b93940",
+                    "F": "sha256:2882c9592bd2749c3a387646c47d5942bcfe036bb966c45e9d69b031de508164"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9524,
+                "rule": "Abstract beta50 series grammar generated from seed 9524; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_24",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_24",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:e7f3151f499acc98ef75dcbe3adc0c128533f8f55e7b3c5d29c92a34ca22eaab"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q25",
+            "item_id": "IQ_BETA_50_ORIGINAL_25",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q25</text><circle cx=\"53\" cy=\"63\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 30 86 Q 53 40 76 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"92\" cy=\"86\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 68 110 Q 92 62 116 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"131\" cy=\"109\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 106 134 Q 131 84 156 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"170\" cy=\"56\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 144 82 Q 170 30 196 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 25."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"174\" cy=\"76\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 158 92 Q 174 60 190 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"48\" cy=\"99\" r=\"8\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 31 116 Q 48 82 65 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"46\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 69 64 Q 87 28 105 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"69\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 107 88 Q 126 50 145 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"92\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 145 112 Q 165 72 185 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"75\" cy=\"53\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 54 74 Q 75 32 96 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"114\" cy=\"76\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 92 98 Q 114 54 136 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"153\" cy=\"99\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 130 122 Q 153 76 176 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"192\" cy=\"46\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 168 70 Q 192 22 216 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"66\" cy=\"69\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 41 94 Q 66 44 91 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"105\" cy=\"92\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 79 118 Q 105 66 131 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"163\" cy=\"86\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 149 100 Q 163 72 177 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"37\" cy=\"109\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 22 124 Q 37 94 52 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"76\" cy=\"56\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 60 72 Q 76 40 92 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"185\" cy=\"120\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 169 136 Q 185 104 201 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"59\" cy=\"67\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 42 84 Q 59 50 76 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"98\" cy=\"90\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 80 108 Q 98 72 116 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"137\" cy=\"113\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 118 132 Q 137 94 156 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"176\" cy=\"60\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 156 80 Q 176 40 196 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"42\" cy=\"78\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 24 96 Q 42 60 60 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"81\" cy=\"101\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 62 120 Q 81 82 100 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"120\" cy=\"48\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 100 68 Q 120 28 140 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 25."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"64\" cy=\"112\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 44 132 Q 64 92 84 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"103\" cy=\"59\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 82 80 Q 103 38 124 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"142\" cy=\"82\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 120 104 Q 142 60 164 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"181\" cy=\"105\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 158 128 Q 181 82 204 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"55\" cy=\"52\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 31 76 Q 55 28 79 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 25."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9525; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:56563d5e1c6022dfcb2bc0b8622361549e57d58ecc40a8380e7330801cf5b484",
+                "options": {
+                    "A": "sha256:58ecde9e97874164e1c8f30b8b548ae59d14450eed3f9b9b870ec7ee192d4aba",
+                    "B": "sha256:2e0e4797070eee8ec5d68d0ab90773bd07e5e9be90500cf26ae67dedb1834e87",
+                    "C": "sha256:35dcf919f669b3b9ebb23a70d8362b08d18e5b960f58206070e73d1e7abe2d38",
+                    "D": "sha256:1155d68dd10ef8598c4be2edbb1b49a475cae5f31373690b857f8117f3649780",
+                    "E": "sha256:cd2624524866db789d276115338aad194f801548d97b63ff9b9e448e621dc1c4",
+                    "F": "sha256:57151bad7369dd981ce719500ead64430a78e1d1bc2ba3997ffbad30d746f31e"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9525,
+                "rule": "Abstract beta50 series grammar generated from seed 9525; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_25",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_25",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:7f3a493f1e9da84938614b3d3944d72fb520eb7eafded4743fb945f67f70af82"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q26",
+            "item_id": "IQ_BETA_50_ORIGINAL_26",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q26</text><circle cx=\"159\" cy=\"69\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 142 86 Q 159 52 176 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"33\" cy=\"92\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 15 110 Q 33 74 51 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"72\" cy=\"115\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 53 134 Q 72 96 91 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"62\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 91 82 Q 111 42 131 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"85\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 129 106 Q 150 64 171 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"108\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 167 130 Q 189 86 211 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 26."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"170\" cy=\"118\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 156 132 Q 170 104 184 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"44\" cy=\"65\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 29 80 Q 44 50 59 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"83\" cy=\"88\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 67 104 Q 83 72 99 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"115\" cy=\"82\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 89 108 Q 115 56 141 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"154\" cy=\"105\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 127 132 Q 154 78 181 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"193\" cy=\"52\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 165 80 Q 193 24 221 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"115\" cy=\"109\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 90 134 Q 115 84 140 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"154\" cy=\"56\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 128 82 Q 154 30 180 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"193\" cy=\"79\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 166 106 Q 193 52 220 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"67\" cy=\"102\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 39 130 Q 67 74 95 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"106\" cy=\"49\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 77 78 Q 106 20 135 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"72\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 131 86 Q 145 58 159 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"137\" cy=\"67\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 110 94 Q 137 40 164 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"176\" cy=\"90\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 148 118 Q 176 62 204 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"50\" cy=\"113\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 21 142 Q 50 84 79 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"89\" cy=\"60\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 75 74 Q 89 46 103 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"159\" cy=\"101\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 130 130 Q 159 72 188 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"33\" cy=\"48\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 19 62 Q 33 34 47 62\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"72\" cy=\"71\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 57 86 Q 72 56 87 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"111\" cy=\"94\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 95 110 Q 111 78 127 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"117\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 133 134 Q 150 100 167 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"64\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 171 82 Q 189 46 207 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 26."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"181\" cy=\"59\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 166 74 Q 181 44 196 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"55\" cy=\"82\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 39 98 Q 55 66 71 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"94\" cy=\"105\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 77 122 Q 94 88 111 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"52\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 115 70 Q 133 34 151 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 26."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9526; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:0c191f73bf58d571d6f6f4308bba528d0857cbf2768245842735acde24d70f2c",
+                "options": {
+                    "A": "sha256:9828ecffa50dc042660a2307012bf3bac9097125440937b693dd3ffce23ebade",
+                    "B": "sha256:af815b5fde79c9d3bb0fc790a87179c54691c1a9da2cb1e0f6d067d7e9ad42f7",
+                    "C": "sha256:aaf428a5fe9ac1e9ab1d1168b55d933b9875164c2afcaab53c4b35691e5c8d44",
+                    "D": "sha256:d54f18fa6f642d6c4eb5036c05deefe25b0a8d99097fa80b1e2ca0d0242c3ccc",
+                    "E": "sha256:667dbb84a6567e9f0500a0f39de3a955a9129869bc1aa95def116e20f660cf1f",
+                    "F": "sha256:a9d8ef6e7fd8699caf469259acc333904af7bc18f92bdaf67806b52e24a55a27"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9526,
+                "rule": "Abstract beta50 series grammar generated from seed 9526; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_26",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_26",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:29e2d87ac03970bd9b7e985d797e7bf1e635e0a031e057aa12936b8638a4fb94"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q27",
+            "item_id": "IQ_BETA_50_ORIGINAL_27",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q27</text><circle cx=\"111\" cy=\"114\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 97 128 Q 111 100 125 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"150\" cy=\"61\" r=\"7\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 135 76 Q 150 46 165 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"84\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 173 100 Q 189 68 205 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 27."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"34\" cy=\"103\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 15 122 Q 34 84 53 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"73\" cy=\"50\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 53 70 Q 73 30 93 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"112\" cy=\"73\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 91 94 Q 112 52 133 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"151\" cy=\"96\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 129 118 Q 151 74 173 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"56\" cy=\"61\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 35 82 Q 56 40 77 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"95\" cy=\"84\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 73 106 Q 95 62 117 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"134\" cy=\"107\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 111 130 Q 134 84 157 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"173\" cy=\"54\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 149 78 Q 173 30 197 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"77\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 22 102 Q 47 52 72 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"100\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 60 126 Q 86 74 112 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"67\" cy=\"51\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 44 74 Q 67 28 90 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"106\" cy=\"74\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 82 98 Q 106 50 130 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"97\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 120 122 Q 145 72 170 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"120\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 158 146 Q 184 94 210 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"100\" cy=\"53\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 75 78 Q 100 28 125 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"139\" cy=\"76\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 113 102 Q 139 50 165 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"178\" cy=\"99\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 151 126 Q 178 72 205 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"52\" cy=\"46\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 24 74 Q 52 18 80 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"91\" cy=\"69\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 62 98 Q 91 40 120 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"130\" cy=\"92\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 116 106 Q 130 78 144 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"122\" cy=\"87\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 95 114 Q 122 60 149 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"161\" cy=\"110\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 133 138 Q 161 82 189 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"35\" cy=\"57\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 6 86 Q 35 28 64 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"74\" cy=\"80\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 60 94 Q 74 66 88 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 27."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"144\" cy=\"121\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 115 150 Q 144 92 173 150\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"183\" cy=\"68\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 169 82 Q 183 54 197 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"57\" cy=\"91\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 42 106 Q 57 76 72 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"96\" cy=\"114\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 80 130 Q 96 98 112 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"135\" cy=\"61\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 118 78 Q 135 44 152 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"174\" cy=\"84\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 156 102 Q 174 66 192 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 27."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9527; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:d2ccb52bbb6b95c1004d96204f081ffa290ec640502288a89f950c79b04e69ec",
+                "options": {
+                    "A": "sha256:ae7a03c2687f3dbca619ee4647558a3610ef437e5a6466c4036b78fe962e116c",
+                    "B": "sha256:9db7a54c80776bfc56df83943d628f2b1ec356056dc4d68cb6e8419b7f34d949",
+                    "C": "sha256:3942ae84d3bac0bb992a00303629f8fef7ee3299220fc75a6eb31c1ada4f4847",
+                    "D": "sha256:d2902e6ff4c9d837957656623dd33c7eedd5300c3cc6bde3d39994851bdefee4",
+                    "E": "sha256:0ca9958640facddfae81ad8a2b9bd16846717c6e0318ab849c72ffd7e6d76c71",
+                    "F": "sha256:a87b7de678ff7efba5e6b30381686e58db458e663644ed4ea755f3ac3567e923"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9527,
+                "rule": "Abstract beta50 series grammar generated from seed 9527; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_27",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_27",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:fe2bca1a96ebbefbb4150ae27f2f1e2b855522a122b968875e9e4da2cefe5944"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q28",
+            "item_id": "IQ_BETA_50_ORIGINAL_28",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q28</text><circle cx=\"52\" cy=\"120\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 28 144 Q 52 96 76 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"91\" cy=\"67\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 66 92 Q 91 42 116 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"130\" cy=\"90\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 104 116 Q 130 64 156 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"169\" cy=\"113\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 142 140 Q 169 86 196 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"43\" cy=\"60\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 15 88 Q 43 32 71 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 28."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"151\" cy=\"50\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 137 64 Q 151 36 165 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"190\" cy=\"73\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 175 88 Q 190 58 205 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"64\" cy=\"96\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 48 112 Q 64 80 80 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"173\" cy=\"84\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 157 100 Q 173 68 189 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"107\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 30 124 Q 47 90 64 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"54\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 68 72 Q 86 36 104 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"77\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 106 96 Q 125 58 144 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"164\" cy=\"100\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 144 120 Q 164 80 184 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"195\" cy=\"118\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 177 136 Q 195 100 213 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"69\" cy=\"65\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 50 84 Q 69 46 88 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"108\" cy=\"88\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 88 108 Q 108 68 128 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"173\" cy=\"57\" r=\"8\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 156 74 Q 173 40 190 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"47\" cy=\"80\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 29 98 Q 47 62 65 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"103\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 67 122 Q 86 84 105 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"50\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 105 70 Q 125 30 145 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"164\" cy=\"73\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 143 94 Q 164 52 185 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"38\" cy=\"96\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 16 118 Q 38 74 60 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"74\" cy=\"110\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 52 132 Q 74 88 96 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"113\" cy=\"57\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 90 80 Q 113 34 136 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"152\" cy=\"80\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 128 104 Q 152 56 176 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 28."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"96\" cy=\"68\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 72 92 Q 96 44 120 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"135\" cy=\"91\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 110 116 Q 135 66 160 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"174\" cy=\"114\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 148 140 Q 174 88 200 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"48\" cy=\"61\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 21 88 Q 48 34 75 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"84\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 59 112 Q 87 56 115 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 28."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9528; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:2274a268b0bbde30419aea26fe933344cb5cd868728324e07de993e6e629038c",
+                "options": {
+                    "A": "sha256:c2cbdb2cd8396f260bace4e72b8f37bf67619f8ff96df0a0f49185bcd334b93f",
+                    "B": "sha256:4a60f1eb2e1fee65102839b92fd6cac43d9a2ad551bbc2706a04ea06a03e2144",
+                    "C": "sha256:c856d65fff8c185089d0e2b73d7165186686786415efc2a704ae1384e5de8a98",
+                    "D": "sha256:e9d47a88dd61220878a050d6874baecbd60640b7f3009a18b6a187d3c59a44b0",
+                    "E": "sha256:53498e60227dee065ead7f99d7d2bb1e66ee4303d2168fd2eb25d19b9d680b2e",
+                    "F": "sha256:a161fcabfb8fea7e4d0259cb01c8b03e2936c582a329dc1cc9b741b0b27072fc"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9528,
+                "rule": "Abstract beta50 series grammar generated from seed 9528; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_28",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_28",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:78faa40f88eec6ac022736d105ba5ffc3f5d197e7de6672a40c9a2188904f186"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q29",
+            "item_id": "IQ_BETA_50_ORIGINAL_29",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q29</text><circle cx=\"158\" cy=\"50\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 140 68 Q 158 32 176 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"32\" cy=\"73\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 13 92 Q 32 54 51 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"96\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 51 116 Q 71 76 91 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 29."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"103\" cy=\"73\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 78 98 Q 103 48 128 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"142\" cy=\"96\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 116 122 Q 142 70 168 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"181\" cy=\"119\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 154 146 Q 181 92 208 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"55\" cy=\"66\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 27 94 Q 55 38 83 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"94\" cy=\"89\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 65 118 Q 94 60 123 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"112\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 119 126 Q 133 98 147 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"125\" cy=\"107\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 98 134 Q 125 80 152 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"164\" cy=\"54\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 136 82 Q 164 26 192 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"38\" cy=\"77\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 9 106 Q 38 48 67 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"77\" cy=\"100\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 63 114 Q 77 86 91 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"147\" cy=\"65\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 118 94 Q 147 36 176 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"186\" cy=\"88\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 172 102 Q 186 74 200 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"60\" cy=\"111\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 45 126 Q 60 96 75 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"99\" cy=\"58\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 83 74 Q 99 42 115 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"138\" cy=\"81\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 121 98 Q 138 64 155 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"177\" cy=\"104\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 159 122 Q 177 86 195 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"169\" cy=\"99\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 154 114 Q 169 84 184 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"43\" cy=\"46\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 27 62 Q 43 30 59 62\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"82\" cy=\"69\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 65 86 Q 82 52 99 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"92\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 103 110 Q 121 74 139 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"114\" cy=\"63\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 87 90 Q 114 36 141 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"153\" cy=\"86\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 125 114 Q 153 58 181 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"192\" cy=\"109\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 163 138 Q 192 80 221 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"66\" cy=\"56\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 52 70 Q 66 42 80 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 29."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"48\" cy=\"91\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 29 110 Q 48 72 67 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"114\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 67 134 Q 87 94 107 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"61\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 105 82 Q 126 40 147 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"84\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 143 106 Q 165 62 187 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 29."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9529; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:402ed12661ffd523361f2d33d389b952e43984899531a6113af3cf35d4109358",
+                "options": {
+                    "A": "sha256:a8919c4c39aca264d1f1cd06ddc019ee8ffd4c91a71b9791f64e350f41d4881d",
+                    "B": "sha256:32a0ab8c05853ac39da10b3e5ea4433c4f57d1ca82dfc827c297082b5ae856d5",
+                    "C": "sha256:23bdb82ec19ab29ed068976d0f00ac5f1469a648a50a2e46a60610b57c96ca0c",
+                    "D": "sha256:919eb494917c2fb90baf60f8a2e74a82e7113b3a7069d7e0790c2d12cf0dfdf4",
+                    "E": "sha256:df8d06d4e269fac85fba09b2a9428b13c02116b2adaeaba4655c2bea69218e9d",
+                    "F": "sha256:98d06f5eb710fa71130e7aa2dc9c099db9d386b96db27543bb8ef925d46bfe08"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9529,
+                "rule": "Abstract beta50 series grammar generated from seed 9529; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_29",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_29",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:ebd6b8ba60a8bed6f8e43e9f624e4e4580054c0e9417ab4f966be80d629cd7be"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q30",
+            "item_id": "IQ_BETA_50_ORIGINAL_30",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 3,
+            "item_family": "series",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">series</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q30</text><circle cx=\"110\" cy=\"95\" r=\"7\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 95 110 Q 110 80 125 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"118\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 133 134 Q 149 102 165 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"65\" r=\"8\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 171 82 Q 188 48 205 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"88\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 44 106 Q 62 70 80 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 series reasoning prompt 30."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"66\" cy=\"59\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 43 82 Q 66 36 89 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"105\" cy=\"82\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 81 106 Q 105 58 129 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"144\" cy=\"105\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 119 130 Q 144 80 169 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"183\" cy=\"52\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 157 78 Q 183 26 209 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"88\" cy=\"93\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 63 118 Q 88 68 113 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"116\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 101 142 Q 127 90 153 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"166\" cy=\"63\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 139 90 Q 166 36 193 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"40\" cy=\"86\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 12 114 Q 40 58 68 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"79\" cy=\"109\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 50 138 Q 79 80 108 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"118\" cy=\"56\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 104 70 Q 118 42 132 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"110\" cy=\"51\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 83 78 Q 110 24 137 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"74\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 121 102 Q 149 46 177 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"97\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 159 126 Q 188 68 217 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"120\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 48 134 Q 62 106 76 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"132\" cy=\"85\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 103 114 Q 132 56 161 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"171\" cy=\"108\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 157 122 Q 171 94 185 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"45\" cy=\"55\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 30 70 Q 45 40 60 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"78\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 68 94 Q 84 62 100 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"123\" cy=\"101\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 106 118 Q 123 84 140 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"162\" cy=\"48\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 144 66 Q 162 30 180 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"154\" cy=\"119\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 139 134 Q 154 104 169 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"193\" cy=\"66\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 177 82 Q 193 50 209 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"67\" cy=\"89\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 50 106 Q 67 72 84 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"106\" cy=\"112\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 88 130 Q 106 94 124 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 30."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"66\" cy=\"108\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 42 132 Q 66 84 90 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"105\" cy=\"55\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 80 80 Q 105 30 130 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"144\" cy=\"78\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 118 104 Q 144 52 170 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"183\" cy=\"101\" r=\"13\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 156 128 Q 183 74 210 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"57\" cy=\"48\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 29 76 Q 57 20 85 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 30."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 series grammar generated from seed 9530; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:bac428c651c5389bb8b533c41f271da6015f36a1eea241499303339e9afe1d12",
+                "options": {
+                    "A": "sha256:04fe2229467a785510c07ac750c01c6c3a1ad752166564e63cda75b333c41ed8",
+                    "B": "sha256:5df0b83eb4d187cef30ac643866b2344a5b3d2401cbd16d3d90d2669163646ae",
+                    "C": "sha256:8bc897b84da42fd16e3c268b50d0715a9c52b9c10d8fd4546ded263bec8ebd6d",
+                    "D": "sha256:3e5e2902bdd5b289d179ad8acc5135c67ad86be9817af69bfbf30c6cf898d70b",
+                    "E": "sha256:83a99ef11e3b67fdd3f281c13b8377d7e2df9a5d93331494b8d3f32931d378be",
+                    "F": "sha256:a47739a45da2753f4b9352f947f533e83ff05b122ef9456bffb62c3d74f8c188"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9530,
+                "rule": "Abstract beta50 series grammar generated from seed 9530; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_series_formal_rule_30",
+                "difficulty": 3,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_series_formal_rule_30",
+                "item_family_template": "series",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:30eb8c2d828ccb26a7bae2b263f69946b1eca012eff088c5700984c80ff5effd"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q31",
+            "item_id": "IQ_BETA_50_ORIGINAL_31",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q31</text><circle cx=\"150\" cy=\"75\" r=\"9\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 131 94 Q 150 56 169 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"189\" cy=\"98\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 169 118 Q 189 78 209 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"63\" cy=\"121\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 42 142 Q 63 100 84 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"102\" cy=\"68\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 80 90 Q 102 46 124 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 odd one out reasoning prompt 31."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"106\" cy=\"88\" r=\"14\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 78 116 Q 106 60 134 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"145\" cy=\"111\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 116 140 Q 145 82 174 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"184\" cy=\"58\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 170 72 Q 184 44 198 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"58\" cy=\"81\" r=\"7\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 43 96 Q 58 66 73 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"97\" cy=\"104\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 81 120 Q 97 88 113 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 31."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"139\" cy=\"90\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 125 104 Q 139 76 153 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"178\" cy=\"113\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 163 128 Q 178 98 193 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"52\" cy=\"60\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 36 76 Q 52 44 68 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 31."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"161\" cy=\"48\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 145 64 Q 161 32 177 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"35\" cy=\"71\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 18 88 Q 35 54 52 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"74\" cy=\"94\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 56 112 Q 74 76 92 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"113\" cy=\"117\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 94 136 Q 113 98 132 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"152\" cy=\"64\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 132 84 Q 152 44 172 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 31."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"183\" cy=\"82\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 165 100 Q 183 64 201 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"57\" cy=\"105\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 38 124 Q 57 86 76 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"96\" cy=\"52\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 76 72 Q 96 32 116 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 31."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"40\" cy=\"116\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 20 136 Q 40 96 60 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"79\" cy=\"63\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 58 84 Q 79 42 100 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"118\" cy=\"86\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 96 108 Q 118 64 140 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"157\" cy=\"109\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 134 132 Q 157 86 180 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"196\" cy=\"56\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 172 80 Q 196 32 220 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 31."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"128\" cy=\"73\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 99 102 Q 128 44 157 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"167\" cy=\"96\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 153 110 Q 167 82 181 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"41\" cy=\"119\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 26 134 Q 41 104 56 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"80\" cy=\"66\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 64 82 Q 80 50 96 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"89\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 102 106 Q 119 72 136 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"158\" cy=\"112\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 140 130 Q 158 94 176 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 31."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 odd one out grammar generated from seed 9531; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:395b0aa0e7058333cd02c7128b113611df7bb3c3abc68d193098964b2a027658",
+                "options": {
+                    "A": "sha256:90a79e125a56230c1ab3e838c07e259aa440f38e76c13c6d020c48014ef6c40f",
+                    "B": "sha256:4c929a746bfbbf61151afa8d7347262438723ec314f3469664848fe5609dd974",
+                    "C": "sha256:763eb6f91d019979977094ea0cc64b70570832d0d7639b026f15036e6daba928",
+                    "D": "sha256:392b32d6408ae1dc22102e33af1a6768c17274595230d5fb60bab9e62a4e7c25",
+                    "E": "sha256:59102d78f14d0edd67b94c8e3e9ecf7da232480859508ed58592e43560aca719",
+                    "F": "sha256:88854c37ed32f6cb17aa29d30e4deeb166c98790a33751adeee994ba419bfaf3"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9531,
+                "rule": "Abstract beta50 odd one out grammar generated from seed 9531; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_odd_one_out_formal_rule_31",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_odd_one_out_formal_rule_31",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:9e27d77f5e8352d2d8940975a78570dd2d29f6fab6335adc990a8b0e67f5d521"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q32",
+            "item_id": "IQ_BETA_50_ORIGINAL_32",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q32</text><circle cx=\"91\" cy=\"81\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 62 110 Q 91 52 120 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"130\" cy=\"104\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 116 118 Q 130 90 144 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"169\" cy=\"51\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 154 66 Q 169 36 184 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"43\" cy=\"74\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 27 90 Q 43 58 59 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"82\" cy=\"97\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 65 114 Q 82 80 99 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"120\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 103 138 Q 121 102 139 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 odd one out reasoning prompt 32."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"69\" cy=\"79\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 46 102 Q 69 56 92 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"108\" cy=\"102\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 84 126 Q 108 78 132 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"147\" cy=\"49\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 122 74 Q 147 24 172 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"186\" cy=\"72\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 160 98 Q 186 46 212 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 32."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"47\" cy=\"94\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 25 116 Q 47 72 69 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"86\" cy=\"117\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 63 140 Q 86 94 109 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"125\" cy=\"64\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 101 88 Q 125 40 149 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 32."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"113\" cy=\"71\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 86 98 Q 113 44 140 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"152\" cy=\"94\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 124 122 Q 152 66 180 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"191\" cy=\"117\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 162 146 Q 191 88 220 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"64\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 51 78 Q 65 50 79 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 32."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"135\" cy=\"105\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 106 134 Q 135 76 164 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"174\" cy=\"52\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 160 66 Q 174 38 188 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"48\" cy=\"75\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 33 90 Q 48 60 63 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"87\" cy=\"98\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 71 114 Q 87 82 103 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"126\" cy=\"121\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 109 138 Q 126 104 143 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"165\" cy=\"68\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 147 86 Q 165 50 183 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 32."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"58\" cy=\"62\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 36 84 Q 58 40 80 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"97\" cy=\"85\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 74 108 Q 97 62 120 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"136\" cy=\"108\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 112 132 Q 136 84 160 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 32."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"80\" cy=\"96\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 56 120 Q 80 72 104 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"119\" cy=\"119\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 94 144 Q 119 94 144 144\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"158\" cy=\"66\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 132 92 Q 158 40 184 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"32\" cy=\"89\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 5 116 Q 32 62 59 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"112\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 43 140 Q 71 84 99 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 32."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 odd one out grammar generated from seed 9532; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:629e96ffcef9265b257e45218015753cf488510e16d3dcf0b7ab259f04f94ffb",
+                "options": {
+                    "A": "sha256:41d5f56d00ea8211cfd6839995260b2279c94aea3ae339f95fcb7c3f689e22bd",
+                    "B": "sha256:f50b62cf4093032bb8fede4f4b7c10128c2369d7f5a6f89a635b02b10db98a5b",
+                    "C": "sha256:65bcf3cf1f72ed8bce0604eebda2e3278aea1573940aea196d5d03dfd049f568",
+                    "D": "sha256:749e3de775541fffa2ff7b45fcb0c3791cc1df69ecd08ff47c6de6e1a05195ff",
+                    "E": "sha256:35ccbcdc9bbffe716795311113e9523381a9ca591307009f747fedb83762be6f",
+                    "F": "sha256:fcfc2e419ad333390b7f719dca7fa570959e4a4545e0b97cd72f5110ca07248f"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9532,
+                "rule": "Abstract beta50 odd one out grammar generated from seed 9532; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_odd_one_out_formal_rule_32",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_odd_one_out_formal_rule_32",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:f793d96d389990e40b34daa083d7fe4b3490c3a2087a5d228098fc29d8bafff7"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q33",
+            "item_id": "IQ_BETA_50_ORIGINAL_33",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q33</text><circle cx=\"32\" cy=\"87\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 9 110 Q 32 64 55 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"110\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 47 134 Q 71 86 95 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"57\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 85 82 Q 110 32 135 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"80\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 123 106 Q 149 54 175 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 odd one out reasoning prompt 33."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"186\" cy=\"102\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 168 120 Q 186 84 204 120\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"60\" cy=\"49\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 41 68 Q 60 30 79 68\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"99\" cy=\"72\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 79 92 Q 99 52 119 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 33."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"43\" cy=\"60\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 23 80 Q 43 40 63 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"82\" cy=\"83\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 61 104 Q 82 62 103 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"121\" cy=\"106\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 99 128 Q 121 84 143 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"160\" cy=\"53\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 137 76 Q 160 30 183 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"34\" cy=\"76\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 10 100 Q 34 52 58 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 33."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"153\" cy=\"100\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 137 116 Q 153 84 169 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"192\" cy=\"47\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 175 64 Q 192 30 209 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"66\" cy=\"70\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 48 88 Q 66 52 84 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"105\" cy=\"93\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 86 112 Q 105 74 124 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"144\" cy=\"116\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 124 136 Q 144 96 164 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 33."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"153\" cy=\"51\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 138 66 Q 153 36 168 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"192\" cy=\"74\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 176 90 Q 192 58 208 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"66\" cy=\"97\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 49 114 Q 66 80 83 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"105\" cy=\"120\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 87 138 Q 105 102 123 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 33."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"175\" cy=\"85\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 158 102 Q 175 68 192 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"49\" cy=\"108\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 31 126 Q 49 90 67 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"88\" cy=\"55\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 69 74 Q 88 36 107 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"127\" cy=\"78\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 107 98 Q 127 58 147 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"166\" cy=\"101\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 145 122 Q 166 80 187 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"40\" cy=\"48\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 18 70 Q 40 26 62 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 33."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"32\" cy=\"119\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 13 138 Q 32 100 51 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"66\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 51 86 Q 71 46 91 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"89\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 89 110 Q 110 68 131 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"112\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 127 134 Q 149 90 171 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 33."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 odd one out grammar generated from seed 9533; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:311c98ad5ac791dc331a9bac7b31976977d8509f22b2f31963da9b13be427695",
+                "options": {
+                    "A": "sha256:0fe26ad3754165f921806a23fec1bbdb9bc462a9df8f5f07b12970b9b0b6c9fc",
+                    "B": "sha256:58843d375590b269711f7b1d8719f62b9fc1bb38dd368e1affc555cb2a571f10",
+                    "C": "sha256:157d0b4919e96f14c8d75999e2075b4cb6149678d5596287134dfa82a010d978",
+                    "D": "sha256:76497a4c7b5d1f459eff95150ba6e3ee56b5eff7503d955f593bb20c38018228",
+                    "E": "sha256:a74aef49fb1412a08d18119d78323b66394b667f77d567508584b523ff627f64",
+                    "F": "sha256:16f38f043fdd9b6fc78e6f0c04fae92de36e3cec6302626c8acc76dc084e3049"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9533,
+                "rule": "Abstract beta50 odd one out grammar generated from seed 9533; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_odd_one_out_formal_rule_33",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_odd_one_out_formal_rule_33",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:7080a15079b8482326df30f9eb2a04364a34f2097e473535f9db9d017deb394f"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q34",
+            "item_id": "IQ_BETA_50_ORIGINAL_34",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q34</text><circle cx=\"149\" cy=\"56\" r=\"10\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 129 76 Q 149 36 169 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"79\" r=\"10\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 167 100 Q 188 58 209 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"102\" r=\"11\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 40 124 Q 62 80 84 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"101\" cy=\"49\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 78 72 Q 101 26 124 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"140\" cy=\"72\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 116 96 Q 140 48 164 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 odd one out reasoning prompt 34."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"149\" cy=\"88\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 133 104 Q 149 72 165 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"188\" cy=\"111\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 171 128 Q 188 94 205 128\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"62\" cy=\"58\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 44 76 Q 62 40 80 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"101\" cy=\"81\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 82 100 Q 101 62 120 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"140\" cy=\"104\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 120 124 Q 140 84 160 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 34."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"171\" cy=\"46\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 153 64 Q 171 28 189 64\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"45\" cy=\"69\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 26 88 Q 45 50 64 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"84\" cy=\"92\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 64 112 Q 84 72 104 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 34."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"94\" cy=\"79\" r=\"13\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 67 106 Q 94 52 121 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"133\" cy=\"102\" r=\"14\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 105 130 Q 133 74 161 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"172\" cy=\"49\" r=\"14\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 143 78 Q 172 20 201 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"46\" cy=\"72\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 32 86 Q 46 58 60 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 34."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"105\" cy=\"69\" r=\"14\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 76 98 Q 105 40 134 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"144\" cy=\"92\" r=\"7\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 130 106 Q 144 78 158 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"183\" cy=\"115\" r=\"7\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 168 130 Q 183 100 198 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"57\" cy=\"62\" r=\"8\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 41 78 Q 57 46 73 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"96\" cy=\"85\" r=\"8\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 79 102 Q 96 68 113 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"135\" cy=\"108\" r=\"9\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 117 126 Q 135 90 153 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 34."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"138\" cy=\"71\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 123 86 Q 138 56 153 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"177\" cy=\"94\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 161 110 Q 177 78 193 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"51\" cy=\"117\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 34 134 Q 51 100 68 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"90\" cy=\"64\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 72 82 Q 90 46 108 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 34."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"160\" cy=\"105\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 143 122 Q 160 88 177 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"34\" cy=\"52\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 16 70 Q 34 34 52 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"73\" cy=\"75\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 54 94 Q 73 56 92 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"112\" cy=\"98\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 92 118 Q 112 78 132 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"151\" cy=\"121\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 130 142 Q 151 100 172 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"190\" cy=\"68\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 168 90 Q 190 46 212 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 34."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 odd one out grammar generated from seed 9534; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:21230259849c2701da78f1212694bdbfa2d33e70ef1faa9bf049b33a1efb7b65",
+                "options": {
+                    "A": "sha256:4b3ee790a607517e3453f47b6a5c20f6c1033957ae41846ebcf58a0ab1dd12ef",
+                    "B": "sha256:846dc2217cc97cf9ccda21718165647c286ece3c0b328c64a87b89ba4714ef8e",
+                    "C": "sha256:668d510e6e9242ceb1d29f08b151c79cceb796c7ed07d10e2f6a0a482881d28d",
+                    "D": "sha256:5eac9e3537d9ab46cca9efb0726757f805c627d0fc3cc5b2fd36a17526975eea",
+                    "E": "sha256:b07100c74b3dc15f8f913eb6b2d427ef6dc98ca71d7b69599bd78db5ee3167bf",
+                    "F": "sha256:321d53ddcad8ede0688cb96a5af012d2937f7ae36e3f29865447b57346767b21"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9534,
+                "rule": "Abstract beta50 odd one out grammar generated from seed 9534; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_odd_one_out_formal_rule_34",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_odd_one_out_formal_rule_34",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:fe4c3892ceb014b2b13bd585c9bc0338347cf6324c4abb411e5ed445f7c7bae7"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q35",
+            "item_id": "IQ_BETA_50_ORIGINAL_35",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q35</text><circle cx=\"90\" cy=\"62\" r=\"7\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 76 76 Q 90 48 104 76\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"129\" cy=\"85\" r=\"7\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 114 100 Q 129 70 144 100\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"168\" cy=\"108\" r=\"8\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 152 124 Q 168 92 184 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 odd one out reasoning prompt 35."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"101\" cy=\"111\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 74 138 Q 101 84 128 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"140\" cy=\"58\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 112 86 Q 140 30 168 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"179\" cy=\"81\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 150 110 Q 179 52 208 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"53\" cy=\"104\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 39 118 Q 53 90 67 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 35."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"189\" cy=\"68\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 169 88 Q 189 48 209 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"63\" cy=\"91\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 42 112 Q 63 70 84 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"102\" cy=\"114\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 80 136 Q 102 92 124 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"141\" cy=\"61\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 118 84 Q 141 38 164 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"180\" cy=\"84\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 156 108 Q 180 60 204 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 35."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"46\" cy=\"102\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 24 124 Q 46 80 68 124\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"85\" cy=\"49\" r=\"11\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 62 72 Q 85 26 108 72\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"124\" cy=\"72\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 100 96 Q 124 48 148 96\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 35."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"68\" cy=\"60\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 44 84 Q 68 36 92 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"107\" cy=\"83\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 82 108 Q 107 58 132 108\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"146\" cy=\"106\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 120 132 Q 146 80 172 132\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"185\" cy=\"53\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 158 80 Q 185 26 212 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"59\" cy=\"76\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 31 104 Q 59 48 87 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 35."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"46\" cy=\"75\" r=\"11\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 23 98 Q 46 52 69 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"85\" cy=\"98\" r=\"12\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 61 122 Q 85 74 109 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"124\" cy=\"121\" r=\"12\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 99 146 Q 124 96 149 146\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"163\" cy=\"68\" r=\"13\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 137 94 Q 163 42 189 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 35."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"112\" cy=\"52\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 84 80 Q 112 24 140 80\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"151\" cy=\"75\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 122 104 Q 151 46 180 104\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"190\" cy=\"98\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 176 112 Q 190 84 204 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"64\" cy=\"121\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 49 136 Q 64 106 79 136\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"103\" cy=\"68\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 87 84 Q 103 52 119 84\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 35."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 odd one out grammar generated from seed 9535; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:32807ca5e91475c260f3ab750391299f8b62138963df5403ccfd6e4108ddab00",
+                "options": {
+                    "A": "sha256:3c0b930affcef2e27233f22f15fac46cc3084ef6189914a50c4ee975986e930e",
+                    "B": "sha256:3954e3bc60864e9729a36e32d88d1110d1191d3a79da7e07fa694bbc59bad610",
+                    "C": "sha256:266c93833c00483a8730cb6920cddc0b1e88873e565c8bb69e4e907004f812af",
+                    "D": "sha256:ad4781c1076a777c3781cab9e05e95a9afdb3c31a48371a1307abf361e7550e7",
+                    "E": "sha256:fd14ca5f3704007c1b388924f91d8b5b41f8b780de51e54a77944279773e6e10",
+                    "F": "sha256:000d39fc52637dbde9d0712e41feea03c2ffab2d424997bf6665e6b267a5de0b"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9535,
+                "rule": "Abstract beta50 odd one out grammar generated from seed 9535; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_odd_one_out_formal_rule_35",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_odd_one_out_formal_rule_35",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:c1192e6025add8bff49b19318306417c2af7f3f685655ffdc6ca267b66f97d1b"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q36",
+            "item_id": "IQ_BETA_50_ORIGINAL_36",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "odd_one_out",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">odd one out</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q36</text><circle cx=\"196\" cy=\"68\" r=\"12\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 172 92 Q 196 44 220 92\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"70\" cy=\"91\" r=\"12\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 45 116 Q 70 66 95 116\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"109\" cy=\"114\" r=\"13\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 83 140 Q 109 88 135 140\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"148\" cy=\"61\" r=\"13\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 121 88 Q 148 34 175 88\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"187\" cy=\"84\" r=\"14\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 159 112 Q 187 56 215 112\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                    "accessibility_label": "Original beta50 odd one out reasoning prompt 36."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"119\" cy=\"57\" r=\"14\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 90 86 Q 119 28 148 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"158\" cy=\"80\" r=\"7\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 144 94 Q 158 66 172 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"32\" cy=\"103\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 17 118 Q 32 88 47 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"71\" cy=\"50\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 55 66 Q 71 34 87 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"110\" cy=\"73\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 93 90 Q 110 56 127 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"149\" cy=\"96\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 131 114 Q 149 78 167 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 36."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"141\" cy=\"91\" r=\"7\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 126 106 Q 141 76 156 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"180\" cy=\"114\" r=\"8\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 164 130 Q 180 98 196 130\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"54\" cy=\"61\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 37 78 Q 54 44 71 78\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"93\" cy=\"84\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 75 102 Q 93 66 111 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 36."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"163\" cy=\"49\" r=\"8\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 146 66 Q 163 32 180 66\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"37\" cy=\"72\" r=\"9\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 19 90 Q 37 54 55 90\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"76\" cy=\"95\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 57 114 Q 76 76 95 114\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"115\" cy=\"118\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 95 138 Q 115 98 135 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"154\" cy=\"65\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 133 86 Q 154 44 175 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"193\" cy=\"88\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 171 110 Q 193 66 215 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 36."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"185\" cy=\"83\" r=\"9\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 166 102 Q 185 64 204 102\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"59\" cy=\"106\" r=\"10\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 39 126 Q 59 86 79 126\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"98\" cy=\"53\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 77 74 Q 98 32 119 74\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"137\" cy=\"76\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 115 98 Q 137 54 159 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 36."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"42\" cy=\"117\" r=\"10\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 21 138 Q 42 96 63 138\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"81\" cy=\"64\" r=\"11\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 59 86 Q 81 42 103 86\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"120\" cy=\"87\" r=\"11\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 97 110 Q 120 64 143 110\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"159\" cy=\"110\" r=\"12\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 135 134 Q 159 86 183 134\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"33\" cy=\"57\" r=\"12\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 8 82 Q 33 32 58 82\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"72\" cy=\"80\" r=\"13\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 46 106 Q 72 54 98 106\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 36."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"152\" cy=\"81\" r=\"8\" fill=\"#a7b35a\" opacity=\"0.7\"/><path d=\"M 135 98 Q 152 64 169 98\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"191\" cy=\"104\" r=\"9\" fill=\"#7b4f8a\" opacity=\"0.7\"/><path d=\"M 173 122 Q 191 86 209 122\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"65\" cy=\"51\" r=\"9\" fill=\"#c7504f\" opacity=\"0.7\"/><path d=\"M 46 70 Q 65 32 84 70\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"104\" cy=\"74\" r=\"10\" fill=\"#1f5d50\" opacity=\"0.7\"/><path d=\"M 84 94 Q 104 54 124 94\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"143\" cy=\"97\" r=\"10\" fill=\"#d9843b\" opacity=\"0.7\"/><path d=\"M 122 118 Q 143 76 164 118\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/><circle cx=\"182\" cy=\"120\" r=\"11\" fill=\"#4666a9\" opacity=\"0.7\"/><path d=\"M 160 142 Q 182 98 204 142\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.42\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 36."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 odd one out grammar generated from seed 9536; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:e2780430572a9cf608ec6722dbfd91f44445cb17dacaa9a0b1142fb1edb3ba30",
+                "options": {
+                    "A": "sha256:120cf0ca558faf2eccec95ab04a8d9e0145cb9f464a6eb61bfd29453cfbc4ef6",
+                    "B": "sha256:a1972f0375a71d89514718269c6b40476d38e22779fa9831470ef9f45abc5093",
+                    "C": "sha256:682e7f9b156a6cbf23be6d6936bb87f043a72b8b54fb4d618bf7f422d5a8b211",
+                    "D": "sha256:47f2ee352e526a72373a92579b0f36b9317255da7611ecb4720570868d885006",
+                    "E": "sha256:aaa92aa614ed44ad6bed0dc9b9965c8346a1a44f229cb1580931ee3dde87a661",
+                    "F": "sha256:696a0d5823852bc88b1ad6e27b341bc2475a29ebb843a2160d970ac96fb80367"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9536,
+                "rule": "Abstract beta50 odd one out grammar generated from seed 9536; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_odd_one_out_formal_rule_36",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_odd_one_out_formal_rule_36",
+                "item_family_template": "odd_one_out",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:5d2e01a6ff131dcf23222e85289c88daa54a28ac2a11215266b795882e191102"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q37",
+            "item_id": "IQ_BETA_50_ORIGINAL_37",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q37</text><path d=\"M 71 20 L 99 76 L 43 76 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(38 71 48)\"/><path d=\"M 110 42 L 139 100 L 81 100 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(85 110 71)\"/><path d=\"M 149 80 L 163 108 L 135 108 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(132 149 94)\"/><path d=\"M 188 102 L 203 132 L 173 132 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(179 188 117)\"/><path d=\"M 62 48 L 78 80 L 46 80 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(226 62 64)\"/></svg>",
+                    "accessibility_label": "Original beta50 rotation reasoning prompt 37."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 192 40 L 213 82 L 171 82 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(229 192 61)\"/><path d=\"M 66 62 L 88 106 L 44 106 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(276 66 84)\"/><path d=\"M 105 84 L 128 130 L 82 130 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(323 105 107)\"/><path d=\"M 144 30 L 168 78 L 120 78 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(10 144 54)\"/><path d=\"M 183 52 L 208 102 L 158 102 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(57 183 77)\"/><path d=\"M 57 74 L 83 126 L 31 126 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(104 57 100)\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 37."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 192 68 L 212 108 L 172 108 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(334 192 88)\"/><path d=\"M 66 90 L 87 132 L 45 132 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(21 66 111)\"/><path d=\"M 105 36 L 127 80 L 83 80 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(68 105 58)\"/><path d=\"M 144 58 L 167 104 L 121 104 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(115 144 81)\"/><path d=\"M 183 80 L 207 128 L 159 128 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(162 183 104)\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 37."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 49 24 L 71 68 L 27 68 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(36 49 46)\"/><path d=\"M 88 46 L 111 92 L 65 92 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(83 88 69)\"/><path d=\"M 127 68 L 151 116 L 103 116 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(130 127 92)\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 37."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 71 56 L 95 104 L 47 104 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(98 71 80)\"/><path d=\"M 110 78 L 135 128 L 85 128 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(145 110 103)\"/><path d=\"M 149 24 L 175 76 L 123 76 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(192 149 50)\"/><path d=\"M 188 46 L 215 100 L 161 100 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(239 188 73)\"/><path d=\"M 62 68 L 90 124 L 34 124 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(286 62 96)\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 37."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 93 88 L 119 140 L 67 140 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(160 93 114)\"/><path d=\"M 132 34 L 159 88 L 105 88 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(207 132 61)\"/><path d=\"M 171 56 L 199 112 L 143 112 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(254 171 84)\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 37."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 115 44 L 143 100 L 87 100 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(222 115 72)\"/><path d=\"M 154 66 L 183 124 L 125 124 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(269 154 95)\"/><path d=\"M 193 104 L 207 132 L 179 132 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(316 193 118)\"/><path d=\"M 67 50 L 82 80 L 52 80 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(3 67 65)\"/><path d=\"M 106 72 L 122 104 L 90 104 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(50 106 88)\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 37."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 rotation grammar generated from seed 9537; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:a910c66602968e2fa6e1e6f0afb98220c1626787440ca314a5feb17e4a5261be",
+                "options": {
+                    "A": "sha256:c69cef2e32807c07e5c13e19f63b08d47de034be9381b087461c1e2372d7ec1c",
+                    "B": "sha256:b4e936720dba23e3cef8ea49804b40fe4d59866e5fad76009799bc8b4ed10fc3",
+                    "C": "sha256:48b87be6e89e3fbb02f0f926d798b3b2624a39a106cc206d9a2174cc6923bd0c",
+                    "D": "sha256:a4a506ce34e1a3d9d2354646d5bb00ad3fa4e8eb86402b624d6983a54add45d3",
+                    "E": "sha256:cfe0a101092027841607eed464da0f1caa1d380b36a32d0858d52a3a76f02996",
+                    "F": "sha256:ae84669524b4a9897ddb0a7b943971916f5a817817d01b290902cc46834422b1"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9537,
+                "rule": "Abstract beta50 rotation grammar generated from seed 9537; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_rotation_formal_rule_37",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_rotation_formal_rule_37",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:fe2c60dfa18013c41b958a0fb98a36444c3f54ff63960e07f37008d19c9d9aab"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q38",
+            "item_id": "IQ_BETA_50_ORIGINAL_38",
+            "dimension": "VSI",
+            "dimension_name": "Visual-spatial imagery",
+            "difficulty_level": 4,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q38</text><path d=\"M 188 68 L 213 118 L 163 118 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(157 188 93)\"/><path d=\"M 62 90 L 88 142 L 36 142 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(204 62 116)\"/><path d=\"M 101 36 L 128 90 L 74 90 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(251 101 63)\"/><path d=\"M 140 58 L 168 114 L 112 114 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(298 140 86)\"/><path d=\"M 179 80 L 208 138 L 150 138 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(345 179 109)\"/><path d=\"M 53 42 L 67 70 L 39 70 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(32 53 56)\"/></svg>",
+                    "accessibility_label": "Original beta50 rotation reasoning prompt 38."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 133 100 L 149 132 L 117 132 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(62 133 116)\"/><path d=\"M 172 46 L 189 80 L 155 80 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(109 172 63)\"/><path d=\"M 46 68 L 64 104 L 28 104 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(156 46 86)\"/><path d=\"M 85 90 L 104 128 L 66 128 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(203 85 109)\"/><path d=\"M 124 36 L 144 76 L 104 76 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(250 124 56)\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 38."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 144 88 L 162 124 L 126 124 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(348 144 106)\"/><path d=\"M 183 34 L 202 72 L 164 72 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(35 183 53)\"/><path d=\"M 57 56 L 77 96 L 37 96 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(82 57 76)\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 38."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 177 88 L 197 128 L 157 128 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(186 177 108)\"/><path d=\"M 51 34 L 72 76 L 30 76 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(233 51 55)\"/><path d=\"M 90 56 L 112 100 L 68 100 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(280 90 78)\"/><path d=\"M 129 78 L 152 124 L 106 124 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(327 129 101)\"/><path d=\"M 168 24 L 192 72 L 144 72 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(14 168 48)\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 38."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 34 44 L 56 88 L 12 88 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(248 34 66)\"/><path d=\"M 73 66 L 96 112 L 50 112 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(295 73 89)\"/><path d=\"M 112 88 L 136 136 L 88 136 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(342 112 112)\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 38."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 56 76 L 80 124 L 32 124 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(310 56 100)\"/><path d=\"M 95 22 L 120 72 L 70 72 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(357 95 47)\"/><path d=\"M 134 44 L 160 96 L 108 96 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(44 134 70)\"/><path d=\"M 173 66 L 200 120 L 146 120 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(91 173 93)\"/><path d=\"M 47 88 L 75 144 L 19 144 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(138 47 116)\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 38."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 78 32 L 104 84 L 52 84 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(12 78 58)\"/><path d=\"M 117 54 L 144 108 L 90 108 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(59 117 81)\"/><path d=\"M 156 76 L 184 132 L 128 132 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(106 156 104)\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 38."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 rotation grammar generated from seed 9538; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:ceee09f5827cc945d518277cea73cba0d7dc914c03056c2253909e0fe755e6f2",
+                "options": {
+                    "A": "sha256:8d69c3c19d9b1ca1beb72eab1e495e82a146869d2824485d0f036ef991e79df1",
+                    "B": "sha256:ccae200c76775f2515f1a75cf279dae8113498e8a118b7f42247e39258778902",
+                    "C": "sha256:f14f17668fd7e87ee2d64a6defb122eb1f8557ff56f805f0a1503c07260fdaa3",
+                    "D": "sha256:49014403d14beb546816e33417d9bec5ec9ea213828e86482fe2c505c1862b64",
+                    "E": "sha256:5f6b5b2501ea9a2e7429e6cdbdcd04cdcb88528ab2ebff76198d1de4e4749adb",
+                    "F": "sha256:91a86f34b808dbbd8b0287ee29169850f4754e457c38d14b8c0b92b221c2f08c"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9538,
+                "rule": "Abstract beta50 rotation grammar generated from seed 9538; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_rotation_formal_rule_38",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_rotation_formal_rule_38",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:c5f42b61b32fc685debcfe26fb42b42808382aa0b27278c0b94be34d62665d62"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q39",
+            "item_id": "IQ_BETA_50_ORIGINAL_39",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 4,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q39</text><path d=\"M 129 80 L 148 118 L 110 118 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(95 129 99)\"/><path d=\"M 168 26 L 188 66 L 148 66 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(142 168 46)\"/><path d=\"M 42 48 L 63 90 L 21 90 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(189 42 69)\"/><path d=\"M 81 70 L 103 114 L 59 114 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(236 81 92)\"/></svg>",
+                    "accessibility_label": "Original beta50 rotation reasoning prompt 39."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 85 36 L 112 90 L 58 90 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(31 85 63)\"/><path d=\"M 124 58 L 152 114 L 96 114 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(78 124 86)\"/><path d=\"M 163 80 L 192 138 L 134 138 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(125 163 109)\"/><path d=\"M 37 42 L 51 70 L 23 70 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(172 37 56)\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 39."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 107 68 L 136 126 L 78 126 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(93 107 97)\"/><path d=\"M 146 106 L 160 134 L 132 134 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(140 146 120)\"/><path d=\"M 185 52 L 200 82 L 170 82 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(187 185 67)\"/><path d=\"M 59 74 L 75 106 L 43 106 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(234 59 90)\"/><path d=\"M 98 96 L 115 130 L 81 130 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(281 98 113)\"/><path d=\"M 137 42 L 155 78 L 119 78 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(328 137 60)\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 39."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 85 84 L 113 140 L 57 140 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(286 85 112)\"/><path d=\"M 124 30 L 153 88 L 95 88 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(333 124 59)\"/><path d=\"M 163 68 L 177 96 L 149 96 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(20 163 82)\"/><path d=\"M 37 90 L 52 120 L 22 120 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(67 37 105)\"/><path d=\"M 76 36 L 92 68 L 60 68 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(114 76 52)\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 39."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 151 72 L 168 106 L 134 106 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(217 151 89)\"/><path d=\"M 190 94 L 208 130 L 172 130 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(264 190 112)\"/><path d=\"M 64 40 L 83 78 L 45 78 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(311 64 59)\"/><path d=\"M 103 62 L 123 102 L 83 102 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(358 103 82)\"/><path d=\"M 142 84 L 163 126 L 121 126 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(45 142 105)\"/><path d=\"M 181 30 L 203 74 L 159 74 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(92 181 52)\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 39."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 173 28 L 192 66 L 154 66 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(279 173 47)\"/><path d=\"M 47 50 L 67 90 L 27 90 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(326 47 70)\"/><path d=\"M 86 72 L 107 114 L 65 114 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(13 86 93)\"/><path d=\"M 125 94 L 147 138 L 103 138 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(60 125 116)\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 39."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 195 60 L 216 102 L 174 102 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(341 195 81)\"/><path d=\"M 69 82 L 91 126 L 47 126 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(28 69 104)\"/><path d=\"M 108 28 L 131 74 L 85 74 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(75 108 51)\"/><path d=\"M 147 50 L 171 98 L 123 98 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(122 147 74)\"/><path d=\"M 186 72 L 211 122 L 161 122 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(169 186 97)\"/><path d=\"M 60 94 L 86 146 L 34 146 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(216 60 120)\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 39."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 rotation grammar generated from seed 9539; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:b2f2e20f905e61dea65ec2680be1f56fe7e94d5d816d94e7ffe0cac1c0527c4a",
+                "options": {
+                    "A": "sha256:13f4abe94cf741cc20a016b38766bd9681b1bcf2f3ada4ade3cbccf8e936dfab",
+                    "B": "sha256:12b94c20ecf81e8c7af264946f903e246b4edb3beb50b33fa175609917f2109b",
+                    "C": "sha256:25275f72ba6222efc60ad95a74eb68ef9858e2e06c3ae2ef0a32cb35687f9091",
+                    "D": "sha256:845c8c79e357a6d2fba8d2bcf979bc25ed8f91739d1a94e8ca5570a64eef6957",
+                    "E": "sha256:4d962cdef5c2cffe1d53b9e880fb347d705a6a4f1f3046f2d1070233a2d17efa",
+                    "F": "sha256:adad93d0f2635f548b9c72a67bd7afff62b75379d8cc4415620a43d754531519"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9539,
+                "rule": "Abstract beta50 rotation grammar generated from seed 9539; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_rotation_formal_rule_39",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_rotation_formal_rule_39",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:2d0d887e78fafa728e313094920a61b05bf6c2d37c495794cf4207f8fa5662bc"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q40",
+            "item_id": "IQ_BETA_50_ORIGINAL_40",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 4,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q40</text><path d=\"M 70 76 L 99 134 L 41 134 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(33 70 105)\"/><path d=\"M 109 38 L 123 66 L 95 66 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(80 109 52)\"/><path d=\"M 148 60 L 163 90 L 133 90 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(127 148 75)\"/><path d=\"M 187 82 L 203 114 L 171 114 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(174 187 98)\"/><path d=\"M 61 104 L 78 138 L 44 138 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(221 61 121)\"/><path d=\"M 100 50 L 118 86 L 82 86 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(268 100 68)\"/></svg>",
+                    "accessibility_label": "Original beta50 rotation reasoning prompt 40."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 37 64 L 59 108 L 15 108 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(0 37 86)\"/><path d=\"M 76 86 L 99 132 L 53 132 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(47 76 109)\"/><path d=\"M 115 32 L 139 80 L 91 80 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(94 115 56)\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 40."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 59 96 L 83 144 L 35 144 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(62 59 120)\"/><path d=\"M 98 42 L 123 92 L 73 92 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(109 98 67)\"/><path d=\"M 137 64 L 163 116 L 111 116 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(156 137 90)\"/><path d=\"M 176 86 L 203 140 L 149 140 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(203 176 113)\"/><path d=\"M 50 32 L 78 88 L 22 88 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(250 50 60)\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 40."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 81 52 L 107 104 L 55 104 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(124 81 78)\"/><path d=\"M 120 74 L 147 128 L 93 128 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(171 120 101)\"/><path d=\"M 159 20 L 187 76 L 131 76 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(218 159 48)\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 40."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 191 96 L 213 140 L 169 140 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(224 191 118)\"/><path d=\"M 65 42 L 88 88 L 42 88 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(271 65 65)\"/><path d=\"M 104 64 L 128 112 L 80 112 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(318 104 88)\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 40."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 125 56 L 139 84 L 111 84 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(248 125 70)\"/><path d=\"M 164 78 L 179 108 L 149 108 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(295 164 93)\"/><path d=\"M 38 100 L 54 132 L 22 132 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(342 38 116)\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 40."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 48 80 L 71 126 L 25 126 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(31 48 103)\"/><path d=\"M 87 26 L 111 74 L 63 74 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(78 87 50)\"/><path d=\"M 126 48 L 151 98 L 101 98 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(125 126 73)\"/><path d=\"M 165 70 L 191 122 L 139 122 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(172 165 96)\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 40."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 rotation grammar generated from seed 9540; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:daababd407640209e7e2cb85029e3e8a1636fb8917e4627a8595249a58821887",
+                "options": {
+                    "A": "sha256:a7b26c84e9b708dc2d284cc8b0ceda81423affb89588f4dd03a1c7c2c1af3fad",
+                    "B": "sha256:f293b674516dbf4c7fa9333c4aa6464555927f508bd8a8de4a898e163f9bed83",
+                    "C": "sha256:dadbbf5a37aa64c445a32cae2a0b047aadcb86081882e510fadb6a9ce7cdde25",
+                    "D": "sha256:da2cf19925591837cee7608c4e2bc19492412474d5517057573a2e82e557aa70",
+                    "E": "sha256:da08653dce4992ff3d84d0529c7c8f7b413d1815857ceb911e9200e26fa8907c",
+                    "F": "sha256:356649aec17bb90bf7b97bfc825a5e9d11d31b4a6340bc047ea869160e267e89"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9540,
+                "rule": "Abstract beta50 rotation grammar generated from seed 9540; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_rotation_formal_rule_40",
+                "difficulty": 4,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_rotation_formal_rule_40",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:60d48db809f22ca60f1610c17fba2fbd0c48781573205e3f69baf846512c3a85"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q41",
+            "item_id": "IQ_BETA_50_ORIGINAL_41",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "rotation",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">rotation</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q41</text><path d=\"M 187 48 L 213 100 L 161 100 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(152 187 74)\"/><path d=\"M 61 70 L 88 124 L 34 124 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(199 61 97)\"/><path d=\"M 100 92 L 128 148 L 72 148 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(246 100 120)\"/></svg>",
+                    "accessibility_label": "Original beta50 rotation reasoning prompt 41."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 165 52 L 185 92 L 145 92 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(150 165 72)\"/><path d=\"M 39 74 L 60 116 L 18 116 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(197 39 95)\"/><path d=\"M 78 96 L 100 140 L 56 140 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(244 78 118)\"/><path d=\"M 117 42 L 140 88 L 94 88 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(291 117 65)\"/><path d=\"M 156 64 L 180 112 L 132 112 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(338 156 88)\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 41."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 187 84 L 209 128 L 165 128 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(212 187 106)\"/><path d=\"M 61 30 L 84 76 L 38 76 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(259 61 53)\"/><path d=\"M 100 52 L 124 100 L 76 100 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(306 100 76)\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 41."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 44 40 L 68 88 L 20 88 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(274 44 64)\"/><path d=\"M 83 62 L 108 112 L 58 112 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(321 83 87)\"/><path d=\"M 122 84 L 148 136 L 96 136 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(8 122 110)\"/><path d=\"M 161 30 L 188 84 L 134 84 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(55 161 57)\"/><path d=\"M 35 52 L 63 108 L 7 108 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(102 35 80)\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 41."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 66 72 L 92 124 L 40 124 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(336 66 98)\"/><path d=\"M 105 94 L 132 148 L 78 148 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(23 105 121)\"/><path d=\"M 144 40 L 172 96 L 116 96 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(70 144 68)\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 41."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 143 68 L 162 106 L 124 106 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(343 143 87)\"/><path d=\"M 182 90 L 202 130 L 162 130 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(30 182 110)\"/><path d=\"M 56 36 L 77 78 L 35 78 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(77 56 57)\"/><path d=\"M 95 58 L 117 102 L 73 102 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(124 95 80)\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 41."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><path d=\"M 176 68 L 197 110 L 155 110 Z\" fill=\"#d9843b\" opacity=\"0.74\" transform=\"rotate(181 176 89)\"/><path d=\"M 50 90 L 72 134 L 28 134 Z\" fill=\"#4666a9\" opacity=\"0.74\" transform=\"rotate(228 50 112)\"/><path d=\"M 89 36 L 112 82 L 66 82 Z\" fill=\"#a7b35a\" opacity=\"0.74\" transform=\"rotate(275 89 59)\"/><path d=\"M 128 58 L 152 106 L 104 106 Z\" fill=\"#7b4f8a\" opacity=\"0.74\" transform=\"rotate(322 128 82)\"/><path d=\"M 167 80 L 192 130 L 142 130 Z\" fill=\"#c7504f\" opacity=\"0.74\" transform=\"rotate(9 167 105)\"/><path d=\"M 41 26 L 67 78 L 15 78 Z\" fill=\"#1f5d50\" opacity=\"0.74\" transform=\"rotate(56 41 52)\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 41."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 rotation grammar generated from seed 9541; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:26dd914355f9822017f73b81a372cd4d995c621239693ea18f1e302497ee738d",
+                "options": {
+                    "A": "sha256:ee182525841981e4c7f5b52b78302661f02c3bccbd4331842030f7925c54fac8",
+                    "B": "sha256:75b91e8552f1095f42944304bec29206a31fc9a7e024729b9c4e947fd1662273",
+                    "C": "sha256:57d09341c3d68d97455b91320f8e165078745227b6b6f1d9b954a95e8034656f",
+                    "D": "sha256:794a9e69f9f8d59c2452b0c033dbdf6a814e6507f00e8cccef7c83d40298fedd",
+                    "E": "sha256:d8047bdbfc6c850bf6e779765a8571892939bedd879915504747523db46eb222",
+                    "F": "sha256:c44d839727b76a00dc9c04fba039bb90cb98f5bf7721653c43771659202d435f"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9541,
+                "rule": "Abstract beta50 rotation grammar generated from seed 9541; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_rotation_formal_rule_41",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_rotation_formal_rule_41",
+                "item_family_template": "rotation",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:77d53e1842edca10740b88545e20ebe1ab474efc1891e01988c58fe9c6f614fe"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q42",
+            "item_id": "IQ_BETA_50_ORIGINAL_42",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q42</text><rect x=\"118\" y=\"70\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(90 128 80)\"/><circle cx=\"136\" cy=\"75\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"156.5\" y=\"92.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(137 167 103)\"/><circle cx=\"175\" cy=\"98\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"30\" y=\"39\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(184 41 50)\"/><circle cx=\"49\" cy=\"45\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"68.5\" y=\"61.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(231 80 73)\"/><circle cx=\"88\" cy=\"68\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"107\" y=\"84\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(278 119 96)\"/><circle cx=\"127\" cy=\"91\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original beta50 overlay reasoning prompt 42."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"109.5\" y=\"87.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(119 117 95)\"/><circle cx=\"125\" cy=\"90\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"148\" y=\"110\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(166 156 118)\"/><circle cx=\"164\" cy=\"113\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"186.5\" y=\"56.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(213 195 65)\"/><circle cx=\"203\" cy=\"60\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"60\" y=\"79\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(260 69 88)\"/><circle cx=\"77\" cy=\"83\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 42."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"130.5\" y=\"44.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(181 139 53)\"/><circle cx=\"147\" cy=\"48\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"169\" y=\"67\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(228 178 76)\"/><circle cx=\"186\" cy=\"71\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"42.5\" y=\"89.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(275 52 99)\"/><circle cx=\"60\" cy=\"94\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"81\" y=\"36\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(322 91 46)\"/><circle cx=\"99\" cy=\"41\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"119.5\" y=\"58.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(9 130 69)\"/><circle cx=\"138\" cy=\"64\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"158\" y=\"81\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(56 169 92)\"/><circle cx=\"177\" cy=\"87\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 42."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"151.5\" y=\"77.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(243 161 87)\"/><circle cx=\"169\" cy=\"82\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"25\" y=\"100\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(290 35 110)\"/><circle cx=\"43\" cy=\"105\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"63.5\" y=\"46.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(337 74 57)\"/><circle cx=\"82\" cy=\"52\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"102\" y=\"69\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(24 113 80)\"/><circle cx=\"121\" cy=\"75\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 42."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"70\" y=\"106\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(26 84 120)\"/><circle cx=\"92\" cy=\"115\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"108.5\" y=\"52.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(73 123 67)\"/><circle cx=\"131\" cy=\"62\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"155\" y=\"83\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(120 162 90)\"/><circle cx=\"170\" cy=\"85\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"28.5\" y=\"105.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(167 36 113)\"/><circle cx=\"44\" cy=\"108\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"67\" y=\"52\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(214 75 60)\"/><circle cx=\"83\" cy=\"55\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 42."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"99\" y=\"71\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(88 106 78)\"/><circle cx=\"114\" cy=\"73\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"137.5\" y=\"93.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(135 145 101)\"/><circle cx=\"153\" cy=\"96\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"176\" y=\"40\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(182 184 48)\"/><circle cx=\"192\" cy=\"43\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 42."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"69.5\" y=\"78.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(281 84 93)\"/><circle cx=\"92\" cy=\"88\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"116\" y=\"109\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(328 123 116)\"/><circle cx=\"131\" cy=\"111\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"154.5\" y=\"55.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(15 162 63)\"/><circle cx=\"170\" cy=\"58\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"28\" y=\"78\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(62 36 86)\"/><circle cx=\"44\" cy=\"81\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"66.5\" y=\"100.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(109 75 109)\"/><circle cx=\"83\" cy=\"104\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"105\" y=\"47\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(156 114 56)\"/><circle cx=\"122\" cy=\"51\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 42."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 overlay grammar generated from seed 9542; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:cefd0a30a47548214bad6d9f506fd6f4d871423e721164f6947ab51e9c05306a",
+                "options": {
+                    "A": "sha256:0600678eee4c6806077842cd7e26ab32fce43b91166426440b39b4562578f4e5",
+                    "B": "sha256:9512acce8635ba3e20956061e09063fc0f8c95b4bc58bf4ee1c2b4b19ee450dd",
+                    "C": "sha256:71eb053e76958d1e3d9a04795e742f292897a63af6ef8fecb24db85cb691ecf8",
+                    "D": "sha256:7c52a3bd0ef3f9c5179531775ee68a8e0e57521adccbafc9b7aa7f2af39d8211",
+                    "E": "sha256:70daa280be325186cf7bab46f732f778c55a0a4202d7d704401becd31ac77c42",
+                    "F": "sha256:2c10e5da07da8314ebf5015b4dd19dbeb9737a1bb33bdf415aa841e75ca2558e"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9542,
+                "rule": "Abstract beta50 overlay grammar generated from seed 9542; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_overlay_formal_rule_42",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_overlay_formal_rule_42",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:291cc15983f7d75af3caea27404705b87e64883b783c89d6849d0a51437b40a9"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q43",
+            "item_id": "IQ_BETA_50_ORIGINAL_43",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q43</text><rect x=\"156\" y=\"48\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(202 168 60)\"/><circle cx=\"176\" cy=\"55\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"29.5\" y=\"70.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(249 42 83)\"/><circle cx=\"50\" cy=\"78\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"68\" y=\"93\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(296 81 106)\"/><circle cx=\"89\" cy=\"101\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"106.5\" y=\"39.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(343 120 53)\"/><circle cx=\"128\" cy=\"48\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"145\" y=\"62\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(30 159 76)\"/><circle cx=\"167\" cy=\"71\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original beta50 overlay reasoning prompt 43."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"115.5\" y=\"64.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(33 124 73)\"/><circle cx=\"132\" cy=\"68\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"154\" y=\"87\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(80 163 96)\"/><circle cx=\"171\" cy=\"91\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"27.5\" y=\"109.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(127 37 119)\"/><circle cx=\"45\" cy=\"114\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"66\" y=\"56\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(174 76 66)\"/><circle cx=\"84\" cy=\"61\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"104.5\" y=\"78.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(221 115 89)\"/><circle cx=\"123\" cy=\"84\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"143\" y=\"101\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(268 154 112)\"/><circle cx=\"162\" cy=\"107\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 43."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"179\" y=\"39\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(324 190 50)\"/><circle cx=\"198\" cy=\"45\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"52.5\" y=\"61.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(11 64 73)\"/><circle cx=\"72\" cy=\"68\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"91\" y=\"84\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(58 103 96)\"/><circle cx=\"111\" cy=\"91\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 43."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"105.5\" y=\"75.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(107 113 83)\"/><circle cx=\"121\" cy=\"78\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"144\" y=\"98\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(154 152 106)\"/><circle cx=\"160\" cy=\"101\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"182.5\" y=\"44.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(201 191 53)\"/><circle cx=\"199\" cy=\"48\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"56\" y=\"67\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(248 65 76)\"/><circle cx=\"73\" cy=\"71\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 43."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"126.5\" y=\"108.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(169 135 117)\"/><circle cx=\"143\" cy=\"112\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"165\" y=\"55\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(216 174 64)\"/><circle cx=\"182\" cy=\"59\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"38.5\" y=\"77.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(263 48 87)\"/><circle cx=\"56\" cy=\"82\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"77\" y=\"100\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(310 87 110)\"/><circle cx=\"95\" cy=\"105\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"115.5\" y=\"46.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(357 126 57)\"/><circle cx=\"134\" cy=\"52\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"154\" y=\"69\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(44 165 80)\"/><circle cx=\"173\" cy=\"75\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 43."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"147.5\" y=\"65.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(231 157 75)\"/><circle cx=\"165\" cy=\"70\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"186\" y=\"88\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(278 196 98)\"/><circle cx=\"204\" cy=\"93\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"59.5\" y=\"110.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(325 70 121)\"/><circle cx=\"78\" cy=\"116\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"98\" y=\"57\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(12 109 68)\"/><circle cx=\"117\" cy=\"63\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 43."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"168.5\" y=\"98.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(293 179 109)\"/><circle cx=\"187\" cy=\"104\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"42\" y=\"45\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(340 53 56)\"/><circle cx=\"61\" cy=\"51\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"80.5\" y=\"67.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(27 92 79)\"/><circle cx=\"100\" cy=\"74\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"119\" y=\"90\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(74 131 102)\"/><circle cx=\"139\" cy=\"97\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"157.5\" y=\"36.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(121 170 49)\"/><circle cx=\"178\" cy=\"44\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"31\" y=\"59\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(168 44 72)\"/><circle cx=\"52\" cy=\"67\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 43."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 overlay grammar generated from seed 9543; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:4e9457d044d15ed0e8c5837475d4323cc39833c3461befb72b83d67367d2eb7a",
+                "options": {
+                    "A": "sha256:d66e01e6f4756f806428f2e78cccc2b6a66bd609a181d927c4fc31fa2c712c83",
+                    "B": "sha256:209d0d9db06b329904b12d3b6765f5a606035d52ef281dc467747e964c9f24b2",
+                    "C": "sha256:3f737946e880ce39e67addb7f10840503d5d25dbe954c0ef023df415c8679006",
+                    "D": "sha256:156ed14c40b4ab45d1c0a5f37248f380ba98974c3273821118771d7cfdc28d8f",
+                    "E": "sha256:0c79982893247db8f26a23288931ce4339148968138dcce1199f457dde35ca9a",
+                    "F": "sha256:549aabb2ebcb8082110b1783591d595bfc1e882521923799495a51a541a2cdc9"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9543,
+                "rule": "Abstract beta50 overlay grammar generated from seed 9543; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_overlay_formal_rule_43",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_overlay_formal_rule_43",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:75e724fd4e838544585c5d1fce58ad63c2141168842f4056f81653da2a26fd47"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q44",
+            "item_id": "IQ_BETA_50_ORIGINAL_44",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q44</text><rect x=\"100\" y=\"57\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(140 109 66)\"/><circle cx=\"117\" cy=\"61\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"138.5\" y=\"79.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(187 148 89)\"/><circle cx=\"156\" cy=\"84\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"177\" y=\"102\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(234 187 112)\"/><circle cx=\"195\" cy=\"107\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original beta50 overlay reasoning prompt 44."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"112.5\" y=\"107.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(231 120 115)\"/><circle cx=\"128\" cy=\"110\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"151\" y=\"54\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(278 159 62)\"/><circle cx=\"167\" cy=\"57\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"24.5\" y=\"76.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(325 33 85)\"/><circle cx=\"41\" cy=\"80\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"63\" y=\"99\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(12 72 108)\"/><circle cx=\"80\" cy=\"103\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 44."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"51.5\" y=\"65.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(331 65 79)\"/><circle cx=\"73\" cy=\"74\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"90\" y=\"88\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(18 104 102)\"/><circle cx=\"112\" cy=\"97\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"128.5\" y=\"34.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(65 143 49)\"/><circle cx=\"151\" cy=\"44\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"175\" y=\"65\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(112 182 72)\"/><circle cx=\"190\" cy=\"67\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 44."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"52\" y=\"93\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(76 65 106)\"/><circle cx=\"73\" cy=\"101\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"90.5\" y=\"39.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(123 104 53)\"/><circle cx=\"112\" cy=\"48\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"129\" y=\"62\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(170 143 76)\"/><circle cx=\"151\" cy=\"71\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 44."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"73\" y=\"50\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(138 87 64)\"/><circle cx=\"95\" cy=\"59\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"111.5\" y=\"72.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(185 126 87)\"/><circle cx=\"134\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"158\" y=\"103\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(232 165 110)\"/><circle cx=\"173\" cy=\"105\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"31.5\" y=\"49.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(279 39 57)\"/><circle cx=\"47\" cy=\"52\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"70\" y=\"72\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(326 78 80)\"/><circle cx=\"86\" cy=\"75\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 44."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"102\" y=\"91\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(200 109 98)\"/><circle cx=\"117\" cy=\"93\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"140.5\" y=\"113.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(247 148 121)\"/><circle cx=\"156\" cy=\"116\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"179\" y=\"60\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(294 187 68)\"/><circle cx=\"195\" cy=\"63\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 44."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"123\" y=\"48\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(262 131 56)\"/><circle cx=\"139\" cy=\"51\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"161.5\" y=\"70.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(309 170 79)\"/><circle cx=\"178\" cy=\"74\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"35\" y=\"93\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(356 44 102)\"/><circle cx=\"52\" cy=\"97\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"73.5\" y=\"39.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(43 83 49)\"/><circle cx=\"91\" cy=\"44\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"112\" y=\"62\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(90 122 72)\"/><circle cx=\"130\" cy=\"67\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 44."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 overlay grammar generated from seed 9544; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:9c42b6c2311ed7bbd3ec8f77a9866261ea3c82eb4091d9571d019ae0c269b674",
+                "options": {
+                    "A": "sha256:8ec45fd6620187516b12a3ce91a9217edc81869298e8f83ee722c8ed2863d6f1",
+                    "B": "sha256:90808dd9d3eddd6b31378f8d1740e27e3f5db7ffb5f185b032885d35ecadfbe2",
+                    "C": "sha256:bc6f5f6344b7c6912aad492bf8f1da4412597cad704eab172463ca63cad027a9",
+                    "D": "sha256:d1886adc2f6b35b16874f6c7fc45830415a10ab07b7caf1716ddcfe70b144d91",
+                    "E": "sha256:1c8a08d6bfaf14a8a9f3e586f75bdd787506fd08d5a6dbc2e1da7337d8ea89e0",
+                    "F": "sha256:868eef1d50ff4999b878a73572889b7b0972cd2a7beb724ff823ba62a980b982"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9544,
+                "rule": "Abstract beta50 overlay grammar generated from seed 9544; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_overlay_formal_rule_44",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_overlay_formal_rule_44",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:bb0040f56bca2bd36c28cba7799423f8045313239fb5529d7655afd9cf8fec9b"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q45",
+            "item_id": "IQ_BETA_50_ORIGINAL_45",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q45</text><rect x=\"53.5\" y=\"103.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(259 61 111)\"/><circle cx=\"69\" cy=\"106\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"92\" y=\"50\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(306 100 58)\"/><circle cx=\"108\" cy=\"53\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"130.5\" y=\"72.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(353 139 81)\"/><circle cx=\"147\" cy=\"76\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"169\" y=\"95\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(40 178 104)\"/><circle cx=\"186\" cy=\"99\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original beta50 overlay reasoning prompt 45."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"139\" y=\"90\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(102 149 100)\"/><circle cx=\"157\" cy=\"95\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"177.5\" y=\"36.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(149 188 47)\"/><circle cx=\"196\" cy=\"42\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"51\" y=\"59\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(196 62 70)\"/><circle cx=\"70\" cy=\"65\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"89.5\" y=\"81.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(243 101 93)\"/><circle cx=\"109\" cy=\"88\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"128\" y=\"104\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(290 140 116)\"/><circle cx=\"148\" cy=\"111\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 45."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"160\" y=\"47\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(164 171 58)\"/><circle cx=\"179\" cy=\"53\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"33.5\" y=\"69.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(211 45 81)\"/><circle cx=\"53\" cy=\"76\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"72\" y=\"92\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(258 84 104)\"/><circle cx=\"92\" cy=\"99\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 45."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"170\" y=\"36\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(90 182 48)\"/><circle cx=\"190\" cy=\"43\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"43.5\" y=\"58.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(137 56 71)\"/><circle cx=\"64\" cy=\"66\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"82\" y=\"81\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(184 95 94)\"/><circle cx=\"103\" cy=\"89\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"120.5\" y=\"103.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(231 134 117)\"/><circle cx=\"142\" cy=\"112\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"159\" y=\"50\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(278 173 64)\"/><circle cx=\"181\" cy=\"59\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 45."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"37\" y=\"37\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(288 50 50)\"/><circle cx=\"58\" cy=\"45\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"75.5\" y=\"59.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(335 89 73)\"/><circle cx=\"97\" cy=\"68\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"114\" y=\"82\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(22 128 96)\"/><circle cx=\"136\" cy=\"91\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 45."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"58\" y=\"70\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(350 72 84)\"/><circle cx=\"80\" cy=\"79\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"96.5\" y=\"92.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(37 111 107)\"/><circle cx=\"119\" cy=\"102\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"143\" y=\"47\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(84 150 54)\"/><circle cx=\"158\" cy=\"49\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"181.5\" y=\"69.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(131 189 77)\"/><circle cx=\"197\" cy=\"72\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"55\" y=\"92\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(178 63 100)\"/><circle cx=\"71\" cy=\"95\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 45."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"87\" y=\"111\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(52 94 118)\"/><circle cx=\"102\" cy=\"113\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"125.5\" y=\"57.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(99 133 65)\"/><circle cx=\"141\" cy=\"60\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"164\" y=\"80\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(146 172 88)\"/><circle cx=\"180\" cy=\"83\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 45."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "C",
+            "solution_rule": "Abstract beta50 overlay grammar generated from seed 9545; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:74d96ce409a6a64334c2af6b25e0a4361fe0f0041b6cb641002a26d66a7386c6",
+                "options": {
+                    "A": "sha256:826ec5fcb108556aec7236360baeec45044a72a0ddabfa775a8dac5e0333e7b4",
+                    "B": "sha256:f1b0c1764fd84a7cd74479a22176c6a90945149af9ea1567bfe9b0063ab49fc8",
+                    "C": "sha256:4b55ab5903850c62316534f4ddd66a4d11b00cdc531fdf3c6456436774e01875",
+                    "D": "sha256:e427798a8b43cb3bb22c4e3103e9e2d4dc89171d274b1b84c4e123a14a2db2ee",
+                    "E": "sha256:4d27031ea76ea753030bdfcddb2d8b64596b1c9f028d80ef83d8e339400cdd59",
+                    "F": "sha256:16475332477bacde79f9225fa5083e30d63d10909104e69239cf50c73e1f3d82"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9545,
+                "rule": "Abstract beta50 overlay grammar generated from seed 9545; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_overlay_formal_rule_45",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_overlay_formal_rule_45",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:25ab9aa33ad688df7abd63a84d1f524d22144f15bc21d5c72841168133c80a19"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q46",
+            "item_id": "IQ_BETA_50_ORIGINAL_46",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "overlay",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">overlay</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q46</text><rect x=\"154.5\" y=\"104.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(197 167 117)\"/><circle cx=\"175\" cy=\"112\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"28\" y=\"51\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(244 41 64)\"/><circle cx=\"49\" cy=\"59\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"66.5\" y=\"73.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(291 80 87)\"/><circle cx=\"88\" cy=\"82\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"105\" y=\"96\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(338 119 110)\"/><circle cx=\"127\" cy=\"105\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"143.5\" y=\"42.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(25 158 57)\"/><circle cx=\"166\" cy=\"52\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"25\" y=\"73\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(72 32 80)\"/><circle cx=\"40\" cy=\"75\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                    "accessibility_label": "Original beta50 overlay reasoning prompt 46."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"93.5\" y=\"39.5\" width=\"15\" height=\"15\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(71 101 47)\"/><circle cx=\"109\" cy=\"42\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"132\" y=\"62\" width=\"16\" height=\"16\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(118 140 70)\"/><circle cx=\"148\" cy=\"65\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"170.5\" y=\"84.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(165 179 93)\"/><circle cx=\"187\" cy=\"88\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"44\" y=\"107\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(212 53 116)\"/><circle cx=\"61\" cy=\"111\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 46."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"114.5\" y=\"72.5\" width=\"17\" height=\"17\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(133 123 81)\"/><circle cx=\"131\" cy=\"76\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"153\" y=\"95\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(180 162 104)\"/><circle cx=\"170\" cy=\"99\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"26.5\" y=\"41.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(227 36 51)\"/><circle cx=\"44\" cy=\"46\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"65\" y=\"64\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(274 75 74)\"/><circle cx=\"83\" cy=\"69\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"103.5\" y=\"86.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(321 114 97)\"/><circle cx=\"122\" cy=\"92\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"142\" y=\"109\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(8 153 120)\"/><circle cx=\"161\" cy=\"115\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 46."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"135.5\" y=\"105.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(195 145 115)\"/><circle cx=\"153\" cy=\"110\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"174\" y=\"52\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(242 184 62)\"/><circle cx=\"192\" cy=\"57\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"47.5\" y=\"74.5\" width=\"21\" height=\"21\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(289 58 85)\"/><circle cx=\"66\" cy=\"80\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"86\" y=\"97\" width=\"22\" height=\"22\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(336 97 108)\"/><circle cx=\"105\" cy=\"103\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 46."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"114\" y=\"45\" width=\"18\" height=\"18\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(28 123 54)\"/><circle cx=\"131\" cy=\"49\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"152.5\" y=\"67.5\" width=\"19\" height=\"19\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(75 162 77)\"/><circle cx=\"170\" cy=\"72\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"26\" y=\"90\" width=\"20\" height=\"20\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(122 36 100)\"/><circle cx=\"44\" cy=\"95\" r=\"6\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 46."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"177.5\" y=\"95.5\" width=\"23\" height=\"23\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(319 189 107)\"/><circle cx=\"197\" cy=\"102\" r=\"7\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"51\" y=\"42\" width=\"24\" height=\"24\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(6 63 54)\"/><circle cx=\"71\" cy=\"49\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"89.5\" y=\"64.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(53 102 77)\"/><circle cx=\"110\" cy=\"72\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"128\" y=\"87\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(100 141 100)\"/><circle cx=\"149\" cy=\"95\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 46."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><rect x=\"33.5\" y=\"52.5\" width=\"25\" height=\"25\" rx=\"5\" fill=\"#a7b35a\" opacity=\"0.42\" transform=\"rotate(21 46 65)\"/><circle cx=\"54\" cy=\"60\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"72\" y=\"75\" width=\"26\" height=\"26\" rx=\"5\" fill=\"#7b4f8a\" opacity=\"0.42\" transform=\"rotate(68 85 88)\"/><circle cx=\"93\" cy=\"83\" r=\"8\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"110.5\" y=\"97.5\" width=\"27\" height=\"27\" rx=\"5\" fill=\"#c7504f\" opacity=\"0.42\" transform=\"rotate(115 124 111)\"/><circle cx=\"132\" cy=\"106\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"149\" y=\"44\" width=\"28\" height=\"28\" rx=\"5\" fill=\"#1f5d50\" opacity=\"0.42\" transform=\"rotate(162 163 58)\"/><circle cx=\"171\" cy=\"53\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"22.5\" y=\"66.5\" width=\"29\" height=\"29\" rx=\"5\" fill=\"#d9843b\" opacity=\"0.42\" transform=\"rotate(209 37 81)\"/><circle cx=\"45\" cy=\"76\" r=\"9\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/><rect x=\"69\" y=\"97\" width=\"14\" height=\"14\" rx=\"5\" fill=\"#4666a9\" opacity=\"0.42\" transform=\"rotate(256 76 104)\"/><circle cx=\"84\" cy=\"99\" r=\"5\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.52\"/></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 46."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "D",
+            "solution_rule": "Abstract beta50 overlay grammar generated from seed 9546; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:08502db8121700681d0abce17f12f273322cc7ccdc10d692db3c17c68c58dd30",
+                "options": {
+                    "A": "sha256:8bb9e9e2e0bae1af04dbfbef9a4f3c0388dc211c0b8e6a0095423455bf1a2906",
+                    "B": "sha256:3e77446a321e6ccd9823a8ce33a5b4ba457cfd3afbf02a3d793e87ad27893947",
+                    "C": "sha256:eb1b61d031bdab5879087604ecccf134b34ab344e589cd91d080b3f54c05feeb",
+                    "D": "sha256:967984c94fd3f1ff533406ffa5ebf23d6e5d47cd0b7a6347685ebf7fa3b0acb7",
+                    "E": "sha256:5d1c712680a1add488b83b51b3aaf8d4714ebe0971dd8e833cb0e8a3a2aec274",
+                    "F": "sha256:9586433eaa144a108daf8e99a9369201c1692a66e770d98bd56772dc49c63d57"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9546,
+                "rule": "Abstract beta50 overlay grammar generated from seed 9546; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_overlay_formal_rule_46",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_overlay_formal_rule_46",
+                "item_family_template": "overlay",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:5fd761c0b6941adffc019c4c0a4306a1e73312bde11c0719556b4cfdd2dd964c"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q47",
+            "item_id": "IQ_BETA_50_ORIGINAL_47",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "numeric_pattern",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q47</text><circle cx=\"108\" cy=\"47\" r=\"9\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"103\" y=\"52\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"147\" cy=\"70\" r=\"10\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"142\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"186\" cy=\"93\" r=\"10\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"181\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"60\" cy=\"116\" r=\"11\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"55\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text></svg>",
+                    "accessibility_label": "Original beta50 numeric pattern reasoning prompt 47."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"53\" cy=\"70\" r=\"13\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"48\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"92\" cy=\"93\" r=\"13\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"87\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"131\" cy=\"116\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"126\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 47."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"75\" cy=\"104\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"70\" y=\"109\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"114\" cy=\"51\" r=\"14\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"109\" y=\"56\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"153\" cy=\"74\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"148\" y=\"79\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"192\" cy=\"97\" r=\"7\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"187\" y=\"102\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"66\" cy=\"120\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"61\" y=\"125\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 47."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"97\" cy=\"62\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"92\" y=\"67\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"136\" cy=\"85\" r=\"7\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"131\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"175\" cy=\"108\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"170\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 47."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"119\" cy=\"96\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"114\" y=\"101\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"158\" cy=\"119\" r=\"8\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"153\" y=\"124\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"32\" cy=\"66\" r=\"9\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"27\" y=\"71\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"71\" cy=\"89\" r=\"9\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"66\" y=\"94\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"110\" cy=\"112\" r=\"10\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"105\" y=\"117\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 47."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"64\" cy=\"60\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"59\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"103\" cy=\"83\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"98\" y=\"88\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"142\" cy=\"106\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"137\" y=\"111\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"181\" cy=\"53\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"176\" y=\"58\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"55\" cy=\"76\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"50\" y=\"81\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 47."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"163\" cy=\"88\" r=\"10\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"158\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"37\" cy=\"111\" r=\"10\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"32\" y=\"116\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"76\" cy=\"58\" r=\"11\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"71\" y=\"63\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"115\" cy=\"81\" r=\"11\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"110\" y=\"86\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"154\" cy=\"104\" r=\"12\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"149\" y=\"109\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 47."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "E",
+            "solution_rule": "Abstract beta50 numeric pattern grammar generated from seed 9547; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:3b63a5a3c3a2b5cca9729f19db2e8ee24f3f7a9b1c8e4daf35761fdd76e5b75e",
+                "options": {
+                    "A": "sha256:5ed0f411746857879f9b62b2ad38bf50d6045b8320332c59ef0e9041fc0c59fa",
+                    "B": "sha256:7c54ad4d4345fb497d44e824ca8fa63c53eb0bc98a21b2f2da694b56aea75250",
+                    "C": "sha256:c4fecdc07cedf6cbdc2fb7e80c01015e99f3e1b123357a97e548fd17cbb74307",
+                    "D": "sha256:7ccb95de709bb4cc3ce3e18bf7a4ea98dd0665b7a50b743123b2a1a27bc5b953",
+                    "E": "sha256:c7dca38592100562433bf37b8eea8f2f705a2106bfa2852d1a5358174f5a3de0",
+                    "F": "sha256:102c7fc9dc4d4d0d7e763a09c392e95bab88bac41d9d7e66fa401fa92198176d"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9547,
+                "rule": "Abstract beta50 numeric pattern grammar generated from seed 9547; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_numeric_pattern_formal_rule_47",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_numeric_pattern_formal_rule_47",
+                "item_family_template": "numeric_pattern",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:03917c7d8808c7a1cc5564732e308bf522187967db8bc66997296cca8dc50f93"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q48",
+            "item_id": "IQ_BETA_50_ORIGINAL_48",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "numeric_pattern",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q48</text><circle cx=\"60\" cy=\"92\" r=\"8\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"55\" y=\"97\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"99\" cy=\"115\" r=\"8\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"94\" y=\"120\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"138\" cy=\"62\" r=\"9\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"133\" y=\"67\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"177\" cy=\"85\" r=\"9\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"172\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"51\" cy=\"108\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"46\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text></svg>",
+                    "accessibility_label": "Original beta50 numeric pattern reasoning prompt 48."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"181\" cy=\"56\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"176\" y=\"61\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"55\" cy=\"79\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"50\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"94\" cy=\"102\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"89\" y=\"107\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"133\" cy=\"49\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"128\" y=\"54\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"172\" cy=\"72\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"167\" y=\"77\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 48."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"38\" cy=\"90\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"33\" y=\"95\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"77\" cy=\"113\" r=\"13\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"72\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"116\" cy=\"60\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"111\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 48."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"60\" cy=\"48\" r=\"14\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"55\" y=\"53\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"99\" cy=\"71\" r=\"14\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"94\" y=\"76\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"138\" cy=\"94\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"133\" y=\"99\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"177\" cy=\"117\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"172\" y=\"122\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"51\" cy=\"64\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"46\" y=\"69\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 48."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"82\" cy=\"82\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"77\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"121\" cy=\"105\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"116\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"160\" cy=\"52\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"155\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 48."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"104\" cy=\"116\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"99\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"143\" cy=\"63\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"138\" y=\"68\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"182\" cy=\"86\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"177\" y=\"91\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"56\" cy=\"109\" r=\"9\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"51\" y=\"114\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"95\" cy=\"56\" r=\"10\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"90\" y=\"61\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 48."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"181\" cy=\"105\" r=\"12\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"176\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"55\" cy=\"52\" r=\"13\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"50\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"94\" cy=\"75\" r=\"13\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"89\" y=\"80\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"133\" cy=\"98\" r=\"14\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"128\" y=\"103\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"172\" cy=\"121\" r=\"14\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"167\" y=\"126\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"46\" cy=\"68\" r=\"7\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"41\" y=\"73\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 48."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "F",
+            "solution_rule": "Abstract beta50 numeric pattern grammar generated from seed 9548; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:6cdf6d88f26995dccf6fb6f29238d42c92e71a50a7f31424c1b7d3b044f75406",
+                "options": {
+                    "A": "sha256:b31ba3cd468b20765981eaeb7eb246821dc84e8bc37964ddc8cd211f87d8db69",
+                    "B": "sha256:4290695b28dd2f34da9c3f621f2945d20d744e3081e57d3c643291f57afbffb4",
+                    "C": "sha256:a37f3e848596c0b90e7eef4e3ea492152443cc0a9f11e3a5f6db379ab1e8c15b",
+                    "D": "sha256:f128ed788c21c3b5215efb1e09b21ec6cda1ea944977bd40df15b195f8dad507",
+                    "E": "sha256:b000bf3b39b5aa692863251b3ca93df170e8adce7ca20e2ac1d63cda77817c01",
+                    "F": "sha256:69ea0973527a97f992d36a6ec7923991d3a7101641cb2ae8aec3a2e86f38338b"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9548,
+                "rule": "Abstract beta50 numeric pattern grammar generated from seed 9548; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_numeric_pattern_formal_rule_48",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_numeric_pattern_formal_rule_48",
+                "item_family_template": "numeric_pattern",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:294499ad0823c74815f07d984214bd4dec9638d8fe0018cfbf46035695cd9cd8"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q49",
+            "item_id": "IQ_BETA_50_ORIGINAL_49",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "numeric_pattern",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q49</text><circle cx=\"100\" cy=\"72\" r=\"10\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"95\" y=\"77\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"139\" cy=\"95\" r=\"10\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"134\" y=\"100\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"178\" cy=\"118\" r=\"11\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"173\" y=\"123\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"52\" cy=\"65\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"47\" y=\"70\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"91\" cy=\"88\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"86\" y=\"93\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text></svg>",
+                    "accessibility_label": "Original beta50 numeric pattern reasoning prompt 49."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"56\" cy=\"85\" r=\"14\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"51\" y=\"90\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"95\" cy=\"108\" r=\"7\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"90\" y=\"113\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"134\" cy=\"55\" r=\"7\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"129\" y=\"60\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"173\" cy=\"78\" r=\"8\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"168\" y=\"83\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"47\" cy=\"101\" r=\"8\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"42\" y=\"106\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"86\" cy=\"48\" r=\"9\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"81\" y=\"53\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 49."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"89\" cy=\"87\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"84\" y=\"92\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"128\" cy=\"110\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"123\" y=\"115\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text><circle cx=\"167\" cy=\"57\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"162\" y=\"62\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"41\" cy=\"80\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"36\" y=\"85\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 49."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"111\" cy=\"121\" r=\"8\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"106\" y=\"126\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"150\" cy=\"68\" r=\"9\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"145\" y=\"73\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"189\" cy=\"91\" r=\"9\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"184\" y=\"96\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"63\" cy=\"114\" r=\"10\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"58\" y=\"119\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"102\" cy=\"61\" r=\"10\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"97\" y=\"66\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"141\" cy=\"84\" r=\"11\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"136\" y=\"89\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 49."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"133\" cy=\"79\" r=\"9\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"128\" y=\"84\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text><circle cx=\"172\" cy=\"102\" r=\"10\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"167\" y=\"107\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">16</text><circle cx=\"46\" cy=\"49\" r=\"10\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"41\" y=\"54\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"85\" cy=\"72\" r=\"11\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"80\" y=\"77\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 49."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"155\" cy=\"113\" r=\"10\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"150\" y=\"118\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">2</text><circle cx=\"194\" cy=\"60\" r=\"11\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"189\" y=\"65\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">5</text><circle cx=\"68\" cy=\"83\" r=\"11\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"63\" y=\"88\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"107\" cy=\"106\" r=\"12\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"102\" y=\"111\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"146\" cy=\"53\" r=\"12\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"141\" y=\"58\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"185\" cy=\"76\" r=\"13\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"180\" y=\"81\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 49."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"78\" cy=\"70\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"73\" y=\"75\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"117\" cy=\"93\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"112\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text><circle cx=\"156\" cy=\"116\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"151\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">4</text></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 49."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "A",
+            "solution_rule": "Abstract beta50 numeric pattern grammar generated from seed 9549; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:78d48aa1135297ede8fb44b19fdafde666583ac4e6e513204f47c84ccbe27997",
+                "options": {
+                    "A": "sha256:ba31e3a60b2f915f4a2628c954517eb9e83299828795b1b868f88faec2af34c3",
+                    "B": "sha256:e4cb4c7dc7721dd02cde9a2a25a7d0cd244f21545ad898d8b0221a22bb351274",
+                    "C": "sha256:f48edba7499091d00e7c3cc2fce2d0b7581a57fdebd95f236f002122c5502e7e",
+                    "D": "sha256:079e40d550bec67d8bcf5ba04bfb2145980faf2630104e3a3b9d1d2758c4846f",
+                    "E": "sha256:6431c7a21e0b167d9de51a99dadcc724e98306cc2d76871262a427f27dca830e",
+                    "F": "sha256:5b7953119bd4dced997ea5a8c276d6e0583e624995f9230a88193a6f0a6eac82"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9549,
+                "rule": "Abstract beta50 numeric pattern grammar generated from seed 9549; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_numeric_pattern_formal_rule_49",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_numeric_pattern_formal_rule_49",
+                "item_family_template": "numeric_pattern",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:e411d717c01cd822428217dea9af8da91c96a87a9443f01922fc4aec45bcf116"
+            }
+        },
+        {
+            "schema_version": "fm.iq.item_bank.item.v1",
+            "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+            "bank_id": "IQ_BETA_50_ORIGINAL",
+            "question_id": "IQB50-Q50",
+            "item_id": "IQ_BETA_50_ORIGINAL_50",
+            "dimension": "NPR",
+            "dimension_name": "Numeric pattern reasoning",
+            "difficulty_level": 5,
+            "item_family": "numeric_pattern",
+            "option_count": 6,
+            "assets": {
+                "stem": {
+                    "kind": "inline_svg_markup",
+                    "mime_type": "image/svg+xml",
+                    "view_box": "0 0 240 160",
+                    "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><text x=\"20\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\" opacity=\"0.72\">numeric pattern</text><text x=\"198\" y=\"28\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"12\" fill=\"#243126\" opacity=\"0.54\">Q50</text><circle cx=\"41\" cy=\"78\" r=\"7\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"36\" y=\"83\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">7</text><circle cx=\"80\" cy=\"101\" r=\"7\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"75\" y=\"106\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">10</text><circle cx=\"119\" cy=\"48\" r=\"8\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"114\" y=\"53\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">13</text></svg>",
+                    "accessibility_label": "Original beta50 numeric pattern reasoning prompt 50."
+                },
+                "options": [
+                    {
+                        "code": "A",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"184\" cy=\"76\" r=\"12\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"179\" y=\"81\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"58\" cy=\"99\" r=\"12\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"53\" y=\"104\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"97\" cy=\"46\" r=\"13\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"92\" y=\"51\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"136\" cy=\"69\" r=\"13\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"131\" y=\"74\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"175\" cy=\"92\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"170\" y=\"97\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text></svg>",
+                            "accessibility_label": "Option A for original beta50 IQ item 50."
+                        }
+                    },
+                    {
+                        "code": "B",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"162\" cy=\"91\" r=\"11\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"157\" y=\"96\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"36\" cy=\"114\" r=\"12\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"31\" y=\"119\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"75\" cy=\"61\" r=\"12\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"70\" y=\"66\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"114\" cy=\"84\" r=\"13\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"109\" y=\"89\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text></svg>",
+                            "accessibility_label": "Option B for original beta50 IQ item 50."
+                        }
+                    },
+                    {
+                        "code": "C",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"63\" cy=\"68\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"58\" y=\"73\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"102\" cy=\"91\" r=\"14\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"97\" y=\"96\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"141\" cy=\"114\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"136\" y=\"119\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"180\" cy=\"61\" r=\"7\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"175\" y=\"66\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"54\" cy=\"84\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"49\" y=\"89\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text></svg>",
+                            "accessibility_label": "Option C for original beta50 IQ item 50."
+                        }
+                    },
+                    {
+                        "code": "D",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"85\" cy=\"102\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"80\" y=\"107\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text><circle cx=\"124\" cy=\"49\" r=\"7\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"119\" y=\"54\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">15</text><circle cx=\"163\" cy=\"72\" r=\"8\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"158\" y=\"77\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">18</text></svg>",
+                            "accessibility_label": "Option D for original beta50 IQ item 50."
+                        }
+                    },
+                    {
+                        "code": "E",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"173\" cy=\"59\" r=\"11\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"168\" y=\"64\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">8</text><circle cx=\"47\" cy=\"82\" r=\"12\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"42\" y=\"87\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">11</text><circle cx=\"86\" cy=\"105\" r=\"12\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"81\" y=\"110\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"125\" cy=\"52\" r=\"13\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"120\" y=\"57\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text></svg>",
+                            "accessibility_label": "Option E for original beta50 IQ item 50."
+                        }
+                    },
+                    {
+                        "code": "F",
+                        "asset": {
+                            "kind": "inline_svg_markup",
+                            "mime_type": "image/svg+xml",
+                            "view_box": "0 0 240 160",
+                            "svg_markup": "<svg xmlns=\"http://www.w3.org/2000/svg\" viewBox=\"0 0 240 160\" role=\"img\"><rect width=\"240\" height=\"160\" rx=\"16\" fill=\"#f8faf7\"/><rect x=\"8\" y=\"8\" width=\"224\" height=\"144\" rx=\"12\" fill=\"none\" stroke=\"#243126\" stroke-width=\"2\" opacity=\"0.16\"/><circle cx=\"195\" cy=\"93\" r=\"12\" fill=\"none\" stroke=\"#a7b35a\" stroke-width=\"3\"/><text x=\"190\" y=\"98\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">14</text><circle cx=\"69\" cy=\"116\" r=\"13\" fill=\"none\" stroke=\"#7b4f8a\" stroke-width=\"3\"/><text x=\"64\" y=\"121\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">17</text><circle cx=\"108\" cy=\"63\" r=\"13\" fill=\"none\" stroke=\"#c7504f\" stroke-width=\"3\"/><text x=\"103\" y=\"68\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">3</text><circle cx=\"147\" cy=\"86\" r=\"14\" fill=\"none\" stroke=\"#1f5d50\" stroke-width=\"3\"/><text x=\"142\" y=\"91\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">6</text><circle cx=\"186\" cy=\"109\" r=\"14\" fill=\"none\" stroke=\"#d9843b\" stroke-width=\"3\"/><text x=\"181\" y=\"114\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">9</text><circle cx=\"60\" cy=\"56\" r=\"7\" fill=\"none\" stroke=\"#4666a9\" stroke-width=\"3\"/><text x=\"55\" y=\"61\" font-family=\"Avenir, Helvetica, sans-serif\" font-size=\"13\" fill=\"#243126\">12</text></svg>",
+                            "accessibility_label": "Option F for original beta50 IQ item 50."
+                        }
+                    }
+                ]
+            },
+            "correct_answer": "B",
+            "solution_rule": "Abstract beta50 numeric pattern grammar generated from seed 9550; choose the option preserving the declared multi-attribute transformation.",
+            "distractor_logic": "Distractors are seeded perturbations of count, position, rotation, overlay operation, or numeric step; no competitor item, answer, option, or explanation asset is copied or rewritten.",
+            "asset_hashes": {
+                "stem": "sha256:552724914ac96602eaa5117f6840ea12af3d3ba3ab4156fa85ee63f568f34901",
+                "options": {
+                    "A": "sha256:e6b8adebd16f454e60424b1275e38b2a8ff9b872a50ab04ce7667c335529f561",
+                    "B": "sha256:0ab25a1bb919f5274457eeadbeca8889fb6237a609a170d51229d09683a28a6c",
+                    "C": "sha256:91f90120ba1d18a5d5ef1f815fb8df05051da13beedd155e1b1d805686075856",
+                    "D": "sha256:96a866afb73c91279d7fd249a9ccd5fa3cac684775ad070712458f77fa88d579",
+                    "E": "sha256:0eb322f8f5fc03c80f14cef089fc9806736fd2f4f38c8c3fe1522e6328d3f48b",
+                    "F": "sha256:efc1e40cefcfdefc4c1e7902a24beea5caacc00c49408dc12bc4569e4869e971"
+                }
+            },
+            "generator_metadata": {
+                "source_mode": "repo_generated_original",
+                "copied_from_third_party": false,
+                "traced_from_third_party": false,
+                "seed": 9550,
+                "rule": "Abstract beta50 numeric pattern grammar generated from seed 9550; choose the option preserving the declared multi-attribute transformation.",
+                "rule_key": "beta50_numeric_pattern_formal_rule_50",
+                "difficulty": 5,
+                "reviewer": "codex_beta50_originality_review",
+                "review_status": "originality_reviewed_pending_psychometric_review_and_norm_calibration",
+                "generation_phase": "beta50_formal_original_pending_norms",
+                "template_key": "beta50_numeric_pattern_formal_rule_50",
+                "item_family_template": "numeric_pattern",
+                "generator_version": "iq_beta50_original_bank_v1",
+                "theme_version": "fermatmind_soft_contrast_v1",
+                "params_hash": "sha256:f64f2576334bb4b5360d7b49fd98aa1aea49a0a9fc4bdd8668fc59d282a90f67"
+            }
+        }
+    ]
+}

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/manifest.json
@@ -1,55 +1,80 @@
 {
-  "schema_version": "fm.iq.item_bank_manifest.v1",
-  "bank_id": "IQ_BETA_50_ORIGINAL",
-  "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
-  "legacy_compatibility": {
-    "accepts_legacy_scale_code_alias": "IQ_RAVEN",
-    "legacy_alias_user_facing": false
-  },
-  "status": "future_placeholder_spec_only",
-  "runtime_bound": false,
-  "public_take_enabled": false,
-  "item_count_target": 50,
-  "item_count_imported": 0,
-  "option_count": 6,
-  "option_codes": ["A", "B", "C", "D", "E", "F"],
-  "dimension_targets": {
-    "VSPR": 22,
-    "VSI": 16,
-    "NPR": 12
-  },
-  "item_family_targets": {
-    "matrix_3x3": 16,
-    "matrix_2x2": 6,
-    "series": 8,
-    "odd_one_out": 6,
-    "rotation": 5,
-    "overlay": 5,
-    "numeric_pattern": 4
-  },
-  "launch_gates": {
-    "items_import_required": true,
-    "answer_key_required": true,
-    "scoring_spec_required": true,
-    "norm_authority_required": true,
-    "copyright_gate_required": true,
-    "ambiguity_gate_required": true,
-    "provenance_gate_required": true
-  },
-  "public_payload_policy": {
-    "may_emit_items": false,
-    "may_emit_answer_key": false,
-    "may_emit_solution_rule": false,
-    "may_emit_generator_metadata": false
-  },
-  "norm_policy": {
-    "iq_claims_enabled": false,
-    "percentile_claims_enabled": false,
-    "population_norm_table_required_before_production": true
-  },
-  "notes": {
-    "frontend_display_key": "beta_50",
-    "beta_30_current_bank_id": "IQ_BETA_30_ORIGINAL",
-    "reason": "future beta50 placeholder only; no runtime item import in IQ-BANK-50-01"
-  }
+    "schema_version": "fm.iq.item_bank_manifest.v1",
+    "bank_id": "IQ_BETA_50_ORIGINAL",
+    "scale_code": "IQ_INTELLIGENCE_QUOTIENT",
+    "legacy_compatibility": {
+        "accepts_legacy_scale_code_alias": "IQ_RAVEN",
+        "legacy_alias_user_facing": false
+    },
+    "status": "generated_formal_original_pending_norms",
+    "runtime_bound": false,
+    "public_take_enabled": false,
+    "item_count_target": 50,
+    "item_count_imported": 50,
+    "option_count": 6,
+    "option_codes": [
+        "A",
+        "B",
+        "C",
+        "D",
+        "E",
+        "F"
+    ],
+    "dimension_targets": {
+        "VSPR": 22,
+        "VSI": 16,
+        "NPR": 12
+    },
+    "item_family_targets": {
+        "matrix_3x3": 16,
+        "matrix_2x2": 6,
+        "series": 8,
+        "odd_one_out": 6,
+        "rotation": 5,
+        "overlay": 5,
+        "numeric_pattern": 4
+    },
+    "files": {
+        "items": "items.json",
+        "answer_key": "answer_key.json",
+        "scoring_spec": "scoring_spec.json"
+    },
+    "generation_policy": {
+        "formal_original_item_count": 50,
+        "competitor_item_capture_allowed": false,
+        "competitor_item_rewrite_allowed": false,
+        "formal_item_source_mode": "repo_generated_original",
+        "required_item_metadata": [
+            "source_mode",
+            "seed",
+            "rule",
+            "difficulty",
+            "reviewer"
+        ]
+    },
+    "launch_gates": {
+        "items_import_required": false,
+        "answer_key_required": false,
+        "scoring_spec_required": false,
+        "norm_authority_required": true,
+        "copyright_gate_required": true,
+        "ambiguity_gate_required": true,
+        "provenance_gate_required": true
+    },
+    "public_payload_policy": {
+        "may_emit_items": false,
+        "may_emit_answer_key": false,
+        "may_emit_solution_rule": false,
+        "may_emit_generator_metadata": false
+    },
+    "norm_policy": {
+        "iq_claims_enabled": false,
+        "percentile_claims_enabled": false,
+        "population_norm_table_required_before_production": true
+    },
+    "notes": {
+        "frontend_display_key": "beta_50",
+        "beta_30_current_bank_id": "IQ_BETA_30_ORIGINAL",
+        "reason": "beta50 original bank generated for future calibration; runtime and public take remain disabled until norm authority gates pass."
+    }
 }

--- a/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/scoring_spec.json
+++ b/content_packages/default/CN_MAINLAND/zh-CN/IQ_INTELLIGENCE_QUOTIENT-CN-v0.3.0-DEMO/banks/IQ_BETA_50_ORIGINAL/scoring_spec.json
@@ -1,0 +1,26 @@
+{
+    "schema_version": "fm.iq.scoring_spec.v1",
+    "bank_id": "IQ_BETA_50_ORIGINAL",
+    "status": "generated_formal_original_pending_norms",
+    "raw_score": {
+        "min": 0,
+        "max": 50,
+        "correct_item_value": 1,
+        "incorrect_item_value": 0
+    },
+    "dimension_counts": {
+        "VSPR": 22,
+        "VSI": 16,
+        "NPR": 12
+    },
+    "norm_policy": {
+        "iq_claims_enabled": false,
+        "percentile_claims_enabled": false,
+        "population_norm_table_required_before_production": true,
+        "beta_copy_allowed_claim": "practice-style cognitive reasoning score only"
+    },
+    "runtime_binding": {
+        "enabled": false,
+        "deferred_to_pr": "IQ-SCORE-50-01"
+    }
+}


### PR DESCRIPTION
## What changed

- Promoted IQ_BETA_30_ORIGINAL from a 12-item wave-1 formal set plus scaffolded extension into a 30-item repo-generated original beta bank.
- Added deterministic IQ_BETA_50_ORIGINAL generator, build script, verifier script, and generated 50-item bank artifacts.
- Kept beta50 runtime and public take disabled while allowing generated backend assets to exist for future calibration.
- Updated beta50 content tests from placeholder-only expectations to generated-bank-but-runtime-disabled expectations.
- Updated IQ bank documentation copyright boundary language to allow competitor structure benchmarking only, not copying, rewriting, tracing, reordering, or importing third-party item assets.

## Why

FermatMind needs an owned IQ item-bank path that can move from initial wave-1 original items toward beta30 and beta50 calibration without relying on competitor questions, screenshots, answers, explanations, or third-party bank assets.

## Public payload and copyright boundary

- Items are marked `source_mode: repo_generated_original`.
- Generated metadata records seed, rule, difficulty, reviewer, generation phase, and provenance flags.
- Answer keys remain in backend-only `answer_key.json` files.
- Public payload policy continues to forbid answer keys, solution rules, and generator metadata.
- beta50 remains `runtime_bound=false` and `public_take_enabled=false` until norm/calibration gates are satisfied.

## Validation commands run

- `php backend/scripts/iq/build_iq_beta30_original_bank.php`
- `php backend/scripts/iq/build_iq_beta50_original_bank.php`
- Before the beta30/beta50 expansion step, beta30 generator check and verifier were run and passed.

## Intentionally deferred

- Post-expansion beta30 and beta50 verifier/PHPUnit runs are deferred to follow-up CI/local validation.
- Norm authority, paid report calibration, CMS media assets, and SEO rollout remain deferred.
- beta50 frontend answer entry remains disabled until backend authority gates pass.
