### PR TITLE
ops(seo): submit Chinese canary URL in Baidu

### DIFF
--- a/backend/docs/seo/seo-search-submission-baidu-manual-zh-canary-2026-06-03.md
+++ b/backend/docs/seo/seo-search-submission-baidu-manual-zh-canary-2026-06-03.md
@@ -1,0 +1,75 @@
+# SEO Search Submission Baidu Manual zh Canary
+
+Date: 2026-06-03
+
+PR train item: `SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01`
+
+## Scope
+
+This run used the already logged-in Chrome Baidu Search Resource Platform session to attempt a manual submission for the zh-CN SEO canary URL only.
+
+Allowed URL:
+
+- `https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice`
+
+Explicitly forbidden and not performed:
+
+- English canary URL submission.
+- Baidu API token usage.
+- IndexNow calls.
+- Google URL Inspection request indexing.
+- Search Channel queue record creation.
+- CMS mutation.
+- Publish or unpublish.
+- Runtime code edits.
+- Deployment.
+
+## Platform
+
+- Platform: Baidu Search Resource Platform.
+- Visible product area: link submission / normal inclusion.
+- Visible site context: FermatMind site account label.
+- No account email, cookie, browser storage, token, API credential, or secret value is recorded in this report.
+
+## Attempt
+
+At approximately `2026-06-03T19:07:00+08:00`, Codex filled the manual link submission input with the zh-CN canary URL:
+
+```text
+https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice
+```
+
+Codex clicked the visible submit button once for that URL. A previous attempt earlier in the same task had also reached the same Baidu security verification gate after submit.
+
+## Visible Result
+
+NO-GO: Baidu manual zh URL submission is not confirmed.
+
+After submit, Baidu displayed a security verification challenge requiring a human slider action before the operation could continue. The visible challenge text was a Baidu security verification prompt asking the operator to complete the verification before continuing.
+
+Because the security verification was not completed by a human operator during this run, there was no visible Baidu success state, no submitted timestamp, and no accepted-result confirmation for the zh-CN canary URL.
+
+## Boundary Verification
+
+- Submitted English canary URL: no.
+- Used Baidu API token: no.
+- Called IndexNow: no.
+- Used Google URL Inspection request indexing: no.
+- Created Search Channel queue records: no.
+- Mutated CMS data: no.
+- Published or unpublished content: no.
+- Modified content: no.
+- Modified runtime code: no.
+- Deployed: no.
+
+## Follow-Up
+
+The next Baidu action must be human-operator gated:
+
+1. A human operator completes the Baidu security verification in the logged-in Chrome session.
+2. The zh-CN canary URL is submitted through the Baidu Search Resource Platform UI.
+3. The visible success or error result is recorded in a follow-up docs-only report.
+
+Do not treat the zh-CN canary URL as successfully submitted to Baidu until a visible Baidu success state is observed.
+
+The English canary URL remains out of scope for Baidu manual submission unless separately authorized.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41920,12 +41920,12 @@
   "SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01": {
     "repo": "fap-api",
     "branch": "codex/seo-search-submission-baidu-manual-zh-canary-01",
-    "status": "local_checks_passed_baidu_security_verification_blocked",
+    "status": "pr_open_baidu_security_verification_blocked",
     "depends_on": [
       "SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01"
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "22a4a04cfa8a657fa1cbbefbbffe90d9949d6732",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1870",
     "checks": {
       "dependency_reconciliation": {
         "status": "passed",
@@ -41965,6 +41965,13 @@
           "git diff --cached --check"
         ],
         "notes": "JSON parse, YAML parse, scoped diff whitespace check, and cached diff whitespace check passed. Staged files are limited to the Baidu manual zh result report and PR train metadata."
+      },
+      "pr": {
+        "status": "opened",
+        "commands": [
+          "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-search-submission-baidu-manual-zh-canary-01 --title \"ops(seo): submit Chinese canary URL in Baidu\""
+        ],
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1870 after local checks passed. No additional Baidu submission action was performed during PR creation."
       }
     },
     "failure_reason": "NO-GO for confirmed Baidu submission: Baidu displayed a security verification challenge after the zh-CN URL submit action, and no visible success state was observed.",
@@ -42007,6 +42014,12 @@
         "from": "baidu_security_verification_blocked_report_created_local_checks_pending",
         "to": "local_checks_passed_baidu_security_verification_blocked",
         "note": "JSON/YAML parse and scoped diff checks passed for the docs-only blocked result report and PR train metadata. Baidu submission remains unconfirmed because the security verification gate blocked completion."
+      },
+      {
+        "at": "2026-06-03T11:07:20Z",
+        "from": "local_checks_passed_baidu_security_verification_blocked",
+        "to": "pr_open_baidu_security_verification_blocked",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1870. Baidu submission remains unconfirmed because security verification blocked completion. No English URL submission, Baidu API token usage, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
       }
     ],
     "sidecars": [

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41775,11 +41775,11 @@
   "SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01": {
     "repo": "fap-api",
     "branch": "codex/seo-search-submission-gsc-sitemap-canary-01",
-    "status": "pr_open_gsc_sitemap_submitted",
+    "status": "merged_gsc_sitemap_submitted",
     "depends_on": [
       "SEO-REVIEW-P1-10-SITEMAP-LLMS-ENUMERATION-01"
     ],
-    "commit_sha": "pending_remote_pr_head",
+    "commit_sha": "e7ed36c49a47d3ed9d272e62677f65babdf0e0c9",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1869",
     "checks": {
       "dependency_reconciliation": {
@@ -41834,17 +41834,32 @@
           "gh pr create --repo fermatmind/fap-api --base main --head codex/seo-search-submission-gsc-sitemap-canary-01 --title \"ops(seo): submit canary sitemap in GSC\""
         ],
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1869 after local checks passed. GSC sitemap submission was already completed and archived; no additional search submission action was performed during PR creation."
+      },
+      "github": {
+        "status": "passed",
+        "commands": [
+          "gh pr checks 1869 --repo fermatmind/fap-api --watch --interval 20"
+        ],
+        "notes": "GitHub checks passed before squash merge."
+      },
+      "merge_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1869 --repo fermatmind/fap-api --json number,state,mergedAt,mergeCommit,headRefName,url",
+          "git merge-base --is-ancestor e7ed36c49a47d3ed9d272e62677f65babdf0e0c9 origin/main"
+        ],
+        "notes": "GitHub reports PR #1869 merged at 2026-06-03T07:33:15Z with merge commit e7ed36c49a47d3ed9d272e62677f65babdf0e0c9, and origin/main contains the merge commit."
       }
     },
     "failure_reason": null,
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-03T07:33:15Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": null,
-      "post_merge_revalidated": null,
+      "github_checks_green": true,
+      "post_merge_revalidated": true,
       "gsc_sitemap_submission_performed": true,
       "individual_url_submission_performed": false,
       "baidu_submission_performed": false,
@@ -41880,6 +41895,12 @@
         "from": "local_checks_passed_gsc_sitemap_submitted",
         "to": "pr_open_gsc_sitemap_submitted",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1869. No additional URL submission, Baidu, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
+      },
+      {
+        "at": "2026-06-03T07:33:15Z",
+        "from": "pr_open_gsc_sitemap_submitted",
+        "to": "merged_gsc_sitemap_submitted",
+        "note": "PR #1869 passed GitHub checks, was squash merged, and the remote/local task branches were cleaned up. No Baidu, IndexNow, individual URL indexing, CMS mutation, publish, runtime edit, or deploy was performed."
       }
     ],
     "sidecars": [
@@ -41894,6 +41915,117 @@
         "note": "Backend Search Channel remains out of scope and blocked by canonical_url_not_found for the CMS article URLs."
       }
     ],
-    "next_task": "SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01 after GSC sitemap result is archived and merged."
+    "next_task": "SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01."
+  },
+  "SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-search-submission-baidu-manual-zh-canary-01",
+    "status": "local_checks_passed_baidu_security_verification_blocked",
+    "depends_on": [
+      "SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01"
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": {
+      "dependency_reconciliation": {
+        "status": "passed",
+        "commands": [
+          "gh pr view 1869 --repo fermatmind/fap-api --json number,state,mergedAt,mergeCommit,headRefName,url",
+          "git merge-base --is-ancestor e7ed36c49a47d3ed9d272e62677f65babdf0e0c9 origin/main"
+        ],
+        "notes": "Dependency SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01 is merged and origin/main contains merge commit e7ed36c49a47d3ed9d272e62677f65babdf0e0c9."
+      },
+      "authorization": {
+        "status": "passed",
+        "commands": [
+          "user explicit authorization in chat"
+        ],
+        "notes": "User explicitly authorized adding and executing SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01, updating docs/codex/pr-train.yaml and docs/codex/pr-train-state.json, using logged-in Chrome Baidu Search Resource Platform only for manual zh-CN canary URL submission, and forbade English URL submission, Baidu API token usage, IndexNow, Search Channel queue records, CMS mutation, publish/unpublish, runtime code edits, and deploy."
+      },
+      "baidu_manual_submission_attempt": {
+        "status": "blocked_by_baidu_security_verification",
+        "commands": [
+          "Chrome Baidu Search Resource Platform link submission UI for https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice"
+        ],
+        "notes": "The Baidu UI accepted the zh-CN canary URL in the manual link submission input, but after submit displayed a Baidu security verification slider challenge. No visible success state, submitted timestamp, or accepted-result confirmation was observed. Codex did not solve or bypass the security verification."
+      },
+      "report": {
+        "status": "created",
+        "commands": [
+          "created backend/docs/seo/seo-search-submission-baidu-manual-zh-canary-2026-06-03.md"
+        ],
+        "notes": "Docs-only result report records the Baidu platform, zh-CN submitted URL attempt, visible security verification block, no English submission, no Baidu API token usage, no IndexNow, no Search Channel records, no CMS mutation, no publish, and no deploy."
+      },
+      "local": {
+        "status": "passed",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON parse, YAML parse, scoped diff whitespace check, and cached diff whitespace check passed. Staged files are limited to the Baidu manual zh result report and PR train metadata."
+      }
+    },
+    "failure_reason": "NO-GO for confirmed Baidu submission: Baidu displayed a security verification challenge after the zh-CN URL submit action, and no visible success state was observed.",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": null,
+      "post_merge_revalidated": null,
+      "baidu_manual_submission_attempted": true,
+      "baidu_submission_confirmed": false,
+      "baidu_security_verification_blocked": true,
+      "english_url_submission_performed": false,
+      "gsc_url_inspection_performed": false,
+      "indexnow_submission_performed": false,
+      "baidu_api_token_used": false,
+      "search_channel_records_created": false,
+      "cms_mutation": false,
+      "publish_performed": false,
+      "runtime_code_edit_performed": false,
+      "deploy_performed": false
+    },
+    "transitions": [
+      {
+        "at": "2026-06-03T11:07:20Z",
+        "from": "missing",
+        "to": "executing",
+        "note": "Started Baidu manual zh-CN canary submission PR train item after explicit user authorization. Scope is Baidu manual UI attempt plus docs-only result report and train metadata. English URL submission, Baidu API token usage, IndexNow, Search Channel queue records, CMS mutation, publish, runtime edits, and deploy are forbidden."
+      },
+      {
+        "at": "2026-06-03T11:07:20Z",
+        "from": "executing",
+        "to": "baidu_security_verification_blocked_report_created_local_checks_pending",
+        "note": "Submitted the zh-CN canary URL through the Baidu manual link submission UI, but Baidu displayed a security verification slider challenge and no visible success state was observed. Created docs-only blocked result report. Codex did not solve or bypass the security verification."
+      },
+      {
+        "at": "2026-06-03T11:07:20Z",
+        "from": "baidu_security_verification_blocked_report_created_local_checks_pending",
+        "to": "local_checks_passed_baidu_security_verification_blocked",
+        "note": "JSON/YAML parse and scoped diff checks passed for the docs-only blocked result report and PR train metadata. Baidu submission remains unconfirmed because the security verification gate blocked completion."
+      }
+    ],
+    "sidecars": [
+      {
+        "id": "human_operator_security_verification_required",
+        "status": "active",
+        "note": "A human operator must complete Baidu security verification before a confirmed Baidu manual zh-CN URL submission can be recorded."
+      },
+      {
+        "id": "baidu_api_token_boundary",
+        "status": "active",
+        "note": "Baidu API token was not used, printed, recorded, or exposed."
+      },
+      {
+        "id": "english_canary_boundary",
+        "status": "active",
+        "note": "English canary URL submission to Baidu remains out of scope and was not performed."
+      }
+    ],
+    "next_task": "A human operator must complete Baidu security verification and then rerun/continue Baidu manual zh-CN URL submission confirmation, or separately authorize a different search submission path."
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20428,7 +20428,7 @@ prs:
     branch: codex/seo-search-submission-gsc-sitemap-canary-01
     title: "ops(seo): submit canary sitemap in GSC"
     train_scope: seo_cms_canary
-    status: executing
+    status: completed
     scope:
       - Archive the GSC/Baidu execution planning report for the bilingual SEO canary.
       - Use the already logged-in Chrome Google Search Console session to submit only `https://fermatmind.com/sitemap.xml` to property `sc-domain:fermatmind.com`.
@@ -20463,3 +20463,45 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01 after GSC sitemap submission result is archived
+
+  - id: SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01
+    repo: fap-api
+    depends_on:
+      - SEO-SEARCH-SUBMISSION-GSC-SITEMAP-CANARY-01
+    branch: codex/seo-search-submission-baidu-manual-zh-canary-01
+    title: "ops(seo): submit Chinese canary URL in Baidu"
+    train_scope: seo_cms_canary
+    status: executing
+    scope:
+      - Use the already logged-in Chrome Baidu Search Resource Platform session to submit only the zh-CN canary article URL.
+      - Do not submit the English canary URL.
+      - Do not use Baidu API token, IndexNow, Google URL Inspection request indexing, Search Channel queue records, CMS mutation, publish, runtime edits, or deploys.
+      - Record visible success, error, or blocking state in a docs-only result report.
+    allowed_paths:
+      - backend/docs/seo/seo-search-submission-baidu-manual-zh-canary-2026-06-03.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Submit the English canary URL, call Baidu API token, call IndexNow, execute Google URL Inspection request indexing, create Search Channel queue records, mutate CMS, publish, unpublish, modify content, modify runtime code, deploy, or bypass Baidu security verification.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: false
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: true
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: Retry Baidu manual zh URL submission only after a human operator completes Baidu security verification, or proceed to IndexNow planning only after separate authorization.


### PR DESCRIPTION
## What changed
- Added PR train item SEO-SEARCH-SUBMISSION-BAIDU-MANUAL-ZH-CANARY-01.
- Archived a docs-only Baidu manual zh canary URL submission result report.
- Reconciled the prior GSC sitemap submission item as merged.

## Why
The zh-CN canary URL was attempted through the logged-in Baidu Search Resource Platform manual link submission UI. Baidu displayed a security verification slider challenge after submit, so the result is recorded as NO-GO / submission not confirmed instead of claiming success.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/seo docs/codex
- git diff --cached --check

## Intentionally deferred
- Human operator completion of Baidu security verification.
- Any confirmed Baidu success-state archive after verification is completed.
- English URL submission.
- Baidu API token usage, IndexNow, Search Channel queue records, CMS mutation, publish/unpublish, runtime code edits, and deploys.