### PR TITLE
docs(monetization): scan locale freemium policy readiness

### DIFF
--- a/backend/docs/operations/freemium-locale-policy-scan-2026-06-03.md
+++ b/backend/docs/operations/freemium-locale-policy-scan-2026-06-03.md
@@ -1,0 +1,192 @@
+# Freemium Locale Policy Scan
+
+Date: 2026-06-03
+
+PR id: FREEMIUM-LOCALE-POLICY-SCAN-01
+
+Repo: fap-api
+
+Branch: codex/freemium-locale-policy-scan-01
+
+Mode: read-only scan and docs-only report. No runtime code, CMS data, order/payment provider, deployment, or content asset was changed.
+
+## 1. GO / NO-GO
+
+NO-GO for paid ads and public commercial launch of the proposed locale policy.
+
+GO only for documenting the current state and planning `FREEMIUM-LOCALE-POLICY-01`.
+
+Reason: the backend can prove a general MBTI CNY 1.99 full-report SKU and entitlement unlock chain, but the repository scan did not find an authoritative locale policy that guarantees:
+
+- English users receive full free access until 2026-12-31.
+- Chinese users receive a free test, partial/free result surface, and CNY 1.99 unlock on selected result/report surfaces.
+- Offer visibility, order creation, entitlement, and report access are gated by the same backend-owned locale policy.
+
+## 2. Current Monetization Policy Found In Code
+
+The current codebase has a general commerce and report-access model:
+
+- `backend/database/seed_data/skus_mbti.json` defines active MBTI SKU rows including `MBTI_REPORT_FULL_199` at `price_cents=199`, `currency=CNY`, `benefit_type=report_unlock`, `benefit_code=MBTI_REPORT_FULL`, `scope=attempt`, and modules `core_full`, `career`, `relationships`.
+- `backend/database/seeders/ScaleRegistrySeeder.php` initializes MBTI with `view_policy_json.free_sections=["intro","score"]`, `blur_others=true`, `teaser_percent=0.3`, and an upgrade SKU default. Its `commercial_json.price_tier` still starts as `FREE`.
+- `backend/database/seeders/Pr19CommerceSeeder.php` later refreshes `commercial_json` from active SKU rows and sets `report_unlock_sku` / `upgrade_sku_anchor` for MBTI when a default SKU exists.
+- `backend/app/Services/Commerce/SkuCatalog.php` resolves active SKUs by SKU, scale, org, and global fallback. It does not filter SKUs by locale.
+- `backend/app/Http/Controllers/API/V0_3/CommerceController.php` validates order creation by SKU, attempt ownership, contact identity, provider, and idempotency key. It does not enforce a visible locale-specific freemium policy in the scanned create-order path.
+- `backend/app/Services/Report/ReportGatekeeper.php`, `AccessResolver.php`, and `EntitlementManager.php` map locked/partial/full access using paywall mode, benefit grants, modules, and full-access state.
+
+The current repository shape is therefore "commerce-capable" but not "locale-policy-authoritative".
+
+## 3. English Free Policy Evidence
+
+Status: Unknown / not proven.
+
+Findings:
+
+- No exact repository hit was found for `2026-12-31`, `free_until`, `full_free`, or an equivalent English free-through date in `backend` or `docs`.
+- `ReportGatekeeper::shouldForceFreeOnly()` can force free-only for paywall modes and hard-coded scales such as EQ_60 and RIASEC, but it does not encode an English MBTI free-full policy through 2026-12-31.
+- `AccessResolver::isForceFreeFullAccessScale()` grants full free access for BIG5_OCEAN, EQ_60, ENNEAGRAM, and RIASEC when force-free applies. MBTI is not included in that force-free full-access set.
+- `loadCommercialSpecForAttempt()` reads content-pack commercial spec by attempt region/locale, but this scan did not find a proved English full-free deadline policy in the scanned repository files.
+- fap-web maps checkout region from locale (`zh -> CN_MAINLAND`, non-zh -> US`) but checkout availability and SKU truth still come from backend report/CTA/offer payloads.
+
+Conclusion: English full free until 2026-12-31 is not currently proven as a backend authority rule.
+
+## 4. Chinese CNY 1.99 Evidence
+
+Status: Partially proven.
+
+Strong evidence:
+
+- `MBTI_REPORT_FULL_199` exists as an active SKU.
+- Price is `price_cents=199`.
+- Currency is `CNY`.
+- Benefit code is `MBTI_REPORT_FULL`.
+- Scope is `attempt`.
+- Included modules are `core_full`, `career`, and `relationships`.
+- The frontend MBTI checkout contract expects `MBTI_REPORT_FULL_199` and sends `region="CN_MAINLAND"` when the locale is `zh`.
+
+Gaps:
+
+- The SKU row itself is not locale-scoped.
+- The backend SKU catalog does not filter by locale.
+- The order creation controller path does not prove a locale policy gate.
+- The same active SKU can be resolved by scale/org unless a higher-level policy hides or blocks it.
+
+Conclusion: CNY 1.99 MBTI full-report commerce exists, but Chinese-only enforcement is not proven.
+
+## 5. SKU / Price / Currency / Locale Matrix
+
+| Surface | Evidence | Price | Currency | Locale policy status |
+| --- | --- | ---: | --- | --- |
+| MBTI full report | `MBTI_REPORT_FULL_199` active SKU | 199 cents | CNY | No SKU-level locale gate found |
+| MBTI anchor SKU | `MBTI_REPORT_FULL` anchor/deprecated, maps to effective SKU | 199 cents | CNY | Compatibility anchor, not locale policy |
+| MBTI career module | `MBTI_CAREER_99` inactive | 99 cents | CNY | Inactive; not launch evidence |
+| MBTI relationship module | `MBTI_RELATIONSHIP_99` inactive | 99 cents | CNY | Inactive; not launch evidence |
+| English MBTI full free | No authoritative deadline rule found | n/a | n/a | Unknown / not proven |
+| Chinese MBTI CNY 1.99 unlock | Active SKU + frontend CN_MAINLAND checkout region evidence | 199 cents | CNY | Partially proven, not policy-complete |
+
+## 6. Checkout / Unlock / Report Entitlement Flow
+
+Observed chain:
+
+1. fap-web MBTI result shell resolves a checkout SKU from report CTA or full-report offers.
+2. fap-web calls `createCheckoutOrOrder()` with attempt id, SKU, idempotency key, attribution payload, and a region derived from UI locale.
+3. fap-web API client posts to `/v0.3/orders/checkout` and sends `X-Region` when present.
+4. fap-api commerce controller validates SKU, ownership/contact identity, provider, idempotency, and target attempt ownership.
+5. fap-api order manager and payment pipeline can grant a report unlock through `EntitlementManager::grantAttemptUnlock()`.
+6. `EntitlementManager` writes active `benefit_grants`, syncs grant state, and refreshes unified access projection.
+7. `ReportGatekeeper` and `AccessResolver` use benefit grants and modules to resolve locked, partial, or full access.
+
+This proves a general commercial unlock architecture. It does not prove the final locale freemium policy.
+
+## 7. Privacy And Order Boundary
+
+Read-only repository evidence:
+
+- Order creation prohibits caller-supplied `org_id`, `user_id`, and `anon_id`.
+- Order creation requires a user, anon id, or contact email.
+- Target attempt id is resolved through ownership checks.
+- Order read uses ownership context and payment recovery token handling.
+- fap-web private result/order/pay/payment/history surfaces are guarded by existing noindex/discoverability contracts in the commercial readiness scans.
+
+No real order, result, payment, share, or history id was accessed during this scan.
+
+## 8. P0 Blockers Before Paid Ads
+
+1. Backend-owned locale freemium policy is missing or not discoverable as an authority contract.
+2. English full-free-until-2026-12-31 is not proven.
+3. Chinese-only CNY 1.99 offer enforcement is not proven.
+4. SKU/offer visibility and order creation do not appear to share one explicit locale policy gate.
+5. Commercial dashboard taxonomy still needs the event alignment follow-up from `ANALYTICS-COMMERCIAL-EVENTS-SCAN-01`.
+6. Live private URL telemetry and paid funnel smoke remain external operational checks before paid ads.
+7. No authorized production checkout/payment smoke was performed in this scan.
+
+## 9. Follow-Up PR Scope: FREEMIUM-LOCALE-POLICY-01
+
+Proposed PR id: `FREEMIUM-LOCALE-POLICY-01`
+
+Proposed title: `feat(commerce): add authoritative locale freemium policy gate`
+
+Proposed repo: `fap-api`
+
+Proposed scope:
+
+- Add a backend-owned freemium locale policy service/config/read model.
+- Encode English full-free policy and its expiry date as explicit backend authority.
+- Encode Chinese free test, partial/free result, and CNY 1.99 unlock eligibility.
+- Gate offer generation, report access, and order creation through the same policy.
+- Add contract tests for en/zh behavior, SKU visibility, order rejection/allowance, and locked/partial/full result states.
+- Add docs for manual smoke and rollback.
+
+Likely allowed files:
+
+- `backend/app/Services/Commerce/**`
+- `backend/app/Services/Report/**`
+- `backend/config/**`
+- `backend/tests/Feature/Commerce/**`
+- `backend/tests/Feature/Report/**`
+- `backend/docs/operations/**`
+- `docs/codex/pr-train.yaml`
+- `docs/codex/pr-train-state.json`
+
+Required checks:
+
+- Focused commerce/report policy tests.
+- Existing MBTI checkout/order/report entitlement tests.
+- JSON/YAML parse.
+- `git diff --check`.
+- Scope guard.
+
+Dependency assumptions:
+
+- `FREEMIUM-LOCALE-POLICY-SCAN-01` is merged.
+- `ANALYTICS-COMMERCIAL-EVENTS-01` may remain parallel, but paid ads must remain blocked until both policy and measurement gates pass.
+
+## 10. Manual Smoke Checklist
+
+Do not run against production without separate approval.
+
+- English MBTI result: full/free policy is visible, no paid offer shown, no order creation available, and no checkout CTA.
+- Chinese MBTI free result: free/partial surface renders only approved free modules.
+- Chinese MBTI locked/partial result: full-report offer shows CNY 1.99 and uses `MBTI_REPORT_FULL_199`.
+- Chinese checkout: creates order only for owned attempt and allowed locale/policy state.
+- English checkout attempt with paid SKU: blocked or hidden according to the policy before order creation.
+- Successful sandbox payment/unlock: grants only attempt-scoped `MBTI_REPORT_FULL` and unlocks full modules.
+- Failed/cancelled payment: remains locked/partial and does not grant benefit.
+- Order/result/pay URLs remain noindex and absent from sitemap/llms surfaces.
+- Commercial telemetry emits `view_result`, `click_unlock`, checkout/order, unlock, and purchase events without private ids in public analytics payloads.
+
+## Validation Notes
+
+Commands run or corrected during the scan:
+
+- `git status --short --branch`
+- `git log -n 5 --oneline`
+- `php backend/artisan list | grep -i "order\|payment\|report\|sku\|publish" || true`
+- Initial broad `rg ... backend app config database tests docs -S` was corrected because this repository nests Laravel code under `backend/`.
+- Corrected backend scans used `rg ... backend docs -S` and focused reads of SKU, commerce, report, and entitlement files.
+- fap-web was scanned read-only for checkout/unlock/result wiring evidence.
+
+Not run:
+
+- Broad `cd backend && php artisan test --filter=Order --filter=Payment` was not run because this docs-only scan did not need to create local order/payment fixtures, and the dual-filter command is ambiguous.
+
+No production write, CMS mutation, order creation, payment provider call, deployment, content generation, or frontend/backend runtime code change was performed.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -5,7 +5,7 @@
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "commercial_readiness_day1",
     "title": "docs(monetization): scan locale freemium policy readiness",
     "checks": {
@@ -41,7 +41,7 @@
     },
     "failure_reason": null,
     "commit_sha": "944b2b029963fef53d2dfbf1a9c157bc3df7b8c4",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1878",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -57,6 +57,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Docs-only scan report, manifest, and state parsed and passed scoped diff checks."
+      },
+      {
+        "at": "2026-06-04T01:23:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1878 for docs-only scan review."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,100 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-04T00:25:00+08:00",
+  "updated_at": "2026-06-04T01:13:52+08:00",
+  "FREEMIUM-LOCALE-POLICY-SCAN-01": {
+    "repo": "fap-api",
+    "branch": "codex/freemium-locale-policy-scan-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "commercial_readiness_day1",
+    "title": "docs(monetization): scan locale freemium policy readiness",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the Day 1 Commercial Readiness train, including FREEMIUM-LOCALE-POLICY-SCAN-01, with docs/codex manifest/state updates allowed."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "This scan has no direct PR-train dependency; preceding Day 1 fap-web scans were completed before entering this fap-api item."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/operations/freemium-locale-policy-scan-2026-06-03.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "git status --short --branch",
+          "git log -n 5 --oneline",
+          "php backend/artisan list | grep -i \"order\\|payment\\|report\\|sku\\|publish\" || true",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/operations docs/codex",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON/YAML parse and scoped diff check passed. Broad Order/Payment PHPUnit filter was intentionally not run for this docs-only scan because no local order/payment fixture was required."
+      }
+    },
+    "result": {
+      "go_no_go": "NO-GO for paid ads and public commercial launch of the proposed locale policy; GO for docs-only scan/report.",
+      "highest_blocker": "No backend-authoritative locale freemium policy was found that proves English full-free through 2026-12-31 and Chinese CNY 1.99 unlock enforcement."
+    },
+    "failure_reason": null,
+    "commit_sha": "944b2b029963fef53d2dfbf1a9c157bc3df7b8c4",
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-04T01:13:52+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit Day 1 Commercial Readiness goal."
+      },
+      {
+        "at": "2026-06-04T01:20:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Docs-only scan report, manifest, and state parsed and passed scoped diff checks."
+      }
+    ]
+  },
+  "DAILY-GIVING-OPS-READINESS-SCAN-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-ops-readiness-scan-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "commercial_readiness_day1",
+    "title": "docs(ops): scan daily giving readiness",
+    "depends_on": [
+      "FREEMIUM-LOCALE-POLICY-SCAN-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the Day 1 Commercial Readiness train, including DAILY-GIVING-OPS-READINESS-SCAN-01, with docs/codex manifest/state updates allowed."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Must wait for FREEMIUM-LOCALE-POLICY-SCAN-01 to merge and clean up."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-04T01:13:52+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as the next Day 1 fap-api scan after FREEMIUM-LOCALE-POLICY-SCAN-01."
+      }
+    ]
+  },
   "items": {
     "SEO-CMS-CANARY-BE-01": {
       "repo": "fap-api",

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20762,3 +20762,90 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: SEO-DASH-COLLECTOR-01 after separate production migration readiness/deploy approval
+
+  - id: FREEMIUM-LOCALE-POLICY-SCAN-01
+    repo: fap-api
+    branch: codex/freemium-locale-policy-scan-01
+    title: "docs(monetization): scan locale freemium policy readiness"
+    train_scope: commercial_readiness_day1
+    status: executing
+    depends_on: []
+    scope:
+      - Run a read-only scan of backend commerce, report access, SKU, entitlement, locale, and fap-web checkout/unlock wiring evidence.
+      - Determine whether English full-free through 2026-12-31 and Chinese free/partial plus CNY 1.99 unlock policy is currently backend-authoritative.
+      - Create a docs-only scan report with GO/NO-GO, blockers, and a follow-up PR scope.
+    allowed_paths:
+      - backend/docs/operations/freemium-locale-policy-scan-2026-06-03.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify backend runtime code, routes, database, tests, frontend code, CMS data, production config, payment provider state, orders, result/share/payment/history private URLs, GPT content assets, or deploy.
+      - Create CMS drafts, publish, unpublish, submit search, create Search Channel queue records, or call production write APIs.
+    validation:
+      - git status --short --branch
+      - git log -n 5 --oneline
+      - php backend/artisan list | grep -i "order\|payment\|report\|sku\|publish" || true
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/operations docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: backend
+    next_task: DAILY-GIVING-OPS-READINESS-SCAN-01
+
+  - id: DAILY-GIVING-OPS-READINESS-SCAN-01
+    repo: fap-api
+    branch: codex/daily-giving-ops-readiness-scan-01
+    title: "docs(ops): scan daily giving readiness"
+    train_scope: commercial_readiness_day1
+    status: planned
+    depends_on:
+      - FREEMIUM-LOCALE-POLICY-SCAN-01
+    scope:
+      - Run a read-only scan of Daily Giving operations, foundation/public-benefit docs, donation/payment boundaries, and amplification readiness.
+      - Create a docs-only report with GO/NO-GO, blockers, and a follow-up PR scope.
+    allowed_paths:
+      - backend/docs/operations/daily-giving-ops-readiness-scan-2026-06-03.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify backend runtime code, routes, database, tests, frontend code, CMS data, production config, payment provider state, donation/order records, result/share/payment/history private URLs, GPT content assets, or deploy.
+      - Publish, submit search, create Search Channel queue records, or call production write APIs.
+    validation:
+      - git status --short --branch
+      - git log -n 5 --oneline
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/operations docs/codex
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: backend
+    next_task: Day 1 commercial readiness summary after merge


### PR DESCRIPTION
## What changed
- Added the FREEMIUM-LOCALE-POLICY-SCAN-01 docs-only readiness scan report.
- Registered FREEMIUM-LOCALE-POLICY-SCAN-01 and the next DAILY-GIVING-OPS-READINESS-SCAN-01 train item in docs/codex metadata.
- Recorded NO-GO for paid ads/public commercial launch until a backend-authoritative locale freemium policy exists.

## Why
- Day 1 Commercial Readiness needs evidence on whether EN full-free and ZH CNY 1.99 unlock policy is actually supported by backend/frontend authority.
- The scan found general MBTI CNY 1.99 SKU and entitlement flow evidence, but no proven backend locale policy for EN free-through-2026-12-31 and ZH-only paid unlock enforcement.

## Validation
- git status --short --branch
- git log -n 5 --oneline
- php backend/artisan list | grep -i "order\|payment\|report\|sku\|publish" || true
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/operations docs/codex
- git diff --cached --check

## Intentionally deferred
- No runtime code, tests, database, frontend, CMS, order/payment, production config, deploy, or content asset changes.
- No real order creation, payment provider call, publish/unpublish, search submission, or Search Channel queue records.
- FREEMIUM-LOCALE-POLICY-01 remains the follow-up for an authoritative backend locale freemium policy gate.