### PR TITLE
ops(seo): submit canary sitemap in GSC

### DIFF
--- a/backend/docs/seo/seo-search-submission-canary-execution-plan-2026-06-03.md
+++ b/backend/docs/seo/seo-search-submission-canary-execution-plan-2026-06-03.md
@@ -1,0 +1,332 @@
+# SEO-SEARCH-SUBMISSION-CANARY-EXECUTION-PLAN-01
+
+Date: 2026-06-03
+Repo: fap-api
+Task type: read-only search submission execution planning
+
+## Boundary
+
+This planning task did not submit sitemap, call Google Search Console indexing submission, call Baidu push, call IndexNow, create Search Channel queue records, mutate CMS, publish, unpublish, deploy, read cookies/local storage, or expose secrets.
+
+Chrome dashboard checks were read-only and used the already logged-in browser session. Dashboard account identifiers and submission tokens were intentionally not recorded in this report.
+
+## Inputs
+
+Primary input report:
+
+- `backend/docs/seo/seo-search-submission-preflight-scan-2026-06-03.md`
+
+Target canary URLs:
+
+- zh-CN: `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice`
+- en: `https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice`
+
+Target sitemap:
+
+- `https://fermatmind.com/sitemap.xml`
+
+## Current Readiness Summary
+
+Public SEO readiness remains usable for execution planning:
+
+- article pages: PASS
+- canonical / hreflang: PASS
+- robots index/follow: PASS
+- Article / FAQPage / BreadcrumbList schema: PASS
+- sitemap / llms / llms-full enumeration: PASS
+- public article API / SEO API: PASS
+- CMS publish state: PASS
+- private URL exposure check: PASS
+- existing target URL submission rows: PASS, none found
+
+Execution path readiness:
+
+| Path | Decision | Reason |
+| --- | --- | --- |
+| GSC sitemap submit | GO after exact user authorization | GSC property and sitemap page are accessible; sitemap submit UI is visible. |
+| GSC URL inspection / request indexing | CONDITIONAL GO after exact user authorization | URL inspection entry is visible; actual request-indexing flow was not opened or executed. |
+| Baidu manual URL submit | GO after exact user authorization, zh URL only by default | Baidu verified-site dashboard and 普通收录 page are accessible; manual submit UI is visible. |
+| Baidu sitemap submit | CONDITIONAL GO after exact user authorization | 普通收录 sitemap section is visible; exact field state should be rechecked immediately before execution. |
+| Baidu API push | NO-GO by default | Dashboard exposes an API token, but Codex must not record or use it unless a separate secret-safe execution path is explicitly authorized. |
+| IndexNow | NO-GO | Backend live gate/key are not confirmed and production config previously showed live submission disabled. |
+| Backend Search Channel | NO-GO | Both canary canonical dry-runs returned `canonical_url_not_found`; CMS article URL Truth / candidacy is missing. |
+
+Overall decision:
+
+GO for channel-specific execution planning.
+
+Do not run any submission until the user provides an exact approval phrase for the chosen channel.
+
+## Chrome Dashboard Evidence
+
+### Google Search Console
+
+Observed through Chrome:
+
+- Search Console property for `fermatmind.com` is accessible.
+- Performance dashboard for `sc-domain:fermatmind.com` is accessible.
+- Left navigation includes:
+  - URL inspection
+  - Pages
+  - Sitemaps
+  - Removals
+  - Settings
+- Sitemaps page is accessible at the `sc-domain:fermatmind.com` property.
+- Sitemaps page shows:
+  - "Add a new sitemap"
+  - sitemap URL input
+  - submit control
+  - submitted sitemaps table
+
+Not done:
+
+- no sitemap was submitted
+- no URL inspection query was run
+- no request indexing action was run
+- no account email was recorded
+
+GSC readiness:
+
+- property access: PASS
+- sitemap submit UI access: PASS
+- URL inspection UI access: PASS
+- actual write/submit action: NOT PERFORMED
+
+### Baidu Search Resource Platform
+
+Observed through Chrome:
+
+- Baidu Search Resource dashboard is accessible for site `https://fermatmind.com/`.
+- Site dashboard shows site information and resource submission navigation.
+- 普通收录 page is accessible.
+- 普通收录 page shows:
+  - API submission section
+  - sitemap section
+  - manual submission section
+  - submission controls
+- Manual submission area is visible.
+
+Not done:
+
+- no Baidu URL was submitted
+- no sitemap was submitted
+- no API push was called
+- no token was copied into this report
+- no token was used
+
+Baidu readiness:
+
+- dashboard access: PASS
+- verified site context: PASS
+- manual submit UI access: PASS
+- sitemap submit UI access: CONDITIONAL, recheck field state before execution
+- API push: NO-GO by default because it requires secret handling
+
+## Recommended Execution Strategy
+
+### Phase 1: GSC Sitemap Submission
+
+Recommended first execution PR/task:
+
+`SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01`
+
+Why:
+
+- Sitemap now contains both canary URLs.
+- GSC sitemap submit UI is visible.
+- This is lower risk than immediate URL Inspection request-indexing.
+- It avoids sending individual URL request-indexing actions before post-submit monitoring is ready.
+
+Execution scope:
+
+- submit `https://fermatmind.com/sitemap.xml` in GSC for `sc-domain:fermatmind.com`
+- capture visible success/error state
+- do not submit individual URLs
+- do not submit Baidu or IndexNow
+- do not mutate CMS
+- do not create Search Channel records
+
+Exact confirmation phrase:
+
+```text
+I explicitly approve GSC sitemap submission for https://fermatmind.com/sitemap.xml on property sc-domain:fermatmind.com. Do not request indexing for individual URLs. Do not submit Baidu or IndexNow. Do not mutate CMS.
+```
+
+### Phase 2: Baidu Manual zh URL Submission
+
+Recommended second execution PR/task:
+
+`SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01`
+
+Why:
+
+- Baidu verified-site dashboard is accessible.
+- Baidu priority should be the Chinese canonical URL by default.
+- Manual submission avoids Codex handling the Baidu API token.
+
+Execution scope:
+
+- submit only `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice`
+- do not submit the English URL to Baidu by default
+- do not use API push/token
+- capture visible success/error state
+- do not submit GSC or IndexNow
+- do not mutate CMS
+- do not create Search Channel records
+
+Exact confirmation phrase:
+
+```text
+I explicitly approve Baidu Search Resource manual submission for https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice only. Do not submit the English URL. Do not use Baidu API push or expose the token. Do not submit GSC or IndexNow. Do not mutate CMS.
+```
+
+### Optional: GSC URL Inspection Request Indexing
+
+Recommended only after GSC sitemap submission is recorded or if a human specifically wants individual URL acceleration.
+
+Potential task:
+
+`SEO-SEARCH-SUBMISSION-GSC-URL-INSPECTION-CANARY-01`
+
+Exact confirmation phrase:
+
+```text
+I explicitly approve GSC URL Inspection request indexing for https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice and https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice on property sc-domain:fermatmind.com. Do not submit Baidu or IndexNow. Do not mutate CMS.
+```
+
+### Optional: Baidu Sitemap Submission
+
+Recommended only if Baidu manual zh URL submission is not enough or if the user wants sitemap-level discovery.
+
+Potential task:
+
+`SEO-SEARCH-SUBMISSION-BAIDU-SITEMAP-CANARY-01`
+
+Exact confirmation phrase:
+
+```text
+I explicitly approve Baidu Search Resource sitemap submission for https://fermatmind.com/sitemap.xml on site https://fermatmind.com/. Do not use Baidu API push or expose the token. Do not submit GSC or IndexNow. Do not mutate CMS.
+```
+
+### Deferred: IndexNow
+
+Potential task:
+
+`SEO-SEARCH-SUBMISSION-INDEXNOW-CANARY-01`
+
+Current decision:
+
+NO-GO.
+
+Required before execution:
+
+- confirm safe key presence without printing key
+- confirm live gate policy
+- decide whether to use backend runtime or manual external endpoint
+- re-run no-write preflight
+
+### Deferred: Backend Search Channel CMS Article Candidacy
+
+Potential fix/planning task:
+
+`SEO-SEARCH-CHANNEL-CMS-ARTICLE-CANDIDACY-01`
+
+Current decision:
+
+NO-GO.
+
+Reason:
+
+- Search Channel dry-run returned `canonical_url_not_found` for both CMS article canonical URLs.
+
+Scope for later:
+
+- make URL Truth / Search Channel planner recognize published CMS article canonical URLs
+- preserve private/noindex/canonical gates
+- do not live-submit during the fix
+
+## Risk Boundary
+
+Do not submit:
+
+- draft URLs
+- preview URLs
+- noindex URLs
+- non-canonical URLs
+- result/order/share/payment/history/take URLs
+- tokenized URLs
+- English URL to Baidu unless later policy explicitly allows it
+
+Do not use:
+
+- Baidu API token unless a separate secret-safe path is authorized
+- IndexNow key unless a separate secret-safe path is authorized
+- backend Search Channel until CMS article candidacy is fixed
+
+## Recommended Task Order
+
+1. `SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01`
+2. `SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01`
+3. Optional: `SEO-SEARCH-SUBMISSION-GSC-URL-INSPECTION-CANARY-01`
+4. Optional: `SEO-SEARCH-SUBMISSION-BAIDU-SITEMAP-CANARY-01`
+5. Deferred: `SEO-SEARCH-SUBMISSION-INDEXNOW-CANARY-01`
+6. Deferred fix: `SEO-SEARCH-CHANNEL-CMS-ARTICLE-CANDIDACY-01`
+
+## Proposed PR Train Entries Requiring User Authorization
+
+This planning task did not update `docs/codex/pr-train.yaml` or `docs/codex/pr-train-state.json`.
+
+Before opening PRs or doing channel-specific execution, user authorization should add the relevant train item. Suggested entries:
+
+```yaml
+- id: SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01
+  repo: fap-api
+  branch: codex/seo-search-submission-gsc-sitemap-canary-01
+  title: "ops(seo): submit canary sitemap in GSC"
+  train_scope: seo_cms_canary
+  status: planned
+  depends_on:
+    - SEO-SEARCH-SUBMISSION-CANARY-EXECUTION-PLAN-01
+  allowed_paths:
+    - backend/docs/seo/**
+    - docs/codex/pr-train.yaml
+    - docs/codex/pr-train-state.json
+  checks:
+    - git diff --check -- backend/docs/seo docs/codex
+
+- id: SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01
+  repo: fap-api
+  branch: codex/seo-search-submission-baidu-manual-zh-canary-01
+  title: "ops(seo): submit Chinese canary URL in Baidu"
+  train_scope: seo_cms_canary
+  status: planned
+  depends_on:
+    - SEO-SEARCH-SUBMISSION-CANARY-EXECUTION-PLAN-01
+  allowed_paths:
+    - backend/docs/seo/**
+    - docs/codex/pr-train.yaml
+    - docs/codex/pr-train-state.json
+  checks:
+    - git diff --check -- backend/docs/seo docs/codex
+```
+
+Follow-up authorization prompt:
+
+```text
+明确授权在 fap-api 新增并执行 PR train item SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01，更新 docs/codex/pr-train.yaml 和 docs/codex/pr-train-state.json，使用已登录 Chrome 的 Google Search Console 仅提交 https://fermatmind.com/sitemap.xml 到 sc-domain:fermatmind.com；不执行 URL Inspection request indexing，不提交百度/IndexNow，不改 CMS，不 publish，不创建 Search Channel 记录。
+```
+
+## Validation
+
+Commands/checks run:
+
+```bash
+Chrome read-only GSC dashboard inspection
+Chrome read-only Baidu Search Resource dashboard inspection
+```
+
+Local file check:
+
+```bash
+git diff --check -- backend/docs/seo/seo-search-submission-canary-execution-plan-2026-06-03.md
+```

--- a/backend/docs/seo/seo-search-submission-gsc-sitemap-canary-2026-06-03.md
+++ b/backend/docs/seo/seo-search-submission-gsc-sitemap-canary-2026-06-03.md
@@ -1,0 +1,104 @@
+# SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01
+
+Date: 2026-06-03
+Repo: fap-api
+Task type: controlled GSC sitemap-only submission result archive
+
+## Boundary
+
+This task submitted only the public sitemap URL in Google Search Console after exact user authorization.
+
+No URL Inspection request indexing, Baidu submission, IndexNow call, Baidu API token use, Search Channel queue record creation, CMS mutation, publish, unpublish, content edit, runtime code edit, deploy, or private URL access was performed.
+
+## Submitted Surface
+
+| Field | Value |
+| --- | --- |
+| GSC property | `sc-domain:fermatmind.com` |
+| Submitted sitemap URL | `https://fermatmind.com/sitemap.xml` |
+| Submission method | Logged-in Chrome Google Search Console sitemap page |
+| Individual URL request indexing | Not performed |
+
+## Visible GSC Result
+
+GSC accepted the sitemap submission and displayed the success message:
+
+- `已成功提交站点地图`
+
+Immediate post-submit table state briefly showed the submitted sitemap row with an initial `无法抓取` state. After a read-only refresh and wait, the submitted sitemap table converged to:
+
+| Field | Visible value |
+| --- | --- |
+| Sitemap | `https://fermatmind.com/sitemap.xml` |
+| Type | `站点地图` |
+| Submitted / read date | `2026年6月3日` |
+| Status | `成功` |
+| Discovered pages | `2,272` |
+| Discovered videos | `0` |
+
+Final visible state: PASS.
+
+## Public Sitemap Cross-Check
+
+Read-only public check after submission:
+
+| Check | Result |
+| --- | --- |
+| `https://fermatmind.com/sitemap.xml` HTTP status | 200 |
+| Response length | 333,760 bytes |
+| Cache-Control | `public, max-age=0` |
+| Contains zh canary URL | yes |
+| Contains en canary URL | yes |
+
+## Explicit Non-Actions
+
+| Action | Performed |
+| --- | --- |
+| GSC URL Inspection request indexing | no |
+| Individual URL submission | no |
+| Baidu manual submission | no |
+| Baidu sitemap submission | no |
+| Baidu API push/token use | no |
+| IndexNow call | no |
+| Search Channel queue record creation | no |
+| CMS mutation | no |
+| Publish / unpublish | no |
+| Runtime code edit | no |
+| Deployment | no |
+
+## Search Channel / Submission Surface Boundary
+
+Backend Search Channel remains out of scope for this PR. The prior execution plan recorded that current backend Search Channel dry-runs return `canonical_url_not_found` for CMS article canonical URLs.
+
+No Search Channel queue row was created by this task.
+
+## Next Step
+
+The next recommended task can proceed after this PR is merged:
+
+`SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01`
+
+Recommended scope:
+
+- submit only `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice`
+- use Baidu Search Resource manual submission UI
+- do not submit the English URL to Baidu
+- do not use Baidu API push or expose the token
+- do not submit GSC or IndexNow in the same task
+- do not mutate CMS
+- do not create Search Channel records
+
+Exact confirmation phrase:
+
+```text
+I explicitly approve Baidu Search Resource manual submission for https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice only. Do not submit the English URL. Do not use Baidu API push or expose the token. Do not submit GSC or IndexNow. Do not mutate CMS.
+```
+
+## Validation Commands
+
+```bash
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/seo docs/codex
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-03T07:24:09Z",
+  "updated_at": "2026-06-03T07:26:01Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
@@ -41775,12 +41775,12 @@
   "SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01": {
     "repo": "fap-api",
     "branch": "codex/seo-search-submission-gsc-sitemap-canary-01",
-    "status": "local_checks_passed_gsc_sitemap_submitted",
+    "status": "pr_open_gsc_sitemap_submitted",
     "depends_on": [
       "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "pending_remote_pr_head",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1869",
     "checks": {
       "dependency_reconciliation": {
         "status": "passed",
@@ -41827,6 +41827,13 @@
           "git diff --cached --check"
         ],
         "notes": "JSON parse, YAML parse, scoped diff whitespace check, and cached diff whitespace check passed. Staged files were limited to the execution-plan archive, GSC sitemap result report, and PR train metadata."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-search-submission-gsc-sitemap-canary-01 --title \"ops(seo): submit canary sitemap in GSC\""
+        ],
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1869 after local checks passed. GSC sitemap submission was already completed and archived; no additional search submission action was performed during PR creation."
       }
     },
     "failure_reason": null,
@@ -41867,6 +41874,12 @@
         "from": "gsc_sitemap_submitted_report_created_local_checks_pending",
         "to": "local_checks_passed_gsc_sitemap_submitted",
         "note": "JSON/YAML parse, scoped diff check, cached diff check, and path-limited staging passed. Staged scope is docs-only plus train metadata."
+      },
+      {
+        "at": "2026-06-03T07:26:01Z",
+        "from": "local_checks_passed_gsc_sitemap_submitted",
+        "to": "pr_open_gsc_sitemap_submitted",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1869. No additional URL submission, Baidu, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-02T14:43:50Z",
+  "updated_at": "2026-06-03T07:24:09Z",
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",
@@ -41628,11 +41628,11 @@
   "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01": {
     "repo": "fap-api",
     "branch": "codex/seo-review-p1-10-sitemap-llms-enumeration-01",
-    "status": "pr_open_no_go_search_submission",
+    "status": "merged_no_go_search_submission",
     "depends_on": [
       "SEO-REVIEW-P1-10"
     ],
-    "commit_sha": "385b58c4cd21df412fc455e7cfa7307107c05bfd",
+    "commit_sha": "8da3405f75ca779e27b10c01f0db2157d0ea3cb0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1868",
     "checks": {
       "dependency_reconciliation": {
@@ -41684,22 +41684,30 @@
         "notes": "JSON parse, YAML parse, scoped whitespace diff check, and cached diff check passed before commit after path-limited staging."
       },
       "pr": {
-        "status": "opened",
+        "status": "merged",
         "commands": [
           "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-review-p1-10-sitemap-llms-enumeration-01 --title \"docs(seo): investigate SEO canary sitemap and llms-full enumeration gap\""
         ],
-        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1868. Search submission remains NO-GO."
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1868. Search submission remained NO-GO until the later sitemap/llms convergence fix and frontend deploy."
+      },
+      "merge_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1868 --repo fermatmind/fap-api --json number,state,mergedAt,mergeCommit,url,headRefName,title",
+          "git merge-base --is-ancestor 8da3405f75ca779e27b10c01f0db2157d0ea3cb0 origin/main"
+        ],
+        "notes": "GitHub reports PR #1868 merged at 2026-06-03T05:21:44Z with merge commit 8da3405f75ca779e27b10c01f0db2157d0ea3cb0, and origin/main contains the merge commit."
       }
     },
     "failure_reason": "NO-GO for search submission: sitemap.xml and llms-full.txt still do not enumerate the canary URLs. Backend sitemap-source is serving stale cache, frontend sitemap.xml is a static build artifact, and llms-full is blocked by response cache/revalidation gap.",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T05:21:44Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "production_write_execution": false,
       "database_mutation": false,
       "cms_mutation": false,
@@ -41732,6 +41740,12 @@
         "from": "local_checks_passed_no_go_search_submission",
         "to": "pr_open_no_go_search_submission",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1868. No search submission, publish, CMS mutation, runtime edit, fap-web edit, test edit, or GPT content edit was performed."
+      },
+      {
+        "at": "2026-06-03T07:20:22Z",
+        "from": "pr_open_no_go_search_submission",
+        "to": "merged_no_go_search_submission",
+        "note": "Reconciled ledger: PR #1868 is merged and origin/main contains merge commit 8da3405f75ca779e27b10c01f0db2157d0ea3cb0."
       }
     ],
     "sidecars": [
@@ -41757,5 +41771,116 @@
       }
     ],
     "next_task": "SEO-REVIEW-P1-10-SITEMAP-LLMS-FIX-01 proposed in fap-web; search submission remains forbidden."
+  },
+  "SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-search-submission-gsc-sitemap-canary-01",
+    "status": "local_checks_passed_gsc_sitemap_submitted",
+    "depends_on": [
+      "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1868 --repo fermatmind/fap-api --json number,state,mergedAt,mergeCommit,url,headRefName,title",
+          "git merge-base --is-ancestor 8da3405f75ca779e27b10c01f0db2157d0ea3cb0 origin/main"
+        ],
+        "notes": "Dependency SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01 is merged and origin/main contains merge commit 8da3405f75ca779e27b10c01f0db2157d0ea3cb0."
+      },
+      "authorization": {
+        "status": "passed",
+        "commands": [
+          "user explicit authorization in chat"
+        ],
+        "notes": "User explicitly authorized adding and executing SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01, updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json, archiving the execution-plan report, submitting only https://fermatmind.com/sitemap.xml to GSC property sc-domain:fermatmind.com through logged-in Chrome, and creating a docs-only result report. URL Inspection request indexing, Baidu, IndexNow, Baidu API token usage, Search Channel queue records, CMS mutation, publish/unpublish, content edits, runtime code edits, and deploy remain forbidden."
+      },
+      "gsc_submission": {
+        "status": "passed",
+        "commands": [
+          "Chrome Google Search Console sitemap page submission for https://fermatmind.com/sitemap.xml"
+        ],
+        "notes": "GSC displayed '已成功提交站点地图'. After a read-only refresh, the submitted sitemap table showed https://fermatmind.com/sitemap.xml, type 站点地图, date 2026年6月3日, status 成功, discovered pages 2,272, discovered videos 0. No URL Inspection request indexing or individual URL submission was performed."
+      },
+      "public_sitemap_cross_check": {
+        "status": "passed",
+        "commands": [
+          "python3 inline urllib check for https://fermatmind.com/sitemap.xml"
+        ],
+        "notes": "Public sitemap returned 200, response length 333760 bytes, Cache-Control public max-age=0, and contained both bilingual canary slugs."
+      },
+      "report": {
+        "status": "created",
+        "commands": [
+          "created backend/docs/seo/seo-search-submission-gsc-sitemap-canary-2026-06-03.md"
+        ],
+        "notes": "Docs-only result report records the GSC property, submitted sitemap URL, visible success state, submitted/read date, no individual URL submission, no Baidu/IndexNow, no CMS mutation, no Search Channel records, and next Baidu manual zh URL submission readiness."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON parse, YAML parse, scoped diff whitespace check, and cached diff whitespace check passed. Staged files were limited to the execution-plan archive, GSC sitemap result report, and PR train metadata."
+      }
+    },
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null,
+      "gsc_sitemap_submission_performed": true,
+      "individual_url_submission_performed": false,
+      "baidu_submission_performed": false,
+      "indexnow_submission_performed": false,
+      "baidu_api_token_used": false,
+      "search_channel_records_created": false,
+      "cms_mutation": false,
+      "publish_performed": false,
+      "runtime_code_edit_performed": false,
+      "deploy_performed": false
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T07:16:36Z",
+        "from": "missing",
+        "to": "executing",
+        "note": "Started GSC sitemap-only submission PR train item after explicit user authorization. Scope is GSC sitemap submission plus docs-only archive/report and train metadata. No URL Inspection request indexing, Baidu, IndexNow, CMS mutation, publish, Search Channel queue write, runtime edit, or deploy is allowed."
+      },
+      {
+        "at": "2026-06-03T07:20:22Z",
+        "from": "executing",
+        "to": "gsc_sitemap_submitted_report_created_local_checks_pending",
+        "note": "Submitted only https://fermatmind.com/sitemap.xml in GSC. Final visible GSC table state after refresh was 成功 with 2,272 discovered pages. Created docs-only result report. No individual URL request indexing, Baidu, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
+      },
+      {
+        "at": "2026-06-03T07:24:09Z",
+        "from": "gsc_sitemap_submitted_report_created_local_checks_pending",
+        "to": "local_checks_passed_gsc_sitemap_submitted",
+        "note": "JSON/YAML parse, scoped diff check, cached diff check, and path-limited staging passed. Staged scope is docs-only plus train metadata."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "baidu_api_token_boundary",
+        "status": "active",
+        "note": "Baidu API token must not be recorded, printed, used, or submitted in this PR."
+      },
+      {
+        "id": "search_channel_candidacy_still_blocked",
+        "status": "active",
+        "note": "Backend Search Channel remains out of scope and blocked by canonical_url_not_found for the CMS article URLs."
+      }
+    ],
+    "next_task": "SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01 after GSC sitemap result is archived and merged."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20420,3 +20420,46 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-REVIEW-P1-10-SITEMAP-LLMS-FIX-01 proposed in fap-web; search submission remains forbidden until sitemap.xml and llms-full.txt enumerate the canary URLs
+
+  - id: SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01
+    repo: fap-api
+    depends_on:
+      - SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01
+    branch: codex/seo-search-submission-gsc-sitemap-canary-01
+    title: "ops(seo): submit canary sitemap in GSC"
+    train_scope: seo_cms_canary
+    status: executing
+    scope:
+      - Archive the GSC/Baidu execution planning report for the bilingual SEO canary.
+      - Use the already logged-in Chrome Google Search Console session to submit only `https://fermatmind.com/sitemap.xml` to property `sc-domain:fermatmind.com`.
+      - Record visible success or error state and whether any timestamp/status is visible.
+      - Create a docs-only execution result report.
+    allowed_paths:
+      - backend/docs/seo/seo-search-submission-canary-execution-plan-2026-06-03.md
+      - backend/docs/seo/seo-search-submission-gsc-sitemap-canary-2026-06-03.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute URL Inspection request indexing, submit Baidu, call IndexNow, use Baidu API token, create Search Channel queue records, mutate CMS, publish, unpublish, modify content, modify runtime code, or deploy.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: true
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01 after GSC sitemap submission result is archived


### PR DESCRIPTION
## What changed

- Added the archived search submission execution plan report.
- Submitted only `https://fermatmind.com/sitemap.xml` in Google Search Console for `sc-domain:fermatmind.com` after exact user authorization.
- Added a docs-only result report recording the visible GSC success state.
- Registered `SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01` in the PR train manifest/state and reconciled the merged dependency ledger for PR #1868.

## Why

The bilingual SEO canary public surfaces are now published, indexable, and enumerated in sitemap/llms. This PR records the first controlled search submission action: GSC sitemap-only submission, without individual URL indexing or other search channels.

## Validation commands

```bash
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
git diff --check -- backend/docs/seo docs/codex
git diff --cached --check
```

## Intentionally deferred

- No GSC URL Inspection request indexing.
- No Baidu manual submission, sitemap submission, or API push.
- No Baidu API token use or exposure.
- No IndexNow call.
- No Search Channel queue records.
- No CMS mutation, publish/unpublish, content edit, runtime code edit, frontend edit, deploy, or tests change.

## Repository rule impact

Docs/ops-only search submission archive. No content ownership, publishing authority, runtime sitemap/llms behavior, CMS model, public API, media, or frontend fallback rule changes.
