### PR TITLE
fix(cms): validate article SEO field lengths before draft import

### DIFF
--- a/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
+++ b/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
@@ -81,6 +81,25 @@ final class EditorialPackageDraftImporter
 
     private const REVIEWERS = ['editor', 'psychometrics', 'legal', 'founder'];
 
+    /**
+     * Fixed DB column limits that the draft importer writes directly. Keep this
+     * guard ahead of writes so dry-run sees the same schema blockers as import.
+     *
+     * @var array<string, int>
+     */
+    private const FIELD_LENGTH_LIMITS = [
+        'author' => 128,
+        'title' => 255,
+        'slug' => 127,
+        'locale' => 16,
+        'translation_group_id' => 64,
+        'cover_image' => 255,
+        'cover_image_alt' => 255,
+        'seo_title' => 60,
+        'meta_description' => 160,
+        'canonical' => 255,
+    ];
+
     private const FORBIDDEN_CLAIMS = [
         '最准' => '可作为参考',
         '官方 MBTI' => 'MBTI 相关',
@@ -485,12 +504,9 @@ final class EditorialPackageDraftImporter
             $errors[] = $this->issue('ability_disclaimer_required', 'ability_disclaimer_required', 'ability_sensitive content requires an ability disclaimer.');
         }
 
+        $this->schemaLengthValidation($package, $errors);
         $this->trackSpecificValidation($package, $errors);
         $this->answerSurfaceBoundaryValidation($package, $errors);
-
-        if (mb_strlen((string) $package['translation_group_id']) > 64) {
-            $errors[] = $this->issue('translation_group_id', 'translation_group_id_too_long', 'translation_group_id must be 64 characters or fewer.');
-        }
 
         $claimMatches = $this->claimMatches($package);
         foreach ($claimMatches as $match) {
@@ -506,6 +522,39 @@ final class EditorialPackageDraftImporter
             'warnings' => $warnings,
             'claim_matches' => $claimMatches,
         ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function schemaLengthValidation(array $package, array &$errors): void
+    {
+        foreach (self::FIELD_LENGTH_LIMITS as $field => $limit) {
+            $value = (string) ($package[$field] ?? '');
+            if ($value !== '' && mb_strlen($value) > $limit) {
+                $errors[] = $this->issue(
+                    $field,
+                    'schema_length_exceeded',
+                    "{$field} exceeds database column limit of {$limit} characters."
+                ) + [
+                    'max_length' => $limit,
+                    'actual_length' => mb_strlen($value),
+                ];
+            }
+        }
+
+        foreach ($this->stringList($package['target_tests'] ?? []) as $testSlug) {
+            if (mb_strlen($testSlug) > 127) {
+                $errors[] = $this->issue(
+                    'target_tests',
+                    'schema_length_exceeded',
+                    'target_tests contains a test slug longer than related_test_slug column limit of 127 characters.'
+                ) + [
+                    'max_length' => 127,
+                    'actual_length' => mb_strlen($testSlug),
+                ];
+            }
+        }
     }
 
     /**

--- a/backend/docs/seo/seo-cms-canary-importer-schema-gate-2026-06-03.md
+++ b/backend/docs/seo/seo-cms-canary-importer-schema-gate-2026-06-03.md
@@ -1,0 +1,64 @@
+# SEO CMS Canary Importer Schema Gate - 2026-06-03
+
+Task: `SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01`
+
+This change adds a pre-write schema-length guard to the controlled editorial package importer. It does not create CMS drafts, does not publish, does not call production write APIs, does not submit sitemap/Baidu/IndexNow, and does not modify GPT-5.5 Pro content or adapter prose.
+
+## Context
+
+`SEO-CONTENT-P1-08` draft-only execution partially completed in production:
+
+- zh-CN draft creation succeeded and remains draft-only.
+- en draft creation failed before completion when `article_seo_meta.seo_title` exceeded the production column limit.
+- No English partial Article row was left behind.
+- Public article pages and public APIs remained absent, and publish stayed forbidden.
+
+The blocker showed that the importer dry-run did not previously model all fixed DB column length constraints before a real import.
+
+## Gate
+
+The importer now validates fixed-length DB-backed fields before any write plan can proceed:
+
+- `author`
+- `title`
+- `slug`
+- `locale`
+- `translation_group_id`
+- `cover_image`
+- `cover_image_alt`
+- `seo_title`
+- `meta_description`
+- `canonical`
+- `target_tests` slugs used for Article test placement
+
+When a field exceeds its DB-backed limit, dry-run returns `schema_length_exceeded`, `action=will_skip`, `would_write=false`, and no Article, revision, SEO meta, or import telemetry row is created.
+
+## Current Canary Impact
+
+The approved English adapter still preserves the GPT-5.5 Pro source content exactly. Because the English `seo_title` and `meta_description` exceed current production SEO meta limits, the adapter should now fail dry-run with explicit validation errors instead of failing during a real import write.
+
+This PR does not shorten, rewrite, or mechanically adapt the English content package. A follow-up authorization is required to decide whether to:
+
+- create a mechanical adapter metadata adjustment that preserves content authority, or
+- change backend schema/authority limits through a separate runtime/schema PR.
+
+## Validation
+
+Required checks:
+
+```bash
+cd backend && php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/app/Services/Cms/EditorialPackage backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php backend/docs/seo docs/codex
+git diff --cached --check
+```
+
+## Deferred
+
+- No CMS draft creation.
+- No publish.
+- No GPT content edits.
+- No sitemap, Baidu, IndexNow, or Search Channel action.
+- No frontend changes.

--- a/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
@@ -297,7 +297,7 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
     }
 
-    public function test_canary_importer_adapters_dry_run_pass_without_database_writes(): void
+    public function test_canary_importer_adapters_dry_run_schema_gate_blocks_oversized_english_seo_fields_without_database_writes(): void
     {
         $this->assertCanaryAdapterPreservesSource(
             base_path('docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json'),
@@ -328,12 +328,14 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
             '--dry-run' => true,
         ])
             ->expectsOutputToContain('dry_run=1')
-            ->expectsOutputToContain('action=will_create')
+            ->expectsOutputToContain('action=will_skip')
             ->expectsOutputToContain('content_track=evergreen_knowledge')
             ->expectsOutputToContain('target_tests=holland-career-interest-test-riasec,mbti-personality-test-16-personality-types,big-five-personality-test-ocean-model')
             ->expectsOutputToContain('target_topics=riasec,mbti')
-            ->expectsOutputToContain('errors_count=0')
-            ->assertExitCode(0);
+            ->expectsOutputToContain('errors_count=2')
+            ->expectsOutputToContain('validation_error=seo_title:schema_length_exceeded')
+            ->expectsOutputToContain('validation_error=meta_description:schema_length_exceeded')
+            ->assertExitCode(1);
 
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
         $this->assertSame(0, ArticleTranslationRevision::query()->withoutGlobalScopes()->count());

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40674,11 +40674,11 @@
   "SEO-CMS-CANARY-OPERATOR-COLLISION-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-operator-collision-01",
-    "status": "local_checks_passed",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-IMPORTER-GATE-01"
     ],
-    "commit_sha": "pending_remote_pr_head",
+    "commit_sha": "d919e9009c270ed344301f2f8b3fd1c6487e093f",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1861",
     "checks": {
       "dependency_verification": {
@@ -40719,14 +40719,14 @@
       }
     },
     "failure_reason": "NO-GO for SEO-CONTENT-P1-08: public absence checks pass, but hidden production CMS/DB slug and translation_group_id collision remains Unknown because no authorized readonly private-record check was executed.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-02T17:05:22Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -40740,6 +40740,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1861 for docs-only operator collision path review. SEO-CONTENT-P1-08 remains blocked because hidden CMS/DB collision remains Unknown."
+      },
+      {
+        "at": "2026-06-03T09:45:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01: GitHub PR #1861 is merged with merge commit d919e9009c270ed344301f2f8b3fd1c6487e093f, origin/main/local main are at that SHA, and the prior operator collision path is available on main."
       }
     ],
     "sidecars": [
@@ -40753,6 +40759,67 @@
         "required_resolution": "Authorized operator must report PASS for the documented readonly production CMS/DB Article collision query before any CMS draft creation."
       }
     ],
-    "next_task": "SEO-CONTENT-P1-08 remains blocked. Next action is authorized operator readonly hidden collision verification; publish remains forbidden."
+    "next_task": "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01 adds importer schema-length preflight after partial SEO-CONTENT-P1-08 EN draft failure; publish remains forbidden."
+  },
+  "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-cms-canary-importer-schema-gate-01",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "SEO-CMS-CANARY-OPERATOR-COLLISION-01"
+    ],
+    "commit_sha": "ae060ffc782d272a5f3761ec4d6dde85f3deb687",
+    "pr_url": null,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "commands": [
+          "git fetch origin main --prune",
+          "git pull --ff-only origin main",
+          "gh pr view 1861 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,url",
+          "git rev-parse HEAD origin/main main"
+        ],
+        "notes": "User explicitly authorized adding SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01. SEO-CMS-CANARY-OPERATOR-COLLISION-01 is reconciled as merged at d919e9009c270ed344301f2f8b3fd1c6487e093f before this scoped fix."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "cd backend && php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php",
+          "rm -f /tmp/seo-cms-canary-schema-gate.sqlite && touch /tmp/seo-cms-canary-schema-gate.sqlite && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-cms-canary-schema-gate.sqlite php backend/artisan migrate --force --no-interaction >/dev/null && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-cms-canary-schema-gate.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json >/tmp/seo-cms-canary-en-schema-gate.json; test $? -eq 1; python3 -c \"import json; d=json.load(open('/tmp/seo-cms-canary-en-schema-gate.json')); codes=[e.get('code') for e in d.get('errors', [])]; fields=[e.get('field') for e in d.get('errors', [])]; assert d.get('ok') is False and d.get('action') == 'will_skip' and d.get('would_write') is False and 'schema_length_exceeded' in codes and 'seo_title' in fields and 'meta_description' in fields; print('en schema gate ok')\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/app/Services/Cms/EditorialPackage backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "Focused importer console test passed. EN canary adapter dry-run against an isolated testing SQLite database now fails before writes with schema_length_exceeded for seo_title and meta_description, action=will_skip, would_write=false. JSON/YAML parse and scoped diff whitespace checks passed.",
+        "commit_sha": "ae060ffc782d272a5f3761ec4d6dde85f3deb687"
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T09:45:00+08:00",
+        "from": "missing",
+        "to": "local_checks_pending",
+        "note": "User authorized a scoped importer schema-length preflight gate after SEO-CONTENT-P1-08 partially created the zh-CN draft and EN draft creation failed on article_seo_meta.seo_title length. Scope excludes CMS draft creation, publish, production writes, GPT content edits, frontend, sitemap, Baidu, and IndexNow."
+      },
+      {
+        "at": "2026-06-03T09:58:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed",
+        "note": "Added importer schema-length preflight validation for fixed DB-backed Article/SEO fields and updated canary adapter test expectations. No CMS draft, publish, production write action, GPT content edit, frontend change, sitemap submission, Baidu, or IndexNow action was performed."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "After this PR is merged and deployed, rerun SEO-CONTENT-P1-08 preflight. EN draft remains blocked until approved adapter/schema handling satisfies schema-length gates."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40764,12 +40764,12 @@
   "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-importer-schema-gate-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "SEO-CMS-CANARY-OPERATOR-COLLISION-01"
     ],
-    "commit_sha": "ae060ffc782d272a5f3761ec4d6dde85f3deb687",
-    "pr_url": null,
+    "commit_sha": "710b1b362e10424a7958a6c86f1c1cd40e69340c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1862",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40792,7 +40792,7 @@
           "git diff --cached --check"
         ],
         "notes": "Focused importer console test passed. EN canary adapter dry-run against an isolated testing SQLite database now fails before writes with schema_length_exceeded for seo_title and meta_description, action=will_skip, would_write=false. JSON/YAML parse and scoped diff whitespace checks passed.",
-        "commit_sha": "ae060ffc782d272a5f3761ec4d6dde85f3deb687"
+        "commit_sha": "710b1b362e10424a7958a6c86f1c1cd40e69340c"
       }
     },
     "failure_reason": null,
@@ -40802,7 +40802,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": "pending",
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -40817,6 +40817,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed",
         "note": "Added importer schema-length preflight validation for fixed DB-backed Article/SEO fields and updated canary adapter test expectations. No CMS draft, publish, production write action, GPT content edit, frontend change, sitemap submission, Baidu, or IndexNow action was performed."
+      },
+      {
+        "at": "2026-06-03T10:08:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened GitHub PR #1862 after local validation passed. GitHub checks are pending; merge remains blocked until required checks pass. No CMS draft, publish, production write action, GPT content edit, frontend change, sitemap submission, Baidu, or IndexNow action was performed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19963,3 +19963,52 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-CONTENT-P1-08 remains blocked unless hidden CMS/DB collision is operator-verified as PASS or the user explicitly authorizes operator verification before P1-08
+
+  - id: SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-OPERATOR-COLLISION-01
+    branch: codex/seo-cms-canary-importer-schema-gate-01
+    title: "fix(cms): validate article SEO field lengths before draft import"
+    train_scope: seo_cms_canary
+    scope:
+      - Add a controlled editorial package importer schema-length preflight gate for DB-backed Article SEO fields.
+      - Ensure overlong seo_title and meta_description values fail during dry-run before any draft Article write is attempted.
+      - Keep the approved GPT-5.5 Pro content package and mechanical adapter content unchanged.
+      - Record the production EN draft blocker and retry requirements without creating CMS drafts or publishing.
+    allowed_paths:
+      - backend/app/Services/Cms/EditorialPackage/**
+      - backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create CMS drafts, save CMS forms, create Articles, publish, or call production write APIs.
+      - Modify original GPT-5.5 Pro title, H1, meta, body, FAQ, CTA labels, CTA hrefs, or prose.
+      - Modify routes, migrations, package files, sitemap runtime, analytics runtime, frontend files, or production configuration.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+    validation:
+      - cd backend && php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+      - rm -f /tmp/seo-cms-canary-schema-gate.sqlite && touch /tmp/seo-cms-canary-schema-gate.sqlite && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-cms-canary-schema-gate.sqlite php backend/artisan migrate --force --no-interaction >/dev/null && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-cms-canary-schema-gate.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json >/tmp/seo-cms-canary-en-schema-gate.json; test $? -eq 1; python3 -c "import json; d=json.load(open('/tmp/seo-cms-canary-en-schema-gate.json')); codes=[e.get('code') for e in d.get('errors', [])]; fields=[e.get('field') for e in d.get('errors', [])]; assert d.get('ok') is False and d.get('action') == 'will_skip' and d.get('would_write') is False and 'schema_length_exceeded' in codes and 'seo_title' in fields and 'meta_description' in fields; print('en schema gate ok')"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/app/Services/Cms/EditorialPackage backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: After merge and deploy, rerun SEO-CONTENT-P1-08 preflight; EN draft creation remains blocked until the approved adapter content satisfies schema-length gates.


### PR DESCRIPTION
## What changed
- Added a schema-length preflight gate to the controlled editorial package draft importer for DB-backed article, SEO meta, canonical, and target test slug fields.
- Updated the focused console feature test so the approved EN canary adapter fails during dry-run with explicit `schema_length_exceeded` errors for `seo_title` and `meta_description`, without database writes.
- Added the PR-train manifest/state entry and a docs note for the partial SEO-CONTENT-P1-08 blocker.

## Why
The EN canary draft creation failed only at the formal insert step with `Data too long for column 'seo_title'`. This change moves that failure into importer validation/dry-run so oversized CMS SEO fields are visible before any draft creation attempt.

## Validation
- `cd backend && php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php` PASS: 9 tests, 228 assertions.
- `rm -f /tmp/seo-cms-canary-schema-gate.sqlite && touch /tmp/seo-cms-canary-schema-gate.sqlite && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-cms-canary-schema-gate.sqlite php backend/artisan migrate --force --no-interaction >/dev/null && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-cms-canary-schema-gate.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json >/tmp/seo-cms-canary-en-schema-gate.json; test $? -eq 1; python3 -c "import json; d=json.load(open('/tmp/seo-cms-canary-en-schema-gate.json')); codes=[e.get('code') for e in d.get('errors', [])]; fields=[e.get('field') for e in d.get('errors', [])]; assert d.get('ok') is False and d.get('action') == 'will_skip' and d.get('would_write') is False and 'schema_length_exceeded' in codes and 'seo_title' in fields and 'meta_description' in fields; print('en schema gate ok')"` PASS.
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null` PASS.
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"` PASS.
- `git diff --check -- backend/app/Services/Cms/EditorialPackage backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php backend/docs/seo docs/codex` PASS.
- `git diff --cached --check` PASS.

## Intentionally deferred
- No GPT-5.5 Pro content package prose/title/meta/body/FAQ/CTA changes.
- No CMS draft creation or publish.
- No production write API, sitemap submit, Baidu push, or IndexNow call.
- No fap-web/frontend change.
- EN SEO field content/schema resolution remains a follow-up decision after this gate is merged and deployed.

## Repository rule impact
This preserves CMS/backend as the content authority. It adds importer validation only; it does not introduce frontend fallback content or change publishing authority.
