### PR TITLE
docs(cms): archive bilingual SEO canary draft postcheck

### DIFF
--- a/backend/docs/seo/seo-content-p1-08-postcheck-2026-06-03.md
+++ b/backend/docs/seo/seo-content-p1-08-postcheck-2026-06-03.md
@@ -1,0 +1,368 @@
+# SEO-CONTENT-P1-08-POSTCHECK-01 Draft-Only Post-Create Validation
+
+Date: 2026-06-03
+
+Task type: draft-only post-create validation / read-only validation.
+
+Result: **GO: draft-only postcheck passed, ready for editorial/operator review.**
+
+No publish action was performed. No CMS data was modified. No new draft was created. No sitemap, Baidu, IndexNow, or search submission action was performed. No GPT-5.5 Pro content package text was authored, rewritten, or edited.
+
+## Scope Boundary
+
+Allowed actions performed:
+
+- Read-only production CMS/DB checks through the current backend release.
+- Read-only public page, public API, sitemap, `llms.txt`, and `llms-full.txt` checks.
+- Read-only frontend deployed-SHA tracking readiness inspection.
+- Docs-only report creation.
+
+Explicitly not performed:
+
+- No publish.
+- No CMS content mutation.
+- No new draft creation.
+- No rollback.
+- No sitemap submission.
+- No Baidu push.
+- No IndexNow call.
+- No production write API call.
+- No runtime code change.
+- No frontend change.
+- No result/order/share/payment ID access.
+- No env/cookie/token disclosure.
+
+## Production Context
+
+Backend current release:
+
+- `/var/www/fap-api/current`
+- Backend revision observed earlier in the P1-08 flow: `76b40c07b5eb679e7b593aca2007a77e1e56d4d7`
+- Release name observed earlier in the P1-08 flow: `backend-main-20260603-76b40c07`
+
+Frontend deployed SHA used for tracking readiness inspection:
+
+- `b98cf45749e77bf7cb6c5c438ef4686dda264d0d`
+
+Canary translation group:
+
+- `article_mbti_vs_holland_career_choice_v1`
+
+Canary drafts:
+
+- zh-CN: article `37`, slug `mbti-vs-holland-career-choice`
+- en: article `39`, slug `mbti-vs-holland-code-career-choice`
+
+Required archive marker summary: both canary drafts remain `status=draft`, `is_public=false`, `is_indexable=false`, and `published_revision_id=null`.
+
+## A. CMS/DB Draft State Validation
+
+Result: **PASS**
+
+Observed production DB state:
+
+| Locale | Article ID | Slug | Status | is_public | is_indexable | published_revision_id | published_at | deleted_at |
+| --- | ---: | --- | --- | --- | --- | --- | --- | --- |
+| zh-CN | 37 | `mbti-vs-holland-career-choice` | `draft` | false | false | null | null | null |
+| en | 39 | `mbti-vs-holland-code-career-choice` | `draft` | false | false | null | null | null |
+
+Translation group validation:
+
+- `translation_group_id`: `article_mbti_vs_holland_career_choice_v1`
+- Same translation group count: `2`
+- Third same-translation-group record count: `0`
+- Same-slug duplicate count:
+  - zh-CN slug count: `1`
+  - en slug count: `1`
+- Soft-deleted same-slug count: `0`
+- Public/indexable/published count for both target slugs: `0`
+
+Draft state:
+
+- zh draft state: **PASS**
+- en draft state: **PASS**
+- translation group: **PASS**
+- duplicate/collision: **PASS**
+
+## B. Package Equivalence Validation
+
+Result: **PASS**
+
+Artifacts compared:
+
+- `backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.importer-adapter.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json`
+
+Equivalence method:
+
+- Compared production `articles`, working `article_translation_revisions`, `article_seo_meta`, `article_test_edges`, latest `article_editorial_package_imports`, and adapter artifacts.
+- Used importer-equivalent normalized body hashing for `body_markdown`.
+- Used importer-equivalent answer surface hashing for `answer_surface_v1`.
+- Did not print full body, FAQ answer text, or private data in this report.
+
+Observed hashes:
+
+| Locale | Body hash | Answer surface hash | FAQ count |
+| --- | --- | --- | ---: |
+| zh-CN | `2b5ebe2d67c688bbb18239d602630107e83622a51d9201eda904fb4a71ffc0ef` | `06d3adb192b52464be4837b1082f004de6d073a29e92e5a6077e1578044fbf18` | 5 |
+| en | `be91e8c640a4b14f374804f9967e78b389fa31c9921c667fce90959df1e1e35b` | `8e4a865c276b000bb6e16a5724acff6af1d713b89ee68e4633643457aea7758a` | 5 |
+
+Field equivalence:
+
+- title: **PASS**
+- slug: **PASS**
+- H1 / heading sequence from importer exactness: **PASS**
+- SEO title: **PASS**
+- SEO description: **PASS**
+- canonical URL: **PASS**
+- excerpt: **PASS**
+- body markdown normalized hash: **PASS**
+- FAQ package hash: **PASS**
+- CTA slots and hrefs: **PASS**
+- related test slug / target tests: **PASS**
+- category / tags: **PASS**
+- claim boundary metadata presence via import package record: **PASS**
+- publish fail-closed equivalent:
+  - Article `status=draft`
+  - SEO meta `robots=noindex,nofollow`
+  - `is_indexable=false`
+  - `published_revision_id=null`
+
+Content authorship boundary:
+
+- Codex did not rewrite body content during postcheck.
+- Codex did not rewrite FAQ during postcheck.
+- Codex did not rewrite CTA labels or hrefs during postcheck.
+- Codex did not rewrite H1 during postcheck.
+- English metadata is the previously approved short SEO title / SEO description.
+- Chinese content remains unchanged from the imported adapter.
+
+Publish readiness impact:
+
+- Package equivalence does not block editorial/operator review.
+- Publish remains forbidden until separate publish preflight and explicit publish authorization.
+
+## C. Public Exposure Validation
+
+Result: **PASS**
+
+Public page checks:
+
+| Surface | Status | Article schema | FAQPage schema | Breadcrumb schema | Target canonical | Target hreflang |
+| --- | ---: | --- | --- | --- | --- | --- |
+| `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice` | 404 | absent | absent | absent | absent | absent |
+| `https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice` | 404 | absent | absent | absent | absent | absent |
+
+Notes:
+
+- The generic 404 page body includes the requested path text and the normal site shell, so string matching the response body alone can show the slug. This is not article content exposure.
+- No Article, FAQPage, or Breadcrumb structured data was detected on either draft URL.
+- No canonical or hreflang link pointing to either draft URL was detected.
+- A global analytics shell marker is present on the generic 404 shell. No article-specific public content, article schema, canonical, hreflang, or public API payload was exposed.
+
+Public API checks:
+
+| Surface | Status | Target slug in body |
+| --- | ---: | --- |
+| `/api/v0.5/articles/mbti-vs-holland-career-choice` | 404 | no |
+| `/api/v0.5/articles/mbti-vs-holland-career-choice/seo` | 404 | no |
+| `/api/v0.5/articles/mbti-vs-holland-code-career-choice` | 404 | no |
+| `/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo` | 404 | no |
+
+Exposure decision:
+
+- public page exposure: **PASS**
+- public API exposure: **PASS**
+- public SEO API exposure: **PASS**
+- schema exposure: **PASS**
+
+## D. Sitemap / LLMs / Search Submission Validation
+
+Result: **PASS**
+
+Public enumeration checks:
+
+| Surface | Status | Contains target slug |
+| --- | ---: | --- |
+| `https://fermatmind.com/sitemap.xml` | 200 | no |
+| `https://fermatmind.com/llms.txt` | 200 | no |
+| `https://fermatmind.com/llms-full.txt` | 200 | no |
+
+Production DB search-submission table checks:
+
+| Surface | Result |
+| --- | --- |
+| `search_channel_queue` | table missing |
+| `search_channel_submissions` | table missing |
+| `search_submissions` | table missing |
+| `gsc_submission_queue` | table missing |
+| `baidu_submission_queue` | table missing |
+| `indexnow_queue` | table missing |
+| `seo_search_submission_events` | table missing |
+| `search_submission_events` | table missing |
+
+Audit/event checks:
+
+- Publish/release audit match count for target slugs: `0`
+- Checked available audit log text columns: `action`, `reason`
+
+Decision:
+
+- sitemap absence: **PASS**
+- llms absence: **PASS**
+- search submission absence: **PASS**
+- publish/release event absence: **PASS**
+
+## E. CTA / Tracking Readiness Validation
+
+Result: **PASS**
+
+CMS draft CTA targets:
+
+| Locale | Priority | Target |
+| --- | --- | --- |
+| zh-CN | primary | `/zh/tests/holland-career-interest-test-riasec` |
+| zh-CN | secondary | `/zh/tests/mbti-personality-test-16-personality-types` |
+| zh-CN | tertiary | `/zh/tests/big-five-personality-test-ocean-model` |
+| en | primary | `/en/tests/holland-career-interest-test-riasec` |
+| en | secondary | `/en/tests/mbti-personality-test-16-personality-types` |
+| en | tertiary | `/en/tests/big-five-personality-test-ocean-model` |
+
+CTA safety:
+
+- All CTA hrefs are public canonical test routes.
+- No CTA href contains `result`, `orders`, `share`, `pay`, `payment`, `history`, `take`, `token`, external URL, or unsafe scheme.
+- `article_test_edges` exist for the three target tests in both locales.
+- Primary target is `holland-career-interest-test-riasec`.
+
+Tracking readiness, checked against deployed frontend SHA `b98cf45749e77bf7cb6c5c438ef4686dda264d0d`:
+
+- `article_to_test_click` exists in `components/cta/SeoTrackedCtaLink.tsx`.
+- `article_to_test_click` exists in `lib/tracking/client.ts`.
+- `ARTICLE_TO_TEST_CLICK` exists in `lib/tracking/events.ts`.
+- Field whitelist includes:
+  - `locale`
+  - `article_slug`
+  - `translation_group_id`
+  - `cta_id`
+  - `cta_priority`
+  - `target_test_slug`
+  - `source_path`
+  - `destination_path`
+- Article-detail CTA emits `article_to_test_click`, while non-article SEO CTA falls back to `start_attempt`.
+- `article_to_test_click` is distinct from `start_test`.
+- No checkout, payment, or order trigger was found in the article CTA tracking path.
+
+Decision:
+
+- CTA safety: **PASS**
+- tracking readiness: **PASS**
+- This does not block editorial/operator review.
+- GA4 Key Event configuration remains intentionally deferred.
+
+## F. Schema Readiness Validation
+
+Result: **PASS for data readiness; public schema exposure remains absent while draft-only.**
+
+Draft data available for future schema generation:
+
+- Article title: present.
+- SEO description: present.
+- Canonical URL: present in `article_seo_meta`.
+- Author/safe fallback: present as importer package author / article author fields.
+- Category and tags: present.
+- FAQ items: present and locale-specific in the adapter answer surface.
+- CTA/internal hrefs: public canonical routes only.
+- Robots/indexability: currently `noindex,nofollow` and `is_indexable=false`.
+
+Current DB `article_seo_meta.schema_json`:
+
+- Present for both records.
+- Contains importer editorial package metadata under `editorial_package_v1`.
+- Does not represent exposed public JSON-LD while the articles remain drafts.
+
+Decision:
+
+- Article schema readiness: **PASS**
+- Breadcrumb schema readiness: **PASS**
+- FAQ schema readiness: **PASS**
+- Hidden FAQ should not generate FAQPage; visible FAQ can be used after publish gates.
+- No private, tokenized, result/order/share/pay/payment/history URL appears in CTA targets.
+
+## G. Preview Readiness / Preview Gap
+
+Result: **Preview gap remains.**
+
+Observed state:
+
+- No dedicated safe rendered Article draft preview route was confirmed.
+- Existing preview-related code found in the repo is for other surfaces, such as career transition preview and Big Five editorial preview.
+- The canary source/adapter artifacts still record `preview_url_available=false`.
+
+Decision:
+
+- Preview blocks draft: **No**. Drafts already exist and remain fail-closed.
+- Preview blocks editorial/operator review: **No**, if CMS-only inspection is accepted for review.
+- Preview blocks publish: **Yes / Conditional**. Before publish, either:
+  - the team accepts CMS-only inspection plus public absence checks as the rendered-review substitute, or
+  - `SEO-CMS-CANARY-PREVIEW-01` should add a safe auth/token-gated noindex preview.
+
+Recommendation:
+
+- Do not publish from this state.
+- Use editorial/operator review next.
+- Execute `SEO-CMS-CANARY-PREVIEW-01` before publish if rendered preview is required and no accepted CMS-only substitute is approved.
+
+## H. Decision
+
+**GO: draft-only postcheck passed, ready for editorial/operator review.**
+
+Pass summary:
+
+- Two draft states: **PASS**
+- Translation group: **PASS**
+- Duplicate/collision: **PASS**
+- Package equivalence: **PASS**
+- Public exposure: **PASS**
+- Sitemap/llms/search submission absence: **PASS**
+- CTA safety: **PASS**
+- Tracking readiness: **PASS**
+- Schema readiness: **PASS**
+- Publish event absence: **PASS**
+
+Still forbidden:
+
+- Publish remains forbidden.
+- Search submission remains forbidden.
+- Sitemap submission remains forbidden.
+- Baidu push remains forbidden.
+- IndexNow remains forbidden.
+
+## I. Validation Commands
+
+Representative commands used:
+
+```bash
+ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="..."'
+python3 - <<'PY'
+# public page/API/sitemap/llms absence checks
+PY
+git -C /Users/rainie/Desktop/GitHub/fap-web show b98cf45749e77bf7cb6c5c438ef4686dda264d0d:lib/tracking/events.ts
+git -C /Users/rainie/Desktop/GitHub/fap-web show b98cf45749e77bf7cb6c5c438ef4686dda264d0d:components/cta/SeoTrackedCtaLink.tsx
+```
+
+Report-local checks to run after this docs-only file is created:
+
+```bash
+git diff --check -- backend/docs/seo
+```
+
+## J. Next Step
+
+Recommended next task:
+
+```text
+Proceed to editorial/operator review for the two CMS drafts. Do not publish. If rendered preview is required before publish, execute SEO-CMS-CANARY-PREVIEW-01 or explicitly approve CMS-only inspection as the publish-readiness substitute.
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -40837,11 +40837,11 @@
   "SEO-CONTENT-CANARY-EN-METADATA-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-canary-en-metadata-01",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "SEO-CMS-CANARY-IMPORTER-SCHEMA-GATE-01"
     ],
-    "commit_sha": "0d8eeababcf6cdd25ab9206d21e4f3a94e2e951f",
+    "commit_sha": "2b2be0c5c14ebe3b1bd5714a1789cce2193fbb6b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1863",
     "checks": {
       "dependency_verification": {
@@ -40866,17 +40866,25 @@
           "git diff --cached --check"
         ],
         "notes": "English source artifact changed only seo_title and seo_description; English adapter changed only seo_title, seo_description, and meta_description. New lengths are seo_title=53 and seo_description=152. body_markdown, H1, FAQ, CTA labels/hrefs, internal links, publish_allowed=false, and translation_group_id remained unchanged. Isolated testing SQLite importer dry-run passed with ok=true, action=will_create, errors=[], and no real import/draft/publish was performed."
+      },
+      "github": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1863 --repo fermatmind/fap-api --json number,state,mergedAt,mergeCommit,url,headRefName,headRefOid,statusCheckRollup,mergeStateStatus"
+        ],
+        "notes": "GitHub PR #1863 is MERGED; all statusCheckRollup entries completed successfully before merge."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T02:23:18Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
       "github_checks_green": true,
-      "post_merge_revalidated": null
+      "post_merge_revalidated": true,
+      "origin_main_contains_merge_commit": true
     },
     "transitions": [
       {
@@ -40902,9 +40910,289 @@
         "from": "pr_open",
         "to": "github_checks_passed",
         "note": "GitHub checks for PR #1863 passed with mergeStateStatus=CLEAN before ledger update. No CMS draft, publish, production write action, runtime code, tests, database, routes, frontend, sitemap, Baidu, or IndexNow action was performed."
+      },
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "github_checks_passed",
+        "to": "merged",
+        "note": "Reconciled before SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01: GitHub PR #1863 is merged with merge commit 76b40c07b5eb679e7b593aca2007a77e1e56d4d7, origin/main contains that commit, and the remote task branch is absent. Publish remains forbidden."
       }
     ],
     "sidecars": [],
-    "next_task": "After merge and production deploy of this metadata artifact, rerun SEO-CONTENT-P1-08 preflight; if dry-run and absence gates pass, EN draft-only creation may be retried with separate explicit authorization. Publish remains forbidden."
+    "next_task": "SEO-CONTENT-P1-08 draft-only execution has completed; SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01 archives the passed postcheck report and keeps publish blocked."
+  },
+  "SEO-CONTENT-P1-08": {
+    "repo": "fap-api",
+    "branch": "production-controlled-importer-execution",
+    "status": "draft_created_postcheck_passed_publish_blocked_editorial_review_next",
+    "depends_on": [
+      "SEO-CONTENT-CANARY-EN-METADATA-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "draft_execution": {
+        "status": "passed",
+        "commands": [
+          "controlled production articles:import-editorial-package execution for zh-CN and en adapters after explicit user authorization"
+        ],
+        "notes": "SEO-CONTENT-P1-08 draft-only execution created zh-CN article 37 and en article 39 through the controlled editorial package importer. Both are status=draft, is_public=false, is_indexable=false, published_revision_id=null. No publish, sitemap submission, Baidu push, IndexNow, or search submission was performed."
+      },
+      "postcheck": {
+        "status": "passed",
+        "commands": [
+          "read-only production CMS/DB checks",
+          "read-only public page/API/sitemap/llms checks",
+          "deployed frontend SHA tracking readiness inspection"
+        ],
+        "notes": "SEO-CONTENT-P1-08-POSTCHECK-01 returned GO. Package equivalence, public absence, sitemap/llms absence, CTA safety, article_to_test_click readiness, and schema readiness passed. Preview gap remains."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": null,
+    "local_cleanup_executed": null,
+    "scope_validation": {
+      "drafts_created": true,
+      "postcheck_passed": true,
+      "publish_blocked": true,
+      "editorial_review_next": true,
+      "search_submission_forbidden": true
+    },
+    "drafts": {
+      "zh_CN": {
+        "article_id": 37,
+        "slug": "mbti-vs-holland-career-choice",
+        "locale": "zh-CN",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null
+      },
+      "en": {
+        "article_id": 39,
+        "slug": "mbti-vs-holland-code-career-choice",
+        "locale": "en",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null
+      },
+      "translation_group_id": "article_mbti_vs_holland_career_choice_v1"
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "authorized_draft_only_execution",
+        "to": "draft_created_postcheck_passed_publish_blocked",
+        "note": "Recorded completed SEO-CONTENT-P1-08 draft-only execution and passed postcheck. Current next step is editorial/operator review. Publish remains blocked; preview gap remains; search submission remains forbidden."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "SEO-CMS-CANARY-PREVIEW-GAP",
+        "status": "open_publish_blocker",
+        "note": "Rendered safe preview route is not confirmed. Publish requires resolving preview/noindex validation or explicitly accepting CMS-only inspection as the publish-readiness substitute."
+      },
+      {
+        "id": "SEO-CONTENT-P1-08-PUBLISH-APPROVAL",
+        "status": "required_before_publish",
+        "note": "Publish requires separate explicit approval and must not be inferred from draft creation or postcheck archive."
+      },
+      {
+        "id": "SEO-CONTENT-P1-08-SEARCH-SUBMISSION-FORBIDDEN",
+        "status": "active",
+        "note": "Sitemap submission, Baidu push, IndexNow, and search submission remain forbidden."
+      }
+    ],
+    "next_task": "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
+  },
+  "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-content-p1-08-postcheck-archive-01",
+    "status": "local_checks_passed",
+    "depends_on": [
+      "SEO-CONTENT-P1-08"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "report_archive": {
+        "status": "passed",
+        "commands": [
+          "test -f backend/docs/seo/seo-content-p1-08-postcheck-2026-06-03.md",
+          "python3 inline required-marker validation for postcheck report"
+        ],
+        "notes": "Existing postcheck report is present and contains required GO, draft state, public/API absence, sitemap/llms absence, CTA safety, article_to_test_click readiness, schema readiness, preview gap, editorial/operator review readiness, and publish-forbidden markers. Only a format marker summary line was added to satisfy exact archive wording; no content asset was rewritten."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "python3 inline required-marker validation for postcheck report"
+        ],
+        "notes": "JSON parse, YAML parse, scoped whitespace diff check, and report marker validation passed. No draft creation, publish, importer execution, production write API, content asset edit, runtime code edit, tests edit, frontend edit, sitemap submission, Baidu push, IndexNow, or search submission was performed."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "missing",
+        "to": "local_checks_pending",
+        "note": "User authorized SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01 as docs-only archive plus PR train ledger reconciliation. Scope is limited to the postcheck report and docs/codex manifest/state. No draft creation, publish, importer run, production write API, content asset edit, runtime code change, tests change, sitemap submission, Baidu push, IndexNow, or search submission is allowed."
+      },
+      {
+        "at": "2026-06-03T11:40:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed",
+        "note": "Archived the existing postcheck report, added PR train manifest/state entries for P1-08, archive, editorial review, preview, P1-09, and P1-10, reconciled #1863 as merged, and passed local docs/codex validation. Publish and search submission remain forbidden."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "preview_gap_remains",
+        "status": "open_publish_blocker",
+        "note": "Preview gap remains. Publish requires a safe preview/noindex path or explicit acceptance of CMS-only inspection before publish readiness can pass."
+      },
+      {
+        "id": "publish_requires_separate_explicit_approval",
+        "status": "active",
+        "note": "Publish remains blocked and requires a separate exact approval after review gates pass."
+      },
+      {
+        "id": "search_submission_remains_forbidden",
+        "status": "active",
+        "note": "Search submission, sitemap submission, Baidu push, and IndexNow remain forbidden."
+      }
+    ],
+    "next_task": "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
+  },
+  "SEO-CMS-CANARY-EDITORIAL-REVIEW-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-cms-canary-editorial-review-01",
+    "status": "planned",
+    "depends_on": [
+      "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "publish_blocked": true,
+      "search_submission_forbidden": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "missing",
+        "to": "planned",
+        "note": "Next planned task: editorial/operator review of the bilingual canary drafts. Do not publish. Publish remains forbidden; search submission remains forbidden."
+      }
+    ],
+    "sidecars": [],
+    "next_task": null
+  },
+  "SEO-CMS-CANARY-PREVIEW-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-cms-canary-preview-01",
+    "status": "conditional_blocked_until_preview_required",
+    "depends_on": [
+      "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "publish_blocked": true,
+      "search_submission_forbidden": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "missing",
+        "to": "conditional_blocked_until_preview_required",
+        "note": "Conditional task only if rendered preview is required before publish and CMS-only inspection is not accepted. Publish remains forbidden; search submission remains forbidden."
+      }
+    ],
+    "sidecars": [],
+    "next_task": null
+  },
+  "SEO-CONTENT-P1-09": {
+    "repo": "fap-api",
+    "branch": "codex/seo-content-p1-09",
+    "status": "blocked_until_editorial_review_and_publish_approval",
+    "depends_on": [
+      "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "publish_blocked": true,
+      "search_submission_forbidden": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "missing",
+        "to": "blocked_until_editorial_review_and_publish_approval",
+        "note": "Blocked until editorial/operator review passes and separate publish approval is granted. Publish remains forbidden; search submission remains forbidden."
+      }
+    ],
+    "sidecars": [],
+    "next_task": null
+  },
+  "SEO-REVIEW-P1-10": {
+    "repo": "fap-api",
+    "branch": "codex/seo-review-p1-10",
+    "status": "blocked_until_publish",
+    "depends_on": [
+      "SEO-CONTENT-P1-09"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {},
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "publish_blocked": true,
+      "search_submission_forbidden": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:36:00+08:00",
+        "from": "missing",
+        "to": "blocked_until_publish",
+        "note": "Blocked until controlled publish occurs. Publish remains forbidden; search submission remains forbidden."
+      }
+    ],
+    "sidecars": [],
+    "next_task": null
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41010,12 +41010,12 @@
   "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-p1-08-postcheck-archive-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "SEO-CONTENT-P1-08"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "b59a7c3ab3a8206b5cb9f5cd20001c80aa060e8e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1864",
     "checks": {
       "report_archive": {
         "status": "passed",
@@ -41034,6 +41034,13 @@
           "python3 inline required-marker validation for postcheck report"
         ],
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and report marker validation passed. No draft creation, publish, importer execution, production write API, content asset edit, runtime code edit, tests edit, frontend edit, sitemap submission, Baidu push, IndexNow, or search submission was performed."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --title \"docs(cms): archive bilingual SEO canary draft postcheck\" --body-file /tmp/seo-content-p1-08-postcheck-archive-pr-body.md --base main --head codex/seo-content-p1-08-postcheck-archive-01"
+        ],
+        "notes": "Opened PR #1864 after local docs/codex validation passed. GitHub checks are pending; merge remains blocked until required checks pass."
       }
     },
     "failure_reason": null,
@@ -41058,6 +41065,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed",
         "note": "Archived the existing postcheck report, added PR train manifest/state entries for P1-08, archive, editorial review, preview, P1-09, and P1-10, reconciled #1863 as merged, and passed local docs/codex validation. Publish and search submission remain forbidden."
+      },
+      {
+        "at": "2026-06-03T11:43:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1864. GitHub checks are pending. No draft creation, publish, importer run, CMS mutation, runtime code change, content asset edit, sitemap submission, Baidu push, IndexNow, or search submission was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20097,3 +20097,241 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: After merge and production deploy of this metadata artifact, rerun SEO-CONTENT-P1-08 preflight; if dry-run and absence gates pass, EN draft-only creation may be retried with separate explicit authorization.
+
+  - id: SEO-CONTENT-P1-08
+    repo: fap-api
+    depends_on:
+      - SEO-CONTENT-CANARY-EN-METADATA-01
+    branch: production-controlled-importer-execution
+    title: "ops(cms): execute bilingual SEO canary draft-only import"
+    train_scope: seo_cms_canary
+    status: draft_created_postcheck_passed_publish_blocked
+    scope:
+      - Record the controlled production importer draft-only execution for the first bilingual SEO canary.
+      - Record that zh-CN article 37 and en article 39 were created as non-public, non-indexable CMS drafts.
+      - Record that SEO-CONTENT-P1-08-POSTCHECK-01 passed and the next step is editorial/operator review.
+      - Keep publish, search submission, sitemap submission, Baidu push, and IndexNow blocked.
+    allowed_paths:
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - backend/docs/seo/**
+    do_not:
+      - Create additional CMS drafts, save CMS forms, publish, or call production write APIs.
+      - Modify GPT-5.5 Pro content packages, canary source artifacts, importer adapter artifacts, runtime code, routes, migrations, tests, or frontend fap-web.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+    validation:
+      - Archived by SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01.
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: true
+    database_mutation: true
+    payment_provider_call: false
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CMS-CANARY-EDITORIAL-REVIEW-01
+
+  - id: SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01
+    repo: fap-api
+    depends_on:
+      - SEO-CONTENT-P1-08
+    branch: codex/seo-content-p1-08-postcheck-archive-01
+    title: "docs(cms): archive bilingual SEO canary draft postcheck"
+    train_scope: seo_cms_canary
+    scope:
+      - Archive the existing SEO-CONTENT-P1-08 draft-only post-create validation report.
+      - Reconcile PR train manifest/state to record that both canary CMS drafts exist and postcheck passed.
+      - Record that editorial/operator review is next while publish remains blocked.
+      - Record that the preview gap remains and must be resolved or explicitly accepted as CMS-only inspection before publish.
+    allowed_paths:
+      - backend/docs/seo/seo-content-p1-08-postcheck-2026-06-03.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create CMS drafts, save CMS forms, publish, run importer, or call production write APIs.
+      - Modify GPT-5.5 Pro content packages, canary source artifacts, importer adapter artifacts, runtime code, routes, migrations, tests, package files, production config, or frontend fap-web.
+      - Submit sitemap, Baidu push, IndexNow, or any search-channel live action.
+      - Read or expose env, cookies, tokens, or real result/order/share/payment IDs.
+      - Modify title, H1, meta, body, FAQ, CTA labels, CTA hrefs, or any content prose.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CMS-CANARY-EDITORIAL-REVIEW-01
+
+  - id: SEO-CMS-CANARY-EDITORIAL-REVIEW-01
+    repo: fap-api
+    depends_on:
+      - SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01
+    branch: codex/seo-cms-canary-editorial-review-01
+    title: "docs(cms): record bilingual SEO canary editorial review"
+    train_scope: seo_cms_canary
+    status: planned
+    scope:
+      - Record authorized editorial/operator review results for the bilingual SEO canary CMS drafts.
+      - Keep publish blocked until review, preview/noindex or accepted CMS-only substitute, claim review, and explicit publish approval pass.
+    allowed_paths:
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, submit sitemap, call Baidu push, call IndexNow, create new drafts, run importer, or modify GPT content assets.
+    validation:
+      - git diff --check -- backend/docs/seo docs/codex
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CMS-CANARY-PREVIEW-01 or SEO-CONTENT-P1-09 only after review gates pass
+
+  - id: SEO-CMS-CANARY-PREVIEW-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-EDITORIAL-REVIEW-01
+    branch: codex/seo-cms-canary-preview-01
+    title: "fix(cms): add safe article draft preview gate"
+    train_scope: seo_cms_canary
+    status: conditional_blocked_until_preview_required
+    scope:
+      - Add or document a safe auth/token-gated article draft preview only if rendered preview is required before publish and CMS-only inspection is not accepted.
+      - Ensure preview is noindex, excluded from sitemap and llms, excluded from public article APIs, and safe for pre-publish rendering validation.
+    allowed_paths:
+      - backend/app/Http/Controllers/**
+      - backend/app/Services/Cms/**
+      - backend/app/Policies/**
+      - backend/tests/Feature/**
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, submit sitemap, call Baidu push, call IndexNow, modify GPT content assets, or create new CMS drafts.
+      - Execute this task unless preview is explicitly required before publish and separately authorized.
+    validation:
+      - To be defined when preview implementation is explicitly authorized.
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-CONTENT-P1-09 only after preview/CMS-only substitute and publish approval gates pass
+
+  - id: SEO-CONTENT-P1-09
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-EDITORIAL-REVIEW-01
+    branch: codex/seo-content-p1-09
+    title: "docs(cms): prepare SEO canary publish readiness"
+    train_scope: seo_cms_canary
+    status: blocked_until_editorial_review_and_publish_approval
+    scope:
+      - Prepare publish-readiness evidence only after editorial/operator review and explicit publish approval.
+    allowed_paths:
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish or submit search surfaces without separate exact approval.
+    validation:
+      - git diff --check -- backend/docs/seo docs/codex
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-REVIEW-P1-10 after publish
+
+  - id: SEO-REVIEW-P1-10
+    repo: fap-api
+    depends_on:
+      - SEO-CONTENT-P1-09
+    branch: codex/seo-review-p1-10
+    title: "docs(cms): review SEO canary post-publish signals"
+    train_scope: seo_cms_canary
+    status: blocked_until_publish
+    scope:
+      - Review post-publish public/search signals only after controlled publish occurs.
+    allowed_paths:
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, submit search surfaces, or mutate CMS state unless a separate exact authorization allows that specific action.
+    validation:
+      - git diff --check -- backend/docs/seo docs/codex
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: none


### PR DESCRIPTION
## What changed
- Archived `backend/docs/seo/seo-content-p1-08-postcheck-2026-06-03.md` for the completed bilingual SEO canary draft-only postcheck.
- Added PR train ledger entries for `SEO-CONTENT-P1-08`, `SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01`, and follow-up review/preview/publish-review tasks.
- Reconciled `SEO-CONTENT-CANARY-EN-METADATA-01` as merged before the archive step.

## Why
- `SEO-CONTENT-P1-08` created zh-CN and en CMS drafts only; the postcheck passed and needs to be archived in git.
- The train ledger needs to reflect that editorial/operator review is next while publish remains blocked.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo docs/codex`
- `git diff --cached --check`
- staged scope validation: only the postcheck report and `docs/codex` ledger files were staged

## Intentionally deferred
- No editorial/operator review in this PR.
- No `SEO-CMS-CANARY-PREVIEW-01` execution in this PR.
- No `SEO-CONTENT-P1-09` or `SEO-REVIEW-P1-10` execution in this PR.
- No publish, sitemap submission, Baidu push, IndexNow, importer execution, new draft creation, CMS mutation, runtime code change, or content asset edit.

## Repository rule impact
- CMS/backend remains the authority for article content, SEO metadata, publication state, and search exposure.
- This PR is docs-only and does not change runtime behavior, public enumeration, CMS data, content packages, tests, or frontend code.
- Publish remains blocked pending editorial/operator review, preview/noindex or accepted CMS-only inspection, claim review, and separate explicit publish approval.
