### PR TITLE
docs(cms): record bilingual SEO canary editorial review

### DIFF
--- a/backend/docs/seo/seo-cms-canary-editorial-review-2026-06-03.md
+++ b/backend/docs/seo/seo-cms-canary-editorial-review-2026-06-03.md
@@ -1,0 +1,242 @@
+# SEO-CMS-CANARY-EDITORIAL-REVIEW-01 Bilingual Canary Editorial Review
+
+Date: 2026-06-03
+
+Task type: docs-only editorial/operator review.
+
+Result: **GO: editorial/operator review passed; CMS-only inspection accepted for this canary.**
+
+Publish remains forbidden. This review does not publish, does not create a new draft, does not run importer, does not modify CMS data, and does not edit GPT-5.5 Pro content assets.
+
+## Reviewer Boundary
+
+Reviewer: Codex acting as the operator/editorial reviewer at the user's request.
+
+This is an operator-style content, SEO, safety, and workflow review. It is not a licensed psychometric, medical, legal, or external human specialist sign-off. It does not replace the separate controlled publish preflight or the explicit publish approval required by the repository rules.
+
+## Inputs Reviewed
+
+CMS draft records:
+
+- zh-CN article `37`: `mbti-vs-holland-career-choice`
+- en article `39`: `mbti-vs-holland-code-career-choice`
+- translation group: `article_mbti_vs_holland_career_choice_v1`
+
+Repository artifacts:
+
+- `backend/docs/seo/seo-content-p1-08-postcheck-2026-06-03.md`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.importer-adapter.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json`
+- `backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.package-notes.md`
+
+Read-only production checks:
+
+- Production article state, SEO robots state, import status, claim warning status, and translation group count.
+- Public page/API/sitemap/llms absence checks.
+
+## Draft State
+
+Result: **PASS**
+
+Production read-only state:
+
+| Locale | Article ID | Slug | Status | Public | Indexable | Published revision | Robots | Import status |
+| --- | ---: | --- | --- | --- | --- | --- | --- | --- |
+| zh-CN | 37 | `mbti-vs-holland-career-choice` | `draft` | false | false | null | `noindex,nofollow` | `warning` |
+| en | 39 | `mbti-vs-holland-code-career-choice` | `draft` | false | false | null | `noindex,nofollow` | `imported` |
+
+Additional checks:
+
+- Same `translation_group_id` count: `2`.
+- Public/indexable/published count for the two slugs: `0`.
+- Both articles remain draft-only and fail-closed.
+- No publish action was performed.
+
+## Editorial Content Review
+
+Result: **PASS**
+
+Scope of review:
+
+- Title / H1 intent alignment.
+- SEO title / description suitability and length.
+- Article structure and heading completeness.
+- FAQ completeness and alignment with body intent.
+- CTA slot consistency and target safety.
+- Claim boundary and non-diagnostic framing.
+- Bilingual parity at intent, structure, FAQ, CTA, and translation group levels.
+
+Observed structure:
+
+| Locale | H1 count | Heading count | FAQ count | CTA count | Primary CTA |
+| --- | ---: | ---: | ---: | ---: | --- |
+| zh-CN | 1 | 23 | 5 | 3 | `/zh/tests/holland-career-interest-test-riasec` |
+| en | 1 | 23 | 5 | 3 | `/en/tests/holland-career-interest-test-riasec` |
+
+Editorial findings:
+
+- Both versions answer the same search intent: comparing MBTI and Holland/RIASEC for career choice.
+- Both versions lead with the same practical conclusion: Holland/RIASEC is the stronger starting point for career-interest direction; MBTI is a supplement for work style.
+- Both versions include the same conceptual flow: quick answer, RIASEC explanation, MBTI explanation, when to use each, combined method, mistakes, final recommendation, FAQ.
+- Both versions preserve non-deterministic language and repeatedly state that assessments support decision-making rather than deciding career outcomes.
+- Both versions point users back to real job validation, skills, experience, course/project/internship evidence, and work environment checks.
+- English approved short SEO metadata is present and within field limits.
+- Chinese SEO metadata is concise and aligned with the article intent.
+- The content is suitable for editorial/operator review completion.
+
+No content rewrite was performed.
+
+## Claim Boundary Review
+
+Result: **PASS with publish-preflight acknowledgement still required where the controlled publish command demands it.**
+
+English import status:
+
+- `imported`
+- warnings count: `0`
+- claim matches count: `0`
+
+Chinese import status:
+
+- `warning`
+- warnings count: `2`
+- claim matches count: `2`
+
+Chinese warning review:
+
+- Phrase `医学诊断` appears in a boundary sentence stating that Holland/RIASEC is not a medical diagnosis.
+- Phrase `一定适合` appears in a boundary sentence stating that MBTI should not directly judge whether a career is definitely suitable or unsuitable.
+- Both matches were recorded with `boundary_context=true`.
+
+Operator decision:
+
+- The Chinese warnings are acceptable as boundary-context disclaimers for editorial review.
+- They are not positive claims and do not require content rewrite in this task.
+- They do not authorize publish.
+- Controlled publish preflight may still require explicit warning acknowledgement for article `37`; that acknowledgement must happen only in a later publish-authorized task.
+
+Forbidden positive-claim review:
+
+- No guaranteed outcome claim accepted.
+- No medical/psychological diagnostic positioning accepted.
+- No "official MBTI" or unsupported authority claim accepted.
+- No deterministic career-destiny framing accepted.
+- No treatment, depression diagnosis, or anxiety diagnosis framing accepted.
+
+## CTA Review
+
+Result: **PASS**
+
+CTA placeholders match adapter CTA slots in both locales:
+
+- `article_mbti_vs_holland_primary_riasec`
+- `article_mbti_vs_holland_secondary_mbti`
+- `article_mbti_vs_holland_tertiary_big_five`
+
+CTA targets:
+
+| Locale | Priority | Target |
+| --- | --- | --- |
+| zh-CN | primary | `/zh/tests/holland-career-interest-test-riasec` |
+| zh-CN | secondary | `/zh/tests/mbti-personality-test-16-personality-types` |
+| zh-CN | tertiary | `/zh/tests/big-five-personality-test-ocean-model` |
+| en | primary | `/en/tests/holland-career-interest-test-riasec` |
+| en | secondary | `/en/tests/mbti-personality-test-16-personality-types` |
+| en | tertiary | `/en/tests/big-five-personality-test-ocean-model` |
+
+Safety decision:
+
+- CTA targets are public canonical test routes.
+- No CTA target contains result, orders, share, pay, payment, history, take, token, an external URL, or an unsafe scheme.
+- CTA events remain `article_to_test_click`.
+- CTA review does not authorize publish or search submission.
+
+## Public Exposure Review
+
+Result: **PASS**
+
+Read-only checks:
+
+| Surface | Result |
+| --- | --- |
+| `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice` | 404 |
+| `https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice` | 404 |
+| `/api/v0.5/articles/mbti-vs-holland-career-choice` | 404 |
+| `/api/v0.5/articles/mbti-vs-holland-career-choice/seo` | 404 |
+| `/api/v0.5/articles/mbti-vs-holland-code-career-choice` | 404 |
+| `/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo` | 404 |
+| `sitemap.xml` | target slugs absent |
+| `llms.txt` | target slugs absent |
+| `llms-full.txt` | target slugs absent |
+
+Note: The generic 404 page shell may include the requested path in its body. This is not article content exposure and does not expose Article/FAQ/Breadcrumb schema.
+
+## CMS-Only Inspection Decision
+
+Decision: **Accepted for this canary.**
+
+Rationale:
+
+- Postcheck already proved production CMS draft state, package equivalence, public API absence, public page absence, sitemap/llms absence, CTA safety, tracking readiness, and schema data readiness.
+- This editorial review directly inspected the approved adapter artifacts and production draft state.
+- CTA placeholders match CTA slot IDs.
+- The content is markdown-only with standard headings, tables, FAQ sections, and CMS CTA placeholders; no bespoke interactive rendering dependency was found.
+- The remaining preview gap is a publish-process risk, not a content correctness blocker for this specific canary.
+
+Scope of acceptance:
+
+- Accepted as the editorial/operator review inspection path for the current bilingual canary drafts.
+- Accepted as a preview substitute for this canary unless a later publish preflight or operator requirement explicitly requires rendered preview.
+- Does not authorize publish.
+- Does not authorize search submission.
+- Does not waive controlled publish preflight.
+- Does not waive explicit publish approval.
+- Does not waive any claim-warning acknowledgement required by the controlled publish command.
+
+Preview task decision:
+
+- `SEO-CMS-CANARY-PREVIEW-01` is not required before this canary can proceed to publish-readiness planning.
+- `SEO-CMS-CANARY-PREVIEW-01` remains conditional for future canaries or if a later reviewer rejects CMS-only inspection.
+
+## Publish Boundary
+
+Publish status: **blocked**
+
+The following remain forbidden:
+
+- Publish.
+- Sitemap submission.
+- Baidu push.
+- IndexNow.
+- Search submission.
+- CMS mutation outside separately authorized controlled publish flow.
+- GPT-5.5 Pro content rewrite.
+
+Before publish can be considered, a separate task must run controlled publish preflight and obtain explicit publish approval. The later publish task must repeat public/sitemap/llms checks and handle any controlled publish warning acknowledgements explicitly.
+
+## Decision
+
+**GO: editorial/operator review passed.**
+
+Status after this task:
+
+- zh-CN draft: accepted for editorial/operator review.
+- en draft: accepted for editorial/operator review.
+- CMS-only inspection: accepted for this canary.
+- `SEO-CMS-CANARY-PREVIEW-01`: not required for this canary unless later publish preflight requires rendered preview.
+- `SEO-CONTENT-P1-09`: may proceed only as publish-readiness planning; actual publish remains blocked until separate explicit approval.
+- `SEO-REVIEW-P1-10`: remains blocked until publish.
+
+## Validation Commands
+
+Commands used for this docs-only review:
+
+```bash
+python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.importer-adapter.json >/dev/null
+python3 -m json.tool backend/docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json >/dev/null
+ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="..."'
+python3 - <<'PY'
+# public page/API/sitemap/llms absence checks
+PY
+git diff --check -- backend/docs/seo docs/codex
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41112,12 +41112,12 @@
   "SEO-CMS-CANARY-EDITORIAL-REVIEW-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-editorial-review-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "depends_on": [
       "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "11d13f6f65f05d5bb8493feb82385a0e7a40ee38",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1865",
     "checks": {
       "dependency_reconciliation": {
         "status": "passed",
@@ -41179,6 +41179,13 @@
           "git diff --cached --check"
         ],
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed after path-limited staging. No publish, search submission, importer execution, new draft creation, CMS mutation, runtime code edit, test edit, frontend edit, or GPT content asset edit was performed."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-cms-canary-editorial-review-01 --title \"docs(cms): record bilingual SEO canary editorial review\""
+        ],
+        "notes": "Opened PR #1865 after local docs/codex validation passed. GitHub checks are pending; merge remains blocked until required checks pass. Publish remains forbidden."
       }
     },
     "failure_reason": null,
@@ -41216,6 +41223,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed",
         "note": "Created the docs-only editorial review report, reconciled #1864 as merged, updated preview/P1-09 ledger state, and passed local JSON/YAML/diff validation. CMS-only inspection is accepted for the current canary; publish remains forbidden."
+      },
+      {
+        "at": "2026-06-03T12:15:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1865. GitHub checks are pending. No publish, search submission, importer execution, new draft creation, CMS mutation, runtime code change, test change, frontend change, or GPT content asset edit was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41010,11 +41010,11 @@
   "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-p1-08-postcheck-archive-01",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "SEO-CONTENT-P1-08"
     ],
-    "commit_sha": "b59a7c3ab3a8206b5cb9f5cd20001c80aa060e8e",
+    "commit_sha": "5b34332c7791d9900f73e4be5138c47d1518d0a4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1864",
     "checks": {
       "report_archive": {
@@ -41036,22 +41036,33 @@
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and report marker validation passed. No draft creation, publish, importer execution, production write API, content asset edit, runtime code edit, tests edit, frontend edit, sitemap submission, Baidu push, IndexNow, or search submission was performed."
       },
       "pr": {
-        "status": "opened",
+        "status": "merged",
         "commands": [
           "gh pr create --repo fermatmind/fap-api --title \"docs(cms): archive bilingual SEO canary draft postcheck\" --body-file /tmp/seo-content-p1-08-postcheck-archive-pr-body.md --base main --head codex/seo-content-p1-08-postcheck-archive-01"
         ],
-        "notes": "Opened PR #1864 after local docs/codex validation passed. GitHub checks are pending; merge remains blocked until required checks pass."
+        "notes": "PR #1864 merged as 5b34332c7791d9900f73e4be5138c47d1518d0a4 on 2026-06-03T03:45:55Z."
+      },
+      "post_merge_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1864 --repo fermatmind/fap-api --json state,mergeCommit,mergedAt,headRefName,baseRefName,url,title",
+          "git fetch origin main --prune",
+          "git merge-base --is-ancestor 5b34332c7791d9900f73e4be5138c47d1518d0a4 origin/main",
+          "git branch --list codex/seo-content-p1-08-postcheck-archive-01",
+          "git branch -r --list origin/codex/seo-content-p1-08-postcheck-archive-01"
+        ],
+        "notes": "GitHub shows PR #1864 merged, origin/main contains the merge commit, and the local/remote task branches are absent. This reconciliation is bookkeeping only to unblock SEO-CMS-CANARY-EDITORIAL-REVIEW-01."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T03:45:55Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null
+      "github_checks_green": true,
+      "post_merge_revalidated": true
     },
     "transitions": [
       {
@@ -41071,6 +41082,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1864. GitHub checks are pending. No draft creation, publish, importer run, CMS mutation, runtime code change, content asset edit, sitemap submission, Baidu push, IndexNow, or search submission was performed."
+      },
+      {
+        "at": "2026-06-03T12:05:10+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CMS-CANARY-EDITORIAL-REVIEW-01: GitHub PR #1864 is merged, origin/main contains merge commit 5b34332c7791d9900f73e4be5138c47d1518d0a4, and local/remote task branches are absent."
       }
     ],
     "sidecars": [
@@ -41095,20 +41112,91 @@
   "SEO-CMS-CANARY-EDITORIAL-REVIEW-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-editorial-review-01",
-    "status": "planned",
+    "status": "local_checks_passed",
     "depends_on": [
       "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01"
     ],
     "commit_sha": null,
     "pr_url": null,
-    "checks": {},
+    "checks": {
+      "dependency_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1864 --repo fermatmind/fap-api --json state,mergeCommit,mergedAt,headRefName,baseRefName,url,title",
+          "git merge-base --is-ancestor 5b34332c7791d9900f73e4be5138c47d1518d0a4 origin/main"
+        ],
+        "notes": "Dependency SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01 is merged and origin/main contains merge commit 5b34332c7791d9900f73e4be5138c47d1518d0a4."
+      },
+      "editorial_review": {
+        "status": "passed",
+        "commands": [
+          "Manual/operator review of production draft state and importer adapter artifacts",
+          "python3 inline adapter structure and CTA placeholder inspection"
+        ],
+        "notes": "Codex acted as the operator/editorial reviewer at the user's request. Both locales passed title/H1 intent, structure, FAQ, CTA, bilingual parity, and non-deterministic framing review. No content rewrite was performed."
+      },
+      "production_draft_state": {
+        "status": "passed",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"...\"'"
+        ],
+        "notes": "Production read-only checks confirmed zh-CN article 37 and en article 39 remain status=draft, is_public=false, is_indexable=false, published_revision_id=null, robots=noindex,nofollow, and the translation group count is 2. Public/indexable/published count for the two slugs is 0."
+      },
+      "claim_boundary_review": {
+        "status": "passed_with_publish_acknowledgement_still_required",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"...\"'"
+        ],
+        "notes": "English has 0 claim warnings. Chinese has 2 boundary_context=true warnings for boundary/disclaimer sentences: 医学诊断 and 一定适合. These are acceptable for editorial review but may require explicit acknowledgement in a later controlled publish preflight. Publish remains forbidden."
+      },
+      "cta_review": {
+        "status": "passed",
+        "commands": [
+          "python3 inline adapter CTA placeholder and target route validation"
+        ],
+        "notes": "CTA placeholders match adapter CTA slots. CTA targets are public canonical test routes and do not include result, orders, share, pay, payment, history, take, tokenized, external, or unsafe URLs."
+      },
+      "public_exposure_review": {
+        "status": "passed",
+        "commands": [
+          "python3 inline public page/API/sitemap/llms absence checks"
+        ],
+        "notes": "Public article pages and public article/SEO APIs still return 404 for both target slugs. sitemap.xml, llms.txt, and llms-full.txt do not contain either slug. No publish or search submission was performed."
+      },
+      "cms_only_inspection": {
+        "status": "accepted_for_current_canary",
+        "commands": [
+          "Manual/operator decision recorded in backend/docs/seo/seo-cms-canary-editorial-review-2026-06-03.md"
+        ],
+        "notes": "CMS-only inspection is accepted as the editorial/operator review path and preview substitute for this bilingual canary unless a later publish preflight or reviewer explicitly requires rendered preview. This does not authorize publish."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed after path-limited staging. No publish, search submission, importer execution, new draft creation, CMS mutation, runtime code edit, test edit, frontend edit, or GPT content asset edit was performed."
+      }
+    },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null,
       "publish_blocked": true,
-      "search_submission_forbidden": true
+      "search_submission_forbidden": true,
+      "cms_only_inspection_accepted_for_current_canary": true,
+      "cms_mutation_performed": false,
+      "importer_run_performed": false,
+      "content_asset_edit_performed": false,
+      "runtime_code_edit_performed": false
     },
     "transitions": [
       {
@@ -41116,15 +41204,48 @@
         "from": "missing",
         "to": "planned",
         "note": "Next planned task: editorial/operator review of the bilingual canary drafts. Do not publish. Publish remains forbidden; search submission remains forbidden."
+      },
+      {
+        "at": "2026-06-03T12:05:10+08:00",
+        "from": "planned",
+        "to": "local_checks_pending",
+        "note": "Recorded bilingual canary editorial/operator review. CMS-only inspection is accepted for this canary; publish, search submission, importer execution, new draft creation, CMS mutation, runtime code edits, tests edits, frontend edits, and GPT content asset edits remain forbidden."
+      },
+      {
+        "at": "2026-06-03T12:11:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed",
+        "note": "Created the docs-only editorial review report, reconciled #1864 as merged, updated preview/P1-09 ledger state, and passed local JSON/YAML/diff validation. CMS-only inspection is accepted for the current canary; publish remains forbidden."
       }
     ],
-    "sidecars": [],
-    "next_task": null
+    "sidecars": [
+      {
+        "id": "cms_only_inspection_accepted_current_canary",
+        "status": "accepted",
+        "note": "Accepted as the editorial/operator inspection path and preview substitute for this bilingual canary unless a later publish preflight or reviewer explicitly requires rendered preview."
+      },
+      {
+        "id": "claim_warning_acknowledgement_required_if_publish",
+        "status": "active_publish_gate",
+        "note": "Chinese article 37 has two boundary_context=true claim warnings. They are acceptable for editorial review, but a later controlled publish preflight may require explicit acknowledgement before publish."
+      },
+      {
+        "id": "publish_requires_separate_explicit_approval",
+        "status": "active",
+        "note": "Publish remains blocked and requires separate exact approval plus controlled publish preflight. This review does not authorize publish."
+      },
+      {
+        "id": "search_submission_remains_forbidden",
+        "status": "active",
+        "note": "Sitemap submission, Baidu push, IndexNow, and search submission remain forbidden."
+      }
+    ],
+    "next_task": "SEO-CONTENT-P1-09 publish-readiness planning only after separate authorization; publish remains forbidden."
   },
   "SEO-CMS-CANARY-PREVIEW-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-preview-01",
-    "status": "conditional_blocked_until_preview_required",
+    "status": "conditional_not_required_for_current_canary_cms_only_accepted",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
@@ -41137,7 +41258,8 @@
     "local_cleanup_executed": false,
     "scope_validation": {
       "publish_blocked": true,
-      "search_submission_forbidden": true
+      "search_submission_forbidden": true,
+      "cms_only_inspection_accepted_for_current_canary": true
     },
     "transitions": [
       {
@@ -41145,15 +41267,27 @@
         "from": "missing",
         "to": "conditional_blocked_until_preview_required",
         "note": "Conditional task only if rendered preview is required before publish and CMS-only inspection is not accepted. Publish remains forbidden; search submission remains forbidden."
+      },
+      {
+        "at": "2026-06-03T12:05:10+08:00",
+        "from": "conditional_blocked_until_preview_required",
+        "to": "conditional_not_required_for_current_canary_cms_only_accepted",
+        "note": "SEO-CMS-CANARY-EDITORIAL-REVIEW-01 accepted CMS-only inspection for the current bilingual canary. Preview implementation is not required for this canary unless a later publish preflight or reviewer explicitly rejects CMS-only inspection. Publish remains forbidden."
       }
     ],
-    "sidecars": [],
+    "sidecars": [
+      {
+        "id": "not_required_for_current_canary",
+        "status": "active",
+        "note": "CMS-only inspection was accepted for the current bilingual canary; this preview implementation task remains conditional for future canaries or later reviewer/preflight rejection."
+      }
+    ],
     "next_task": null
   },
   "SEO-CONTENT-P1-09": {
     "repo": "fap-api",
     "branch": "codex/seo-content-p1-09",
-    "status": "blocked_until_editorial_review_and_publish_approval",
+    "status": "planned_publish_readiness_only_publish_blocked",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
@@ -41166,7 +41300,9 @@
     "local_cleanup_executed": false,
     "scope_validation": {
       "publish_blocked": true,
-      "search_submission_forbidden": true
+      "search_submission_forbidden": true,
+      "editorial_review_passed": true,
+      "cms_only_inspection_accepted_for_current_canary": true
     },
     "transitions": [
       {
@@ -41174,10 +41310,22 @@
         "from": "missing",
         "to": "blocked_until_editorial_review_and_publish_approval",
         "note": "Blocked until editorial/operator review passes and separate publish approval is granted. Publish remains forbidden; search submission remains forbidden."
+      },
+      {
+        "at": "2026-06-03T12:05:10+08:00",
+        "from": "blocked_until_editorial_review_and_publish_approval",
+        "to": "planned_publish_readiness_only_publish_blocked",
+        "note": "Editorial/operator review passed and CMS-only inspection was accepted for the current bilingual canary. SEO-CONTENT-P1-09 may be separately authorized for publish-readiness planning only. Actual publish remains blocked until separate exact approval and controlled publish preflight pass."
       }
     ],
-    "sidecars": [],
-    "next_task": null
+    "sidecars": [
+      {
+        "id": "publish_still_requires_exact_approval",
+        "status": "active",
+        "note": "This readiness task must not publish by implication. Controlled publish requires a later exact approval and preflight."
+      }
+    ],
+    "next_task": "SEO-REVIEW-P1-10 only after controlled publish with separate exact approval"
   },
   "SEO-REVIEW-P1-10": {
     "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20147,6 +20147,7 @@ prs:
     branch: codex/seo-content-p1-08-postcheck-archive-01
     title: "docs(cms): archive bilingual SEO canary draft postcheck"
     train_scope: seo_cms_canary
+    status: merged
     scope:
       - Archive the existing SEO-CONTENT-P1-08 draft-only post-create validation report.
       - Reconcile PR train manifest/state to record that both canary CMS drafts exist and postcheck passed.
@@ -20192,10 +20193,10 @@ prs:
     branch: codex/seo-cms-canary-editorial-review-01
     title: "docs(cms): record bilingual SEO canary editorial review"
     train_scope: seo_cms_canary
-    status: planned
+    status: editorial_review_passed_cms_only_accepted_publish_blocked
     scope:
       - Record authorized editorial/operator review results for the bilingual SEO canary CMS drafts.
-      - Keep publish blocked until review, preview/noindex or accepted CMS-only substitute, claim review, and explicit publish approval pass.
+      - Record CMS-only inspection acceptance for this canary while keeping publish blocked until controlled publish preflight, any required claim-warning acknowledgement, and separate explicit publish approval pass.
     allowed_paths:
       - backend/docs/seo/**
       - docs/codex/pr-train.yaml
@@ -20220,7 +20221,7 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: SEO-CMS-CANARY-PREVIEW-01 or SEO-CONTENT-P1-09 only after review gates pass
+    next_task: SEO-CONTENT-P1-09 publish-readiness planning only after separate authorization; publish remains forbidden
 
   - id: SEO-CMS-CANARY-PREVIEW-01
     repo: fap-api
@@ -20229,10 +20230,11 @@ prs:
     branch: codex/seo-cms-canary-preview-01
     title: "fix(cms): add safe article draft preview gate"
     train_scope: seo_cms_canary
-    status: conditional_blocked_until_preview_required
+    status: conditional_not_required_for_current_canary_cms_only_accepted
     scope:
       - Add or document a safe auth/token-gated article draft preview only if rendered preview is required before publish and CMS-only inspection is not accepted.
       - Ensure preview is noindex, excluded from sitemap and llms, excluded from public article APIs, and safe for pre-publish rendering validation.
+      - Current bilingual canary accepted CMS-only inspection, so this task is not required for the current canary unless a later publish preflight or reviewer explicitly rejects that substitute.
     allowed_paths:
       - backend/app/Http/Controllers/**
       - backend/app/Services/Cms/**
@@ -20262,7 +20264,7 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: SEO-CONTENT-P1-09 only after preview/CMS-only substitute and publish approval gates pass
+    next_task: None for current canary unless preview is later explicitly required
 
   - id: SEO-CONTENT-P1-09
     repo: fap-api
@@ -20271,9 +20273,10 @@ prs:
     branch: codex/seo-content-p1-09
     title: "docs(cms): prepare SEO canary publish readiness"
     train_scope: seo_cms_canary
-    status: blocked_until_editorial_review_and_publish_approval
+    status: planned_publish_readiness_only_publish_blocked
     scope:
-      - Prepare publish-readiness evidence only after editorial/operator review and explicit publish approval.
+      - Prepare publish-readiness evidence after editorial/operator review passed and CMS-only inspection was accepted for this canary.
+      - Actual publish remains blocked until a separate exact approval and controlled publish preflight pass.
     allowed_paths:
       - backend/docs/seo/**
       - docs/codex/pr-train.yaml
@@ -20298,7 +20301,7 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: SEO-REVIEW-P1-10 after publish
+    next_task: SEO-REVIEW-P1-10 only after controlled publish with separate exact approval
 
   - id: SEO-REVIEW-P1-10
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added the bilingual SEO canary editorial/operator review report.
- Recorded that CMS-only inspection is accepted for this canary while publish remains blocked.
- Reconciled the prior postcheck archive PR #1864 as merged in the PR train ledger.
- Updated preview/P1-09 ledger state to reflect that preview is conditional for this canary and publish-readiness remains publish-blocked.

## Why
- SEO-CMS-CANARY-EDITORIAL-REVIEW-01 requires an operator/editorial decision before any publish-readiness discussion can continue.
- The current task is docs-only bookkeeping and review evidence; it must not mutate CMS data or publish content.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo docs/codex`
- `git diff --cached --check`

## Intentionally deferred
- No publish.
- No sitemap submission, Baidu push, IndexNow, or search submission.
- No importer run, no new draft creation, and no CMS mutation.
- No GPT-5.5 Pro content rewrite.
- No runtime code, route, migration, test, or frontend changes.
- Later controlled publish preflight may still require explicit acknowledgement of the zh-CN boundary-context claim warnings.

## Repository rule impact
- CMS/backend remains the content authority.
- No public SEO enumeration/runtime behavior changes are introduced.
- No deploy is required for this docs-only PR.