### PR TITLE
docs(content): shorten English SEO canary metadata for CMS import

### DIFF
--- a/backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md
+++ b/backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md
@@ -25,6 +25,12 @@ Date: 2026-06-02
 - CMS draft creation remains blocked until `SEO-CMS-CANARY-IMPORT-DRYRUN-01` passes.
 - `SEO-CONTENT-P1-08` remains blocked until a separate explicit draft-only execution authorization is granted.
 
+## English metadata replacement
+
+- `SEO-CONTENT-CANARY-EN-METADATA-01` uses GPT-5.5 Pro approved replacement values for the English SEO title and SEO description only.
+- Codex did not author, rewrite, expand, polish, or localize the English body, H1, FAQ, CTA labels, CTA hrefs, or internal links.
+- The replacement is intended only to satisfy the Article SEO metadata length gate before any later draft-only retry.
+
 ## Forbidden actions
 
 - Do not create a CMS draft from this package yet.

--- a/backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json
+++ b/backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json
@@ -20,9 +20,9 @@
     "Myers-Briggs 16 Types https://www.myersbriggs.org/my-mbti-personality-type/the-16-mbti-personality-types/",
     "APA Dictionary: Big Five personality model https://dictionary.apa.org/big-five-personality-model"
   ],
-  "seo_title": "MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take? | FermatMind",
-  "seo_description": "For choosing a major, job, or career direction, Holland Code/RIASEC is usually more direct. MBTI helps explain work style, communication, and preferences. Learn how to use both.",
-  "meta_description": "For choosing a major, job, or career direction, Holland Code/RIASEC is usually more direct. MBTI helps explain work style, communication, and preferences. Learn how to use both.",
+  "seo_title": "MBTI vs Holland Code: Which Career Test? | FermatMind",
+  "seo_description": "Use Holland Code/RIASEC to explore interests and work environments; use MBTI to understand work style. Compare both for majors, jobs, and career change.",
+  "meta_description": "Use Holland Code/RIASEC to explore interests and work environments; use MBTI to understand work style. Compare both for majors, jobs, and career change.",
   "excerpt": "If your question is “What career fits me?”, the Holland Code/RIASEC framework is usually more direct than MBTI. If your question is “How do I tend to work with people, structure, and decisions?”, MBTI can be useful as a work-style lens. The strongest approach is not choosing one test over the other, but combining career interests, personality preferences, and real job evidence.",
   "canonical_path": "/en/articles/mbti-vs-holland-code-career-choice",
   "canonical": "https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice",

--- a/backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json
+++ b/backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json
@@ -12,8 +12,8 @@
   "slug": "mbti-vs-holland-code-career-choice",
   "h1": "MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take?",
   "canonical_path": "/en/articles/mbti-vs-holland-code-career-choice",
-  "seo_title": "MBTI vs. Holland Code/RIASEC: Which Career Test Should You Take? | FermatMind",
-  "seo_description": "For choosing a major, job, or career direction, Holland Code/RIASEC is usually more direct. MBTI helps explain work style, communication, and preferences. Learn how to use both.",
+  "seo_title": "MBTI vs Holland Code: Which Career Test? | FermatMind",
+  "seo_description": "Use Holland Code/RIASEC to explore interests and work environments; use MBTI to understand work style. Compare both for majors, jobs, and career change.",
   "excerpt": "If your question is “What career fits me?”, the Holland Code/RIASEC framework is usually more direct than MBTI. If your question is “How do I tend to work with people, structure, and decisions?”, MBTI can be useful as a work-style lens. The strongest approach is not choosing one test over the other, but combining career interests, personality preferences, and real job evidence.",
   "category": "Career Decision-Making",
   "tags": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40837,12 +40837,12 @@
   "SEO-CONTENT-CANARY-EN-METADATA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-canary-en-metadata-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "0d8eeababcf6cdd25ab9206d21e4f3a94e2e951f",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1863",
     "checks": {
       "dependency_verification": {
         "status": "passed",
@@ -40875,7 +40875,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
+      "github_checks_green": "pending",
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -40890,6 +40890,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed",
         "note": "Local validation passed for JSON parse, YAML parse, field-level metadata equivalence, unchanged body/H1/FAQ/CTA/internal links/publish gate/translation_group_id, public canonical CTA targets, isolated importer dry-run, and scoped diff whitespace checks. No CMS draft, publish, production write action, runtime code, tests, database, routes, frontend, sitemap, Baidu, or IndexNow action was performed."
+      },
+      {
+        "at": "2026-06-03T10:33:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened GitHub PR #1863 after local validation passed. GitHub checks are pending; merge remains blocked until required checks pass. No CMS draft, publish, production write action, runtime code, tests, database, routes, frontend, sitemap, Baidu, or IndexNow action was performed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40764,11 +40764,11 @@
   "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-importer-schema-gate-01",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-OPERATOR-COLLISION-01"
     ],
-    "commit_sha": "710b1b362e10424a7958a6c86f1c1cd40e69340c",
+    "commit_sha": "52a3efa1657244e61648875e31dd2fe97d1f195b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1862",
     "checks": {
       "dependency_verification": {
@@ -40796,14 +40796,14 @@
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T01:46:13Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": "pending",
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -40823,9 +40823,76 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened GitHub PR #1862 after local validation passed. GitHub checks are pending; merge remains blocked until required checks pass. No CMS draft, publish, production write action, GPT content edit, frontend change, sitemap submission, Baidu, or IndexNow action was performed."
+      },
+      {
+        "at": "2026-06-03T10:20:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CONTENT-CANARY-EN-METADATA-01: GitHub PR #1862 is merged with merge commit 52a3efa1657244e61648875e31dd2fe97d1f195b, origin/main/local main are at that SHA, and the local/remote task branches were cleaned up."
       }
     ],
     "sidecars": [],
-    "next_task": "After this PR is merged and deployed, rerun SEO-CONTENT-P1-08 preflight. EN draft remains blocked until approved adapter/schema handling satisfies schema-length gates."
+    "next_task": "SEO-CONTENT-CANARY-EN-METADATA-01 may proceed to apply GPT-5.5 Pro approved English SEO metadata replacements; publish remains forbidden."
+  },
+  "SEO-CONTENT-CANARY-EN-METADATA-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-content-canary-en-metadata-01",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_verification": {
+        "status": "passed",
+        "commands": [
+          "git fetch origin main --prune",
+          "git rev-parse HEAD origin/main main",
+          "gh pr view 1862 --repo fermatmind/fap-api --json state,mergedAt,mergeCommit,url,statusCheckRollup"
+        ],
+        "notes": "User explicitly authorized adding SEO-CONTENT-CANARY-EN-METADATA-01. SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01 is reconciled as merged at 52a3efa1657244e61648875e31dd2fe97d1f195b before this docs/content metadata fix."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null",
+          "python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json >/dev/null",
+          "python3 inline metadata equivalence validation against origin/main",
+          "rm -f /tmp/seo-content-canary-en-metadata.sqlite /tmp/seo-content-canary-en-metadata-dryrun.json && touch /tmp/seo-content-canary-en-metadata.sqlite && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-content-canary-en-metadata.sqlite php backend/artisan migrate --force --no-interaction >/dev/null && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-content-canary-en-metadata.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json >/tmp/seo-content-canary-en-metadata-dryrun.json && python3 -c \"import json; d=json.load(open('/tmp/seo-content-canary-en-metadata-dryrun.json')); assert d.get('ok') is True and d.get('action') == 'will_create' and d.get('errors') == []; print('en metadata dry-run ok')\"",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "English source artifact changed only seo_title and seo_description; English adapter changed only seo_title, seo_description, and meta_description. New lengths are seo_title=53 and seo_description=152. body_markdown, H1, FAQ, CTA labels/hrefs, internal links, publish_allowed=false, and translation_group_id remained unchanged. Isolated testing SQLite importer dry-run passed with ok=true, action=will_create, errors=[], and no real import/draft/publish was performed."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T10:20:00+08:00",
+        "from": "missing",
+        "to": "local_checks_pending",
+        "note": "User authorized SEO-CONTENT-CANARY-EN-METADATA-01 to mechanically apply GPT-5.5 Pro approved English SEO title and SEO description replacements to the source and importer adapter artifacts. Scope excludes CMS draft creation, publish, production writes, GPT body/H1/FAQ/CTA/internal link edits, Chinese artifact edits, runtime code, tests, database, routes, frontend, sitemap, Baidu, and IndexNow."
+      },
+      {
+        "at": "2026-06-03T10:28:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed",
+        "note": "Local validation passed for JSON parse, YAML parse, field-level metadata equivalence, unchanged body/H1/FAQ/CTA/internal links/publish gate/translation_group_id, public canonical CTA targets, isolated importer dry-run, and scoped diff whitespace checks. No CMS draft, publish, production write action, runtime code, tests, database, routes, frontend, sitemap, Baidu, or IndexNow action was performed."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "After merge and production deploy of this metadata artifact, rerun SEO-CONTENT-P1-08 preflight; if dry-run and absence gates pass, EN draft-only creation may be retried with separate explicit authorization. Publish remains forbidden."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26263,7 +26263,7 @@
   "SEARCH-CHANNEL-LIVE-01-PREFLIGHT": {
     "repo": "fap-api",
     "branch": "codex/search-channel-live-01-preflight",
-    "status": "pr_open",
+    "status": "github_checks_passed",
     "depends_on": [
       "INDEXNOW-LIVE-00"
     ],
@@ -40875,7 +40875,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": "pending",
+      "github_checks_green": true,
       "post_merge_revalidated": null
     },
     "transitions": [
@@ -40896,6 +40896,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened GitHub PR #1863 after local validation passed. GitHub checks are pending; merge remains blocked until required checks pass. No CMS draft, publish, production write action, runtime code, tests, database, routes, frontend, sitemap, Baidu, or IndexNow action was performed."
+      },
+      {
+        "at": "2026-06-03T10:45:00+08:00",
+        "from": "pr_open",
+        "to": "github_checks_passed",
+        "note": "GitHub checks for PR #1863 passed with mergeStateStatus=CLEAN before ledger update. No CMS draft, publish, production write action, runtime code, tests, database, routes, frontend, sitemap, Baidu, or IndexNow action was performed."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20012,3 +20012,88 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: After merge and deploy, rerun SEO-CONTENT-P1-08 preflight; EN draft creation remains blocked until the approved adapter content satisfies schema-length gates.
+
+  - id: SEO-CONTENT-CANARY-EN-METADATA-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01
+    branch: codex/seo-content-canary-en-metadata-01
+    title: "docs(content): shorten English SEO canary metadata for CMS import"
+    train_scope: seo_cms_canary
+    scope:
+      - Mechanically apply GPT-5.5 Pro approved English SEO title and SEO description replacement values to the canary source artifact.
+      - Mechanically apply the same approved values to the English importer adapter SEO metadata aliases.
+      - Preserve English body_markdown, H1, FAQ, CTA labels, CTA hrefs, internal links, publish gate, slug, and translation_group_id.
+      - Keep CMS draft creation and publish forbidden; this PR only prepares metadata for a later dry-run and draft-only retry after deploy.
+    allowed_paths:
+      - backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json
+      - backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json
+      - backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create CMS drafts, save CMS forms, create Articles, publish, or call production write APIs.
+      - Modify English body_markdown, H1, FAQ, CTA labels, CTA hrefs, internal links, or any Chinese artifact.
+      - Modify backend app, routes, database, tests, runtime code, production config, frontend fap-web, sitemap runtime, or analytics runtime.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+    validation:
+      - python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json >/dev/null
+      - python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json >/dev/null
+      - |
+        python3 - <<'PY'
+        import json
+        import subprocess
+        from pathlib import Path
+
+        source_path = Path('backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json')
+        adapter_path = Path('backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json')
+        old_source = json.loads(subprocess.check_output(['git', 'show', f'origin/main:{source_path}']))
+        old_adapter = json.loads(subprocess.check_output(['git', 'show', f'origin/main:{adapter_path}']))
+        source = json.loads(source_path.read_text())
+        adapter = json.loads(adapter_path.read_text())
+        assert source['seo_title'] == 'MBTI vs Holland Code: Which Career Test? | FermatMind'
+        assert source['seo_description'] == 'Use Holland Code/RIASEC to explore interests and work environments; use MBTI to understand work style. Compare both for majors, jobs, and career change.'
+        assert adapter['seo_title'] == source['seo_title']
+        assert adapter['seo_description'] == source['seo_description']
+        assert adapter['meta_description'] == source['seo_description']
+        assert len(source['seo_title']) <= 60
+        assert len(source['seo_description']) <= 160
+        unchanged = ['body_markdown', 'h1', 'faq', 'cta_slots', 'internal_links', 'publish_gate', 'translation_group_id']
+        for key in unchanged:
+            assert source[key] == old_source[key], key
+        adapter_unchanged = ['body_markdown', 'h1', 'faq', 'answer_surface_v1', 'cta_slots', 'internal_links', 'publish_gate', 'translation_group_id']
+        for key in adapter_unchanged:
+            assert adapter[key] == old_adapter[key], key
+        forbidden = ['result', 'orders', 'share', 'pay', 'payment', 'history', 'take', 'token']
+        for slot in adapter['cta_slots']:
+            href = slot['href']
+            assert href.startswith('/en/tests/')
+            assert not href.startswith(('http://', 'https://', '//'))
+            assert not any(part in href for part in forbidden), href
+        assert source['publish_gate']['publish_allowed'] is False
+        assert adapter['publish_gate']['publish_allowed'] is False
+        print('metadata equivalence ok')
+        PY
+      - rm -f /tmp/seo-content-canary-en-metadata.sqlite /tmp/seo-content-canary-en-metadata-dryrun.json && touch /tmp/seo-content-canary-en-metadata.sqlite && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-content-canary-en-metadata.sqlite php backend/artisan migrate --force --no-interaction >/dev/null && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/seo-content-canary-en-metadata.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json >/tmp/seo-content-canary-en-metadata-dryrun.json && python3 -c "import json; d=json.load(open('/tmp/seo-content-canary-en-metadata-dryrun.json')); assert d.get('ok') is True and d.get('action') == 'will_create' and d.get('errors') == []; print('en metadata dry-run ok')"
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: After merge and production deploy of this metadata artifact, rerun SEO-CONTENT-P1-08 preflight; if dry-run and absence gates pass, EN draft-only creation may be retried with separate explicit authorization.


### PR DESCRIPTION
## What changed
- Applied the GPT-5.5 Pro approved English SEO metadata replacements to the canary source artifact:
  - `seo_title`: `MBTI vs Holland Code: Which Career Test? | FermatMind`
  - `seo_description`: `Use Holland Code/RIASEC to explore interests and work environments; use MBTI to understand work style. Compare both for majors, jobs, and career change.`
- Applied the same approved values to the English importer adapter aliases: `seo_title`, `seo_description`, and `meta_description`.
- Recorded the metadata-only scope in package notes and PR train manifest/state.

## Why
The English canary CMS draft is still blocked because the previous metadata exceeded production Article SEO field limits. PR #1862 now catches that in dry-run; this PR updates only the approved English SEO metadata so the controlled importer can dry-run the English adapter successfully.

## Validation
- English SEO title length: old 77, new 53.
- English SEO description length: old 177, new 152.
- JSON parse passed for source and adapter artifacts.
- Field-level comparison against `origin/main` passed:
  - source changed only `seo_title` and `seo_description`.
  - adapter changed only `seo_title`, `seo_description`, and `meta_description`.
  - `body_markdown`, H1, FAQ, CTA labels/hrefs, internal links, `publish_allowed=false`, and `translation_group_id` stayed unchanged.
- CTA hrefs remain public canonical test routes and contain no result/orders/share/pay/payment/history/take/token/external URL patterns.
- Isolated testing SQLite importer dry-run passed: `ok=true`, `action=will_create`, `errors=[]`, no DB writes.
- YAML parse passed for `docs/codex/pr-train.yaml`.
- JSON parse passed for `docs/codex/pr-train-state.json`.
- `git diff --check -- backend/docs/seo docs/codex` passed.
- `git diff --cached --check` passed.

## Intentionally deferred
- No CMS draft creation.
- No publish.
- No production write API.
- No sitemap, Baidu, IndexNow, or search-channel action.
- No body, H1, FAQ, CTA label, CTA href, internal link, Chinese artifact, runtime code, route, database, test, production config, or fap-web change.
- EN draft-only creation must wait until this artifact is merged and deployed, then SEO-CONTENT-P1-08 preflight is rerun and separately authorized.

## Repository rule impact
CMS/backend remains the content authority. This PR updates backend docs/content package artifacts only; it does not introduce runtime frontend content or fallback authority.
