### PR TITLE
docs(content): add approved bilingual SEO canary CMS package

### DIFF
--- a/backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md
+++ b/backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md
@@ -1,0 +1,35 @@
+# MBTI vs Holland Bilingual Canary Package Notes
+
+Date: 2026-06-02
+
+## Content authority
+
+- Content owner: GPT-5.5 Pro.
+- Codex did not author, rewrite, expand, polish, or localize the content.
+- Codex only copied the user-provided approved package artifacts into the repository path and validated package structure, paths, CTA targets, and publish gates.
+- CMS/backend is the final content authority.
+
+## Package purpose
+
+- These artifacts are for controlled importer dry-run and draft-only preparation.
+- They are not runtime content authority.
+- They do not authorize CMS draft creation.
+- They do not authorize publish.
+- They do not authorize search submission.
+
+## Required gates still open
+
+- Controlled importer dry-run is still required.
+- Hidden slug collision check is still required.
+- Translation group collision check is still required.
+- CMS draft creation remains blocked until `SEO-CMS-CANARY-IMPORT-DRYRUN-01` passes.
+- `SEO-CONTENT-P1-08` remains blocked until a separate explicit draft-only execution authorization is granted.
+
+## Forbidden actions
+
+- Do not create a CMS draft from this package yet.
+- Do not publish.
+- Do not submit sitemap updates.
+- Do not call Baidu API push.
+- Do not call IndexNow.
+- Do not use this package as frontend runtime content.

--- a/backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json
+++ b/backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json
@@ -1,0 +1,173 @@
+{
+  "package_schema": "fermatmind.editorial_package.v1",
+  "content_status": "cms_ready_draft_package_only",
+  "approval_status": "requires_user_approval_before_importer_dry_run",
+  "content_owner": "GPT-5.5 Pro",
+  "codex_role": "structure_and_validation_only",
+  "final_content_authority": "CMS/backend",
+  "request_id": "SEO-ARTICLE-REQ-2026-06-02-B",
+  "locale": "zh-CN",
+  "translation_group_id": "article_mbti_vs_holland_career_choice_v1",
+  "title": "MBTI和霍兰德哪个更适合选职业？",
+  "slug": "mbti-vs-holland-career-choice",
+  "h1": "MBTI和霍兰德哪个更适合选职业？",
+  "canonical_path": "/zh/articles/mbti-vs-holland-career-choice",
+  "seo_title": "MBTI和霍兰德哪个更适合选职业？职业测评怎么选｜费马测试",
+  "seo_description": "选专业、找工作或转行时，霍兰德更适合看职业兴趣和工作环境，MBTI更适合理解偏好、沟通和协作方式。本文教你如何组合使用两类测评。",
+  "excerpt": "如果你的问题是“我适合什么职业”，霍兰德/RIASEC通常比MBTI更直接；如果你的问题是“我在工作中更像什么样的人”，MBTI更适合作为沟通风格和偏好参考。更稳的做法不是二选一，而是把职业兴趣、人格偏好和现实岗位信息一起看。",
+  "category": "职业决策",
+  "tags": [
+    "MBTI",
+    "霍兰德",
+    "RIASEC",
+    "职业测评",
+    "职业兴趣测试",
+    "16型人格",
+    "大五人格",
+    "选专业",
+    "转行"
+  ],
+  "related_test_slug": "holland-career-interest-test-riasec",
+  "body_markdown": "# MBTI和霍兰德哪个更适合选职业？\n\n如果你的问题是“我适合什么职业”，霍兰德职业兴趣测试通常比 MBTI 更直接；如果你的问题是“我在工作中更像什么样的人”，MBTI 性格测试更适合帮助你理解偏好、沟通方式和协作风格。\n\n更稳的做法不是在 MBTI 和霍兰德之间二选一，而是先用霍兰德/RIASEC 看职业兴趣和工作环境，再用 MBTI 理解自己的工作偏好，最后结合能力、经验、行业信息和真实岗位要求做判断。\n\n## 先给结论：选职业时，霍兰德更直接，MBTI更适合补充\n\n两类测评回答的问题不同。\n\n| 你想解决的问题 | 更适合先看什么 | 为什么 |\n|---|---|---|\n| 我适合什么职业方向？ | 霍兰德/RIASEC | 它更直接关注职业兴趣、工作活动和工作环境 |\n| 我适合什么工作方式？ | MBTI | 它更适合帮助你理解精力来源、信息处理、决策偏好和组织方式 |\n| 我适合选什么专业？ | 霍兰德/RIASEC + 现实课程信息 | 专业选择更接近兴趣结构、课程任务和长期工作环境 |\n| 我适合什么团队角色？ | MBTI + 大五人格 | 团队协作更接近沟通偏好、稳定特质和行为习惯 |\n| 我到底该不该转行？ | 霍兰德/RIASEC + 能力盘点 + 岗位验证 | 转行不能只靠人格类型，需要验证技能、行业和成本 |\n\n所以，如果你现在正处在选专业、找工作、转行、职业迷茫阶段，建议先做霍兰德职业兴趣测试。\n\n如果你已经有几个职业方向，但想理解自己适合怎样的沟通、协作和工作节奏，再补充做 MBTI 性格测试。\n\n{{ cms_cta:article_mbti_vs_holland_primary_riasec }}\n\n## 霍兰德/RIASEC更适合回答“我想做什么类型的工作”\n\n霍兰德职业兴趣测试常用 RIASEC 六个维度描述职业兴趣：现实型、研究型、艺术型、社会型、企业型、常规型。它不是在问“你是什么人格”，而是在问：\n\n- 你更愿意处理物理对象、数据、想法、人、商业机会，还是规则流程？\n- 你更容易被哪类工作活动吸引？\n- 你愿意长期面对哪种任务环境？\n- 哪些岗位的日常活动更接近你的兴趣结构？\n\n这对职业探索很有用，因为职业选择不是只看“我是什么样的人”，还要看“我愿意长期面对什么样的任务”。\n\n### RIASEC 六型可以这样理解\n\n| 类型 | 核心行为倾向与工作活动 | 典型工作场景 |\n|---|---|---|\n| R 现实型 | 实体操作、机械协调、空间结构处理、物理客体推演 | 工程技术、设备维护、精密制造、自动化控制、现场执行 |\n| I 研究型 | 数据分析、模型推导、假设验证、复杂问题拆解 | 研发、算法、数据科学、实验研究、行业分析 |\n| A 艺术型 | 非结构化内容创作、审美表达、概念设计、符号表达 | 工业设计、视觉传达、交互媒介、内容创作、品牌叙事 |\n| S 社会型 | 教育支持、人际沟通、知识传递、群体协作 | 教育、培训、咨询、组织发展、公共服务 |\n| E 企业型 | 资源调度、商业推进、组织影响、风险决策 | 增长、销售、商务谈判、创业、战略运营 |\n| C 常规型 | 结构化数据处理、流程合规、细节校验、秩序维护 | 财务、审计、法务合规、行政运营、系统维护 |\n\n这六型不是标签，也不是职业命运。它们更像一张职业兴趣地图，帮助你缩小探索范围。\n\n## MBTI更适合回答“我在工作中更像什么样的人”\n\nMBTI 常用四组偏好组合成 16 种类型。四个字母通常对应精力来源、信息获取、决策方式和生活组织方式。\n\n职业选择里，MBTI 的价值主要不是直接告诉你“做哪个职业”，而是帮助你理解：\n\n- 你更习惯独立思考，还是从互动中获得能量？\n- 你更关注事实细节，还是整体模式和可能性？\n- 你做决定时更重视逻辑标准，还是人与价值？\n- 你更喜欢提前规划，还是保留弹性？\n- 你在团队沟通和压力场景里更容易出现什么模式？\n\n这些信息在职业选择中有参考价值，但它更适合看工作方式，而不是直接替你决定职业。\n\n比如，同样是“产品经理”，不同人可能面对完全不同的工作环境：\n\n- 有的人喜欢早期探索、模糊问题和用户洞察；\n- 有的人喜欢稳定迭代、需求拆解和项目推进；\n- 有的人擅长跨团队沟通；\n- 有的人更适合深度分析和策略研究。\n\n这时，MBTI 性格测试可以帮助你理解自己的偏好，但不能单独替代职业兴趣、能力和岗位要求。\n\n{{ cms_cta:article_mbti_vs_holland_secondary_mbti }}\n\n## 什么时候应该先做霍兰德？\n\n如果你符合下面任意一种情况，建议先做霍兰德/RIASEC：\n\n- 你不知道自己适合什么职业方向；\n- 你正在选专业、转专业或考虑升学方向；\n- 你准备找第一份工作；\n- 你想转行，但不知道往哪个方向探索；\n- 你发现自己对很多岗位都“说不上喜欢也说不上讨厌”；\n- 你需要把职业范围从几十个缩小到几个方向。\n\n这些问题的本质是职业兴趣和工作环境匹配，不只是人格偏好。\n\n尤其是大学生、应届生和转行者，先看 RIASEC 通常更有效，因为它会把问题从“我是什么人”拉回到“我愿意长期做什么类型的任务”。\n\n## 什么时候应该先做 MBTI？\n\n如果你的职业方向已经大致确定，但还不清楚自己适合怎样的工作方式，可以先看 MBTI。\n\n例如：\n\n- 你想知道自己适合独立工作还是频繁协作；\n- 你想理解自己为什么讨厌某些沟通方式；\n- 你想知道自己适合结构明确的工作，还是探索型任务；\n- 你想理解自己在团队里的决策和表达方式；\n- 你想复盘自己在实习、项目或工作里的压力来源。\n\n这时 MBTI 更像一套“工作偏好语言”。它可以帮你整理自我观察，但不应该被当成职业判决书。\n\n## 更稳的做法：三步组合，而不是二选一\n\n如果你正在认真做职业选择，可以按这个顺序。\n\n### 第一步：用霍兰德/RIASEC缩小职业方向\n\n先问：\n\n- 我喜欢和物、数据、想法、人、商业机会还是规则流程打交道？\n- 我更愿意长期面对哪类任务？\n- 我对哪些职业活动天然更有兴趣？\n- 我希望工作环境更稳定、开放、互动，还是竞争性更强？\n\n这一步的目标不是马上定职业，而是缩小范围。\n\n### 第二步：用MBTI理解工作风格\n\n再问：\n\n- 我适合高互动还是深度独立？\n- 我偏好明确结构还是开放探索？\n- 我在压力下会怎样沟通和决策？\n- 我更容易在哪种团队环境中发挥？\n\n这一步的目标是看工作方式是否匹配。\n\n### 第三步：用大五人格和现实岗位做补充验证\n\n大五人格通常用开放性、尽责性、外向性、宜人性和神经质等维度描述人格差异。和类型标签不同，大五人格更像连续谱系，它不把人分进固定盒子，而是帮助你理解更稳定的行为倾向。\n\n在职业决策中，大五人格可以补充回答这些问题：\n\n- 你的执行和计划倾向是否稳定？\n- 你更适合高互动还是低干扰环境？\n- 你对变化、新经验和复杂问题的接受度如何？\n- 你在压力下是否更容易波动？\n- 你更适合强竞争、强协作，还是高自主的环境？\n\n它不是职业预测器，也不应该被神化为单一答案。更合理的用法，是把它作为职业兴趣和工作风格之外的第三个观察角度。\n\n{{ cms_cta:article_mbti_vs_holland_tertiary_big_five }}\n\n最后，还要回到真实岗位：\n\n- 工作内容是什么？\n- 日常任务是什么？\n- 团队节奏是什么？\n- 成长路径是什么？\n- 这个行业的门槛和成本是什么？\n\n测评能帮你提出更好的问题，但不能替你跳过现实验证。\n\n## 常见误区\n\n### 误区一：用 MBTI 直接决定职业\n\n“我是 INFP，所以只能做某些职业”这种用法太粗糙。\n\n同一种 MBTI 类型的人，可能有不同能力、兴趣、家庭背景、教育经历、行业机会和现实约束。MBTI 可以帮助你理解偏好，但不能单独决定职业。\n\n### 误区二：把霍兰德当成人格诊断\n\n霍兰德/RIASEC 更偏职业兴趣和工作环境，不是医学诊断，也不是人格诊断。它适合帮助你探索职业方向，而不是定义你这个人。\n\n### 误区三：只看测试结果，不看真实岗位\n\n职业不是抽象标签。一个“适合你的职业方向”仍然可能因为公司文化、岗位阶段、城市、薪资、行业周期而变得不适合。\n\n测评结果应该用来缩小探索范围，再通过课程、实习、项目、访谈和岗位信息继续验证。\n\n### 误区四：一次测试就想得到最终答案\n\n职业选择通常不是一次性决定，而是逐步收敛。你可以先用测试筛方向，再用现实行动验证，再根据反馈修正。\n\n## 最后建议\n\n如果你现在最关心的是“我适合什么职业”，先做霍兰德职业兴趣测试。\n\n如果你还想理解自己在工作中的沟通、协作和压力模式，再补充做 MBTI 性格测试。\n\n如果你希望从更稳定的人格维度理解自己，可以再做大五人格测试。\n\n这三类工具最好组合使用：\n\n- 霍兰德/RIASEC：看职业兴趣和工作环境；\n- MBTI：看偏好、沟通和工作风格；\n- 大五人格：看更稳定的人格维度。\n\n职业选择不是测出一个标签，而是逐步把“我可能适合什么”变成“我愿意验证什么”。\n\n## FAQ\n\n### MBTI和霍兰德哪个更适合选职业？\n\n如果只选一个，霍兰德/RIASEC 通常更适合职业方向探索，因为它更直接关注职业兴趣、工作活动和工作环境。MBTI 更适合理解工作偏好、沟通方式和团队协作风格。\n\n### MBTI可以用来选职业吗？\n\n可以作为参考，但不建议单独使用。MBTI 更适合帮助你理解工作方式和偏好，不适合直接判断某个职业一定适合或不适合你。\n\n### 霍兰德职业兴趣测试是什么？\n\n霍兰德职业兴趣测试通常用 RIASEC 六型描述你的职业兴趣结构，包括现实型、研究型、艺术型、社会型、企业型和常规型。它适合用于选专业、职业探索和转行前的方向判断。\n\n### 如果MBTI和霍兰德结果看起来冲突怎么办？\n\n这不一定是冲突。MBTI 更多看工作风格，霍兰德更多看职业兴趣。比如你可能是偏内向的人，但对社会型或企业型任务有兴趣；也可能喜欢研究型任务，但更适合独立、低干扰的工作环境。应该把两个结果放在不同层面理解。\n\n### 做完测试后下一步是什么？\n\n先把测试结果转成现实问题：我想探索哪些职业？这些职业每天做什么？需要什么能力？我能不能通过课程、项目、实习或访谈验证？测评只是起点，真正的职业判断需要现实反馈。\n",
+  "cta_slots": [
+    {
+      "slot_id": "article_mbti_vs_holland_primary_riasec",
+      "priority": "primary",
+      "label": "先做霍兰德职业兴趣测试",
+      "href": "/zh/tests/holland-career-interest-test-riasec",
+      "event": "article_to_test_click",
+      "target_test_slug": "holland-career-interest-test-riasec",
+      "placement": "after_section_conclusion_table"
+    },
+    {
+      "slot_id": "article_mbti_vs_holland_secondary_mbti",
+      "priority": "secondary",
+      "label": "再做 MBTI 性格测试",
+      "href": "/zh/tests/mbti-personality-test-16-personality-types",
+      "event": "article_to_test_click",
+      "target_test_slug": "mbti-personality-test-16-personality-types",
+      "placement": "after_mbti_section"
+    },
+    {
+      "slot_id": "article_mbti_vs_holland_tertiary_big_five",
+      "priority": "tertiary",
+      "label": "补充做大五人格测试",
+      "href": "/zh/tests/big-five-personality-test-ocean-model",
+      "event": "article_to_test_click",
+      "target_test_slug": "big-five-personality-test-ocean-model",
+      "placement": "after_combination_method"
+    }
+  ],
+  "internal_links": [
+    {
+      "anchor": "霍兰德职业兴趣测试",
+      "href": "/zh/tests/holland-career-interest-test-riasec",
+      "intent": "start_test"
+    },
+    {
+      "anchor": "MBTI 性格测试",
+      "href": "/zh/tests/mbti-personality-test-16-personality-types",
+      "intent": "related_test"
+    },
+    {
+      "anchor": "大五人格测试",
+      "href": "/zh/tests/big-five-personality-test-ocean-model",
+      "intent": "compare_framework"
+    },
+    {
+      "anchor": "测评入口中心",
+      "href": "/zh/tests",
+      "intent": "learn_more"
+    },
+    {
+      "anchor": "人格类型",
+      "href": "/zh/personality",
+      "intent": "explore_type"
+    }
+  ],
+  "faq": [
+    {
+      "question": "MBTI和霍兰德哪个更适合选职业？",
+      "answer": "如果只选一个，霍兰德/RIASEC 通常更适合职业方向探索，因为它更直接关注职业兴趣、工作活动和工作环境。MBTI 更适合理解工作偏好、沟通方式和团队协作风格。"
+    },
+    {
+      "question": "MBTI可以用来选职业吗？",
+      "answer": "可以作为参考，但不建议单独使用。MBTI 更适合帮助你理解工作方式和偏好，不适合直接判断某个职业一定适合或不适合你。"
+    },
+    {
+      "question": "霍兰德职业兴趣测试是什么？",
+      "answer": "霍兰德职业兴趣测试通常用 RIASEC 六型描述你的职业兴趣结构，包括现实型、研究型、艺术型、社会型、企业型和常规型。它适合用于选专业、职业探索和转行前的方向判断。"
+    },
+    {
+      "question": "如果MBTI和霍兰德结果看起来冲突怎么办？",
+      "answer": "这不一定是冲突。MBTI 更多看工作风格，霍兰德更多看职业兴趣。比如你可能是偏内向的人，但对社会型或企业型任务有兴趣；也可能喜欢研究型任务，但更适合独立、低干扰的工作环境。应该把两个结果放在不同层面理解。"
+    },
+    {
+      "question": "做完测试后下一步是什么？",
+      "answer": "先把测试结果转成现实问题：我想探索哪些职业？这些职业每天做什么？需要什么能力？我能不能通过课程、项目、实习或访谈验证？测评只是起点，真正的职业判断需要现实反馈。"
+    }
+  ],
+  "schema_suggestions": {
+    "article": true,
+    "breadcrumb": true,
+    "faq_page": "only_if_faq_visible_on_page"
+  },
+  "claim_boundary_checklist": {
+    "forbidden_positive_claims_absent": [
+      "最准",
+      "官方 MBTI",
+      "医学诊断作为正向承诺",
+      "心理诊断作为正向承诺",
+      "保证找到职业",
+      "预测命运",
+      "一定适合",
+      "百万用户",
+      "治疗",
+      "抑郁诊断",
+      "焦虑诊断"
+    ],
+    "required_boundaries_present": [
+      "测试是辅助理解与决策工具",
+      "测试不是决定论",
+      "职业选择需要现实岗位验证",
+      "MBTI 不应单独决定职业",
+      "Holland/RIASEC 是职业兴趣和工作环境线索，不是人格诊断",
+      "大五人格是补充视角，不是职业预测器"
+    ]
+  },
+  "publish_gate": {
+    "publish_allowed": false,
+    "cms_draft_created": false,
+    "preview_url_available": false,
+    "draft_noindex_verified": false,
+    "absent_from_sitemap_verified": false,
+    "canonical_verified": false,
+    "seo_title_reviewed": false,
+    "seo_description_reviewed": false,
+    "faq_visible_before_schema": false,
+    "internal_links_public_canonical_only": false,
+    "cta_targets_verified": false,
+    "no_private_routes_linked": true,
+    "article_to_test_click_tracking_verified": false,
+    "human_review_approved": false,
+    "publish_approval_granted": false
+  },
+  "reference_notes_for_editor": [
+    {
+      "title": "O*NET Interest Profiler",
+      "url": "https://www.onetcenter.org/IP.html"
+    },
+    {
+      "title": "O*NET Online Interests",
+      "url": "https://www.onetonline.org/find/descriptor/browse/Interests/"
+    },
+    {
+      "title": "Myers-Briggs 16 Types",
+      "url": "https://www.myersbriggs.org/my-mbti-personality-type/the-16-mbti-personality-types/"
+    },
+    {
+      "title": "APA Dictionary: Big Five personality model",
+      "url": "https://dictionary.apa.org/big-five-personality-model"
+    }
+  ]
+}

--- a/backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json
+++ b/backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json
@@ -1,0 +1,173 @@
+{
+  "package_schema": "fermatmind.editorial_package.v1",
+  "content_status": "cms_ready_draft_package_only",
+  "approval_status": "requires_user_approval_before_importer_dry_run",
+  "content_owner": "GPT-5.5 Pro",
+  "codex_role": "structure_and_validation_only",
+  "final_content_authority": "CMS/backend",
+  "request_id": "SEO-ARTICLE-REQ-2026-06-02-B",
+  "locale": "en",
+  "translation_group_id": "article_mbti_vs_holland_career_choice_v1",
+  "title": "MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take?",
+  "slug": "mbti-vs-holland-code-career-choice",
+  "h1": "MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take?",
+  "canonical_path": "/en/articles/mbti-vs-holland-code-career-choice",
+  "seo_title": "MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take? | FermatMind",
+  "seo_description": "For choosing a major, job, or career direction, Holland Code/RIASEC is usually more direct. MBTI helps explain work style, communication, and preferences. Learn how to use both.",
+  "excerpt": "If your question is “What career fits me?”, the Holland Code/RIASEC framework is usually more direct than MBTI. If your question is “How do I tend to work with people, structure, and decisions?”, MBTI can be useful as a work-style lens. The strongest approach is not choosing one test over the other, but combining career interests, personality preferences, and real job evidence.",
+  "category": "Career Decision-Making",
+  "tags": [
+    "MBTI",
+    "Holland Code",
+    "RIASEC",
+    "Career Assessment",
+    "Career Interest Test",
+    "Personality Test",
+    "Big Five",
+    "College Major",
+    "Career Change"
+  ],
+  "related_test_slug": "holland-career-interest-test-riasec",
+  "body_markdown": "# MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take?\n\nIf your question is “What career fits me?”, the Holland Code/RIASEC framework is usually more direct than MBTI. If your question is “What kind of person am I at work?”, the MBTI Personality Test is better used as a lens for work preferences, communication style, and collaboration patterns.\n\nA better approach is not to choose between MBTI and Holland Code/RIASEC as if one must replace the other. Use RIASEC first to understand career interests and work environments, then use MBTI to understand work style, and finally compare both with skills, experience, industry information, and real job requirements.\n\n## Quick answer: Holland Code/RIASEC is more direct for career direction; MBTI is better as a supplement\n\nThe two assessments answer different questions.\n\n| Question you are trying to answer | Better starting point | Why |\n|---|---|---|\n| What career direction fits me? | Holland Code/RIASEC | It focuses more directly on career interests, work activities, and work environments |\n| What work style fits me? | MBTI | It helps explain energy patterns, information processing, decision preferences, and structure preferences |\n| What college major should I consider? | Holland Code/RIASEC + real course information | Major choice is closer to interest structure, task exposure, and long-term work environment |\n| What team role fits me? | MBTI + Big Five | Team fit involves communication preferences, stable traits, and behavior patterns |\n| Should I change careers? | Holland Code/RIASEC + skill audit + job validation | Career change requires testing skills, industry fit, timing, and cost, not only personality type |\n\nSo if you are choosing a major, searching for your first job, considering a career change, or feeling unsure about your career direction, start with the Holland Career Interest Test.\n\nIf you already have a few possible career directions and want to understand your preferred communication, collaboration, and work rhythm, add the MBTI Personality Test afterward.\n\n{{ cms_cta:article_mbti_vs_holland_primary_riasec }}\n\n## Holland Code/RIASEC is better for answering “what kind of work activities interest me?”\n\nThe Holland Code/RIASEC framework describes career interests through six areas: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional.\n\nIn plain language, RIASEC is not asking “what personality type are you?” It is asking:\n\n- Do you prefer working with physical objects, data, ideas, people, business opportunities, or structured procedures?\n- Which types of work activities naturally attract your attention?\n- What kind of task environment can you imagine working in for a long time?\n- Which jobs have daily activities that match your interest structure?\n\nThis is useful because career choice is not only about who you are. It is also about what kinds of tasks you are willing to face repeatedly.\n\n### A practical way to understand the six RIASEC types\n\n| Type | Core behavioral tendency and work activity | Typical work contexts |\n|---|---|---|\n| R — Realistic | Hands-on operation, mechanical coordination, spatial handling, physical object reasoning | Engineering, equipment maintenance, manufacturing, automation, field execution |\n| I — Investigative | Data analysis, model reasoning, hypothesis testing, complex problem decomposition | Research, algorithms, data science, lab work, industry analysis |\n| A — Artistic | Unstructured creation, aesthetic expression, concept design, symbolic communication | Industrial design, visual communication, interaction media, content creation, brand storytelling |\n| S — Social | Education, support, interpersonal communication, knowledge transfer, group collaboration | Education, training, consulting, organizational development, public service |\n| E — Enterprising | Resource coordination, commercial initiative, organizational influence, risk decisions | Growth, sales, business negotiation, entrepreneurship, strategic operations |\n| C — Conventional | Structured data processing, process compliance, detail verification, order maintenance | Finance, audit, legal compliance, administrative operations, system maintenance |\n\nThese types are not boxes and not destiny. They are a career-interest map that helps narrow your search.\n\n## MBTI is better for answering “what kind of worker am I?”\n\nMBTI commonly describes preferences across four pairs that combine into 16 personality types. These letters are often used to describe energy orientation, information preference, decision style, and structure preference.\n\nFor career decisions, MBTI is usually most useful not as a direct career selector, but as a way to understand:\n\n- Do you prefer independent thinking or frequent interaction?\n- Do you focus more on concrete details or broader patterns?\n- Do you make decisions more through logic and criteria or people and values?\n- Do you prefer planning ahead or keeping options open?\n- What patterns tend to appear in your communication and stress response?\n\nThese signals can help you understand your work style. They should not be used as a stand-alone career verdict.\n\nFor example, two people considering “product manager” may be looking at very different work environments:\n\n- One may enjoy early-stage discovery, ambiguous problems, and user research.\n- Another may prefer stable iteration, requirement breakdown, and project execution.\n- One may thrive in cross-functional communication.\n- Another may prefer deep analysis and strategy work.\n\nIn this context, the MBTI Personality Test can help you understand your preferences, but it should not replace career interests, skills, or job requirements.\n\n{{ cms_cta:article_mbti_vs_holland_secondary_mbti }}\n\n## When should you start with Holland Code/RIASEC?\n\nStart with Holland Code/RIASEC if any of these describe you:\n\n- You do not know what career direction fits you.\n- You are choosing or changing a college major.\n- You are preparing for your first job.\n- You are considering a career change but do not know which direction to explore.\n- Many jobs feel vaguely “fine” or “not quite right,” but you cannot explain why.\n- You need to narrow a large set of possibilities into a smaller set of directions.\n\nThese are career-interest and work-environment questions, not only personality questions.\n\nFor college students, early-career professionals, and career changers, RIASEC is often the better starting point because it moves the question from “what type of person am I?” to “what type of work activities can I sustain?”\n\n## When should you start with MBTI?\n\nStart with MBTI if your general career direction is already somewhat clear, but you want to understand your work style.\n\nFor example:\n\n- You want to know whether you fit independent or highly collaborative work.\n- You want to understand why certain communication styles drain you.\n- You want to know whether you prefer structured tasks or exploratory projects.\n- You want to understand how you make decisions in a team.\n- You want to reflect on stress patterns from internships, projects, or previous jobs.\n\nIn this use case, MBTI works more like a work-preference language. It can help organize self-observation, but it should not be treated as a career verdict.\n\n## The stronger method: combine the two instead of choosing one\n\nIf you are making a serious career decision, use a three-step approach.\n\n### Step 1: Use Holland Code/RIASEC to narrow your career direction\n\nAsk:\n\n- Do I prefer working with objects, data, ideas, people, business opportunities, or procedures?\n- Which type of work activity can I sustain over time?\n- Which career activities naturally interest me?\n- Do I prefer stable, open-ended, interactive, or competitive environments?\n\nThe goal here is not to decide your whole career immediately. The goal is to narrow the search space.\n\n### Step 2: Use MBTI to understand your work style\n\nThen ask:\n\n- Do I fit better in high-interaction work or deep independent work?\n- Do I prefer clear structure or open exploration?\n- How do I communicate and make decisions under stress?\n- What kind of team environment helps me perform better?\n\nThe goal here is to understand the way you work.\n\n### Step 3: Use the Big Five and real job evidence as a reality check\n\nThe Big Five model describes personality differences using dimensions such as openness, conscientiousness, extraversion, agreeableness, and neuroticism. Unlike type labels, the Big Five is dimensional: it does not place you in a fixed box, but helps describe stable behavioral tendencies.\n\nFor career decisions, the Big Five Personality Test can help you ask:\n\n- How consistent are your planning and follow-through patterns?\n- Do you fit better in high-interaction or low-distraction environments?\n- How open are you to novelty, ambiguity, and complex problems?\n- How sensitive are you to pressure and volatility?\n- Do you fit better in competitive, collaborative, or highly autonomous environments?\n\nIt is not a career predictor and should not be treated as a single answer. Its better use is as a third lens alongside career interests and work style.\n\n{{ cms_cta:article_mbti_vs_holland_tertiary_big_five }}\n\nFinally, return to real jobs:\n\n- What does the job actually involve?\n- What are the daily tasks?\n- What is the team rhythm?\n- What is the growth path?\n- What are the entry costs, skill requirements, and industry constraints?\n\nAssessments can help you ask better questions. They cannot replace real-world validation.\n\n## Common mistakes\n\n### Mistake 1: Using MBTI to directly decide your career\n\n“I am INFP, so I can only do certain jobs” is too simplistic.\n\nPeople with the same MBTI type can have different skills, interests, education, opportunities, values, and constraints. MBTI can help explain preferences, but it should not decide your career by itself.\n\n### Mistake 2: Treating Holland Code/RIASEC as a personality diagnosis\n\nHolland Code/RIASEC is closer to career interests and work environments. It is not a medical diagnosis, not a psychological diagnosis, and not a total definition of who you are.\n\n### Mistake 3: Reading test results without checking real jobs\n\nA career direction that looks suitable in theory may still be a poor fit because of company culture, job stage, city, salary, industry cycle, or daily tasks.\n\nUse assessments to narrow your options, then validate them through courses, projects, internships, job shadowing, interviews, or real job descriptions.\n\n### Mistake 4: Expecting one test to give a final answer\n\nCareer choice is usually a process of narrowing, testing, and revising. A test can help you form a hypothesis, but real feedback is what turns that hypothesis into a decision.\n\n## Final recommendation\n\nIf your main question is “What career fits me?”, start with the Holland Career Interest Test.\n\nIf you also want to understand your communication style, collaboration pattern, and stress response at work, add the MBTI Personality Test.\n\nIf you want a more dimensional view of stable personality tendencies, add the Big Five Personality Test.\n\nA practical combination is:\n\n- Holland Code/RIASEC: career interests and work environments\n- MBTI: preferences, communication, and work style\n- Big Five: stable personality dimensions\n\nCareer choice is not about finding a label. It is about turning “what might fit me?” into “what am I willing to test in the real world?”\n\n## FAQ\n\n### Is MBTI or Holland Code better for career choice?\n\nIf you can only start with one, Holland Code/RIASEC is usually more direct for career exploration because it focuses on career interests, work activities, and work environments. MBTI is better for understanding work style, communication, and collaboration preferences.\n\n### Can MBTI be used for career choice?\n\nYes, but only as a reference. MBTI is more useful for understanding work preferences and communication style than for deciding whether a specific career is definitely suitable or unsuitable.\n\n### What is the Holland Career Interest Test?\n\nThe Holland Career Interest Test uses the RIASEC framework to describe career interests: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional. It is useful for exploring majors, career directions, and career-change options.\n\n### What if my MBTI and Holland Code results seem to conflict?\n\nThey may not truly conflict. MBTI focuses more on work style, while Holland Code/RIASEC focuses more on career interests. For example, you may prefer lower-interaction environments but still have strong Social or Enterprising interests, or you may enjoy Investigative work but need deep independent time. Interpret the two results at different levels.\n\n### What should I do after taking the tests?\n\nTurn your results into real questions: Which careers should I explore? What do these jobs involve every day? What skills do they require? Can I test this through a course, project, internship, interview, or job shadowing? Assessments are a starting point, not a final decision.\n",
+  "cta_slots": [
+    {
+      "slot_id": "article_mbti_vs_holland_primary_riasec",
+      "priority": "primary",
+      "label": "Start with the Holland Code/RIASEC Test",
+      "href": "/en/tests/holland-career-interest-test-riasec",
+      "event": "article_to_test_click",
+      "target_test_slug": "holland-career-interest-test-riasec",
+      "placement": "after_section_conclusion_table"
+    },
+    {
+      "slot_id": "article_mbti_vs_holland_secondary_mbti",
+      "priority": "secondary",
+      "label": "Then take the MBTI Personality Test",
+      "href": "/en/tests/mbti-personality-test-16-personality-types",
+      "event": "article_to_test_click",
+      "target_test_slug": "mbti-personality-test-16-personality-types",
+      "placement": "after_mbti_section"
+    },
+    {
+      "slot_id": "article_mbti_vs_holland_tertiary_big_five",
+      "priority": "tertiary",
+      "label": "Add the Big Five Personality Test",
+      "href": "/en/tests/big-five-personality-test-ocean-model",
+      "event": "article_to_test_click",
+      "target_test_slug": "big-five-personality-test-ocean-model",
+      "placement": "after_combination_method"
+    }
+  ],
+  "internal_links": [
+    {
+      "anchor": "Holland Career Interest Test",
+      "href": "/en/tests/holland-career-interest-test-riasec",
+      "intent": "start_test"
+    },
+    {
+      "anchor": "MBTI Personality Test",
+      "href": "/en/tests/mbti-personality-test-16-personality-types",
+      "intent": "related_test"
+    },
+    {
+      "anchor": "Big Five Personality Test",
+      "href": "/en/tests/big-five-personality-test-ocean-model",
+      "intent": "compare_framework"
+    },
+    {
+      "anchor": "test hub",
+      "href": "/en/tests",
+      "intent": "learn_more"
+    },
+    {
+      "anchor": "personality types",
+      "href": "/en/personality",
+      "intent": "explore_type"
+    }
+  ],
+  "faq": [
+    {
+      "question": "Is MBTI or Holland Code better for career choice?",
+      "answer": "If you can only start with one, Holland Code/RIASEC is usually more direct for career exploration because it focuses on career interests, work activities, and work environments. MBTI is better for understanding work style, communication, and collaboration preferences."
+    },
+    {
+      "question": "Can MBTI be used for career choice?",
+      "answer": "Yes, but only as a reference. MBTI is more useful for understanding work preferences and communication style than for deciding whether a specific career is definitely suitable or unsuitable."
+    },
+    {
+      "question": "What is the Holland Career Interest Test?",
+      "answer": "The Holland Career Interest Test uses the RIASEC framework to describe career interests: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional. It is useful for exploring majors, career directions, and career-change options."
+    },
+    {
+      "question": "What if my MBTI and Holland Code results seem to conflict?",
+      "answer": "They may not truly conflict. MBTI focuses more on work style, while Holland Code/RIASEC focuses more on career interests. For example, you may prefer lower-interaction environments but still have strong Social or Enterprising interests, or you may enjoy Investigative work but need deep independent time. Interpret the two results at different levels."
+    },
+    {
+      "question": "What should I do after taking the tests?",
+      "answer": "Turn your results into real questions: Which careers should I explore? What do these jobs involve every day? What skills do they require? Can I test this through a course, project, internship, interview, or job shadowing? Assessments are a starting point, not a final decision."
+    }
+  ],
+  "schema_suggestions": {
+    "article": true,
+    "breadcrumb": true,
+    "faq_page": "only_if_faq_visible_on_page"
+  },
+  "claim_boundary_checklist": {
+    "forbidden_positive_claims_absent": [
+      "most accurate",
+      "official MBTI",
+      "medical diagnosis",
+      "psychological diagnosis",
+      "guaranteed career outcome",
+      "career destiny prediction",
+      "absolute fit claim",
+      "unsupported user-count claim",
+      "treatment",
+      "depression diagnosis",
+      "anxiety diagnosis"
+    ],
+    "required_boundaries_present": [
+      "Assessments are decision-support tools",
+      "Assessments are not deterministic",
+      "Career decisions require real job validation",
+      "MBTI should not decide career choice alone",
+      "Holland Code/RIASEC reflects career interests and work environments, not a diagnosis",
+      "Big Five is a supplementary lens, not a career predictor"
+    ]
+  },
+  "publish_gate": {
+    "publish_allowed": false,
+    "cms_draft_created": false,
+    "preview_url_available": false,
+    "draft_noindex_verified": false,
+    "absent_from_sitemap_verified": false,
+    "canonical_verified": false,
+    "seo_title_reviewed": false,
+    "seo_description_reviewed": false,
+    "faq_visible_before_schema": false,
+    "internal_links_public_canonical_only": false,
+    "cta_targets_verified": false,
+    "no_private_routes_linked": true,
+    "article_to_test_click_tracking_verified": false,
+    "human_review_approved": false,
+    "publish_approval_granted": false
+  },
+  "reference_notes_for_editor": [
+    {
+      "title": "O*NET Interest Profiler",
+      "url": "https://www.onetcenter.org/IP.html"
+    },
+    {
+      "title": "O*NET Online Interests",
+      "url": "https://www.onetonline.org/find/descriptor/browse/Interests/"
+    },
+    {
+      "title": "Myers-Briggs 16 Types",
+      "url": "https://www.myersbriggs.org/my-mbti-personality-type/the-16-mbti-personality-types/"
+    },
+    {
+      "title": "APA Dictionary: Big Five personality model",
+      "url": "https://dictionary.apa.org/big-five-personality-model"
+    }
+  ]
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40333,7 +40333,7 @@
     "depends_on": [
       "SEO-CMS-CANARY-DRAFT-VERIFY-01"
     ],
-    "commit_sha": null,
+    "commit_sha": "pending_remote_pr_head",
     "pr_url": null,
     "checks": {
       "dependency_verification": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40247,7 +40247,7 @@
   "SEO-CMS-CANARY-DRAFT-VERIFY-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-draft-verify-01",
-    "status": "in_progress",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-BE-01",
       "SEO-CMS-CANARY-DRAFT-PATH-01"
@@ -40288,14 +40288,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-02T14:49:21Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -40315,9 +40315,83 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1856 for docs-only review. No CMS draft, publish, runtime code, tests, frontend, GPT content, or production write action was performed."
+      },
+      {
+        "at": "2026-06-02T15:15:19Z",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CONTENT-CANARY-PACKAGE-01: GitHub PR #1856 is MERGED with merge commit 1e75eef2631274554a4776fcc028b2ffb0e82dbc, local main equals origin/main, and the task branch cleanup was completed."
       }
     ],
     "sidecars": [],
     "next_task": "SEO-CONTENT-P1-08 remains blocked unless this verification returns GO and user separately authorizes draft-only execution."
+  },
+  "SEO-CONTENT-CANARY-PACKAGE-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-content-canary-package-01",
+    "status": "in_progress",
+    "depends_on": [
+      "SEO-CMS-CANARY-DRAFT-VERIFY-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1856 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,headRefName,isCrossRepository,headRepositoryOwner,url,title",
+          "git log --oneline --decorate -5"
+        ],
+        "notes": "SEO-CMS-CANARY-DRAFT-VERIFY-01 is merged as PR #1856 with merge commit 1e75eef2631274554a4776fcc028b2ffb0e82dbc; current branch starts from origin/main at that commit."
+      },
+      "source_artifact_validation": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null",
+          "python3 - <<'PY' ... required field, CTA target, forbidden route, publish_allowed, and translation_group_id validation ... PY"
+        ],
+        "notes": "Both provided GPT-5.5 Pro V2 artifacts parse as JSON, include the required package fields, use only the expected public canonical test CTA routes, contain no forbidden result/order/share/pay/payment/history/tokenized CTA URLs, set publish_allowed=false, and share translation_group_id article_mbti_vs_holland_career_choice_v1."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "python3 -c \"import json,pathlib,re; paths=[pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json'),pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json')]; data=[json.loads(p.read_text()) for p in paths]; forbidden=re.compile(r'(result|orders|share|pay|payment|history|token)',re.I); ctas=[s['href'] for d in data for s in d['cta_slots']]; assert {d['translation_group_id'] for d in data} == {'article_mbti_vs_holland_career_choice_v1'}; assert all(d['publish_gate']['publish_allowed'] is False for d in data); assert all(h.startswith(('/zh/tests/','/en/tests/')) for h in ctas); assert not any(forbidden.search(h) for h in ctas); print('canary package checks ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON parse, YAML parse, package validation, and docs diff whitespace checks passed. Cached diff check is run after path-limited staging."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-02T15:15:19Z",
+        "from": "missing",
+        "to": "in_progress",
+        "note": "User explicitly authorized adding SEO-CONTENT-CANARY-PACKAGE-01 to fap-api manifest/state and packaging the provided GPT-5.5 Pro approved bilingual V2 canary artifacts. No content authorship, importer dry-run, CMS draft, publish, runtime code, tests, frontend, or search submission is allowed."
+      },
+      {
+        "at": "2026-06-02T15:18:19Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "note": "Copied the user-provided bilingual package artifacts into backend docs, added package notes, registered manifest/state, and passed JSON parse, YAML parse, package CTA/publish-gate validation, and docs diff whitespace checks. No importer dry-run, CMS draft, publish, runtime code, tests, frontend, GPT content rewrite, or search submission was performed."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "SEO-CMS-CANARY-IMPORT-DRYRUN-01 should run controlled importer dry-run and collision validation before any draft-only execution."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40329,12 +40329,12 @@
   "SEO-CONTENT-CANARY-PACKAGE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-canary-package-01",
-    "status": "in_progress",
+    "status": "pr_open",
     "depends_on": [
       "SEO-CMS-CANARY-DRAFT-VERIFY-01"
     ],
     "commit_sha": "pending_remote_pr_head",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1857",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40389,6 +40389,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "note": "Copied the user-provided bilingual package artifacts into backend docs, added package notes, registered manifest/state, and passed JSON parse, YAML parse, package CTA/publish-gate validation, and docs diff whitespace checks. No importer dry-run, CMS draft, publish, runtime code, tests, frontend, GPT content rewrite, or search submission was performed."
+      },
+      {
+        "at": "2026-06-02T15:21:59Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1857 for docs-only review. No importer dry-run, CMS draft, publish, runtime code, tests, frontend, GPT content rewrite, or search submission was performed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19710,3 +19710,52 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     next_task: SEO-CONTENT-P1-08 remains blocked unless this task returns GO and user separately authorizes draft-only execution
+
+  - id: SEO-CONTENT-CANARY-PACKAGE-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-DRAFT-VERIFY-01
+    branch: codex/seo-content-canary-package-01
+    title: "docs(content): add approved bilingual SEO canary CMS package"
+    train_scope: seo_cms_canary
+    scope:
+      - Package the user-approved GPT-5.5 Pro bilingual V2 canary content artifacts for controlled importer consumption.
+      - Preserve approved title, H1, SEO fields, body, FAQ, CTA labels, category, tags, and claim boundary content without Codex authorship or rewriting.
+      - Produce docs-only CMS-ready package artifacts and notes for future dry-run and draft-only validation.
+    allowed_paths:
+      - backend/docs/seo/canary-packages/**
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute SEO-CONTENT-P1-08.
+      - Run the controlled importer dry-run.
+      - Create CMS drafts, save CMS forms, publish, or call production write APIs.
+      - Generate or edit canary title, H1, meta, body, FAQ, CTA, or GPT content package prose.
+      - Modify runtime code, routes, migrations, tests, package files, sitemap runtime, analytics runtime, or frontend files.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+    validation:
+      - python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - python3 -c "import json,pathlib,re; paths=[pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json'),pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json')]; data=[json.loads(p.read_text()) for p in paths]; forbidden=re.compile(r'(result|orders|share|pay|payment|history|token)',re.I); ctas=[s['href'] for d in data for s in d['cta_slots']]; assert {d['translation_group_id'] for d in data} == {'article_mbti_vs_holland_career_choice_v1'}; assert all(d['publish_gate']['publish_allowed'] is False for d in data); assert all(h.startswith(('/zh/tests/','/en/tests/')) for h in ctas); assert not any(forbidden.search(h) for h in ctas); print('canary package checks ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CMS-CANARY-IMPORT-DRYRUN-01 should verify these package artifacts before any draft-only execution


### PR DESCRIPTION
## What changed
- Added the user-provided GPT-5.5 Pro bilingual V2 canary package artifacts under backend/docs/seo/canary-packages/.
- Added package notes documenting content ownership, Codex non-authorship, draft-only intent, and forbidden publish/search actions.
- Registered SEO-CONTENT-CANARY-PACKAGE-01 in docs/codex/pr-train.yaml and updated docs/codex/pr-train-state.json, including reconciliation that #1856 is merged.

## Why
- Prepare the approved bilingual canary content package for the next controlled importer dry-run validation without creating CMS data or changing runtime code.

## Validation commands
- python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null
- python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- python3 -c "import json,pathlib,re; paths=[pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json'),pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json')]; data=[json.loads(p.read_text()) for p in paths]; forbidden=re.compile(r'(result|orders|share|pay|payment|history|token)',re.I); ctas=[s['href'] for d in data for s in d['cta_slots']]; assert {d['translation_group_id'] for d in data} == {'article_mbti_vs_holland_career_choice_v1'}; assert all(d['publish_gate']['publish_allowed'] is False for d in data); assert all(h.startswith(('/zh/tests/','/en/tests/')) for h in ctas); assert not any(forbidden.search(h) for h in ctas); print('canary package checks ok')"
- git diff --check origin/main -- backend/docs/seo docs/codex
- git diff --cached --check

## Intentionally deferred
- Do not run the controlled importer dry-run in this PR.
- Do not create CMS drafts, save CMS forms, publish, or call production write APIs.
- Do not execute SEO-CONTENT-P1-08.
- Do not submit sitemap, Baidu push, IndexNow, or any search-channel action.

## Repository rule impact
- Docs-only package artifact; no runtime authority change.
- CMS/backend remains final content authority.
- Package is for future dry-run and draft-only validation only; publish remains forbidden.