### PR TITLE
docs(seo): record collector dry-run smoke evidence

### DIFF
--- a/backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json
+++ b/backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json
@@ -1,0 +1,279 @@
+{
+  "version": "seo-dash-collector-01-smoke-evidence.v1",
+  "task": "SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE",
+  "repo": "fap-api",
+  "evidence_only": true,
+  "runtime_changed": false,
+  "scheduler_enabled": false,
+  "production_writes_allowed": false,
+  "production_writes_attempted": false,
+  "production_writes_committed": false,
+  "external_api_calls_allowed": false,
+  "cms_mutation_allowed": false,
+  "search_submission_allowed": false,
+  "deployment_allowed": false,
+  "production_env_edit_allowed": false,
+  "fap_web_modified": false,
+  "approval_scope": {
+    "backend_production_sha": "619ce5881cbb63200568796c07467aacd66b52c2",
+    "collector_commands_must_include": [
+      "--dry-run",
+      "--no-write",
+      "--json"
+    ],
+    "scheduler_enablement_approved": false,
+    "production_writes_approved": false,
+    "external_api_calls_approved": false,
+    "cms_mutation_approved": false,
+    "search_submission_approved": false,
+    "deployment_approved": false,
+    "production_env_edits_approved": false
+  },
+  "pre_smoke": {
+    "production_backend_sha": "619ce5881cbb63200568796c07467aacd66b52c2",
+    "seo_intel_routes_present": 5,
+    "seo_intel_migrations_all_ran": true,
+    "seo_intel_migration_path": "database/migrations/seo_intel",
+    "collectors_enabled": false,
+    "write_enabled": false,
+    "dry_run_default": true,
+    "allow_external_api_calls": false,
+    "crawler_log_aggregate_write_enabled": false,
+    "scheduler_no_activation": true,
+    "seo_crawler_log_daily_aggregates_exists": true,
+    "seo_crawler_log_daily_aggregates_rows": 0,
+    "private_overview_without_token_http_status": 401,
+    "public_scale_lookup_http_status": 200
+  },
+  "collector_results": [
+    {
+      "collector": "noop",
+      "command": "php artisan seo-intel:collect --collector=noop --dry-run --no-write --json",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 0,
+      "issues": []
+    },
+    {
+      "collector": "url_truth_inventory",
+      "command": "php artisan seo-intel:collect --collector=url_truth_inventory --dry-run --no-write --json --canary",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 52,
+      "issues": []
+    },
+    {
+      "collector": "drift_foundation",
+      "command": "php artisan seo-intel:collect --collector=drift_foundation --dry-run --no-write --json --canary",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 12,
+      "issues": [
+        "missing_in_sitemap",
+        "extra_in_sitemap",
+        "missing_in_llms",
+        "private_flow_exposure_warning"
+      ]
+    },
+    {
+      "collector": "crawler_log_foundation",
+      "command": "php artisan seo-intel:collect --collector=crawler_log_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 1,
+      "issues": []
+    },
+    {
+      "collector": "attribution_revenue_foundation",
+      "command": "php artisan seo-intel:collect --collector=attribution_revenue_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 5,
+      "issues": [
+        "fixture_only_no_live_data_read",
+        "writes_blocked_by_default"
+      ]
+    },
+    {
+      "collector": "gsc_foundation",
+      "command": "php artisan seo-intel:collect --collector=gsc_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 2,
+      "issues": [
+        "fixture_only_no_live_gsc_api_call",
+        "writes_blocked_by_default"
+      ]
+    },
+    {
+      "collector": "baidu_foundation",
+      "command": "php artisan seo-intel:collect --collector=baidu_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 3,
+      "issues": [
+        "fixture_only_no_live_baidu_api_call",
+        "real_url_submission_blocked",
+        "draft_url_rejected",
+        "non_indexable_rejected"
+      ]
+    },
+    {
+      "collector": "indexnow_foundation",
+      "command": "php artisan seo-intel:collect --collector=indexnow_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 3,
+      "issues": [
+        "fixture_only_no_live_indexnow_api_call",
+        "real_url_submission_blocked",
+        "private_flow_rejected"
+      ]
+    },
+    {
+      "collector": "so360_foundation",
+      "command": "php artisan seo-intel:collect --collector=so360_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 4,
+      "issues": [
+        "fixture_only_no_live_so360_api_call",
+        "real_url_submission_blocked",
+        "engine_specific_page_generation_blocked",
+        "draft_url_rejected",
+        "non_indexable_rejected",
+        "private_flow_rejected",
+        "private_flow_entity_type_rejected"
+      ]
+    },
+    {
+      "collector": "sogou_foundation",
+      "command": "php artisan seo-intel:collect --collector=sogou_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 4,
+      "issues": [
+        "fixture_only_no_live_sogou_api_call",
+        "real_url_submission_blocked",
+        "engine_specific_page_generation_blocked",
+        "draft_url_rejected",
+        "non_indexable_rejected",
+        "private_flow_rejected",
+        "private_flow_entity_type_rejected"
+      ]
+    },
+    {
+      "collector": "shenma_foundation",
+      "command": "php artisan seo-intel:collect --collector=shenma_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 4,
+      "issues": [
+        "fixture_only_no_live_shenma_api_call",
+        "real_url_submission_blocked",
+        "engine_specific_page_generation_blocked",
+        "draft_url_rejected",
+        "non_indexable_rejected",
+        "private_flow_rejected",
+        "private_flow_entity_type_rejected"
+      ]
+    },
+    {
+      "collector": "chinese_crawler_log_foundation",
+      "command": "php artisan seo-intel:collect --collector=chinese_crawler_log_foundation --dry-run --no-write --json --limit=5",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 5,
+      "issues": [
+        "fixture_only_no_production_log_read",
+        "raw_ip_storage_blocked",
+        "raw_cookie_storage_blocked",
+        "raw_user_agent_storage_blocked",
+        "private_flow_crawler_hit_warning",
+        "noindex_crawler_hit_warning"
+      ]
+    },
+    {
+      "collector": "issue_queue_foundation",
+      "command": "php artisan seo-intel:collect --collector=issue_queue_foundation --dry-run --no-write --json --canary",
+      "status": "success",
+      "dry_run": true,
+      "writes_attempted": false,
+      "writes_committed": false,
+      "external_calls_attempted": false,
+      "items_seen": 3,
+      "issues": [
+        "fixture_only_no_live_data_read",
+        "cms_mutation_blocked",
+        "auto_publish_blocked",
+        "auto_pseo_blocked",
+        "raw_pii_blocked"
+      ]
+    }
+  ],
+  "post_smoke": {
+    "production_backend_sha": "619ce5881cbb63200568796c07467aacd66b52c2",
+    "collectors_enabled": false,
+    "write_enabled": false,
+    "dry_run_default": true,
+    "allow_external_api_calls": false,
+    "crawler_log_aggregate_write_enabled": false,
+    "seo_crawler_log_daily_aggregates_exists": true,
+    "seo_crawler_log_daily_aggregates_rows": 0
+  },
+  "outcome": {
+    "collector_count": 13,
+    "all_collectors_success": true,
+    "all_collectors_dry_run": true,
+    "any_writes_attempted": false,
+    "any_writes_committed": false,
+    "any_external_calls_attempted": false,
+    "scheduler_still_disabled": true,
+    "aggregate_rows_unchanged": true
+  },
+  "deferred": [
+    "scheduler_enablement",
+    "collector_write_enablement",
+    "live_gsc_baidu_ga4_or_domestic_search_api_connections",
+    "cms_issue_summary_writeback",
+    "search_platform_submission",
+    "production_data_ingestion"
+  ],
+  "next_task": "SEO-DASH-COLLECTOR-02 controlled collector runbook or write gate"
+}

--- a/backend/docs/seo/seo-dash-collector-01-smoke-evidence.md
+++ b/backend/docs/seo/seo-dash-collector-01-smoke-evidence.md
@@ -1,0 +1,94 @@
+# SEO-DASH-COLLECTOR-01 Smoke Evidence
+
+## Purpose
+
+SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE records the production collector
+dry-run/no-write smoke that was executed after the post-migration readiness
+contract was merged and the user gave exact approval.
+
+This PR records evidence only. It does not run collectors, enable scheduler
+jobs, write production rows, connect external APIs, mutate CMS records, submit
+URLs to search platforms, deploy, edit production env, or modify `fap-web`.
+
+## Approval Boundary
+
+The approved production operation was limited to:
+
+- read-only production verification
+- the allowed `SEO-DASH-COLLECTOR-01` collector commands
+- `--dry-run --no-write --json` only
+- no scheduler enablement
+- no production writes
+- no external API calls
+- no CMS mutation
+- no search submission
+- no deployment or production env edit
+
+## Pre-Smoke Evidence
+
+- Production backend SHA: `619ce5881cbb63200568796c07467aacd66b52c2`.
+- `/api/v0.5/ops/seo-intel/*` route family was present with 5 private routes.
+- `seo_intel` migrations under `database/migrations/seo_intel` were all `Ran`.
+- Collector defaults remained disabled:
+  - `collectors_enabled=false`
+  - `write_enabled=false`
+  - `dry_run_default=true`
+  - `allow_external_api_calls=false`
+  - `crawler_log_aggregate_write_enabled=false`
+- Scheduler scan found no `seo-intel:collect` activation in scheduler entry
+  points.
+- `seo_crawler_log_daily_aggregates` existed with `0` rows.
+- Private overview without token returned HTTP `401`.
+- Public MBTI scale lookup returned HTTP `200`.
+
+## Smoke Results
+
+All 13 approved collectors completed successfully.
+
+| Collector | Status | Items seen | Issues |
+| --- | --- | ---: | --- |
+| `noop` | `success` | 0 | none |
+| `url_truth_inventory` | `success` | 52 | none |
+| `drift_foundation` | `success` | 12 | `missing_in_sitemap`, `extra_in_sitemap`, `missing_in_llms`, `private_flow_exposure_warning` |
+| `crawler_log_foundation` | `success` | 1 | none |
+| `attribution_revenue_foundation` | `success` | 5 | `fixture_only_no_live_data_read`, `writes_blocked_by_default` |
+| `gsc_foundation` | `success` | 2 | `fixture_only_no_live_gsc_api_call`, `writes_blocked_by_default` |
+| `baidu_foundation` | `success` | 3 | `fixture_only_no_live_baidu_api_call`, `real_url_submission_blocked`, `draft_url_rejected`, `non_indexable_rejected` |
+| `indexnow_foundation` | `success` | 3 | `fixture_only_no_live_indexnow_api_call`, `real_url_submission_blocked`, `private_flow_rejected` |
+| `so360_foundation` | `success` | 4 | `fixture_only_no_live_so360_api_call`, `real_url_submission_blocked`, `engine_specific_page_generation_blocked`, `draft_url_rejected`, `non_indexable_rejected`, `private_flow_rejected`, `private_flow_entity_type_rejected` |
+| `sogou_foundation` | `success` | 4 | `fixture_only_no_live_sogou_api_call`, `real_url_submission_blocked`, `engine_specific_page_generation_blocked`, `draft_url_rejected`, `non_indexable_rejected`, `private_flow_rejected`, `private_flow_entity_type_rejected` |
+| `shenma_foundation` | `success` | 4 | `fixture_only_no_live_shenma_api_call`, `real_url_submission_blocked`, `engine_specific_page_generation_blocked`, `draft_url_rejected`, `non_indexable_rejected`, `private_flow_rejected`, `private_flow_entity_type_rejected` |
+| `chinese_crawler_log_foundation` | `success` | 5 | `fixture_only_no_production_log_read`, `raw_ip_storage_blocked`, `raw_cookie_storage_blocked`, `raw_user_agent_storage_blocked`, `private_flow_crawler_hit_warning`, `noindex_crawler_hit_warning` |
+| `issue_queue_foundation` | `success` | 3 | `fixture_only_no_live_data_read`, `cms_mutation_blocked`, `auto_publish_blocked`, `auto_pseo_blocked`, `raw_pii_blocked` |
+
+Every collector reported:
+
+- `dry_run=true`
+- `writes_attempted=false`
+- `writes_committed=false`
+- `external_calls_attempted=false`
+
+## Post-Smoke Evidence
+
+- Production backend SHA still matched
+  `619ce5881cbb63200568796c07467aacd66b52c2`.
+- Collector defaults still blocked writes and external calls:
+  - `collectors_enabled=false`
+  - `write_enabled=false`
+  - `dry_run_default=true`
+  - `allow_external_api_calls=false`
+  - `crawler_log_aggregate_write_enabled=false`
+- `seo_crawler_log_daily_aggregates` still existed with `0` rows.
+
+## Interpretation
+
+The smoke proves the collector command family can execute the approved
+readiness path without production writes or external calls. It does not approve
+scheduled operation, write enablement, live search API integration, CMS
+writeback, search submission, or production data ingestion.
+
+## Next Task
+
+Proceed to `SEO-DASH-COLLECTOR-02` only as a separate PR. That PR should define
+the next collector runbook or controlled write gate without enabling writes by
+default.

--- a/backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php
@@ -1,0 +1,167 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoDashCollector01SmokeEvidenceTest extends TestCase
+{
+    #[Test]
+    public function artifact_records_evidence_only_boundary(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('seo-dash-collector-01-smoke-evidence.v1', $artifact['version'] ?? null);
+        $this->assertSame('SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE', $artifact['task'] ?? null);
+        $this->assertTrue((bool) ($artifact['evidence_only'] ?? false));
+
+        foreach ([
+            'runtime_changed',
+            'scheduler_enabled',
+            'production_writes_allowed',
+            'production_writes_attempted',
+            'production_writes_committed',
+            'external_api_calls_allowed',
+            'cms_mutation_allowed',
+            'search_submission_allowed',
+            'deployment_allowed',
+            'production_env_edit_allowed',
+            'fap_web_modified',
+        ] as $flag) {
+            $this->assertFalse((bool) ($artifact[$flag] ?? true), $flag.' must remain false');
+        }
+    }
+
+    #[Test]
+    public function pre_and_post_smoke_evidence_lock_production_state(): void
+    {
+        $artifact = $this->artifact();
+        $pre = $artifact['pre_smoke'] ?? [];
+        $post = $artifact['post_smoke'] ?? [];
+
+        $this->assertSame('619ce5881cbb63200568796c07467aacd66b52c2', $pre['production_backend_sha'] ?? null);
+        $this->assertSame('619ce5881cbb63200568796c07467aacd66b52c2', $post['production_backend_sha'] ?? null);
+        $this->assertSame(5, $pre['seo_intel_routes_present'] ?? null);
+        $this->assertTrue((bool) ($pre['seo_intel_migrations_all_ran'] ?? false));
+        $this->assertSame('database/migrations/seo_intel', $pre['seo_intel_migration_path'] ?? null);
+        $this->assertTrue((bool) ($pre['scheduler_no_activation'] ?? false));
+        $this->assertTrue((bool) ($pre['seo_crawler_log_daily_aggregates_exists'] ?? false));
+        $this->assertTrue((bool) ($post['seo_crawler_log_daily_aggregates_exists'] ?? false));
+        $this->assertSame(0, $pre['seo_crawler_log_daily_aggregates_rows'] ?? null);
+        $this->assertSame(0, $post['seo_crawler_log_daily_aggregates_rows'] ?? null);
+        $this->assertSame(401, $pre['private_overview_without_token_http_status'] ?? null);
+        $this->assertSame(200, $pre['public_scale_lookup_http_status'] ?? null);
+
+        foreach (['collectors_enabled', 'write_enabled', 'allow_external_api_calls', 'crawler_log_aggregate_write_enabled'] as $flag) {
+            $this->assertFalse((bool) ($pre[$flag] ?? true), $flag.' pre-smoke must be false');
+            $this->assertFalse((bool) ($post[$flag] ?? true), $flag.' post-smoke must be false');
+        }
+
+        $this->assertTrue((bool) ($pre['dry_run_default'] ?? false));
+        $this->assertTrue((bool) ($post['dry_run_default'] ?? false));
+    }
+
+    #[Test]
+    public function all_collectors_succeeded_as_dry_run_no_write_no_external_call(): void
+    {
+        $artifact = $this->artifact();
+        $results = $artifact['collector_results'] ?? [];
+        $collectorNames = array_column($results, 'collector');
+
+        $this->assertCount(13, $results);
+        $this->assertSame([
+            'noop',
+            'url_truth_inventory',
+            'drift_foundation',
+            'crawler_log_foundation',
+            'attribution_revenue_foundation',
+            'gsc_foundation',
+            'baidu_foundation',
+            'indexnow_foundation',
+            'so360_foundation',
+            'sogou_foundation',
+            'shenma_foundation',
+            'chinese_crawler_log_foundation',
+            'issue_queue_foundation',
+        ], $collectorNames);
+
+        foreach ($results as $result) {
+            $command = (string) ($result['command'] ?? '');
+
+            $this->assertSame('success', $result['status'] ?? null, (string) ($result['collector'] ?? 'unknown'));
+            $this->assertTrue((bool) ($result['dry_run'] ?? false));
+            $this->assertFalse((bool) ($result['writes_attempted'] ?? true));
+            $this->assertFalse((bool) ($result['writes_committed'] ?? true));
+            $this->assertFalse((bool) ($result['external_calls_attempted'] ?? true));
+            $this->assertStringContainsString('--dry-run', $command);
+            $this->assertStringContainsString('--no-write', $command);
+            $this->assertStringContainsString('--json', $command);
+            $this->assertGreaterThanOrEqual(0, $result['items_seen'] ?? -1);
+        }
+    }
+
+    #[Test]
+    public function outcome_and_deferred_work_do_not_enable_future_scope(): void
+    {
+        $artifact = $this->artifact();
+        $outcome = $artifact['outcome'] ?? [];
+        $deferred = $artifact['deferred'] ?? [];
+        $doc = strtolower((string) file_get_contents(base_path('docs/seo/seo-dash-collector-01-smoke-evidence.md')));
+
+        $this->assertSame(13, $outcome['collector_count'] ?? null);
+        $this->assertTrue((bool) ($outcome['all_collectors_success'] ?? false));
+        $this->assertTrue((bool) ($outcome['all_collectors_dry_run'] ?? false));
+        $this->assertFalse((bool) ($outcome['any_writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($outcome['any_writes_committed'] ?? true));
+        $this->assertFalse((bool) ($outcome['any_external_calls_attempted'] ?? true));
+        $this->assertTrue((bool) ($outcome['scheduler_still_disabled'] ?? false));
+        $this->assertTrue((bool) ($outcome['aggregate_rows_unchanged'] ?? false));
+
+        foreach ([
+            'scheduler_enablement',
+            'collector_write_enablement',
+            'live_gsc_baidu_ga4_or_domestic_search_api_connections',
+            'cms_issue_summary_writeback',
+            'search_platform_submission',
+            'production_data_ingestion',
+        ] as $item) {
+            $this->assertContains($item, $deferred);
+        }
+
+        foreach ([
+            'evidence only',
+            'does not run collectors',
+            'dry_run=true',
+            'writes_attempted=false',
+            'writes_committed=false',
+            'external_calls_attempted=false',
+            'seo-dash-collector-02',
+        ] as $required) {
+            $this->assertStringContainsString($required, $doc);
+        }
+
+        $this->assertSame(
+            'SEO-DASH-COLLECTOR-02 controlled collector runbook or write gate',
+            $artifact['next_task'] ?? null
+        );
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json');
+
+        $this->assertFileExists($path);
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43004,5 +43004,89 @@
     "sidecars": [],
     "next_task": "approval-gated production collector dry-run/no-write smoke after separate authorization",
     "merge_commit_sha": "eddebd8d2392f2416cbb1f00802a6002eed45fdf"
+  },
+  "SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE": {
+    "repo": "fap-api",
+    "branch": "codex/seo-dash-collector-01-smoke-reconcile",
+    "base": "main",
+    "status": "local_validation_passed",
+    "train_scope": "seo_intel_collector_dry_run_smoke_evidence",
+    "title": "docs(seo): record collector dry-run smoke evidence",
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE to docs/codex/pr-train.yaml and docs/codex/pr-train-state.json and executing the smoke evidence docs/contract PR."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-DASH-COLLECTOR-01 is merged and reconciled at eddebd8d2392f2416cbb1f00802a6002eed45fdf; production collector dry-run/no-write smoke was executed under separate exact approval."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to backend/docs/seo/seo-dash-collector-01-smoke-evidence.md, backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json, backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. Test-generated BIG5_OCEAN compiled artifacts were restored before staging."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoDashCollector01SmokeEvidenceTest --no-ansi",
+          "cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php",
+          "cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi",
+          "python3 -m json.tool backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-dash-collector-01-smoke-evidence.md backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "bash backend/scripts/ci_verify_mbti.sh",
+          "git diff --cached --check"
+        ],
+        "notes": "All local validation commands passed on 2026-06-04T01:24:42Z. No runtime, scheduler, production write, external API, CMS, search submission, deployment, fap-web, route, or migration file changes were made."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      },
+      "post_merge_cleanup": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "failure_reason": null,
+    "pr_url": null,
+    "commit_sha": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "local_validation_passed": true,
+      "github_checks_green": false,
+      "post_merge_revalidated": false,
+      "runtime_route_changed": false,
+      "migration_files_changed": false,
+      "production_collector_smoke_executed_in_pr": false,
+      "production_write_executed": false,
+      "scheduler_enabled": false,
+      "external_api_connected": false,
+      "cms_mutation": false,
+      "search_submission_performed": false,
+      "fap_web_modified": false,
+      "deploy_performed": false
+    },
+    "transitions": [
+      {
+        "at": "2026-06-04T01:00:00Z",
+        "from": "missing",
+        "to": "executing",
+        "note": "Started authorized SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE evidence PR. Scope is limited to docs/generated/focused contract test/pr-train metadata; the production smoke was already completed under separate approval and is not rerun in this PR."
+      },
+      {
+        "at": "2026-06-04T01:24:42Z",
+        "from": "executing",
+        "to": "local_validation_passed",
+        "note": "Focused contract test, Pint, route-list, migrate pretend, JSON/YAML validation, scoped diff check, full ci_verify_mbti.sh, and cached diff check passed. Scope remains evidence-only."
+      }
+    ],
+    "sidecars": [],
+    "next_task": "SEO-DASH-COLLECTOR-02 controlled collector runbook or write gate"
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43042,8 +43042,8 @@
         "notes": "All local validation commands passed on 2026-06-04T01:24:42Z. No runtime, scheduler, production write, external API, CMS, search submission, deployment, fap-web, route, or migration file changes were made."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "PR #1882 checks passed on GitHub before merge review: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       },
       "post_merge_cleanup": {
         "status": "pending",
@@ -43059,7 +43059,7 @@
     "scope_validation": {
       "allowed_paths_only": true,
       "local_validation_passed": true,
-      "github_checks_green": false,
+      "github_checks_green": true,
       "post_merge_revalidated": false,
       "runtime_route_changed": false,
       "migration_files_changed": false,
@@ -43096,6 +43096,12 @@
         "from": "committed",
         "to": "pr_open",
         "note": "Opened PR https://github.com/fermatmind/fap-api/pull/1882."
+      },
+      {
+        "at": "2026-06-04T01:34:21Z",
+        "from": "pr_open",
+        "to": "github_checks_green",
+        "note": "GitHub checks passed for PR #1882 before merge review."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -41463,7 +41463,7 @@
     "depends_on": [
       "SEO-CMS-CANARY-EDITORIAL-REVIEW-01"
     ],
-    "commit_sha": null,
+    "commit_sha": "6547f4e08aebd665da98916dd5787a4a23adfed9",
     "pr_url": null,
     "checks": {},
     "failure_reason": null,
@@ -43084,6 +43084,12 @@
         "from": "executing",
         "to": "local_validation_passed",
         "note": "Focused contract test, Pint, route-list, migrate pretend, JSON/YAML validation, scoped diff check, full ci_verify_mbti.sh, and cached diff check passed. Scope remains evidence-only."
+      },
+      {
+        "at": "2026-06-04T01:27:09Z",
+        "from": "local_validation_passed",
+        "to": "committed",
+        "note": "Recorded implementation commit 6547f4e08aebd665da98916dd5787a4a23adfed9."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43009,7 +43009,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-dash-collector-01-smoke-reconcile",
     "base": "main",
-    "status": "local_validation_passed",
+    "status": "pr_open",
     "train_scope": "seo_intel_collector_dry_run_smoke_evidence",
     "title": "docs(seo): record collector dry-run smoke evidence",
     "checks": {
@@ -43051,7 +43051,7 @@
       }
     },
     "failure_reason": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1882",
     "commit_sha": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -43090,6 +43090,12 @@
         "from": "local_validation_passed",
         "to": "committed",
         "note": "Recorded implementation commit 6547f4e08aebd665da98916dd5787a4a23adfed9."
+      },
+      {
+        "at": "2026-06-04T01:28:18Z",
+        "from": "committed",
+        "to": "pr_open",
+        "note": "Opened PR https://github.com/fermatmind/fap-api/pull/1882."
       }
     ],
     "sidecars": [],

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20819,6 +20819,60 @@ prs:
     content_authority: CMS/backend
     next_task: approval-gated production collector dry-run/no-write smoke
 
+  - id: SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE
+    repo: fap-api
+    branch: codex/seo-dash-collector-01-smoke-reconcile
+    title: "docs(seo): record collector dry-run smoke evidence"
+    train_scope: seo_intel_collector_dry_run_smoke_evidence
+    status: executing
+    depends_on:
+      - SEO-DASH-COLLECTOR-01
+    scope:
+      - Record production collector dry-run/no-write smoke evidence after the separately approved operation completed.
+      - Lock the 13 collector results, required dry-run/no-write/json output invariants, pre-smoke checks, post-smoke checks, and deferred write/live integration boundaries.
+      - Keep this PR evidence-only; do not run collectors, enable scheduler, write production, connect external APIs, mutate CMS records, submit URLs, deploy, or modify fap-web.
+    allowed_paths:
+      - backend/docs/seo/seo-dash-collector-01-smoke-evidence.md
+      - backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json
+      - backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production collector commands in this PR.
+      - Enable scheduler jobs, queue workers, collectors, writes, crawler-log aggregate writes, or production log reads.
+      - Add or edit runtime routes, controllers, middleware, services, collectors, command behavior, migrations, or env files.
+      - Connect live GSC, Baidu, GA4, IndexNow, 360, Sogou, Shenma, Apify, ScreamingFrog, crawler logs, Metabase, or external APIs.
+      - Mutate CMS records, publish, unpublish, rollback, generate content, submit URLs, or modify fap-web.
+      - Deploy, SSH, edit production env, print secrets, or touch Node2/Node3.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoDashCollector01SmokeEvidenceTest --no-ansi
+      - cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php
+      - cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi
+      - python3 -m json.tool backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-dash-collector-01-smoke-evidence.md backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - bash backend/scripts/ci_verify_mbti.sh
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-DASH-COLLECTOR-02 controlled collector runbook or write gate
+
   - id: FREEMIUM-LOCALE-POLICY-SCAN-01
     repo: fap-api
     branch: codex/freemium-locale-policy-scan-01


### PR DESCRIPTION
## What changed

- Added `SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE` to the PR train manifest and state ledger.
- Added smoke evidence documentation for the approved production collector dry-run/no-write smoke.
- Added a generated JSON evidence artifact covering 13 collector commands, pre/post production observations, and no-write/no-external-call invariants.
- Added a focused contract test that validates the evidence artifact and forbids runtime-like scope drift.

## Why

The production collector dry-run/no-write smoke completed under separate exact approval. This PR records that evidence in docs/generated artifacts and keeps the train ledger unambiguous before the next collector readiness step.

## Validation commands

- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=SeoDashCollector01SmokeEvidenceTest --no-ansi`
- `cd backend && vendor/bin/pint --test tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php`
- `cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi`
- `python3 -m json.tool backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo/seo-dash-collector-01-smoke-evidence.md backend/docs/seo/generated/seo-dash-collector-01-smoke-evidence.v1.json backend/tests/Feature/SeoIntel/SeoDashCollector01SmokeEvidenceTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `bash backend/scripts/ci_verify_mbti.sh`
- `git diff --cached --check`

## Intentionally deferred

- No runtime code changes.
- No scheduler enablement.
- No production writes.
- No external API calls or integrations.
- No CMS mutation.
- No search submission.
- No deployment.
- No fap-web changes.

## Repository rule impact

Evidence-only docs/contract PR. Backend `seo_intel` remains the authority layer; this PR does not enable collector writes, scheduler execution, external API access, or production mutation.
