### PR TITLE
docs(cms): verify bilingual SEO canary importer dry-run

### DIFF
--- a/backend/docs/seo/seo-cms-canary-import-dryrun-2026-06-02.md
+++ b/backend/docs/seo/seo-cms-canary-import-dryrun-2026-06-02.md
@@ -1,0 +1,219 @@
+# SEO CMS Canary Import Dry-Run Verification
+
+Date: 2026-06-02
+
+Task: `SEO-CMS-CANARY-IMPORT-DRYRUN-01`
+
+PR scope: docs-only verification for the first bilingual SEO canary package artifacts.
+
+## Decision
+
+NO-GO: do not create CMS draft yet.
+
+`SEO-CONTENT-P1-08` must remain blocked. Publish remains forbidden.
+
+## Source artifacts
+
+- `backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md`
+
+Codex did not author, rewrite, expand, polish, or localize GPT-5.5 Pro content. The package artifacts were used as-is for validation and dry-run attempts.
+
+## A. Manifest / state
+
+Result: `SEO-CMS-CANARY-IMPORT-DRYRUN-01` was not present in `docs/codex/pr-train.yaml` or `docs/codex/pr-train-state.json` before this task.
+
+Action taken under user authorization:
+
+- Added `SEO-CMS-CANARY-IMPORT-DRYRUN-01` to `docs/codex/pr-train.yaml`.
+- Added `SEO-CMS-CANARY-IMPORT-DRYRUN-01` execution state to `docs/codex/pr-train-state.json`.
+- Reconciled `SEO-CONTENT-CANARY-PACKAGE-01` as merged because GitHub PR #1857 is merged and `origin/main` contains merge commit `e7d5f14d55be02bd9f74bb2a9fbdd9ccd0e30be4`.
+
+## B. Package artifact validation
+
+Result: PASS.
+
+Checks:
+
+- Both JSON files parse.
+- `locale` values are `zh-CN` and `en`.
+- Slugs are:
+  - `mbti-vs-holland-career-choice`
+  - `mbti-vs-holland-code-career-choice`
+- `translation_group_id` is consistent:
+  - `article_mbti_vs_holland_career_choice_v1`
+- `publish_gate.publish_allowed=false` in both artifacts.
+- CTA targets are public canonical test routes:
+  - `/zh/tests/holland-career-interest-test-riasec`
+  - `/zh/tests/mbti-personality-test-16-personality-types`
+  - `/zh/tests/big-five-personality-test-ocean-model`
+  - `/en/tests/holland-career-interest-test-riasec`
+  - `/en/tests/mbti-personality-test-16-personality-types`
+  - `/en/tests/big-five-personality-test-ocean-model`
+- CTA targets do not contain `result`, `orders`, `share`, `pay`, `payment`, `history`, `take`, tokenized URLs, or external URLs.
+- FAQ exists in both artifacts.
+- `body_markdown` exists in both artifacts.
+- `claim_boundary_checklist` exists in both artifacts.
+
+Validation command:
+
+```bash
+python3 - <<'PY'
+import json,pathlib,re
+paths=[pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json'),pathlib.Path('backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json')]
+expected={'zh-CN':('mbti-vs-holland-career-choice','/zh/articles/mbti-vs-holland-career-choice'),'en':('mbti-vs-holland-code-career-choice','/en/articles/mbti-vs-holland-code-career-choice')}
+forbidden=re.compile(r'(result|orders|share|pay|payment|history|take|token|^https?://)', re.I)
+for p in paths:
+    d=json.loads(p.read_text())
+    loc=d['locale']
+    assert loc in expected
+    assert d['slug']==expected[loc][0]
+    assert d['canonical_path']==expected[loc][1]
+    assert d['translation_group_id']=='article_mbti_vs_holland_career_choice_v1'
+    assert d['publish_gate']['publish_allowed'] is False
+    assert d.get('faq')
+    assert d.get('body_markdown')
+    assert d.get('claim_boundary_checklist')
+    for slot in d['cta_slots']:
+        href=slot['href']
+        assert href.startswith(('/zh/tests/','/en/tests/')), (p,href)
+        assert not forbidden.search(href), (p,href)
+print('package artifact validation ok')
+PY
+```
+
+## C. Hidden collision check
+
+Public exposure checks: PASS.
+
+Commands executed:
+
+```bash
+curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' 'https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice?locale=zh-CN'
+curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' 'https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice/seo?locale=zh-CN'
+curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' 'https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice?locale=en'
+curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' 'https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en'
+```
+
+Observed:
+
+- zh public API: 404
+- zh public SEO API: 404
+- en public API: 404
+- en public SEO API: 404
+
+Index surface checks:
+
+- `https://fermatmind.com/sitemap.xml`: target slugs not found.
+- `https://fermatmind.com/llms.txt`: target slugs not found.
+- `https://fermatmind.com/llms-full.txt`: target slugs not found.
+
+CMS/DB readonly collision result: Unknown.
+
+Reason: this task did not receive a verified production CMS/DB readonly path. Codex did not read env/cookies/tokens and did not access CMS private data. Hidden draft/private record collision and translation group collision therefore remain Unknown.
+
+Impact: Unknown hidden collision blocks `SEO-CONTENT-P1-08` unless the user explicitly accepts Unknown and requires an authorized operator to re-check before draft creation.
+
+## D. Controlled importer dry-run
+
+Importer command found:
+
+```bash
+php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/<package>.json --locale=<locale> --dry-run --json
+```
+
+Dry-run write behavior:
+
+- The command exposes `--dry-run`.
+- Command code calls `EditorialPackageDraftImporter::planFromFile()` when `--dry-run` is set.
+- The DB-writing path is `importFromFile()`, which is only used when `--dry-run` is not set.
+- Existing tests confirm dry-run leaves `articles`, `article_translation_revisions`, `article_seo_meta`, and `article_editorial_package_imports` at zero rows in the fixture case.
+
+Dry-run execution result: FAIL.
+
+Commands executed:
+
+```bash
+php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json --locale=zh-CN --dry-run --json
+php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json --locale=en --dry-run --json
+```
+
+Observed for both packages:
+
+```json
+{
+  "ok": false,
+  "action": "will_skip",
+  "errors": [
+    {
+      "field": "command",
+      "code": "unexpected_error",
+      "message": "Array to string conversion"
+    }
+  ],
+  "warnings": [],
+  "claim_matches": []
+}
+```
+
+Root cause assessment: package schema mismatch.
+
+The current importer expects a normalized `editorial_package.v1` shape. The approved canary artifacts are valid V2 docs artifacts but do not match several importer fields directly:
+
+- Artifact has `seo_description`; importer expects `meta_description`.
+- Artifact has `canonical_path`; importer expects `canonical`.
+- Artifact has `faq`; importer expects `answer_surface_v1.faq_items` when answer surface is used.
+- Artifact has `claim_boundary_checklist`; importer expects `claim_boundary_notes`.
+- Artifact has `internal_links` as object entries; importer currently normalizes `internal_links` as a list of strings, causing `Array to string conversion`.
+- Artifact does not contain importer-required operational/media/graph metadata such as `content_track`, `audience_intent`, `decision_domains`, `target_tests`, `target_topics`, `cover_image`, `cover_image_alt`, `cover_image_prompt`, `cover_image_style_tag`, `claim_level`, `sensitivity_level`, and `review_required_by`.
+
+Because Codex is forbidden to modify the GPT-5.5 Pro package content or create additional content fields in this task, no schema adapter package was created.
+
+Dry-run capabilities that could not be verified for these artifacts:
+
+- zh/en two records
+- same `translation_group_id`
+- different slug
+- SEO title / description / canonical ingestion
+- body ingestion
+- FAQ package ingestion
+- CTA slot ingestion
+- draft fail-closed
+- no publish
+
+## E. GO / NO-GO
+
+NO-GO: do not create CMS draft yet.
+
+Reason:
+
+- Package artifact validation passed.
+- Public exposure absence passed.
+- Controlled importer dry-run failed.
+- Hidden CMS/DB collision remains Unknown.
+- Draft fail-closed could not be verified for these artifacts because dry-run failed before a valid plan.
+- Preview is not the current blocker; importer/package schema compatibility and hidden collision are the blockers.
+- Publish remains forbidden.
+
+`SEO-CONTENT-P1-08` is not authorized.
+
+## F. Required next authorization
+
+Before `SEO-CONTENT-P1-08`, the user must authorize one of the following:
+
+1. A docs-only/package-adapter follow-up that creates an importer-consumable mechanical adapter artifact without changing approved GPT-5.5 Pro content prose.
+2. A backend importer schema-mapping follow-up that lets `articles:import-editorial-package --dry-run` consume the approved V2 canary artifact shape without runtime publish behavior changes.
+3. A verified production CMS/DB readonly hidden collision check by an authorized operator, or explicit acceptance that hidden collision remains Unknown until immediately before draft creation.
+
+`SEO-CMS-CANARY-PREVIEW-01` is not required yet. Preview should only be considered after importer dry-run and hidden collision gates pass, or if draft creation remains blocked solely by lack of rendered preview.
+
+## Forbidden actions not performed
+
+- No CMS draft was created.
+- No Article was created.
+- No CMS form was saved.
+- No publish action was performed.
+- No production write API was called.
+- No sitemap, Baidu push, IndexNow, or search-channel action was performed.
+- No runtime code, routes, migrations, tests, frontend files, or GPT content prose were modified.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40409,12 +40409,12 @@
   "SEO-CMS-CANARY-IMPORT-DRYRUN-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-import-dryrun-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "SEO-CONTENT-CANARY-PACKAGE-01"
     ],
     "commit_sha": "pending_remote_pr_head",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1858",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40481,6 +40481,12 @@
         "from": "missing",
         "to": "local_checks_passed",
         "note": "User authorized adding SEO-CMS-CANARY-IMPORT-DRYRUN-01 to fap-api manifest/state and executing docs-only importer dry-run verification. Package validation and public absence checks passed, but importer dry-run failed with schema mismatch and hidden CMS/DB collision remains Unknown. No CMS draft, publish, runtime code, tests, frontend, GPT content edit, production write action, or search submission was performed."
+      },
+      {
+        "at": "2026-06-02T15:59:45Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1858 for docs-only review. NO-GO remains recorded; no CMS draft, publish, runtime code, tests, frontend, GPT content edit, production write action, or search submission was performed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40413,7 +40413,7 @@
     "depends_on": [
       "SEO-CONTENT-CANARY-PACKAGE-01"
     ],
-    "commit_sha": null,
+    "commit_sha": "pending_remote_pr_head",
     "pr_url": null,
     "checks": {
       "dependency_verification": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40329,11 +40329,11 @@
   "SEO-CONTENT-CANARY-PACKAGE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-canary-package-01",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-DRAFT-VERIFY-01"
     ],
-    "commit_sha": "pending_remote_pr_head",
+    "commit_sha": "e7d5f14d55be02bd9f74bb2a9fbdd9ccd0e30be4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1857",
     "checks": {
       "dependency_verification": {
@@ -40368,14 +40368,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-02T15:42:28Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -40395,9 +40395,95 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1857 for docs-only review. No importer dry-run, CMS draft, publish, runtime code, tests, frontend, GPT content rewrite, or search submission was performed."
+      },
+      {
+        "at": "2026-06-02T15:55:37Z",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CMS-CANARY-IMPORT-DRYRUN-01: GitHub PR #1857 is MERGED with merge commit e7d5f14d55be02bd9f74bb2a9fbdd9ccd0e30be4, local main equals origin/main, and task branch cleanup was completed."
       }
     ],
     "sidecars": [],
     "next_task": "SEO-CMS-CANARY-IMPORT-DRYRUN-01 should run controlled importer dry-run and collision validation before any draft-only execution."
+  },
+  "SEO-CMS-CANARY-IMPORT-DRYRUN-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-cms-canary-import-dryrun-01",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "SEO-CONTENT-CANARY-PACKAGE-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1857 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,headRefName,url,title",
+          "git merge-base --is-ancestor e7d5f14d55be02bd9f74bb2a9fbdd9ccd0e30be4 origin/main"
+        ],
+        "notes": "SEO-CONTENT-CANARY-PACKAGE-01 is merged as PR #1857 and origin/main contains merge commit e7d5f14d55be02bd9f74bb2a9fbdd9ccd0e30be4."
+      },
+      "package_artifact_validation": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null",
+          "python3 - <<'PY' ... locale, slug, canonical_path, translation_group_id, publish gate, CTA route, FAQ, body_markdown, and claim boundary validation ... PY"
+        ],
+        "notes": "Both package artifacts are valid JSON, contain expected locale/slug/canonical_path values, share translation_group_id article_mbti_vs_holland_career_choice_v1, set publish_allowed=false, include FAQ/body/claim boundary checklist, and use only public canonical test CTA routes without forbidden route patterns."
+      },
+      "hidden_collision_public_absence": {
+        "status": "partial_pass_unknown_private",
+        "commands": [
+          "curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice?locale=zh-CN",
+          "curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice/seo?locale=zh-CN",
+          "curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice?locale=en",
+          "curl -sS -o /tmp/fm-canary-api.out -w '%{http_code}' https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en",
+          "python3 sitemap/llms absence check for sitemap.xml, llms.txt, and llms-full.txt"
+        ],
+        "notes": "Public detail and SEO APIs returned 404 for both slugs; sitemap.xml, llms.txt, and llms-full.txt do not contain either slug. Production CMS/DB readonly hidden draft/private collision remains Unknown because no verified readonly path was provided and env/cookies/tokens were not read."
+      },
+      "importer_dry_run": {
+        "status": "failed_no_write",
+        "commands": [
+          "php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json --locale=zh-CN --dry-run --json",
+          "php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json --locale=en --dry-run --json"
+        ],
+        "notes": "Both dry-run attempts returned ok=false/action=will_skip with unexpected_error Array to string conversion. This is a package schema mismatch between the approved V2 docs artifacts and the current editorial_package.v1 importer shape. Dry-run used planFromFile and did not create CMS data."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "Docs-only report and train metadata checks passed. Cached diff check is run after path-limited staging."
+      }
+    },
+    "failure_reason": "NO-GO: controlled importer dry-run failed with package schema mismatch and hidden CMS/DB collision remains Unknown. Do not create CMS draft yet.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-02T15:55:37Z",
+        "from": "missing",
+        "to": "local_checks_passed",
+        "note": "User authorized adding SEO-CMS-CANARY-IMPORT-DRYRUN-01 to fap-api manifest/state and executing docs-only importer dry-run verification. Package validation and public absence checks passed, but importer dry-run failed with schema mismatch and hidden CMS/DB collision remains Unknown. No CMS draft, publish, runtime code, tests, frontend, GPT content edit, production write action, or search submission was performed."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "SEO-CONTENT-P1-08 remains blocked. Next authorization should address package/importer schema mapping and hidden CMS/DB readonly collision verification."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19759,3 +19759,52 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-CMS-CANARY-IMPORT-DRYRUN-01 should verify these package artifacts before any draft-only execution
+
+  - id: SEO-CMS-CANARY-IMPORT-DRYRUN-01
+    repo: fap-api
+    depends_on:
+      - SEO-CONTENT-CANARY-PACKAGE-01
+    branch: codex/seo-cms-canary-import-dryrun-01
+    title: "docs(cms): verify bilingual SEO canary importer dry-run"
+    train_scope: seo_cms_canary
+    scope:
+      - Validate the approved bilingual GPT-5.5 Pro V2 canary package artifacts.
+      - Execute controlled editorial package importer dry-run only if it does not write DB.
+      - Check public API, sitemap, llms.txt, and llms-full.txt absence for hidden/public collision signals.
+      - Produce a docs-only GO/NO-GO dry-run report.
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/docs/operations/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute SEO-CONTENT-P1-08.
+      - Create CMS drafts, save CMS forms, create Articles, publish, or call production write APIs.
+      - Modify GPT-5.5 Pro content package prose, title, H1, meta, body, FAQ, or CTA text.
+      - Modify runtime code, routes, migrations, tests, package files, sitemap runtime, analytics runtime, or frontend files.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+    validation:
+      - python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CONTENT-P1-08 remains blocked unless importer dry-run and hidden collision gates pass


### PR DESCRIPTION
## What changed
- Added docs-only dry-run report: backend/docs/seo/seo-cms-canary-import-dryrun-2026-06-02.md.
- Registered SEO-CMS-CANARY-IMPORT-DRYRUN-01 in docs/codex/pr-train.yaml.
- Updated docs/codex/pr-train-state.json, including reconciliation that #1857 is merged.

## Why
- Verify whether the approved bilingual GPT-5.5 Pro V2 canary package artifacts can safely pass the controlled editorial package importer dry-run before any draft-only execution.

## Result
- NO-GO: do not create CMS draft yet.
- Package artifact validation passed.
- Public API/SEO API returned 404 for both target slugs.
- sitemap.xml, llms.txt, and llms-full.txt do not contain the target slugs.
- Controlled importer dry-run failed for both artifacts with package schema mismatch: unexpected_error / Array to string conversion.
- Hidden CMS/DB collision remains Unknown because no verified production readonly path was used.

## Validation commands
- python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json >/dev/null
- python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null
- php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json --locale=zh-CN --dry-run --json
- php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json --locale=en --dry-run --json
- curl public detail/SEO API checks for both slugs
- sitemap.xml / llms.txt / llms-full.txt absence checks
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check origin/main -- backend/docs/seo docs/codex
- git diff --cached --check

## Intentionally deferred
- Do not execute SEO-CONTENT-P1-08.
- Do not create CMS drafts, save CMS forms, create Articles, publish, or call production write APIs.
- Do not modify GPT-5.5 Pro content prose or package artifacts.
- Do not modify runtime code, routes, migrations, tests, frontend files, sitemap runtime, or analytics runtime.
- Do not submit sitemap, Baidu push, IndexNow, or any search-channel action.

## Repository rule impact
- Docs-only verification; no runtime authority change.
- CMS/backend remains final content authority.
- Publish remains forbidden; SEO-CONTENT-P1-08 remains blocked pending importer/package schema compatibility and hidden CMS/DB collision verification.