### PR TITLE
docs(seo): investigate SEO canary sitemap and llms-full enumeration gap

### DIFF
--- a/backend/docs/seo/seo-review-p1-10-sitemap-llms-enumeration-2026-06-03.md
+++ b/backend/docs/seo/seo-review-p1-10-sitemap-llms-enumeration-2026-06-03.md
@@ -1,0 +1,223 @@
+# SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01
+
+Date: 2026-06-03
+Repo: fap-api
+PR train item: SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01
+Scope: sitemap / llms-full enumeration gap investigation only
+
+## Boundary
+
+This investigation did not publish, unpublish, mutate CMS state, submit sitemap, call Baidu push, call IndexNow, call search console submission, or modify runtime code.
+
+Production checks were read-only. fap-web runtime files were read for investigation only and were not modified.
+
+## Target URLs
+
+| Locale | Article id | Slug | Public URL |
+| --- | --- | --- | --- |
+| zh-CN | 37 | `mbti-vs-holland-career-choice` | `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice` |
+| en | 39 | `mbti-vs-holland-code-career-choice` | `https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice` |
+
+## Current Public Signal Snapshot
+
+Latest live check: 2026-06-03T13:10:09+08:00.
+
+| Surface | Result | Evidence |
+| --- | --- | --- |
+| zh article detail API | PASS | 200, contains both canary slugs through article and alternate payload |
+| en article detail API | PASS | 200, contains both canary slugs through article and alternate payload |
+| public article list API | PASS | `page=1&per_page=40` returns zh article id 37 and en article id 39 as first item for their locale |
+| `llms.txt` | PASS | 200, contains both canary slugs |
+| backend `/api/v0.5/seo/sitemap-source` | NOT CONVERGED | 200, `X-Fermat-Cache: stale`, count 2387, contains neither canary slug |
+| frontend `sitemap.xml` | NOT CONVERGED | 200, contains neither canary slug |
+| `llms-full.txt` | NOT CONVERGED | 200, `Generated-At: 2026-06-03T04:43:43.012Z`, contains neither canary slug |
+
+## Finding A: Backend Sitemap Source Is Serving Stale Cache
+
+Read-only production tinker check on `/var/www/fap-api/current/backend`:
+
+```json
+{
+  "fresh_is_array": false,
+  "stale_is_array": true,
+  "stale_count": 2387,
+  "stale_contains": [false, false],
+  "direct_count": 2389,
+  "direct_contains": [true, true],
+  "direct_matches": [
+    {
+      "loc": "https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice",
+      "lastmod": "2026-06-03T04:43:00+00:00",
+      "slug": "articles:en:mbti-vs-holland-code-career-choice"
+    },
+    {
+      "loc": "https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice",
+      "lastmod": "2026-06-03T04:42:59+00:00",
+      "slug": "articles:zh:mbti-vs-holland-career-choice"
+    }
+  ]
+}
+```
+
+Interpretation:
+
+- `SitemapGenerator::generateUrls()` already includes both canary article URLs.
+- The live backend sitemap-source endpoint does not include them because `seo:sitemap-source:v1:stale` still holds the old 2387-item payload.
+- `SitemapSourceController` returns stale cache when no fresh cache exists, so the request path does not rebuild while stale cache is present.
+- The existing `seo:warm-sitemap-source-cache --json` command can build and store a 2389-item payload, but running it is a cache write operation and was not authorized in this investigation.
+
+Result: backend data and generator are correct; backend sitemap-source cache refresh is missing after controlled article publish.
+
+## Finding B: Frontend sitemap.xml Is A Static Build Artifact
+
+Read-only fap-web code inspection:
+
+- `next-sitemap.config.js` builds article paths through `/v0.5/articles`.
+- That build-time article path source would currently see article ids 37 and 39 because the public article list APIs return them on page 1.
+- The live `https://fermatmind.com/sitemap.xml` remains unchanged because it is a generated static sitemap artifact from the active frontend build.
+- A normal HTTP cache window cannot add post-build article URLs to a static sitemap artifact.
+
+Interpretation:
+
+- Waiting for cache alone is not sufficient for `sitemap.xml` to converge.
+- A frontend rebuild/redeploy would likely regenerate `sitemap.xml` with the canary article paths, because the public article APIs now expose them.
+- A durable fix would make sitemap enumeration refresh part of the controlled content publish workflow, or move the relevant sitemap source to a runtime/dynamic authority with a controlled invalidation path.
+
+Result: frontend sitemap convergence requires a separately authorized rebuild/deploy or a separately authorized runtime/workflow fix.
+
+## Finding C: llms-full.txt Is Blocked By Response Cache / Revalidation Gap
+
+Read-only fap-web code inspection:
+
+- `app/llms-full.txt/route.ts` uses `LLMS_FULL_CACHE_FRESH_MS = 60 * 60 * 1000`.
+- It uses `LLMS_FULL_CACHE_STALE_MS = 24 * 60 * 60 * 1000`.
+- It reads articles with `listCmsArticlesForLlmsWithLastKnownGood`, `LLMS_ROUTE_LIMITS.articles = 40`, and `LLMS_ROUTE_ARTICLE_MAX_PAGES = 1`.
+- The canary articles are currently first item in their locale article list API, so the one-page article budget is not the immediate blocker.
+- The current live `llms-full.txt` response has `Generated-At: 2026-06-03T04:43:43.012Z`, but does not contain the canary slugs.
+- `app/api/content-release/revalidate/route.ts` can clear the llms-full response cache only when `/llms-full.txt` is accepted in the revalidation path list.
+- For `content.type === "article"`, the default derived revalidation paths are article list and detail paths only; `/llms.txt` and `/llms-full.txt` are not automatically added.
+
+Interpretation:
+
+- `llms-full.txt` generated and cached an article set that did not include the new canary URLs.
+- The content-release revalidation route has the capability to clear `llms-full` cache, but article release metadata does not derive that path automatically.
+- `llms.txt` is already converged, so the article list source itself is not blocked.
+
+Result: `llms-full.txt` requires a separately authorized revalidation/cache-clear operation or a workflow/runtime fix that includes llms-full in article publish invalidation.
+
+## Search Submission Decision
+
+NO-GO for search submission.
+
+Do not submit sitemap, Baidu push, IndexNow, or search console URLs while:
+
+- `sitemap.xml` does not enumerate the published article URLs.
+- `llms-full.txt` does not enumerate the published article URLs.
+- backend sitemap-source is still serving stale cache for the canary URLs.
+
+## Recommended Next Actions
+
+### Immediate Ops Option Requiring Separate Exact Authorization
+
+These are not executed by this PR:
+
+1. Warm backend sitemap-source cache on production current release:
+
+```bash
+cd /var/www/fap-api/current/backend && php artisan seo:warm-sitemap-source-cache --json
+```
+
+Expected read-after-write evidence:
+
+- `/api/v0.5/seo/sitemap-source` returns count 2389.
+- `/api/v0.5/seo/sitemap-source` contains both canary article URLs.
+
+2. Clear/revalidate frontend llms routes using the existing content-release revalidation endpoint with an authorized token and explicit paths:
+
+```json
+{
+  "cache_signal": {
+    "paths": ["/llms.txt", "/llms-full.txt"]
+  }
+}
+```
+
+Expected read-after-write evidence:
+
+- `llms-full.txt` has a newer `Generated-At`.
+- `llms-full.txt` contains both canary article URLs.
+
+3. Regenerate `sitemap.xml` through a separately authorized frontend deployment or a separately authorized sitemap runtime fix.
+
+Expected evidence:
+
+- `https://fermatmind.com/sitemap.xml` contains both canary article URLs.
+
+### Durable Fix PR Candidates
+
+These require separate authorization and should not be combined with this investigation PR:
+
+1. fap-api controlled publish cache refresh:
+   - Add a post-publish cache refresh or cache invalidation path for `seo:sitemap-source:v1:*`.
+   - Validate that controlled publish causes backend sitemap-source to include newly published article URLs.
+
+2. fap-web content-release revalidation expansion:
+   - For article release metadata, derive `/llms.txt` and `/llms-full.txt`.
+   - Ensure `/llms-full.txt` cache is cleared when the route is revalidated.
+
+3. fap-web sitemap convergence strategy:
+   - Either keep static sitemap and require a controlled frontend rebuild after CMS publish, or move relevant article sitemap enumeration to a runtime source with explicit cache invalidation.
+
+## Proposed Follow-Up PR Train Item
+
+```yaml
+- id: SEO-REVIEW-P1-10-SITEMAP-LLMS-FIX-01
+  repo: fap-web
+  depends_on:
+    - SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01
+  branch: codex/seo-review-p1-10-sitemap-llms-fix-01
+  title: "fix(seo): refresh article publish sitemap and llms enumeration"
+  train_scope: seo_cms_canary
+  status: planned
+  scope:
+    - Add or document the controlled runtime path needed for published CMS article URLs to converge in sitemap.xml and llms-full.txt.
+    - Keep CMS/backend as content authority.
+    - Do not submit search surfaces.
+  allowed_paths:
+    - app/api/content-release/revalidate/**
+    - app/llms-full.txt/**
+    - tests/contracts/**
+    - docs/**
+    - docs/codex/pr-train.yaml
+    - docs/codex/pr-train-state.json
+  do_not:
+    - Publish, unpublish, mutate CMS data, submit sitemap, call Baidu push, call IndexNow, change GPT content, or add frontend editorial fallback content.
+```
+
+Follow-up execution prompt:
+
+```text
+明确授权在 fap-web 新增并执行 PR train item SEO-REVIEW-P1-10-SITEMAP-LLMS-FIX-01，修复 CMS article publish 后 sitemap / llms-full 枚举刷新路径；不提交 sitemap/Baidu/IndexNow，不 publish，不改 CMS 内容，不新增 frontend editorial fallback。
+```
+
+## Validation Commands
+
+Investigation commands:
+
+```bash
+python3 inline public API / sitemap / llms / llms-full signal check
+ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="... read-only Cache::get and SitemapGenerator::generateUrls check ..."'
+sed -n '1,260p' backend/app/Services/SEO/SitemapGenerator.php
+sed -n '1,280p' backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
+sed -n '995,1035p' /Users/rainie/Desktop/GitHub/fap-web/app/llms-full.txt/route.ts
+sed -n '1,310p' /Users/rainie/Desktop/GitHub/fap-web/app/api/content-release/revalidate/route.ts
+```
+
+Local PR validation commands:
+
+```bash
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/seo docs/codex
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41497,11 +41497,11 @@
   "SEO-REVIEW-P1-10": {
     "repo": "fap-api",
     "branch": "codex/seo-review-p1-10",
-    "status": "pr_open_sitemap_llms_full_not_converged",
+    "status": "merged_sitemap_llms_full_not_converged",
     "depends_on": [
       "SEO-CONTENT-P1-09-PUBLISH-PREFLIGHT-01"
     ],
-    "commit_sha": "bd7ab47af4c458918e669598fafc8514abe48861",
+    "commit_sha": "c97974641c8e890b8671535fd7395a2f1ed355c1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1867",
     "checks": {
       "production_db_state": {
@@ -41543,22 +41543,23 @@
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed before commit after path-limited staging."
       },
       "pr": {
-        "status": "opened",
+        "status": "merged",
         "commands": [
-          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-review-p1-10 --title \"docs(cms): review SEO canary post-publish signals\""
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-review-p1-10 --title \"docs(cms): review SEO canary post-publish signals\"",
+          "gh pr merge 1867 --repo fermatmind/fap-api --squash --delete-branch"
         ],
-        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1867. Result remains NO-GO for search submission because sitemap.xml and llms-full.txt have not converged."
+        "notes": "Opened and merged https://github.com/fermatmind/fap-api/pull/1867. Merge commit c97974641c8e890b8671535fd7395a2f1ed355c1 is on origin/main. Result remained NO-GO for search submission because sitemap.xml and llms-full.txt had not converged."
       }
     },
     "failure_reason": "NO-GO for search submission: sitemap.xml and llms-full.txt did not enumerate the published canary slugs during the review window.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T05:03:23Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "published_state_passed": true,
       "public_page_api_passed": true,
       "article_list_api_passed": true,
@@ -41597,6 +41598,12 @@
         "from": "local_checks_passed_sitemap_llms_full_not_converged",
         "to": "pr_open_sitemap_llms_full_not_converged",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1867. No search submission, CMS mutation, publish, runtime edit, test edit, frontend edit, or GPT content edit was performed."
+      },
+      {
+        "at": "2026-06-03T13:03:23+08:00",
+        "from": "pr_open_sitemap_llms_full_not_converged",
+        "to": "merged_sitemap_llms_full_not_converged",
+        "note": "Merged PR #1867 with green GitHub checks. Local cleanup completed, remote branch was deleted, main matched origin/main, and the worktree was clean."
       }
     ],
     "sidecars": [
@@ -41617,5 +41624,125 @@
       }
     ],
     "next_task": "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01 proposed; search submission remains forbidden until sitemap and llms-full enumeration are understood or resolved."
+  },
+  "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-review-p1-10-sitemap-llms-enumeration-01",
+    "status": "local_checks_passed_no_go_search_submission",
+    "depends_on": [
+      "SEO-REVIEW-P1-10"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1867 --repo fermatmind/fap-api --json state,mergeCommit,mergedAt,headRefName,url,title",
+          "git merge-base --is-ancestor c97974641c8e890b8671535fd7395a2f1ed355c1 origin/main"
+        ],
+        "notes": "Dependency SEO-REVIEW-P1-10 is merged and origin/main contains merge commit c97974641c8e890b8671535fd7395a2f1ed355c1."
+      },
+      "public_signal_check": {
+        "status": "passed_with_gaps",
+        "commands": [
+          "python3 inline public API / sitemap / llms / llms-full signal check at 2026-06-03T13:10:09+08:00"
+        ],
+        "notes": "Article detail APIs and llms.txt contain both canary slugs. Backend sitemap-source, frontend sitemap.xml, and llms-full.txt do not contain the canary slugs."
+      },
+      "backend_sitemap_source_readonly": {
+        "status": "stale_cache_identified",
+        "commands": [
+          "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"... read-only Cache::get and SitemapGenerator::generateUrls check ...\"'"
+        ],
+        "notes": "Fresh cache was absent, stale cache had count 2387 and did not contain the canary slugs. Direct SitemapGenerator::generateUrls returned count 2389 and contained both canary article URLs."
+      },
+      "frontend_readonly_code_inspection": {
+        "status": "passed",
+        "commands": [
+          "sed -n '620,900p' /Users/rainie/Desktop/GitHub/fap-web/next-sitemap.config.js",
+          "sed -n '995,1035p' /Users/rainie/Desktop/GitHub/fap-web/app/llms-full.txt/route.ts",
+          "sed -n '1,310p' /Users/rainie/Desktop/GitHub/fap-web/app/api/content-release/revalidate/route.ts"
+        ],
+        "notes": "fap-web was read only. next-sitemap builds article paths at build time; llms-full uses 60-minute fresh and 24-hour stale response cache; article revalidation derives article list/detail paths but not llms.txt or llms-full.txt by default."
+      },
+      "search_submission_boundary": {
+        "status": "passed",
+        "commands": [
+          "manual boundary verification"
+        ],
+        "notes": "No sitemap submission, Baidu push, IndexNow call, search console submission, publish, unpublish, CMS mutation, runtime edit, test edit, frontend edit, or GPT content edit was performed."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed before commit after path-limited staging."
+      }
+    },
+    "failure_reason": "NO-GO for search submission: sitemap.xml and llms-full.txt still do not enumerate the canary URLs. Backend sitemap-source is serving stale cache, frontend sitemap.xml is a static build artifact, and llms-full is blocked by response cache/revalidation gap.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null,
+      "production_write_execution": false,
+      "database_mutation": false,
+      "cms_mutation": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "runtime_code_edit_performed": false,
+      "frontend_edit_performed": false,
+      "fap_web_readonly_inspection": true,
+      "backend_sitemap_generator_contains_canary": true,
+      "backend_sitemap_source_stale_cache_contains_canary": false,
+      "frontend_sitemap_contains_canary": false,
+      "llms_txt_contains_canary": true,
+      "llms_full_contains_canary": false
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T13:04:00+08:00",
+        "from": "missing",
+        "to": "local_checks_pending",
+        "note": "User explicitly authorized adding and executing SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01, including manifest/state updates. Started docs-only investigation. Search submission, publish, CMS mutation, runtime code edits, and fap-web edits remain forbidden."
+      },
+      {
+        "at": "2026-06-03T13:16:00+08:00",
+        "from": "local_checks_pending",
+        "to": "local_checks_passed_no_go_search_submission",
+        "note": "Created the docs-only enumeration investigation report and passed JSON/YAML/scoped diff validation. Search submission remains NO-GO because sitemap.xml and llms-full.txt still do not enumerate the canary URLs."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "search_submission_no_go",
+        "status": "active_blocker",
+        "note": "Do not submit sitemap, Baidu push, IndexNow, or search console URLs until sitemap.xml and llms-full.txt enumerate the canary URLs."
+      },
+      {
+        "id": "backend_sitemap_source_stale_cache",
+        "status": "active",
+        "note": "Direct backend SitemapGenerator includes the canary URLs, but live backend sitemap-source serves stale cache without them."
+      },
+      {
+        "id": "frontend_sitemap_static_build_artifact",
+        "status": "active",
+        "note": "Frontend sitemap.xml is a generated static artifact and cannot include post-build CMS publishes without rebuild/deploy or a runtime enumeration fix."
+      },
+      {
+        "id": "llms_full_response_cache_gap",
+        "status": "active",
+        "note": "llms-full.txt currently serves a cached artifact generated at 2026-06-03T04:43:43.012Z that does not contain the canary URLs."
+      }
+    ],
+    "next_task": "SEO-REVIEW-P1-10-SITEMAP-LLMS-FIX-01 proposed in fap-web; search submission remains forbidden."
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41628,12 +41628,12 @@
   "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01": {
     "repo": "fap-api",
     "branch": "codex/seo-review-p1-10-sitemap-llms-enumeration-01",
-    "status": "local_checks_passed_no_go_search_submission",
+    "status": "pr_open_no_go_search_submission",
     "depends_on": [
       "SEO-REVIEW-P1-10"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "385b58c4cd21df412fc455e7cfa7307107c05bfd",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1868",
     "checks": {
       "dependency_reconciliation": {
         "status": "passed",
@@ -41682,6 +41682,13 @@
           "git diff --cached --check"
         ],
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed before commit after path-limited staging."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-review-p1-10-sitemap-llms-enumeration-01 --title \"docs(seo): investigate SEO canary sitemap and llms-full enumeration gap\""
+        ],
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1868. Search submission remains NO-GO."
       }
     },
     "failure_reason": "NO-GO for search submission: sitemap.xml and llms-full.txt still do not enumerate the canary URLs. Backend sitemap-source is serving stale cache, frontend sitemap.xml is a static build artifact, and llms-full is blocked by response cache/revalidation gap.",
@@ -41719,6 +41726,12 @@
         "from": "local_checks_pending",
         "to": "local_checks_passed_no_go_search_submission",
         "note": "Created the docs-only enumeration investigation report and passed JSON/YAML/scoped diff validation. Search submission remains NO-GO because sitemap.xml and llms-full.txt still do not enumerate the canary URLs."
+      },
+      {
+        "at": "2026-06-03T13:20:00+08:00",
+        "from": "local_checks_passed_no_go_search_submission",
+        "to": "pr_open_no_go_search_submission",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1868. No search submission, publish, CMS mutation, runtime edit, fap-web edit, test edit, or GPT content edit was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20379,3 +20379,44 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01 proposed; search submission remains forbidden until sitemap and llms-full enumeration are understood or resolved
+
+  - id: SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01
+    repo: fap-api
+    depends_on:
+      - SEO-REVIEW-P1-10
+    branch: codex/seo-review-p1-10-sitemap-llms-enumeration-01
+    title: "docs(seo): investigate SEO canary sitemap and llms-full enumeration gap"
+    train_scope: seo_cms_canary
+    status: completed_no_go_search_submission
+    scope:
+      - Investigate why published, public, indexable canary articles enumerate in public APIs and llms.txt but not sitemap.xml or llms-full.txt.
+      - Do not submit search surfaces.
+      - Decide whether the gap is cache lag, frontend enumeration source mismatch, API pagination/filtering behavior, or a runtime bug requiring a separate fix PR.
+    allowed_paths:
+      - backend/docs/seo/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Submit sitemap, call Baidu push, call IndexNow, publish, unpublish, mutate CMS data, or modify runtime code unless separately authorized in a later fix PR.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-REVIEW-P1-10-SITEMAP-LLMS-FIX-01 proposed in fap-web; search submission remains forbidden until sitemap.xml and llms-full.txt enumerate the canary URLs


### PR DESCRIPTION
## What changed
- Added the SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01 investigation report.
- Added the authorized PR train manifest/state entry.
- Reconciled SEO-REVIEW-P1-10 as merged in the train ledger.

## Why
The published bilingual SEO canary is live in article pages/APIs and llms.txt, but sitemap.xml and llms-full.txt did not enumerate the canary URLs. This PR documents the read-only investigation and keeps search submission blocked.

## Findings
- Backend `SitemapGenerator::generateUrls()` already includes both canary URLs.
- Live backend `/api/v0.5/seo/sitemap-source` is serving stale cache with count 2387 and without the canary URLs.
- Frontend `sitemap.xml` is a static generated build artifact and will not naturally converge from an HTTP cache window after post-build CMS publish.
- `llms-full.txt` is serving a cached artifact generated at `2026-06-03T04:43:43.012Z` that does not include the canary URLs.
- `llms.txt` and public article APIs contain both canary URLs.

## Validation
- `python3 inline public API / sitemap / llms / llms-full signal check`
- `ssh "$API_SSH_ALIAS" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="... read-only Cache::get and SitemapGenerator::generateUrls check ..."'`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo docs/codex`
- `git diff --cached --check`

## Intentionally deferred
- No sitemap submission.
- No Baidu push.
- No IndexNow call.
- No search console submission.
- No publish or unpublish.
- No CMS mutation.
- No runtime code changes.
- No fap-web file changes.
- No GPT content edits.

## Repository rule impact
This is a docs-only investigation. CMS/backend remains the content authority. The PR does not change runtime sitemap generation, llms generation, content ownership, frontend fallback behavior, or search submission behavior.
