### PR TITLE
docs(cms): verify canary hidden collision check path

### DIFF
--- a/backend/docs/seo/seo-cms-canary-operator-collision-2026-06-03.md
+++ b/backend/docs/seo/seo-cms-canary-operator-collision-2026-06-03.md
@@ -1,0 +1,178 @@
+# SEO CMS Canary Operator Collision Check Path - 2026-06-03
+
+Task: `SEO-CMS-CANARY-OPERATOR-COLLISION-01`
+
+This PR is docs-only. It did not create a CMS draft, did not publish, did not call a production write API, did not run a migration, did not read or expose env/cookie/token values, did not access private result/order/share/payment IDs, did not edit GPT-5.5 Pro content artifacts, and did not modify runtime code or tests.
+
+Checked at:
+
+- Local time: `2026-06-03 00:56:10 CST`
+- UTC: `2026-06-02T16:56:10Z`
+
+## Target
+
+The collision check is for the first bilingual SEO CMS canary package:
+
+| Field | Value |
+| --- | --- |
+| zh slug | `mbti-vs-holland-career-choice` |
+| en slug | `mbti-vs-holland-code-career-choice` |
+| translation_group_id | `article_mbti_vs_holland_career_choice_v1` |
+| public org scope | `org_id=0` for the current controlled editorial package importer path |
+
+## Dependency Status
+
+`SEO-CMS-CANARY-IMPORTER-GATE-01` is merged as fap-api PR #1860.
+
+- PR URL: `https://github.com/fermatmind/fap-api/pull/1860`
+- Merge commit: `26f4fec3b7112acff6d3276613b1cd57744350f9`
+- Merged at: `2026-06-02T16:51:37Z`
+- Current `origin/main` contains the merge commit.
+
+This means the zh-CN and en adapter artifacts can pass the controlled importer dry-run gate, but it does not prove hidden production CMS/DB collision status.
+
+## Public Absence Checks
+
+These checks are public and read-only. They can detect public exposure but cannot detect private, draft, noindex, unpublished, or soft-deleted rows.
+
+| Check | URL | Result |
+| --- | --- | --- |
+| zh public detail API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice?locale=zh-CN` | `404` |
+| zh public SEO API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice/seo?locale=zh-CN` | `404` |
+| en public detail API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice?locale=en` | `404` |
+| en public SEO API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en` | `404` |
+| sitemap | `https://fermatmind.com/sitemap.xml` | both slugs absent |
+| llms.txt | `https://fermatmind.com/llms.txt` | both slugs absent |
+| llms-full.txt | `https://fermatmind.com/llms-full.txt` | both slugs absent |
+
+Public absence status: **PASS for public surfaces only**.
+
+## Private Hidden Collision Status
+
+Private production CMS/DB hidden collision status: **Unknown**.
+
+Reason:
+
+- This PR did not have explicit authorization to access production CMS/DB private records.
+- This PR did not read env/cookie/token values.
+- Public APIs, sitemap, `llms.txt`, and `llms-full.txt` cannot prove absence of hidden Article rows.
+- Article rows can be non-public, noindex, draft/review-pending, unpublished, published-but-not-public, lifecycle soft-deleted, or soft-deleted while remaining invisible to public surfaces.
+
+`SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01` is therefore created as a sidecar blocker. This blocker must be resolved before `SEO-CONTENT-P1-08` can create any CMS draft.
+
+## Operator Readonly Check Path
+
+The authorized operator should run exactly one readonly production CMS/DB check before any draft creation. The check must include soft-deleted rows and must not save CMS forms, call write APIs, run import without dry-run, publish, or submit URLs.
+
+Code evidence for the collision surface:
+
+- `Article` uses `SoftDeletes`.
+- `Article` fields include `org_id`, `locale`, `slug`, `translation_group_id`, `status`, `is_public`, `is_indexable`, `published_revision_id`, lifecycle fields, and `deleted_at`.
+- `EditorialPackageDraftImporter::existingArticle()` checks `org_id=0`, `locale`, and `slug` through `Article::query()->withoutGlobalScopes()`.
+- Actual importer creation writes draft-only rows with `status=draft`, `is_public=false`, `is_indexable=false`, and `published_revision_id=null`.
+
+Required readonly SQL shape:
+
+```sql
+SELECT
+  id,
+  org_id,
+  locale,
+  slug,
+  translation_group_id,
+  status,
+  is_public,
+  is_indexable,
+  published_revision_id,
+  lifecycle_state,
+  deleted_at,
+  created_at,
+  updated_at
+FROM articles
+WHERE org_id = 0
+  AND (
+    (locale = 'zh-CN' AND slug = 'mbti-vs-holland-career-choice')
+    OR (locale = 'en' AND slug = 'mbti-vs-holland-code-career-choice')
+    OR translation_group_id = 'article_mbti_vs_holland_career_choice_v1'
+  )
+ORDER BY
+  deleted_at IS NULL DESC,
+  updated_at DESC,
+  id DESC;
+```
+
+Required CMS/Tinker-equivalent shape if SQL is not used:
+
+```php
+App\Models\Article::query()
+    ->withoutGlobalScopes()
+    ->withTrashed()
+    ->where('org_id', 0)
+    ->where(function ($query) {
+        $query
+            ->where(function ($query) {
+                $query
+                    ->where('locale', 'zh-CN')
+                    ->where('slug', 'mbti-vs-holland-career-choice');
+            })
+            ->orWhere(function ($query) {
+                $query
+                    ->where('locale', 'en')
+                    ->where('slug', 'mbti-vs-holland-code-career-choice');
+            })
+            ->orWhere('translation_group_id', 'article_mbti_vs_holland_career_choice_v1');
+    })
+    ->get([
+        'id',
+        'org_id',
+        'locale',
+        'slug',
+        'translation_group_id',
+        'status',
+        'is_public',
+        'is_indexable',
+        'published_revision_id',
+        'lifecycle_state',
+        'deleted_at',
+        'created_at',
+        'updated_at',
+    ]);
+```
+
+Required PASS criteria:
+
+- Zero rows returned for both target slug checks.
+- Zero rows returned for `translation_group_id=article_mbti_vs_holland_career_choice_v1`.
+- The readonly operator confirms the query included soft-deleted rows.
+- The readonly operator confirms the query ran against the production CMS Article authority, public org scope `org_id=0`.
+
+Required FAIL criteria:
+
+- Any row exists with either target slug.
+- Any row exists with the target `translation_group_id`.
+- Any row exists in `status=draft`, `status=review_pending`, `status=published`, non-public, noindex, unpublished, lifecycle soft-deleted, or soft-deleted state.
+- The operator cannot confirm soft-deleted rows were included.
+- The operator cannot confirm production CMS Article authority and public org scope.
+
+## Decision
+
+Hidden collision status: **Unknown**.
+
+`SEO-CONTENT-P1-08`: **blocked**.
+
+Publish: **forbidden**.
+
+The next safe action is operator readonly hidden collision verification using the path above. If the operator reports PASS and records evidence without exposing secrets or private content, the train may request authorization for `SEO-CONTENT-P1-08` draft-only execution. If the operator reports FAIL or cannot verify the path, do not create a CMS draft.
+
+## Checks
+
+Local checks required for this PR:
+
+```bash
+git diff --check -- backend/docs/seo backend/docs/operations docs/codex
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+git diff --cached --check
+```
+
+No CMS draft, publish, production write, sitemap submission, Baidu push, IndexNow action, runtime code edit, test edit, frontend edit, or GPT content edit is part of this PR.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40591,11 +40591,11 @@
   "SEO-CMS-CANARY-IMPORTER-GATE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-importer-gate-01",
-    "status": "local_checks_passed",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-PACKAGE-ADAPTER-01"
     ],
-    "commit_sha": null,
+    "commit_sha": "26f4fec3b7112acff6d3276613b1cd57744350f9",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1860",
     "checks": {
       "dependency_verification": {
@@ -40639,14 +40639,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-02T16:51:37Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -40660,9 +40660,93 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1860 for importer gate review. SEO-CONTENT-P1-08 remains blocked until this PR is merged and hidden CMS/DB collision is operator-verified by readonly path."
+      },
+      {
+        "at": "2026-06-02T16:56:10Z",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CMS-CANARY-OPERATOR-COLLISION-01: GitHub PR #1860 is MERGED with merge commit 26f4fec3b7112acff6d3276613b1cd57744350f9, origin/main contains the merge commit, local main equals origin/main, and local/remote task branch cleanup was completed."
       }
     ],
     "sidecars": [],
     "next_task": "SEO-CMS-CANARY-OPERATOR-COLLISION-01 may proceed only after this PR is merged; SEO-CONTENT-P1-08 remains blocked until hidden CMS/DB collision is operator-verified by readonly path."
+  },
+  "SEO-CMS-CANARY-OPERATOR-COLLISION-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-cms-canary-operator-collision-01",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "SEO-CMS-CANARY-IMPORTER-GATE-01"
+    ],
+    "commit_sha": "pending_remote_pr_head",
+    "pr_url": null,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1860 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,url",
+          "git fetch origin main --prune",
+          "git merge-base --is-ancestor 26f4fec3b7112acff6d3276613b1cd57744350f9 origin/main",
+          "git rev-parse main origin/main",
+          "git ls-remote --heads origin codex/seo-cms-canary-operator-collision-01"
+        ],
+        "notes": "SEO-CMS-CANARY-IMPORTER-GATE-01 is merged as PR #1860 and origin/main contains merge commit 26f4fec3b7112acff6d3276613b1cd57744350f9. Local main equals origin/main. The operator collision branch did not exist before this task."
+      },
+      "public_absence": {
+        "status": "passed_public_only",
+        "commands": [
+          "python3 public article detail/SEO API 404 checks for both target slugs",
+          "python3/curl sitemap.xml, llms.txt, and llms-full.txt absence checks for both target slugs"
+        ],
+        "notes": "Both public detail APIs returned 404, both public SEO APIs returned 404, and sitemap.xml, llms.txt, and llms-full.txt do not contain either target slug."
+      },
+      "hidden_collision": {
+        "status": "unknown_sidecar_created",
+        "commands": [
+          "readonly repository scan of Article model, SoftDeletes, importer org_id=0 existingArticle lookup, and article visibility/indexability fields"
+        ],
+        "notes": "No authorized production CMS/DB readonly private-record query was provided or executed. Hidden slug, private/unpublished/draft/review_pending/published/noindex, soft-deleted, and translation_group_id collisions therefore remain Unknown. Sidecar SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01 is recorded and blocks SEO-CONTENT-P1-08."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "git diff --check -- backend/docs/seo backend/docs/operations docs/codex",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --cached --check"
+        ],
+        "notes": "Docs-only report and train metadata checks passed. Cached diff check is run after path-limited staging."
+      }
+    },
+    "failure_reason": "NO-GO for SEO-CONTENT-P1-08: public absence checks pass, but hidden production CMS/DB slug and translation_group_id collision remains Unknown because no authorized readonly private-record check was executed.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-02T16:56:10Z",
+        "from": "missing",
+        "to": "local_checks_passed",
+        "note": "User-provided train prompt authorized SEO-CMS-CANARY-OPERATOR-COLLISION-01 after importer gate merge. Created docs-only operator readonly collision check path, verified public absence, recorded hidden collision Unknown, and created SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01. No CMS draft, publish, production write action, env/cookie/token access, GPT content edit, runtime code edit, test edit, frontend change, or search submission was performed."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01",
+        "status": "open",
+        "blocks": [
+          "SEO-CONTENT-P1-08"
+        ],
+        "reason": "Production CMS/DB hidden/private/unpublished/soft-deleted slug and translation_group_id collision remains Unknown until an authorized operator runs the documented readonly check path.",
+        "required_resolution": "Authorized operator must report PASS for the documented readonly production CMS/DB Article collision query before any CMS draft creation."
+      }
+    ],
+    "next_task": "SEO-CONTENT-P1-08 remains blocked. Next action is authorized operator readonly hidden collision verification; publish remains forbidden."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40048,7 +40048,7 @@
     "repo": "fap-api",
     "branch": "codex/analytics-funnel-purchase-report-truth-bridge-03",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "title": "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03 freeze purchase report truth bridge",
     "depends_on": [
       "ANALYTICS-FUNNEL-GA4-BAIDU-MAPPING-SCAN-01",
@@ -40679,7 +40679,7 @@
       "SEO-CMS-CANARY-IMPORTER-GATE-01"
     ],
     "commit_sha": "pending_remote_pr_head",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1861",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40734,6 +40734,12 @@
         "from": "missing",
         "to": "local_checks_passed",
         "note": "User-provided train prompt authorized SEO-CMS-CANARY-OPERATOR-COLLISION-01 after importer gate merge. Created docs-only operator readonly collision check path, verified public absence, recorded hidden collision Unknown, and created SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01. No CMS draft, publish, production write action, env/cookie/token access, GPT content edit, runtime code edit, test edit, frontend change, or search submission was performed."
+      },
+      {
+        "at": "2026-06-02T16:59:24Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1861 for docs-only operator collision path review. SEO-CONTENT-P1-08 remains blocked because hidden CMS/DB collision remains Unknown."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19915,3 +19915,51 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-CONTENT-P1-08 remains blocked until hidden CMS/DB collision is operator-verified by readonly path
+
+  - id: SEO-CMS-CANARY-OPERATOR-COLLISION-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-IMPORTER-GATE-01
+    branch: codex/seo-cms-canary-operator-collision-01
+    title: "docs(cms): verify canary hidden collision check path"
+    train_scope: seo_cms_canary
+    scope:
+      - Verify the public absence signals for the first bilingual SEO canary target slugs.
+      - Document the authorized operator readonly CMS/DB hidden collision check path for slug and translation_group_id collisions before any CMS draft creation.
+      - Keep hidden collision Unknown when no authorized production CMS/DB readonly access is available.
+      - Create the SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01 blocker when hidden collision remains Unknown.
+      - Reconcile SEO-CMS-CANARY-IMPORTER-GATE-01 train state as merged before continuing.
+    allowed_paths:
+      - backend/docs/seo/**
+      - backend/docs/operations/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute SEO-CONTENT-P1-08.
+      - Create CMS drafts, save CMS forms, create Articles, publish, or call production write APIs.
+      - Run destructive migrations or any production write command.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+      - Modify backend/app/**, backend/routes/**, backend/database/**, backend/tests/**, frontend fap-web, GPT content packages, sitemap runtime, analytics runtime, or production config.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+    validation:
+      - git diff --check -- backend/docs/seo backend/docs/operations docs/codex
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CONTENT-P1-08 remains blocked unless hidden CMS/DB collision is operator-verified as PASS or the user explicitly authorizes operator verification before P1-08


### PR DESCRIPTION
## What changed
- Added `SEO-CMS-CANARY-OPERATOR-COLLISION-01` to the fap-api PR train manifest/state.
- Reconciled `SEO-CMS-CANARY-IMPORTER-GATE-01` / PR #1860 as merged.
- Added a docs-only operator readonly collision check report for the first bilingual SEO canary slugs and `translation_group_id`.
- Recorded `SEO-CMS-CANARY-HIDDEN-COLLISION-SIDECAR-01` because private hidden CMS/DB collision remains Unknown.

## Why
Public APIs, sitemap, `llms.txt`, and `llms-full.txt` can prove public absence, but they cannot prove that no hidden/private/unpublished/soft-deleted Article row already uses the target slugs or translation group. This PR documents the exact readonly operator path required before any draft creation.

## Validation
- `git diff --check -- backend/docs/seo backend/docs/operations docs/codex`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `git diff --cached --check`
- Public detail/SEO APIs returned 404 for both target slugs.
- `sitemap.xml`, `llms.txt`, and `llms-full.txt` do not contain either target slug.

## Intentionally deferred
- Hidden CMS/DB collision remains Unknown because no authorized production readonly private-record query was executed.
- `SEO-CONTENT-P1-08` remains blocked.
- No CMS draft was created. No publish was performed. No production write API, sitemap submission, Baidu push, or IndexNow action was performed.

## Repository rule impact
Docs-only CMS operator runbook update. CMS/backend remains the Article authority; no frontend content authority, runtime behavior, sitemap enumeration, or public editorial content source changes are introduced.