### PR TITLE
docs(cms): run SEO canary publish preflight

### DIFF
--- a/backend/docs/seo/seo-content-p1-09-publish-preflight-2026-06-03.md
+++ b/backend/docs/seo/seo-content-p1-09-publish-preflight-2026-06-03.md
@@ -1,0 +1,251 @@
+# SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01 Controlled Publish Preflight
+
+Date: 2026-06-03
+
+Task type: controlled publish preflight / read-only production validation.
+
+Result: **NO-GO: do not publish.**
+
+No publish action was performed. No CMS data was modified. No new draft was created. No sitemap, Baidu, IndexNow, or search submission action was performed. No GPT-5.5 Pro content package text was authored, rewritten, or edited.
+
+## Scope Boundary
+
+Allowed actions performed:
+
+- Read-only production CMS/DB checks through the current backend release.
+- Controlled `articles:publish-controlled` dry-run checks only.
+- Read-only public page, public API, sitemap, `llms.txt`, and `llms-full.txt` absence checks.
+- Docs-only report and PR train ledger update.
+
+Explicitly not performed:
+
+- No publish.
+- No CMS content mutation.
+- No new draft creation.
+- No importer run.
+- No sitemap submission.
+- No Baidu push.
+- No IndexNow call.
+- No production write API call.
+- No runtime code change.
+- No frontend change.
+- No result/order/share/payment ID access.
+- No env/cookie/token disclosure.
+
+## Production Context
+
+Backend current release path:
+
+- `/var/www/fap-api/current/backend`
+- Resolved release path observed by read-only check: `/var/www/fap-api/releases/backend-main-20260603-76b40c07/backend`
+
+Controlled publish command:
+
+```bash
+php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --json
+php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --ack-claim-warning=37 --json
+```
+
+Canary drafts:
+
+- zh-CN: article `37`, slug `mbti-vs-holland-career-choice`, working revision `42`
+- en: article `39`, slug `mbti-vs-holland-code-career-choice`, working revision `44`
+- translation group: `article_mbti_vs_holland_career_choice_v1`
+
+## A. Before/After No-Write Validation
+
+Result: **PASS**
+
+Production counts before dry-run:
+
+| Table / surface | Count |
+| --- | ---: |
+| `articles` | 36 |
+| `article_translation_revisions` | 43 |
+| `article_seo_meta` | 32 |
+| `article_editorial_package_imports` | 10 |
+| publish audit events for target articles | 0 |
+
+Production counts after dry-run:
+
+| Table / surface | Count |
+| --- | ---: |
+| `articles` | 36 |
+| `article_translation_revisions` | 43 |
+| `article_seo_meta` | 32 |
+| `article_editorial_package_imports` | 10 |
+| publish audit events for target articles | 0 |
+
+Target article state after dry-run:
+
+| Locale | Article ID | Slug | Status | Public | Indexable | Published revision | Published at | Working revision |
+| --- | ---: | --- | --- | --- | --- | --- | --- | ---: |
+| zh-CN | 37 | `mbti-vs-holland-career-choice` | `draft` | false | false | null | null | 42 |
+| en | 39 | `mbti-vs-holland-code-career-choice` | `draft` | false | false | null | null | 44 |
+
+Decision:
+
+- `--dry-run` did not write DB rows.
+- Both target articles remained draft-only and fail-closed.
+- No publish audit event was created.
+
+## B. Controlled Publish Dry-Run
+
+Result: **NO-GO**
+
+### Without claim-warning acknowledgement
+
+Command:
+
+```bash
+php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --json
+```
+
+Summary:
+
+- `ok=false`
+- `dry_run=true`
+- `published_article_ids=[]`
+- expected confirmation emitted by command: `I explicitly approve Codex to publish article ids 37,39 after preflight passes.`
+
+Blocking errors:
+
+| Article ID | Locale | Error code | Meaning |
+| ---: | --- | --- | --- |
+| 37 | zh-CN | `revision_not_editorially_approved` | Working revision is not in the publishable `approved` state. |
+| 37 | zh-CN | `claim_warning_ack_required` | Boundary-context claim warnings require explicit acknowledgement before publish. |
+| 39 | en | `revision_not_editorially_approved` | Working revision is not in the publishable `approved` state. |
+
+### With zh-CN claim-warning acknowledgement
+
+Command:
+
+```bash
+php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --ack-claim-warning=37 --json
+```
+
+Summary:
+
+- `ok=false`
+- `dry_run=true`
+- `published_article_ids=[]`
+- zh-CN `claim_warning_acknowledged=true`
+- expected confirmation emitted by command: `I explicitly approve Codex to publish article ids 37,39 after preflight passes.`
+
+Remaining blocking errors:
+
+| Article ID | Locale | Error code | Meaning |
+| ---: | --- | --- | --- |
+| 37 | zh-CN | `revision_not_editorially_approved` | Working revision is not in the publishable `approved` state. |
+| 39 | en | `revision_not_editorially_approved` | Working revision is not in the publishable `approved` state. |
+
+Working revision state after dry-run:
+
+| Revision ID | Article ID | Locale | Revision status | Reviewed by present | Reviewed at present | Approved at present | Published at |
+| ---: | ---: | --- | --- | --- | --- | --- | --- |
+| 42 | 37 | zh-CN | `machine_draft` | false | false | false | null |
+| 44 | 39 | en | `machine_draft` | false | false | false | null |
+
+Decision:
+
+- Controlled publish dry-run is functioning and fail-closed.
+- The zh-CN claim warning acknowledgement gate is required for article `37`.
+- Acknowledging article `37` in dry-run clears only the claim-warning acknowledgement blocker.
+- Both articles still fail because their working revisions are `machine_draft`, not `approved`.
+- This preflight does not authorize publish.
+
+## C. Public Absence
+
+Result: **PASS**
+
+Read-only public checks:
+
+| Surface | Status | Target slug exposure |
+| --- | ---: | --- |
+| `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice` | 404 | generic 404 body echoes requested path only |
+| `https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice` | 404 | generic 404 body echoes requested path only |
+| `/api/v0.5/articles/mbti-vs-holland-career-choice` | 404 | absent |
+| `/api/v0.5/articles/mbti-vs-holland-career-choice/seo` | 404 | absent |
+| `/api/v0.5/articles/mbti-vs-holland-code-career-choice` | 404 | absent |
+| `/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo` | 404 | absent |
+| `sitemap.xml` | 200 | absent |
+| `llms.txt` | 200 | absent |
+| `llms-full.txt` | 200 | absent |
+
+Decision:
+
+- Draft article pages remain unavailable publicly.
+- Public article APIs remain unavailable.
+- Public SEO APIs remain unavailable.
+- Sitemap and LLM surfaces do not enumerate either target slug.
+- The generic 404 page may echo the requested path, but it does not expose article content or article schema.
+
+## D. GO / NO-GO
+
+**NO-GO: do not publish.**
+
+Blockers:
+
+1. zh-CN working revision `42` is `machine_draft`, not `approved`.
+2. en working revision `44` is `machine_draft`, not `approved`.
+3. zh-CN article `37` has boundary-context claim warnings that must be explicitly acknowledged during a later controlled publish attempt.
+
+Non-blocking checks:
+
+- Controlled publish dry-run command exists.
+- Dry-run did not write DB.
+- `--make-indexable` was included in dry-run and removed the noindex/indexability blocker from the dry-run plan.
+- Media status is `complete` for both articles.
+- Graph status is `complete` for both articles.
+- References count is `4` for both articles.
+- CTA count is `3` for both articles.
+- FAQ count is `5` for both articles.
+- Public absence remains PASS.
+
+## E. Publish Confirmation Boundary
+
+No actionable publish confirmation phrase is issued by this preflight because the result is NO-GO.
+
+The controlled command emitted this expected confirmation phrase during dry-run:
+
+```text
+I explicitly approve Codex to publish article ids 37,39 after preflight passes.
+```
+
+That phrase must not be used yet. A later publish attempt remains forbidden until:
+
+1. Both working revisions are approved through an authorized CMS/operator workflow.
+2. Controlled publish preflight is rerun and returns `ok=true`.
+3. The later task explicitly includes `--ack-claim-warning=37` or equivalent acknowledgement for the zh-CN boundary-context warnings.
+4. The user gives a separate exact publish authorization after preflight passes.
+
+## F. Recommended Next Step
+
+Recommended next step: obtain authorized operator approval for working revisions `42` and `44`, without publishing, then rerun this controlled publish preflight.
+
+Suggested follow-up PR train item, if the operator approval path needs documentation before action:
+
+- proposed id: `SEO-CONTENT-P1-09-REVISION-APPROVAL-GATE-01`
+- proposed title: `docs(cms): verify SEO canary revision approval gate`
+- proposed scope: document or verify the authorized CMS/operator path for approving working revisions `42` and `44` without publishing
+- likely files: `backend/docs/seo/**`, `docs/codex/pr-train.yaml`, `docs/codex/pr-train-state.json`
+- required checks: JSON parse, YAML parse, `git diff --check -- backend/docs/seo docs/codex`
+- dependency assumption: `SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01` merged
+
+Follow-up execution prompt:
+
+```text
+明确授权在 fap-api 新增并执行 SEO-CONTENT-P1-09-REVISION-APPROVAL-GATE-01，验证或记录中英文 canary working revisions 42/44 的 authorized operator approval path。不要 publish。
+```
+
+## Validation Commands
+
+```bash
+php backend/artisan articles:publish-controlled --help
+ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --json'
+ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --ack-claim-warning=37 --json'
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/seo docs/codex
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41112,11 +41112,11 @@
   "SEO-CMS-CANARY-EDITORIAL-REVIEW-01": {
     "repo": "fap-api",
     "branch": "codex/seo-cms-canary-editorial-review-01",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01"
     ],
-    "commit_sha": "11d13f6f65f05d5bb8493feb82385a0e7a40ee38",
+    "commit_sha": "765baf1fb9a8861efc37b525d35bc5c0cc8a1528",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1865",
     "checks": {
       "dependency_reconciliation": {
@@ -41181,22 +41181,30 @@
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed after path-limited staging. No publish, search submission, importer execution, new draft creation, CMS mutation, runtime code edit, test edit, frontend edit, or GPT content asset edit was performed."
       },
       "pr": {
-        "status": "opened",
+        "status": "merged",
         "commands": [
           "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-cms-canary-editorial-review-01 --title \"docs(cms): record bilingual SEO canary editorial review\""
         ],
-        "notes": "Opened PR #1865 after local docs/codex validation passed. GitHub checks are pending; merge remains blocked until required checks pass. Publish remains forbidden."
+        "notes": "PR #1865 merged as 765baf1fb9a8861efc37b525d35bc5c0cc8a1528 on 2026-06-03T04:15:49Z. Publish remains forbidden."
+      },
+      "post_merge_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1865 --repo fermatmind/fap-api --json state,mergeCommit,mergedAt,headRefName,url,title",
+          "git merge-base --is-ancestor 765baf1fb9a8861efc37b525d35bc5c0cc8a1528 origin/main"
+        ],
+        "notes": "GitHub shows PR #1865 merged and origin/main contains merge commit 765baf1fb9a8861efc37b525d35bc5c0cc8a1528. This reconciliation is bookkeeping only to unblock SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T04:15:49Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "publish_blocked": true,
       "search_submission_forbidden": true,
       "cms_only_inspection_accepted_for_current_canary": true,
@@ -41229,6 +41237,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1865. GitHub checks are pending. No publish, search submission, importer execution, new draft creation, CMS mutation, runtime code change, test change, frontend change, or GPT content asset edit was performed."
+      },
+      {
+        "at": "2026-06-03T12:24:51+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "note": "Reconciled before SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01: GitHub PR #1865 is merged, origin/main contains merge commit 765baf1fb9a8861efc37b525d35bc5c0cc8a1528, and publish remains forbidden."
       }
     ],
     "sidecars": [
@@ -41253,7 +41267,7 @@
         "note": "Sitemap submission, Baidu push, IndexNow, and search submission remain forbidden."
       }
     ],
-    "next_task": "SEO-CONTENT-P1-09 publish-readiness planning only after separate authorization; publish remains forbidden."
+    "next_task": "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01"
   },
   "SEO-CMS-CANARY-PREVIEW-01": {
     "repo": "fap-api",
@@ -41300,7 +41314,7 @@
   "SEO-CONTENT-P1-09": {
     "repo": "fap-api",
     "branch": "codex/seo-content-p1-09",
-    "status": "planned_publish_readiness_only_publish_blocked",
+    "status": "blocked_revision_approval_required_publish_blocked",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
@@ -41315,7 +41329,9 @@
       "publish_blocked": true,
       "search_submission_forbidden": true,
       "editorial_review_passed": true,
-      "cms_only_inspection_accepted_for_current_canary": true
+      "cms_only_inspection_accepted_for_current_canary": true,
+      "publish_preflight_ran": true,
+      "publish_preflight_passed": false
     },
     "transitions": [
       {
@@ -41329,6 +41345,12 @@
         "from": "blocked_until_editorial_review_and_publish_approval",
         "to": "planned_publish_readiness_only_publish_blocked",
         "note": "Editorial/operator review passed and CMS-only inspection was accepted for the current bilingual canary. SEO-CONTENT-P1-09 may be separately authorized for publish-readiness planning only. Actual publish remains blocked until separate exact approval and controlled publish preflight pass."
+      },
+      {
+        "at": "2026-06-03T12:24:51+08:00",
+        "from": "planned_publish_readiness_only_publish_blocked",
+        "to": "blocked_revision_approval_required_publish_blocked",
+        "note": "Controlled publish dry-run preflight was NO-GO because working revisions 42 and 44 remain machine_draft rather than approved. zh-CN article 37 also requires explicit boundary-context claim-warning acknowledgement during a later publish attempt. Publish remains forbidden."
       }
     ],
     "sidecars": [
@@ -41336,16 +41358,142 @@
         "id": "publish_still_requires_exact_approval",
         "status": "active",
         "note": "This readiness task must not publish by implication. Controlled publish requires a later exact approval and preflight."
+      },
+      {
+        "id": "revision_approval_required_before_publish",
+        "status": "active_blocker",
+        "note": "Working revisions 42 and 44 must be approved through an authorized operator workflow before controlled publish can pass."
       }
     ],
-    "next_task": "SEO-REVIEW-P1-10 only after controlled publish with separate exact approval"
+    "next_task": "Authorized operator approval of working revisions 42 and 44 without publish, then rerun controlled publish preflight"
+  },
+  "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-content-p1-09-publish-preflight-01",
+    "status": "local_checks_passed_no_go",
+    "depends_on": [
+      "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1865 --repo fermatmind/fap-api --json state,mergeCommit,mergedAt,headRefName,url,title",
+          "git merge-base --is-ancestor 765baf1fb9a8861efc37b525d35bc5c0cc8a1528 origin/main"
+        ],
+        "notes": "Dependency SEO-CMS-CANARY-EDITORIAL-REVIEW-01 is merged and origin/main contains merge commit 765baf1fb9a8861efc37b525d35bc5c0cc8a1528."
+      },
+      "command_discovery": {
+        "status": "passed",
+        "commands": [
+          "php backend/artisan articles:publish-controlled --help",
+          "sed -n '1,620p' backend/app/Console/Commands/ArticlePublishControlled.php"
+        ],
+        "notes": "Controlled article publish command supports --dry-run, --json, --make-indexable, and --ack-claim-warning. The publish branch is skipped when dry_run=true."
+      },
+      "production_no_write": {
+        "status": "passed",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... before counts ...\"'",
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... after counts ...\"'"
+        ],
+        "notes": "Before and after counts matched: articles=36, article_translation_revisions=43, article_seo_meta=32, article_editorial_package_imports=10, publish audit events for target articles=0. Both target articles remained draft, not public, not indexable, and unpublished."
+      },
+      "controlled_publish_dry_run_without_ack": {
+        "status": "failed_expected_gate",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --json'"
+        ],
+        "notes": "Dry-run returned ok=false. Article 37 failed revision_not_editorially_approved and claim_warning_ack_required. Article 39 failed revision_not_editorially_approved. published_article_ids was empty."
+      },
+      "controlled_publish_dry_run_with_ack": {
+        "status": "failed_revision_approval_gate",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --ack-claim-warning=37 --json'"
+        ],
+        "notes": "Dry-run returned ok=false. The zh-CN claim warning acknowledgement blocker was cleared, but both articles still failed revision_not_editorially_approved because working revisions 42 and 44 are machine_draft."
+      },
+      "public_absence": {
+        "status": "passed",
+        "commands": [
+          "python3 inline public page/API/sitemap/llms absence checks"
+        ],
+        "notes": "Public pages still return 404, public article and SEO APIs still return 404, and sitemap.xml, llms.txt, and llms-full.txt do not contain target slugs. Generic 404 pages may echo the requested path only."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed after path-limited staging. Preflight remains NO-GO; publish remains forbidden."
+      }
+    },
+    "failure_reason": "NO-GO: working revisions 42 and 44 are machine_draft, not approved. zh-CN article 37 also requires explicit boundary-context claim-warning acknowledgement for any later publish attempt.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null,
+      "publish_blocked": true,
+      "search_submission_forbidden": true,
+      "cms_mutation_performed": false,
+      "new_draft_created": false,
+      "importer_run_performed": false,
+      "content_asset_edit_performed": false,
+      "runtime_code_edit_performed": false,
+      "controlled_publish_dry_run_ok": false,
+      "dry_run_no_db_write": true,
+      "public_absence_passed": true,
+      "zh_claim_warning_ack_required": true,
+      "revision_approval_required": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T12:24:51+08:00",
+        "from": "missing",
+        "to": "local_checks_pending",
+        "note": "User explicitly authorized adding and executing SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01. Controlled publish preflight ran in dry-run only and returned NO-GO because working revisions 42 and 44 are machine_draft. No publish, CMS mutation, new draft creation, importer run, search submission, runtime code edit, test edit, frontend edit, or GPT content asset edit was performed."
+      },
+      {
+        "at": "2026-06-03T12:29:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed_no_go",
+        "note": "Created the docs-only publish preflight report, added manifest/state entries, reconciled #1865 as merged, and passed local JSON/YAML/diff validation. Result remains NO-GO because working revisions 42 and 44 require authorized approval before publish preflight can pass."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "publish_no_go_revision_approval_required",
+        "status": "active_blocker",
+        "note": "Working revisions 42 and 44 must be approved through an authorized operator workflow before controlled publish preflight can pass."
+      },
+      {
+        "id": "zh_claim_warning_ack_required",
+        "status": "active_publish_gate",
+        "note": "Article 37 has boundary-context claim warnings. A later publish attempt must explicitly acknowledge them with --ack-claim-warning=37 or an equivalent controlled publish acknowledgement."
+      },
+      {
+        "id": "publish_confirmation_not_actionable",
+        "status": "active",
+        "note": "The dry-run emitted expected confirmation phrase 'I explicitly approve Codex to publish article ids 37,39 after preflight passes.', but it must not be used until preflight returns ok=true after revision approval."
+      }
+    ],
+    "next_task": "Authorized operator approval of working revisions 42 and 44 without publish, then rerun controlled publish preflight."
   },
   "SEO-REVIEW-P1-10": {
     "repo": "fap-api",
     "branch": "codex/seo-review-p1-10",
     "status": "blocked_until_publish",
     "depends_on": [
-      "SEO-CONTENT-P1-09"
+      "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01"
     ],
     "commit_sha": null,
     "pr_url": null,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41370,12 +41370,12 @@
   "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-p1-09-publish-preflight-01",
-    "status": "local_checks_passed_no_go",
+    "status": "pr_open_no_go",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "c0fd3cb097cb801c92e5a609d6adae65e6b54fa2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1866",
     "checks": {
       "dependency_reconciliation": {
         "status": "passed",
@@ -41431,6 +41431,13 @@
           "git diff --cached --check"
         ],
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed after path-limited staging. Preflight remains NO-GO; publish remains forbidden."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-content-p1-09-publish-preflight-01 --title \"docs(cms): run SEO canary publish preflight\""
+        ],
+        "notes": "Opened PR #1866 after local docs/codex validation passed. GitHub checks are pending. Preflight result remains NO-GO and publish remains forbidden."
       }
     },
     "failure_reason": "NO-GO: working revisions 42 and 44 are machine_draft, not approved. zh-CN article 37 also requires explicit boundary-context claim-warning acknowledgement for any later publish attempt.",
@@ -41467,6 +41474,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed_no_go",
         "note": "Created the docs-only publish preflight report, added manifest/state entries, reconciled #1865 as merged, and passed local JSON/YAML/diff validation. Result remains NO-GO because working revisions 42 and 44 require authorized approval before publish preflight can pass."
+      },
+      {
+        "at": "2026-06-03T12:34:00+08:00",
+        "from": "local_checks_passed_no_go",
+        "to": "pr_open_no_go",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1866. GitHub checks are pending. Result remains NO-GO; no publish, CMS mutation, new draft creation, importer run, search submission, runtime code change, test change, frontend change, or GPT content asset edit was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20193,7 +20193,7 @@ prs:
     branch: codex/seo-cms-canary-editorial-review-01
     title: "docs(cms): record bilingual SEO canary editorial review"
     train_scope: seo_cms_canary
-    status: editorial_review_passed_cms_only_accepted_publish_blocked
+    status: merged
     scope:
       - Record authorized editorial/operator review results for the bilingual SEO canary CMS drafts.
       - Record CMS-only inspection acceptance for this canary while keeping publish blocked until controlled publish preflight, any required claim-warning acknowledgement, and separate explicit publish approval pass.
@@ -20273,7 +20273,7 @@ prs:
     branch: codex/seo-content-p1-09
     title: "docs(cms): prepare SEO canary publish readiness"
     train_scope: seo_cms_canary
-    status: planned_publish_readiness_only_publish_blocked
+    status: blocked_revision_approval_required_publish_blocked
     scope:
       - Prepare publish-readiness evidence after editorial/operator review passed and CMS-only inspection was accepted for this canary.
       - Actual publish remains blocked until a separate exact approval and controlled publish preflight pass.
@@ -20301,12 +20301,53 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: SEO-REVIEW-P1-10 only after controlled publish with separate exact approval
+    next_task: SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01 documents current NO-GO; operator revision approval required before publish can be retried
+
+  - id: SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01
+    repo: fap-api
+    depends_on:
+      - SEO-CMS-CANARY-EDITORIAL-REVIEW-01
+    branch: codex/seo-content-p1-09-publish-preflight-01
+    title: "docs(cms): run SEO canary publish preflight"
+    train_scope: seo_cms_canary
+    status: no_go_blocked_revision_approval_required
+    scope:
+      - Run controlled publish preflight only for the bilingual SEO canary drafts.
+      - Validate production draft state, controlled publish dry-run behavior, no-write guarantee, public absence, and publish blockers.
+      - Output GO/NO-GO and do not publish.
+    allowed_paths:
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, submit sitemap, call Baidu push, call IndexNow, call production write APIs, create new drafts, run importer, modify GPT content assets, modify runtime code, modify tests, or modify frontend fap-web.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: Authorized operator approval of working revisions 42 and 44 without publish, then rerun controlled publish preflight
 
   - id: SEO-REVIEW-P1-10
     repo: fap-api
     depends_on:
-      - SEO-CONTENT-P1-09
+      - SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01
     branch: codex/seo-review-p1-10
     title: "docs(cms): review SEO canary post-publish signals"
     train_scope: seo_cms_canary


### PR DESCRIPTION
## What changed
- Added the SEO canary controlled publish preflight report.
- Added the authorized PR train item `SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01` to manifest/state.
- Reconciled the prior editorial review PR #1865 as merged in the ledger.
- Recorded the current NO-GO publish state.

## Why
- The bilingual SEO canary needed controlled publish preflight before any publish approval can be considered.
- The dry-run correctly failed closed because working revisions 42 and 44 are still `machine_draft`, not `approved`.
- zh-CN article 37 also requires explicit boundary-context claim-warning acknowledgement in any later publish attempt.

## Validation
- `php backend/artisan articles:publish-controlled --help`
- Production read-only before/after DB counts around dry-run
- Production dry-run without ack: `articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --json`
- Production dry-run with ack: `articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --ack-claim-warning=37 --json`
- Public page/API/sitemap/llms absence checks
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- YAML parse for `docs/codex/pr-train.yaml`
- `git diff --check -- backend/docs/seo docs/codex`
- `git diff --cached --check`

## Result
- NO-GO: do not publish.
- Dry-run did not write DB.
- Public absence remains PASS.
- Publish remains forbidden.

## Intentionally deferred
- No publish.
- No sitemap submission, Baidu push, IndexNow, or search submission.
- No CMS mutation, no new draft creation, and no importer run.
- No GPT content package edits.
- No runtime code, tests, routes, migrations, frontend, or production config changes.

## Repository rule impact
- CMS/backend remains the content authority.
- No public SEO enumeration/runtime behavior changes are introduced.
- No deploy is required for this docs-only PR.