### PR TITLE
docs(cms): review SEO canary post-publish signals

### DIFF
--- a/backend/docs/seo/seo-review-p1-10-post-publish-signals-2026-06-03.md
+++ b/backend/docs/seo/seo-review-p1-10-post-publish-signals-2026-06-03.md
@@ -1,0 +1,155 @@
+# SEO-REVIEW-P1-10 Post-Publish Signals Review
+
+Date: 2026-06-03
+Repo: fap-api
+PR train item: SEO-REVIEW-P1-10
+Scope: post-publish public/search signal review only
+
+## Boundary
+
+This review did not publish, unpublish, mutate CMS state, submit sitemap, call Baidu push, call IndexNow, or trigger any search submission surface.
+
+The production checks were read-only. The only production write referenced by this report was the earlier separately authorized controlled publish of article ids 37 and 39.
+
+## Target Articles
+
+| Article id | Locale | Slug | Published revision |
+| --- | --- | --- | --- |
+| 37 | zh-CN | `mbti-vs-holland-career-choice` | 42 |
+| 39 | en | `mbti-vs-holland-code-career-choice` | 44 |
+
+## Production CMS State
+
+Read-only production DB verification on `/var/www/fap-api/current/backend` confirmed:
+
+| Article id | Status | is_public | is_indexable | published_revision_id | translation_status | published_at UTC |
+| --- | --- | --- | --- | --- | --- | --- |
+| 37 | published | true | true | 42 | approved | 2026-06-03 04:42:59 |
+| 39 | published | true | true | 44 | approved | 2026-06-03 04:43:00 |
+
+Revision state:
+
+| Revision id | Article id | revision_status | approved_at UTC | published_at UTC |
+| --- | --- | --- | --- | --- |
+| 42 | 37 | published | 2026-06-03 04:38:58 | 2026-06-03 04:42:59 |
+| 44 | 39 | published | 2026-06-03 04:38:59 | 2026-06-03 04:43:00 |
+
+SEO meta:
+
+| Article id | robots | is_indexable |
+| --- | --- | --- |
+| 37 | index,follow | true |
+| 39 | index,follow | true |
+
+Relevant audit log rows were present for operator approval, content release publish, and Codex controlled publish for both article ids.
+
+Result: PASS.
+
+## Public Page And API Signals
+
+Latest review check: 2026-06-03T12:50:30+08:00.
+
+| Surface | URL | Status | Target slug present | noindex present | Result |
+| --- | --- | --- | --- | --- | --- |
+| zh page | `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice` | 200 | yes | no | PASS |
+| en page | `https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice` | 200 | yes | no | PASS |
+| zh article API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice?locale=zh-CN` | 200 | yes | no | PASS |
+| en article API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice?locale=en` | 200 | yes | no | PASS |
+| zh SEO API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-career-choice/seo?locale=zh-CN` | 200 | yes | no | PASS |
+| en SEO API | `https://api.fermatmind.com/api/v0.5/articles/mbti-vs-holland-code-career-choice/seo?locale=en` | 200 | yes | no | PASS |
+| zh article list API | `https://api.fermatmind.com/api/v0.5/articles?locale=zh-CN&page=1&per_page=50` | 200 | zh slug yes | no | PASS |
+| en article list API | `https://api.fermatmind.com/api/v0.5/articles?locale=en&page=1&per_page=50` | 200 | en slug yes | no | PASS |
+
+Page checks also found Article schema and FAQ schema on both public article pages. SEO API checks found Article schema and FAQ schema.
+
+Result: PASS.
+
+## Sitemap And LLM Enumeration
+
+Latest review check: 2026-06-03T12:50:30+08:00.
+
+| Surface | URL | Cache-Control | Target slugs present | Result |
+| --- | --- | --- | --- | --- |
+| sitemap.xml | `https://fermatmind.com/sitemap.xml` | `public, max-age=0` | no | NOT CONVERGED |
+| llms.txt | `https://fermatmind.com/llms.txt` | `public, s-maxage=3600, stale-while-revalidate=86400` | yes | PASS, cache-sensitive |
+| llms-full.txt | `https://fermatmind.com/llms-full.txt` | `public, s-maxage=3600, stale-while-revalidate=86400` | no | NOT CONVERGED |
+
+Observed review history:
+
+- Immediate public pages/API checks converged after publish.
+- `llms.txt` showed cache-sensitive behavior during the review window: earlier checks varied, but the latest review check contained both target slugs.
+- `sitemap.xml` did not contain either target slug during the review window.
+- `llms-full.txt` did not contain either target slug during the review window.
+
+Result: PARTIAL. `llms.txt` currently converged, but `sitemap.xml` and `llms-full.txt` did not converge.
+
+## Search Submission Boundary
+
+No search submission action was performed:
+
+- No sitemap submission.
+- No Baidu push.
+- No IndexNow call.
+- No search console submission.
+
+Search submission should remain forbidden until sitemap and llms-full enumeration are understood or resolved.
+
+## Decision
+
+NO-GO for search submission.
+
+The bilingual canary is published and public article/page/API signals are live, but sitemap and llms-full enumeration did not converge inside this review window. `llms.txt` is currently converged but cache-sensitive.
+
+## Recommended Follow-Up
+
+Proposed follow-up PR train item, requiring separate authorization before execution:
+
+```yaml
+- id: SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01
+  repo: fap-api
+  depends_on:
+    - SEO-REVIEW-P1-10
+  branch: codex/seo-review-p1-10-sitemap-llms-enumeration-01
+  title: "docs(seo): investigate SEO canary sitemap and llms-full enumeration gap"
+  train_scope: seo_cms_canary
+  status: planned
+  scope:
+    - Investigate why published, public, indexable canary articles enumerate in public APIs and llms.txt but not sitemap.xml or llms-full.txt.
+    - Do not submit search surfaces.
+    - Decide whether the gap is cache lag, frontend enumeration source mismatch, API pagination/filtering behavior, or a runtime bug requiring a separate fix PR.
+  allowed_paths:
+    - backend/docs/seo/**
+    - docs/codex/pr-train.yaml
+    - docs/codex/pr-train-state.json
+  do_not:
+    - Submit sitemap, call Baidu push, call IndexNow, publish, unpublish, mutate CMS data, or modify runtime code unless separately authorized in a later fix PR.
+  validation:
+    - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+    - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+    - git diff --check -- backend/docs/seo docs/codex
+    - git diff --cached --check
+```
+
+Follow-up execution prompt:
+
+```text
+明确授权在 fap-api 新增并执行 PR train item SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01，更新 docs/codex/pr-train.yaml 和 docs/codex/pr-train-state.json，只做 sitemap/llms-full enumeration gap investigation，不提交 sitemap/Baidu/IndexNow，不 publish，不改 runtime code，除非调查报告后单独授权 fix PR。
+```
+
+## Validation Commands
+
+Commands run for this review:
+
+```bash
+ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="... read-only articles/revisions/seo_meta/audit_logs check ..."'
+python3 inline public page/API/sitemap/llms/llms-full check
+```
+
+Local PR validation commands:
+
+```bash
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/seo docs/codex
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41497,12 +41497,12 @@
   "SEO-REVIEW-P1-10": {
     "repo": "fap-api",
     "branch": "codex/seo-review-p1-10",
-    "status": "local_checks_passed_sitemap_llms_full_not_converged",
+    "status": "pr_open_sitemap_llms_full_not_converged",
     "depends_on": [
       "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "bd7ab47af4c458918e669598fafc8514abe48861",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1867",
     "checks": {
       "production_db_state": {
         "status": "passed",
@@ -41541,6 +41541,13 @@
           "git diff --cached --check"
         ],
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed before commit after path-limited staging."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-review-p1-10 --title \"docs(cms): review SEO canary post-publish signals\""
+        ],
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1867. Result remains NO-GO for search submission because sitemap.xml and llms-full.txt have not converged."
       }
     },
     "failure_reason": "NO-GO for search submission: sitemap.xml and llms-full.txt did not enumerate the published canary slugs during the review window.",
@@ -41584,6 +41591,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed_sitemap_llms_full_not_converged",
         "note": "Created the post-publish signals review report, reconciled P1-09 publish completion, and passed JSON/YAML/scoped diff validation. Search submission remains NO-GO because sitemap.xml and llms-full.txt have not converged."
+      },
+      {
+        "at": "2026-06-03T13:02:00+08:00",
+        "from": "local_checks_passed_sitemap_llms_full_not_converged",
+        "to": "pr_open_sitemap_llms_full_not_converged",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1867. No search submission, CMS mutation, publish, runtime edit, test edit, frontend edit, or GPT content edit was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41370,11 +41370,11 @@
   "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01": {
     "repo": "fap-api",
     "branch": "codex/seo-content-p1-09-publish-preflight-01",
-    "status": "pr_open_no_go",
+    "status": "merged_then_controlled_publish_completed",
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
-    "commit_sha": "c0fd3cb097cb801c92e5a609d6adae65e6b54fa2",
+    "commit_sha": "5dc9f8e9fabd72c143493dbeeac685116beec282",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1866",
     "checks": {
       "dependency_reconciliation": {
@@ -41385,42 +41385,152 @@
         ],
         "notes": "Dependency SEO-CMS-CANARY-EDITORIAL-REVIEW-01 is merged and origin/main contains merge commit 765baf1fb9a8861efc37b525d35bc5c0cc8a1528."
       },
-      "command_discovery": {
-        "status": "passed",
-        "commands": [
-          "php backend/artisan articles:publish-controlled --help",
-          "sed -n '1,620p' backend/app/Console/Commands/ArticlePublishControlled.php"
-        ],
-        "notes": "Controlled article publish command supports --dry-run, --json, --make-indexable, and --ack-claim-warning. The publish branch is skipped when dry_run=true."
-      },
-      "production_no_write": {
-        "status": "passed",
-        "commands": [
-          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... before counts ...\"'",
-          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... after counts ...\"'"
-        ],
-        "notes": "Before and after counts matched: articles=36, article_translation_revisions=43, article_seo_meta=32, article_editorial_package_imports=10, publish audit events for target articles=0. Both target articles remained draft, not public, not indexable, and unpublished."
-      },
-      "controlled_publish_dry_run_without_ack": {
-        "status": "failed_expected_gate",
-        "commands": [
-          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --json'"
-        ],
-        "notes": "Dry-run returned ok=false. Article 37 failed revision_not_editorially_approved and claim_warning_ack_required. Article 39 failed revision_not_editorially_approved. published_article_ids was empty."
-      },
-      "controlled_publish_dry_run_with_ack": {
-        "status": "failed_revision_approval_gate",
+      "original_publish_preflight": {
+        "status": "no_go_recorded",
         "commands": [
           "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan articles:publish-controlled --article=37 --article=39 --dry-run --make-indexable --ack-claim-warning=37 --json'"
         ],
-        "notes": "Dry-run returned ok=false. The zh-CN claim warning acknowledgement blocker was cleared, but both articles still failed revision_not_editorially_approved because working revisions 42 and 44 are machine_draft."
+        "notes": "The docs-only PR recorded NO-GO because working revisions 42 and 44 were machine_draft. No publish occurred inside PR #1866."
       },
-      "public_absence": {
+      "pr_merge_reconciliation": {
         "status": "passed",
         "commands": [
-          "python3 inline public page/API/sitemap/llms absence checks"
+          "gh pr view 1866 --repo fermatmind/fap-api --json number,state,mergeCommit,mergedAt,headRefName,url,title,isCrossRepository",
+          "git merge-base --is-ancestor 5dc9f8e9fabd72c143493dbeeac685116beec282 origin/main",
+          "git ls-remote --heads origin codex/seo-content-p1-09-publish-preflight-01"
         ],
-        "notes": "Public pages still return 404, public article and SEO APIs still return 404, and sitemap.xml, llms.txt, and llms-full.txt do not contain target slugs. Generic 404 pages may echo the requested path only."
+        "notes": "GitHub shows PR #1866 merged at 2026-06-03T04:34:28Z. origin/main contains merge commit 5dc9f8e9fabd72c143493dbeeac685116beec282. The remote task branch query returned no branch."
+      },
+      "operator_approval_after_merge": {
+        "status": "completed_external_operation",
+        "commands": [
+          "authorized operator approval path for working revisions 42 and 44"
+        ],
+        "notes": "Working revisions 42 and 44 moved from machine_draft through human_review to approved without publish. Audit logs recorded article_translation_approved for article ids 37 and 39."
+      },
+      "controlled_publish_after_exact_approval": {
+        "status": "completed_external_operation",
+        "commands": [
+          "php artisan articles:publish-controlled --article=37 --article=39 --confirm=\"I explicitly approve Codex to publish article ids 37,39 after preflight passes.\" --make-indexable --ack-claim-warning=37 --json"
+        ],
+        "notes": "After exact user approval, controlled publish returned ok=true with published_article_ids=[37,39]. No sitemap submission, Baidu push, IndexNow call, or search submission was performed."
+      },
+      "post_publish_db_state": {
+        "status": "passed",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... read-only articles/revisions/seo_meta/audit_logs check ...\"'"
+        ],
+        "notes": "Article 37 and 39 are published, public, indexable, and use published revisions 42 and 44. SEO meta robots are index,follow. Audit logs include approval and controlled publish success rows."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": "2026-06-03T04:34:28Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
+      "publish_completed_after_separate_exact_approval": true,
+      "search_submission_forbidden": true,
+      "cms_mutation_performed_in_pr": false,
+      "new_draft_created_in_pr": false,
+      "importer_run_performed_in_pr": false,
+      "content_asset_edit_performed": false,
+      "runtime_code_edit_performed": false,
+      "controlled_publish_completed": true,
+      "public_absence_before_publish_passed": true,
+      "zh_claim_warning_acknowledged_for_publish": true,
+      "revision_approval_completed": true,
+      "sitemap_submission_performed": false,
+      "baidu_push_performed": false,
+      "indexnow_performed": false
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T12:24:51+08:00",
+        "from": "missing",
+        "to": "local_checks_pending",
+        "note": "User explicitly authorized adding and executing SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01. Controlled publish preflight ran in dry-run only and returned NO-GO because working revisions 42 and 44 were machine_draft. No publish, CMS mutation, new draft creation, importer run, search submission, runtime code edit, test edit, frontend edit, or GPT content asset edit was performed."
+      },
+      {
+        "at": "2026-06-03T12:29:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed_no_go",
+        "note": "Created the docs-only publish preflight report, added manifest/state entries, reconciled #1865 as merged, and passed local JSON/YAML/diff validation. Result remained NO-GO because working revisions 42 and 44 required authorized approval before publish preflight could pass."
+      },
+      {
+        "at": "2026-06-03T12:34:00+08:00",
+        "from": "local_checks_passed_no_go",
+        "to": "pr_open_no_go",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1866. Result remained NO-GO; no publish, CMS mutation, new draft creation, importer run, search submission, runtime code change, test change, frontend change, or GPT content asset edit was performed."
+      },
+      {
+        "at": "2026-06-03T12:42:00+08:00",
+        "from": "pr_open_no_go",
+        "to": "merged_no_go_then_external_publish_authorized",
+        "note": "PR #1866 was merged as a docs-only NO-GO preflight. User then separately authorized operator approval for revisions 42 and 44 and explicitly approved controlled publish of article ids 37 and 39 after preflight passed."
+      },
+      {
+        "at": "2026-06-03T12:43:00+08:00",
+        "from": "merged_no_go_then_external_publish_authorized",
+        "to": "controlled_publish_completed",
+        "note": "Controlled publish completed for article ids 37 and 39 with exact user confirmation and zh-CN claim warning acknowledgement. Search submission remained forbidden and was not performed."
+      },
+      {
+        "at": "2026-06-03T12:50:30+08:00",
+        "from": "controlled_publish_completed",
+        "to": "merged_then_controlled_publish_completed",
+        "note": "P1-10 bookkeeping reconciled PR #1866 merge, controlled publish completion, and post-publish DB state. No search submission was performed."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "search_submission_still_forbidden",
+        "status": "active",
+        "note": "Publishing article ids 37 and 39 did not authorize sitemap submission, Baidu push, IndexNow, or any search submission surface."
+      }
+    ],
+    "next_task": "SEO-REVIEW-P1-10 post-publish signals review."
+  },
+  "SEO-REVIEW-P1-10": {
+    "repo": "fap-api",
+    "branch": "codex/seo-review-p1-10",
+    "status": "local_checks_passed_sitemap_llms_full_not_converged",
+    "depends_on": [
+      "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "production_db_state": {
+        "status": "passed",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... read-only articles/revisions/seo_meta/audit_logs check ...\"'"
+        ],
+        "notes": "Article 37 and 39 are published, public, indexable, and use published revisions 42 and 44. SEO meta robots are index,follow. Audit logs include article_translation_approved, content_release_publish, and codex_controlled_article_publish success rows."
+      },
+      "public_pages_and_apis": {
+        "status": "passed",
+        "commands": [
+          "python3 inline public page/API/list/SEO API check at 2026-06-03T12:50:30+08:00"
+        ],
+        "notes": "Public zh/en article pages returned 200 without noindex and included Article and FAQ schema. Article detail APIs, SEO APIs, and locale article list APIs returned 200 and contained the expected locale slug."
+      },
+      "sitemap_llms_review": {
+        "status": "partial_sitemap_and_llms_full_not_converged",
+        "commands": [
+          "python3 inline sitemap.xml, llms.txt, and llms-full.txt check at 2026-06-03T12:50:30+08:00"
+        ],
+        "notes": "llms.txt currently contains both target slugs, but sitemap.xml and llms-full.txt do not contain either target slug after the review window. Earlier llms.txt checks were cache-sensitive."
+      },
+      "search_submission_boundary": {
+        "status": "passed",
+        "commands": [
+          "manual boundary verification"
+        ],
+        "notes": "No sitemap submission, Baidu push, IndexNow call, search console submission, publish, unpublish, CMS mutation, runtime change, test change, frontend change, or GPT content edit was performed by this review PR."
       },
       "local": {
         "status": "passed",
@@ -41430,17 +41540,10 @@
           "git diff --check -- backend/docs/seo docs/codex",
           "git diff --cached --check"
         ],
-        "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed after path-limited staging. Preflight remains NO-GO; publish remains forbidden."
-      },
-      "pr": {
-        "status": "opened",
-        "commands": [
-          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-content-p1-09-publish-preflight-01 --title \"docs(cms): run SEO canary publish preflight\""
-        ],
-        "notes": "Opened PR #1866 after local docs/codex validation passed. GitHub checks are pending. Preflight result remains NO-GO and publish remains forbidden."
+        "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed before commit after path-limited staging."
       }
     },
-    "failure_reason": "NO-GO: working revisions 42 and 44 are machine_draft, not approved. zh-CN article 37 also requires explicit boundary-context claim-warning acknowledgement for any later publish attempt.",
+    "failure_reason": "NO-GO for search submission: sitemap.xml and llms-full.txt did not enumerate the published canary slugs during the review window.",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -41449,85 +41552,57 @@
       "local_validation_passed": true,
       "github_checks_green": null,
       "post_merge_revalidated": null,
-      "publish_blocked": true,
+      "published_state_passed": true,
+      "public_page_api_passed": true,
+      "article_list_api_passed": true,
+      "sitemap_converged": false,
+      "llms_txt_converged_currently": true,
+      "llms_txt_cache_sensitive": true,
+      "llms_full_converged": false,
       "search_submission_forbidden": true,
+      "search_submission_performed": false,
       "cms_mutation_performed": false,
-      "new_draft_created": false,
-      "importer_run_performed": false,
-      "content_asset_edit_performed": false,
+      "publish_performed_by_this_pr": false,
       "runtime_code_edit_performed": false,
-      "controlled_publish_dry_run_ok": false,
-      "dry_run_no_db_write": true,
-      "public_absence_passed": true,
-      "zh_claim_warning_ack_required": true,
-      "revision_approval_required": true
-    },
-    "transitions": [
-      {
-        "at": "2026-06-03T12:24:51+08:00",
-        "from": "missing",
-        "to": "local_checks_pending",
-        "note": "User explicitly authorized adding and executing SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01. Controlled publish preflight ran in dry-run only and returned NO-GO because working revisions 42 and 44 are machine_draft. No publish, CMS mutation, new draft creation, importer run, search submission, runtime code edit, test edit, frontend edit, or GPT content asset edit was performed."
-      },
-      {
-        "at": "2026-06-03T12:29:00+08:00",
-        "from": "local_checks_pending",
-        "to": "local_checks_passed_no_go",
-        "note": "Created the docs-only publish preflight report, added manifest/state entries, reconciled #1865 as merged, and passed local JSON/YAML/diff validation. Result remains NO-GO because working revisions 42 and 44 require authorized approval before publish preflight can pass."
-      },
-      {
-        "at": "2026-06-03T12:34:00+08:00",
-        "from": "local_checks_passed_no_go",
-        "to": "pr_open_no_go",
-        "note": "Opened https://github.com/fermatmind/fap-api/pull/1866. GitHub checks are pending. Result remains NO-GO; no publish, CMS mutation, new draft creation, importer run, search submission, runtime code change, test change, frontend change, or GPT content asset edit was performed."
-      }
-    ],
-    "sidecars": [
-      {
-        "id": "publish_no_go_revision_approval_required",
-        "status": "active_blocker",
-        "note": "Working revisions 42 and 44 must be approved through an authorized operator workflow before controlled publish preflight can pass."
-      },
-      {
-        "id": "zh_claim_warning_ack_required",
-        "status": "active_publish_gate",
-        "note": "Article 37 has boundary-context claim warnings. A later publish attempt must explicitly acknowledge them with --ack-claim-warning=37 or an equivalent controlled publish acknowledgement."
-      },
-      {
-        "id": "publish_confirmation_not_actionable",
-        "status": "active",
-        "note": "The dry-run emitted expected confirmation phrase 'I explicitly approve Codex to publish article ids 37,39 after preflight passes.', but it must not be used until preflight returns ok=true after revision approval."
-      }
-    ],
-    "next_task": "Authorized operator approval of working revisions 42 and 44 without publish, then rerun controlled publish preflight."
-  },
-  "SEO-REVIEW-P1-10": {
-    "repo": "fap-api",
-    "branch": "codex/seo-review-p1-10",
-    "status": "blocked_until_publish",
-    "depends_on": [
-      "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01"
-    ],
-    "commit_sha": null,
-    "pr_url": null,
-    "checks": {},
-    "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
-    "scope_validation": {
-      "publish_blocked": true,
-      "search_submission_forbidden": true
+      "frontend_edit_performed": false
     },
     "transitions": [
       {
         "at": "2026-06-03T11:36:00+08:00",
         "from": "missing",
         "to": "blocked_until_publish",
-        "note": "Blocked until controlled publish occurs. Publish remains forbidden; search submission remains forbidden."
+        "note": "Blocked until controlled publish occurs. Publish remained forbidden; search submission remained forbidden."
+      },
+      {
+        "at": "2026-06-03T12:50:30+08:00",
+        "from": "blocked_until_publish",
+        "to": "local_checks_pending",
+        "note": "Controlled publish had completed under separate exact authorization. Started post-publish signals review. Published state and public pages/APIs passed; sitemap.xml and llms-full.txt did not enumerate the target slugs during the review window. Search submission remains forbidden."
+      },
+      {
+        "at": "2026-06-03T12:58:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed_sitemap_llms_full_not_converged",
+        "note": "Created the post-publish signals review report, reconciled P1-09 publish completion, and passed JSON/YAML/scoped diff validation. Search submission remains NO-GO because sitemap.xml and llms-full.txt have not converged."
       }
     ],
-    "sidecars": [],
-    "next_task": null
+    "sidecars": [
+      {
+        "id": "sitemap_not_converged",
+        "status": "active_blocker",
+        "note": "sitemap.xml did not contain either target slug during the post-publish review window."
+      },
+      {
+        "id": "llms_full_not_converged",
+        "status": "active_blocker",
+        "note": "llms-full.txt did not contain either target slug during the post-publish review window."
+      },
+      {
+        "id": "search_submission_still_forbidden",
+        "status": "active",
+        "note": "Do not submit sitemap, Baidu push, IndexNow, or any search submission until enumeration is understood or resolved through a separately authorized follow-up."
+      }
+    ],
+    "next_task": "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01 proposed; search submission remains forbidden until sitemap and llms-full enumeration are understood or resolved."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20310,7 +20310,7 @@ prs:
     branch: codex/seo-content-p1-09-publish-preflight-01
     title: "docs(cms): run SEO canary publish preflight"
     train_scope: seo_cms_canary
-    status: no_go_blocked_revision_approval_required
+    status: merged_then_controlled_publish_completed
     scope:
       - Run controlled publish preflight only for the bilingual SEO canary drafts.
       - Validate production draft state, controlled publish dry-run behavior, no-write guarantee, public absence, and publish blockers.
@@ -20342,7 +20342,7 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: Authorized operator approval of working revisions 42 and 44 without publish, then rerun controlled publish preflight
+    next_task: SEO-REVIEW-P1-10 post-publish signals review
 
   - id: SEO-REVIEW-P1-10
     repo: fap-api
@@ -20351,7 +20351,7 @@ prs:
     branch: codex/seo-review-p1-10
     title: "docs(cms): review SEO canary post-publish signals"
     train_scope: seo_cms_canary
-    status: blocked_until_publish
+    status: completed_sitemap_and_llms_full_not_converged
     scope:
       - Review post-publish public/search signals only after controlled publish occurs.
     allowed_paths:
@@ -20378,4 +20378,4 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: none
+    next_task: SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01 proposed; search submission remains forbidden until sitemap and llms-full enumeration are understood or resolved


### PR DESCRIPTION
## What changed
- Added the SEO-REVIEW-P1-10 post-publish signals review report for the bilingual SEO canary.
- Reconciled PR train state for #1866, the later operator approval path, and the controlled publish completion for article ids 37 and 39.
- Updated the PR train ledger to record that public pages/APIs converged while sitemap.xml and llms-full.txt did not enumerate the target slugs during the review window.

## Why
The bilingual canary is now published under separate exact approval, so the train needs a post-publish signals review before any search submission can be considered. The review found that article pages and APIs are live, but sitemap and llms-full enumeration have not converged.

## Validation
- `ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="... read-only articles/revisions/seo_meta/audit_logs check ..."'`
- `python3 inline public page/API/sitemap/llms/llms-full check`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo docs/codex`
- `git diff --cached --check`

## Intentionally deferred
- No sitemap submission.
- No Baidu push.
- No IndexNow call.
- No search console submission.
- No runtime fix for sitemap or llms-full enumeration in this docs-only PR.
- No CMS mutation, publish, unpublish, GPT content edit, frontend edit, or test change.

## Repository rule impact
This is a docs-only SEO/CMS operational review. CMS/backend remains the content authority. The PR does not change runtime enumeration logic, sitemap generation, llms generation, public API behavior, frontend fallback behavior, or content ownership rules.
