### PR TITLE
docs(cms): verify canary draft dry-run and collision checks

### DIFF
--- a/backend/docs/seo/seo-cms-canary-draft-verify-2026-06-02.md
+++ b/backend/docs/seo/seo-cms-canary-draft-verify-2026-06-02.md
@@ -1,0 +1,137 @@
+# SEO CMS Canary Draft Verify — 2026-06-02
+
+Task: `SEO-CMS-CANARY-DRAFT-VERIFY-01`
+
+This report verifies whether the first bilingual SEO canary can safely enter a controlled importer draft-only flow. It does not create a CMS draft, does not publish, does not save CMS forms, does not call production write APIs, does not edit GPT-5.5 Pro content packages, does not generate or modify title/H1/meta/body/FAQ/CTA copy, and does not change runtime code, routes, migrations, tests, sitemap runtime, analytics runtime, or frontend files.
+
+Dependencies verified:
+
+- `SEO-CMS-CANARY-BE-01`: fap-api PR #1852 is merged.
+- `SEO-CMS-CANARY-DRAFT-PATH-01`: fap-api PR #1855 is merged.
+
+Target canary:
+
+- zh slug: `mbti-vs-holland-career-choice`
+- en slug: `mbti-vs-holland-code-career-choice`
+- translation group: `article_mbti_vs_holland_career_choice_v1`
+
+## A. Operator Permissions
+
+Result: **partially confirmed by code; current operator remains Unknown**.
+
+Confirmed by code:
+
+1. A draft-capable Article operator role exists in the RBAC model. `ROLE_CONTENT` receives `admin.content.read`, `admin.content.write`, and `admin.content.probe`.
+2. A create/edit-but-not-release role exists. `ContentAccess::canWrite()` accepts `admin.content.write`, while `ContentAccess::canRelease()` requires `admin.content.release`, `admin.content.publish`, or owner authority.
+3. `ArticleResource::canCreate()` and `ArticleResource::canEdit()` use `canWrite()`.
+4. Publish/release requires higher permission and editorial approval. The ArticleResource release action is visible only when `canRelease()` is true, the article is not already published, and latest editorial review state is approved. `releaseRecord()` repeats those checks and requires a publishable revision.
+
+Unknown:
+
+- The current human/operator account was not authenticated through CMS in this run.
+- No cookies, tokens, env secrets, or live CMS session data were read.
+- Therefore current operator draft create/edit permission is **Unknown**.
+
+## B. Hidden Collision Check
+
+Result: **public absence passed; hidden CMS/DB collision remains Unknown**.
+
+Read-only public checks:
+
+- `GET https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice?locale=zh-CN` returned `404`.
+- `GET https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice/seo?locale=zh-CN` returned `404`.
+- `GET https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice?locale=en` returned `404`.
+- `GET https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en` returned `404`.
+- `sitemap.xml`, `llms.txt`, and `llms-full.txt` did not contain either target slug.
+
+Code confirms why public absence is insufficient:
+
+- Public article detail and SEO endpoints use `Article::publiclyReadable()`.
+- `publiclyReadable()` requires `status=published`, `is_public=true`, `published_revision_id` present, and a published revision.
+- Sitemap article URLs use `Article::publiclyIndexable()`, which adds `is_indexable=true`.
+- Hidden draft/private/noindex/unpublished records can therefore be absent from public API, sitemap, and LLM files.
+
+Not verified:
+
+- CMS/DB hidden draft row for `zh-CN` slug `mbti-vs-holland-career-choice`.
+- CMS/DB hidden draft row for `en` slug `mbti-vs-holland-code-career-choice`.
+- CMS/DB row with `translation_group_id=article_mbti_vs_holland_career_choice_v1`.
+- Any noindex/private/unpublished record collision.
+
+Because no authorized production CMS/DB read-only collision path was available in this run, hidden collision status is **Unknown** and must not be treated as passed.
+
+## C. Controlled Importer Dry-Run
+
+Result: **importer dry-run capability confirmed; target canary dry-run not passed**.
+
+Confirmed by code:
+
+1. `articles:import-editorial-package` has `--dry-run`.
+2. With `--dry-run`, the command calls `EditorialPackageDraftImporter::planFromFile()` rather than `importFromFile()`.
+3. `plan()` validates the normalized package, resolves existing Article by public org + locale + slug, emits `action`, `existing_article_id`, `would_write`, body hash, answer surface hash, references count, claim matches, warnings, and errors.
+4. Importer normalization supports `translation_group_id`, locale, slug, `answer_surface_v1`, and `cta_slots`.
+5. Actual import, if separately authorized later, sets `status=draft`, `is_public=false`, `is_indexable=false`, and `published_revision_id=null`, and writes SEO meta as `robots=noindex,nofollow`.
+6. Existing published/public articles are refused by importer action planning and runtime import guard.
+7. Test coverage includes the exact translation group string `article_mbti_vs_holland_career_choice_v1`, draft-only state, CTA slots, and FAQ package persistence.
+
+Not passed for the target canary:
+
+- No approved GPT-5.5 Pro V2 canary editorial package artifact was present or provided for the exact bilingual target.
+- This run did not create, edit, infer, or generate a content package.
+- Therefore no target `articles:import-editorial-package --dry-run --json` was executed for the first bilingual canary.
+- The importer dry-run has not validated the actual zh/en package pair, shared `translation_group_id`, different slugs, CTA slots, FAQ package, or validation report for this target.
+
+User-provided artifact needed:
+
+- Yes. A pre-approved CMS-ready GPT-5.5 Pro V2 editorial package artifact is required for both locales before the controlled dry-run can be meaningful.
+
+## D. Draft-Only Preview Alternative
+
+Result: **preview does not appear to block draft creation, but it still blocks publish readiness unless an accepted alternative is approved**.
+
+Based on code and prior DRAFT-PATH report:
+
+- Drafts are fail-closed from public Article API and sitemap surfaces when they remain `draft`, non-public, noindex, and without `published_revision_id`.
+- CMS-only inspection plus controlled dry-run plus public API/sitemap/LLM absence checks can be a reasonable draft creation gate only after operator permissions and hidden collisions are confirmed.
+- No dedicated rendered draft preview route was found.
+- Preview absence should be treated as a publish-readiness blocker, not a draft blocker, unless product/SEO owners explicitly require rendered preview before draft creation.
+
+Current state:
+
+- Because hidden collision and target dry-run are not passed, draft creation is blocked regardless of preview.
+- `SEO-CMS-CANARY-PREVIEW-01` is not required before this docs-only PR can merge.
+- `SEO-CMS-CANARY-PREVIEW-01` should be executed only if the next authorized verification proves that no CMS-only/noindex alternative is acceptable before publish.
+
+## E. SEO-CONTENT-P1-08 Decision
+
+Decision: **NO-GO: do not create CMS draft yet**.
+
+`SEO-CONTENT-P1-08` must remain blocked because:
+
+- Current operator permissions are not confirmed.
+- Hidden CMS/DB slug collisions are not confirmed.
+- Hidden `translation_group_id` collision is not confirmed.
+- The actual target canary importer dry-run did not run and did not pass.
+- Required GPT-5.5 Pro V2 content package artifact was not provided.
+
+The recommended draft creation path remains:
+
+1. Use the controlled editorial package importer.
+2. First run authorized read-only CMS/DB collision checks.
+3. Then run authorized `articles:import-editorial-package --dry-run --json` against the approved zh/en canary package artifacts.
+4. Only after those pass, request separate authorization for draft-only import.
+
+Publish remains forbidden.
+
+## F. Checks
+
+Executed validation for this docs-only PR:
+
+```bash
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- docs/codex backend/docs/seo
+git diff --cached --check
+```
+
+No CMS write, draft create, publish, production DB mutation, runtime edit, test edit, GPT content edit, sitemap submission, Baidu push, IndexNow action, or frontend change was performed.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-02T14:21:21Z",
+  "updated_at": "2026-06-02T14:41:24Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
@@ -40177,13 +40177,13 @@
   "SEO-CMS-CANARY-DRAFT-PATH-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-draft-path-01",
-    "status": "local_checks_passed",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-BE-01",
       "SEO-CMS-CANARY-PREFLIGHT-LEDGER-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "88efaf9b6e25e1a77b775de2ff07ade65eadbda0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1855",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40193,6 +40193,88 @@
           "gh pr view 1004 --repo fermatmind/fap-web --json state,mergedAt,mergeCommit,headRefName,baseRefName,url,title"
         ],
         "notes": "BE-01 and fap-web preflight ledger dependencies are merged before this docs-only scan."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- docs/codex backend/docs/seo",
+          "git diff --cached --check"
+        ],
+        "notes": "Docs-only JSON/YAML/diff checks passed; cached diff check passed after path-limited staging."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": "2026-06-02T14:26:58Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": true,
+      "post_merge_revalidated": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-02T14:16:10Z",
+        "from": "missing",
+        "to": "in_progress",
+        "note": "User explicitly authorized adding SEO-CMS-CANARY-DRAFT-PATH-01 to fap-api manifest/state and executing the docs-only draft path verification report. CMS draft, publish, runtime code, tests, frontend, and GPT content edits remain forbidden."
+      },
+      {
+        "at": "2026-06-02T14:18:48Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Created docs-only draft path verification report, registered manifest/state, and passed JSON parse, YAML parse, and docs diff whitespace checks. No CMS draft, publish, runtime code, tests, frontend, or GPT content edits were performed."
+      },
+      {
+        "at": "2026-06-02T14:21:21Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1855 for docs-only review. No CMS draft, publish, runtime code, tests, frontend, or GPT content edits were performed."
+      },
+      {
+        "at": "2026-06-02T14:39:08Z",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CMS-CANARY-DRAFT-VERIFY-01: GitHub PR #1855 is MERGED with merge commit 88efaf9b6e25e1a77b775de2ff07ade65eadbda0, local main equals origin/main, and the task branch cleanup was completed."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "Authorized importer dry-run and read-only collision check, or SEO-CMS-CANARY-PREVIEW-01 only if no safe preview alternative exists."
+  },
+  "SEO-CMS-CANARY-DRAFT-VERIFY-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-cms-canary-draft-verify-01",
+    "status": "in_progress",
+    "depends_on": [
+      "SEO-CMS-CANARY-BE-01",
+      "SEO-CMS-CANARY-DRAFT-PATH-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1852 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,url,title",
+          "gh pr view 1855 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,url,title"
+        ],
+        "notes": "BE-01 and DRAFT-PATH-01 are merged before this docs-only verification."
+      },
+      "readonly_public_absence": {
+        "status": "passed",
+        "commands": [
+          "curl -sS -o /tmp/canary_api_check.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice?locale=zh-CN",
+          "curl -sS -o /tmp/canary_api_check.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice/seo?locale=zh-CN",
+          "curl -sS -o /tmp/canary_api_check.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice?locale=en",
+          "curl -sS -o /tmp/canary_api_check.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en",
+          "curl -sS https://fermatmind.com/sitemap.xml and grep target slugs",
+          "curl -sS https://fermatmind.com/llms.txt and grep target slugs",
+          "curl -sS https://fermatmind.com/llms-full.txt and grep target slugs"
+        ],
+        "notes": "Public API detail/SEO endpoints returned 404 for both target slugs; sitemap.xml, llms.txt, and llms-full.txt did not contain either target slug."
       },
       "local": {
         "status": "passed",
@@ -40217,25 +40299,19 @@
     },
     "transitions": [
       {
-        "at": "2026-06-02T14:16:10Z",
+        "at": "2026-06-02T14:39:08Z",
         "from": "missing",
         "to": "in_progress",
-        "note": "User explicitly authorized adding SEO-CMS-CANARY-DRAFT-PATH-01 to fap-api manifest/state and executing the docs-only draft path verification report. CMS draft, publish, runtime code, tests, frontend, and GPT content edits remain forbidden."
+        "note": "User authorized adding SEO-CMS-CANARY-DRAFT-VERIFY-01 to fap-api manifest/state and executing docs-only dry-run/collision verification. No CMS draft, publish, runtime code, tests, frontend, GPT content, or production write action is allowed."
       },
       {
-        "at": "2026-06-02T14:18:48Z",
+        "at": "2026-06-02T14:41:24Z",
         "from": "in_progress",
         "to": "local_checks_passed",
-        "note": "Created docs-only draft path verification report, registered manifest/state, and passed JSON parse, YAML parse, and docs diff whitespace checks. No CMS draft, publish, runtime code, tests, frontend, or GPT content edits were performed."
-      },
-      {
-        "at": "2026-06-02T14:21:21Z",
-        "from": "local_checks_passed",
-        "to": "pr_open",
-        "note": "Opened https://github.com/fermatmind/fap-api/pull/1855 for docs-only review. No CMS draft, publish, runtime code, tests, frontend, or GPT content edits were performed."
+        "note": "Created docs-only draft verify report with NO-GO, registered manifest/state, and passed JSON parse, YAML parse, and docs diff whitespace checks. No CMS draft, publish, runtime code, tests, frontend, or GPT content edits were performed."
       }
     ],
     "sidecars": [],
-    "next_task": "Authorized importer dry-run and read-only collision check, or SEO-CMS-CANARY-PREVIEW-01 only if no safe preview alternative exists."
+    "next_task": "SEO-CONTENT-P1-08 remains blocked unless this verification returns GO and user separately authorizes draft-only execution."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-02T14:41:24Z",
+  "updated_at": "2026-06-02T14:43:50Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
@@ -38613,7 +38613,7 @@
     "repo": "fap-api",
     "branch": "codex/pr-fdn-social-sync-mvp-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "title": "feat(foundation): add manual Daily Giving social sync MVP",
     "depends_on": [
       "PR-FDN-SOCIAL-SYNC-READINESS"
@@ -40252,8 +40252,8 @@
       "SEO-CMS-CANARY-BE-01",
       "SEO-CMS-CANARY-DRAFT-PATH-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "7c8af8b6ab3c8e2a5578d45d94681efebb69a5ef",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1856",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40309,6 +40309,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Created docs-only draft verify report with NO-GO, registered manifest/state, and passed JSON parse, YAML parse, and docs diff whitespace checks. No CMS draft, publish, runtime code, tests, frontend, or GPT content edits were performed."
+      },
+      {
+        "at": "2026-06-02T14:43:50Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1856 for docs-only review. No CMS draft, publish, runtime code, tests, frontend, GPT content, or production write action was performed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19664,3 +19664,49 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: SEO-CMS-CANARY-DRAFT-PATH-01 authorized dry-run/collision check or SEO-CMS-CANARY-PREVIEW-01 only if no safe preview alternative exists
+
+  - id: SEO-CMS-CANARY-DRAFT-VERIFY-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-BE-01
+      - SEO-CMS-CANARY-DRAFT-PATH-01
+    branch: codex/seo-cms-canary-draft-verify-01
+    title: "docs(cms): verify canary draft dry-run and collision checks"
+    train_scope: seo_cms_canary
+    scope:
+      - Verify whether the first bilingual SEO canary can safely enter a controlled importer draft-only flow.
+      - Check operator permission model, public exposure absence, hidden collision status, importer dry-run feasibility, and preview-vs-draft gating.
+      - Produce a docs-only GO/NO-GO report without CMS writes.
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/docs/operations/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute SEO-CONTENT-P1-08 unless this report returns GO.
+      - Create CMS drafts, save CMS forms, publish, or call production write APIs.
+      - Generate or edit canary title, H1, meta, body, FAQ, CTA, or GPT content packages.
+      - Modify runtime code, routes, migrations, tests, package files, sitemap runtime, analytics runtime, or frontend files.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- docs/codex backend/docs/seo
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    next_task: SEO-CONTENT-P1-08 remains blocked unless this task returns GO and user separately authorizes draft-only execution


### PR DESCRIPTION
## What changed

- Added `SEO-CMS-CANARY-DRAFT-VERIFY-01` to the fap-api PR train manifest/state ledger.
- Reconciled `SEO-CMS-CANARY-DRAFT-PATH-01` as merged after PR #1855 cleanup.
- Added the docs-only verification report:
  - `backend/docs/seo/seo-cms-canary-draft-verify-2026-06-02.md`

## Why

The prior DRAFT-PATH report kept CMS draft and publish blocked until operator permissions, hidden collision checks, and controlled importer dry-run could be verified. This PR performs the next docs-only verification without writing CMS data.

## Validation commands

```bash
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
git diff --check -- docs/codex backend/docs/seo
git diff --cached --check
```

## Result

- GO / NO-GO: NO-GO, do not create CMS draft yet.
- Recommended draft path: controlled editorial package importer.
- Hidden collision: public absence passed, hidden CMS/DB collision remains Unknown.
- Controlled importer dry-run: capability confirmed, target canary dry-run did not pass because no approved package artifact was available.
- Content package artifact needed: yes, pre-approved zh/en GPT-5.5 Pro V2 CMS-ready package artifacts are required.
- Preview: does not appear to block draft creation once other gates pass; still blocks publish readiness unless an accepted alternative is approved.
- SEO-CONTENT-P1-08: remains blocked.
- Publish: still forbidden.

## Intentionally deferred

- No CMS draft creation, CMS form save, publish, production write API call, sitemap submission, Baidu push, or IndexNow action.
- No GPT-5.5 Pro V2 content package edits and no generated/modified title, H1, meta, body, FAQ, or CTA copy.
- No runtime code, route, migration, test, package, sitemap runtime, analytics runtime, fap-web, result/order/share/payment ID, env, cookie, or token access.

## Repository rule impact

Docs-only PR. CMS/backend remains the source of truth for Article content and publishing state. No runtime content authority, frontend fallback, public enumeration, or publishing SOP behavior changes are introduced.
