### PR TITLE
docs(seo): summarize ops program and workflow rules

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -38,6 +38,8 @@ C. Minimal acceptance commands set:
    - `curl` examples
    - `bash backend/scripts/ci_verify_mbti.sh`
 
+For docs-only, rules-only, and generated-contract-only changes, C may state that runtime commands are not applicable and list the lightweight checks that were actually run.
+
 If A/B/C is missing, the answer is incomplete.
 
 ### Extra constraint
@@ -74,6 +76,8 @@ Prefer a repo-compatible default implementation and mark options as optional.
 
 ### PR Train Manifest Discipline
 - If a requested PR train item is missing from `docs/codex/pr-train.yaml`, stop and report the gap unless the user explicitly authorizes updating the train manifest and state ledger.
+- This stop rule applies only when the user requested a PR-train item. It must not block an explicitly requested ad-hoc PR whose scope does not modify PR-train metadata.
+- Only PR-train work requires a PR id and PR-train metadata. Ordinary scoped PRs may be opened without a train id and must not touch PR-train metadata unless explicitly requested.
 - If the user explicitly authorizes proceeding with a missing PR train item, Codex may add the missing `docs/codex/pr-train.yaml` and `docs/codex/pr-train-state.json` entries first, then continue under the declared scope.
 - Never invent a PR id or scope that is not either:
   - already present in the manifest, or
@@ -88,6 +92,8 @@ Prefer a repo-compatible default implementation and mark options as optional.
   - a follow-up execution prompt that explicitly asks for manifest/state authorization
 - Scan/planning-only tasks must not modify `docs/codex/pr-train.yaml` or `docs/codex/pr-train-state.json` unless the user explicitly authorizes manifest/state updates in that same turn.
 - If the user provides a concrete `/goal` or equivalent execution request with an explicit PR id, title, and scope, Codex may treat those as user-provided manifest details. If the id is missing from the manifest, Codex may add the manifest/state entry before implementation only when the user also explicitly authorizes updating both files.
+- After merging a PR-train PR, close its state as `merged` in the same workflow whenever possible.
+- If branch protection prevents direct ledger closeout, use one ledger-only follow-up PR with no new train id.
 
 ### Controlled CMS Publish Discipline
 - Controlled Codex-assisted article publish is permitted only through the backend `articles:publish-controlled` command after exact user confirmation, successful preflight, explicit boundary-context claim-warning acknowledgement when needed, and audit logging.

--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -14,7 +14,7 @@
   - the unrelated changes are in files outside the declared PR scope, and the current PR can avoid touching them
   - the current PR can be staged with an explicit path-limited file list
   - the unrelated changes are already committed on another branch and are not part of the current branch diff
-- Stop if the worktree is dirty and the current PR scope cannot be isolated cleanly from those existing changes.
+- Dirty worktree is allowed when the current task can stage only explicit scoped paths. Stop only when scoped paths overlap unrelated dirty changes or cannot be isolated cleanly.
 - If scoped changes were made on `main` before a PR branch was created, Codex may still create the correct PR branch immediately, provided:
   - the changes are fully within the declared scope
   - the worktree contains no unrelated modifications
@@ -27,6 +27,7 @@
 
 ## Verification discipline
 - Run all local checks listed in the PR manifest before push.
+- For docs-only, rules-only, and generated-contract-only changes, use lightweight validation such as `git diff --check` plus JSON/YAML/focused contract checks when relevant. Do not require full runtime checks unless runtime, API, migration, or scheduler files changed.
 - If local checks fail, do not open a PR.
 - Record failed checks in `docs/codex/pr-train-state.json`.
 - Never continue to the next PR after a failed check.
@@ -35,7 +36,7 @@
 
 ## PR discipline
 - Open exactly one PR for the current task.
-- The PR title must match the PR id and scope from the manifest.
+- For PR-train PRs, the PR title must match the PR id and scope from the manifest.
 - The PR body must include:
   - what changed
   - why
@@ -45,10 +46,18 @@
 - Stacked draft PR exception: if the user explicitly asks to split the current task into multiple PRs, Codex may open multiple draft PRs for the same declared task only when each PR has a distinct scope, the dependency order is stated in every dependent PR body, and no PR contains files from another PR's scope.
 - This exception does not allow merging dependent PRs out of order or bypassing required checks.
 
+## Ad-hoc PR discipline
+- Not every PR needs a PR-train id.
+- Only PR-train work requires a PR id and PR-train metadata.
+- Ordinary scoped PRs, such as repository rule updates, documentation summaries, cleanup-only changes, CI fixes, and small emergency repairs, may be opened without a train id.
+- Ad-hoc PRs must not modify `docs/codex/pr-train.yaml` or `docs/codex/pr-train-state.json` unless the user explicitly asks for PR-train metadata updates.
+
 ## Merge discipline
 - Merge only when the current PR satisfies its `merge_policy`.
 - Use squash merge unless the manifest explicitly says otherwise.
 - After merge, delete the remote branch.
+- After merging a PR-train PR, close its state as `merged` in the same workflow whenever possible.
+- If branch protection prevents direct ledger closeout, use one ledger-only follow-up PR with no new train id.
 - If running in a local clone, run `scripts/post_merge_cleanup.sh <branch> [base]`.
 - If running outside a local clone, do not claim local cleanup was executed.
 
@@ -63,6 +72,7 @@
   - merged_at
   - remote_branch_deleted
   - local_cleanup_executed
+- Do not create a new PR-train task just to mark the previous task as `merged`.
 - Never continue after a failed PR unless the manifest explicitly allows retry.
 
 ## Failure policy

--- a/backend/docs/seo/seo-url-issue-brief-program-summary-2026-06-04.md
+++ b/backend/docs/seo/seo-url-issue-brief-program-summary-2026-06-04.md
@@ -1,0 +1,239 @@
+# SEO URL, Issue Queue, and Brief Program Summary
+
+Date: 2026-06-04
+
+This document summarizes the SEO operations work completed across `fap-web`
+and `fap-api` during the recent PR train. It focuses on the URL inventory,
+SEO issue queue, dashboard, and future SERP/content brief generator line.
+
+## Executive status
+
+| Track | Status | Current authority | Notes |
+| --- | --- | --- | --- |
+| `SEO-COMPETITOR-URL-00` competitor URL inventory tracker contract | Complete | `fap-web` docs/contracts | Contract was merged in PR #1013. |
+| `SEO-COMPETITOR-URL-01` read-only competitor URL inventory generator | Complete | `fap-web` script + generated artifact | Generator was merged in PR #1014. It remains read-only and does not write CMS or submit search URLs. |
+| `SEO-ISSUE-QUEUE-00` SEO issue queue read model | Complete | `fap-web` docs/contracts | Read model contract was merged in PR #1015. |
+| `SEO-ISSUE-QUEUE-01` read-only issue queue generator | Complete | `fap-web` script + generated artifact | Generator was merged in PR #1017, with ledger reconciliation in PR #1018. |
+| `SEO-ISSUE-QUEUE-02` dashboard shell artifact adapter | Complete | `fap-web` ops shell | Dashboard reads the artifact-backed issue queue mock/adapter. Merged in PR #1020, with ledger reconciliation in PR #1021. |
+| `SEO-BRIEF-00` SERP/content brief generator contract | Not started | Proposed contract | No merged PR, manifest entry, state entry, or local git evidence was found. This should be the next item in this line. |
+| Backend `seo_intel` schema/API/migration/collector gates | In progress foundation complete | `fap-api` | Docs/contracts, migration, read-only API, production migration, dry-run smoke evidence, and controlled write gate are in place. Real collector writes remain approval-gated. |
+
+## Completed frontend/docs line
+
+### Competitor URL inventory
+
+Completed PRs:
+
+- `SEO-COMPETITOR-URL-00`: [fap-web PR #1013](https://github.com/fermatmind/fap-web/pull/1013), merged at `ea4e5b83283f5488113bbc80422fe291a60391a4`.
+- `SEO-COMPETITOR-URL-01`: [fap-web PR #1014](https://github.com/fermatmind/fap-web/pull/1014), merged at `c04305fce2deeb50c4180e26975515ea37c250a5`.
+
+Key outputs:
+
+- `docs/seo/competitor-url-inventory-tracker.md`
+- `docs/seo/generated/competitor-url-inventory-tracker.v1.json`
+- `docs/seo/generated/competitor-url-inventory-generator.v1.json`
+- `scripts/seo/generate-competitor-url-inventory.mjs`
+- `tests/contracts/competitor-url-inventory-tracker.contract.test.ts`
+- `tests/contracts/competitor-url-inventory-generator.contract.test.ts`
+
+Contract boundaries:
+
+- Pull competitor sitemaps as read-only inputs.
+- Normalize URLs before classification and diffing.
+- Classify URLs into page families such as `test_detail`, `career_job`,
+  `career_guide`, `article`, `topic`, `tool`, `support`, and `unknown`.
+- Detect locale, canonical, and hreflang where available.
+- Produce monthly diff outputs such as added URLs, removed URLs, directory
+  movement, and content-family movement.
+- Align competitor inventory with FermatMind URL Truth.
+- Produce JSON/CSV artifacts.
+- Do not write CMS, generate content automatically, submit search URLs, or
+  block publish flows.
+
+### SEO issue queue
+
+Completed PRs:
+
+- `SEO-ISSUE-QUEUE-00`: [fap-web PR #1015](https://github.com/fermatmind/fap-web/pull/1015), merged at `2026-06-03T07:52:24Z`.
+- `SEO-ISSUE-QUEUE-00` ledger reconciliation: [fap-web PR #1016](https://github.com/fermatmind/fap-web/pull/1016), merged at `2026-06-03T11:35:32Z`.
+- `SEO-ISSUE-QUEUE-01`: [fap-web PR #1017](https://github.com/fermatmind/fap-web/pull/1017), merged at `cae0a98c24c5894478b80b4809f78239068f7705`.
+- `SEO-ISSUE-QUEUE-01` ledger reconciliation: [fap-web PR #1018](https://github.com/fermatmind/fap-web/pull/1018), merged at `118f07d3f8c2e31041e929ff6138f4b511a854d4`.
+- `SEO-ISSUE-QUEUE-02`: [fap-web PR #1020](https://github.com/fermatmind/fap-web/pull/1020), merged at `2026-06-03T12:57:20Z`.
+- `SEO-ISSUE-QUEUE-02` ledger reconciliation: [fap-web PR #1021](https://github.com/fermatmind/fap-web/pull/1021), merged at `2026-06-03T14:57:53Z`.
+
+Key outputs:
+
+- `docs/seo/seo-issue-queue-read-model.md`
+- `docs/seo/generated/seo-issue-queue.v1.json`
+- `docs/seo/generated/seo-issue-queue.v1.csv`
+- `scripts/seo/generate-seo-issue-queue.mjs`
+- `tests/contracts/seo-issue-queue.contract.test.ts`
+- `tests/contracts/seo-issue-queue-generator.contract.test.ts`
+- `components/ops/seo/IssueQueueTable.tsx`
+- `components/ops/seo/SeoOperationsDashboard.tsx`
+- `components/ops/seo/seoIssueQueueArtifactAdapter.ts`
+- `tests/contracts/seo-issue-queue-dashboard-shell.contract.test.ts`
+
+Contract boundaries:
+
+- Read from URL Truth, sitemap inventory, competitor inventory, CMS
+  draft/release samples, and search/analytics sample artifacts.
+- Produce a sanitized, actionable queue for SEO operations.
+- Keep `fap-web` as an ops dashboard shell, not the backend authority system.
+- Keep CMS publish, search submission, and production collector writes out of
+  scope.
+
+## Completed backend `seo_intel` foundation
+
+The backend line moved beyond docs-only planning into disabled, approval-gated
+runtime foundations.
+
+Important completed backend items include:
+
+- `SEO-DASH-00-RECONCILE`: schema, PII/consent, source-of-truth, and read-only
+  API contract reconciliation.
+- `SEO-DASH-API-01`: read-only SEO Intelligence API route and permission
+  contract foundation.
+- `SEO-DASH-MIGRATION-01`: production migration readiness and migration
+  execution after explicit approval.
+- `SEO-DASH-COLLECTOR-01`: post-migration collector dry-run/no-write readiness.
+- Production collector smoke: 13 collectors completed with `dry_run=true`,
+  `writes_attempted=false`, `writes_committed=false`, and
+  `external_calls_attempted=false`.
+- `SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE`: smoke evidence docs/contract.
+- `SEO-DASH-COLLECTOR-02`: controlled collector write gate contract, merged in
+  [fap-api PR #1883](https://github.com/fermatmind/fap-api/pull/1883) at
+  `949b623976499b9c36010fd618bdd9cfbd0aa0dc`.
+
+Current backend constraints:
+
+- Scheduler remains disabled by default.
+- Production writes are not enabled by default.
+- External API calls are not enabled by default.
+- CMS mutation and search submission are not enabled by default.
+- Any future production write must use an exact approval phrase and a bounded
+  canary plan.
+
+## Is the URL, issue queue, and brief line complete?
+
+No. The line is partially complete.
+
+Complete:
+
+- Competitor URL inventory contract.
+- Competitor URL inventory read-only generator.
+- SEO issue queue read model.
+- SEO issue queue read-only generator.
+- Dashboard shell connected to issue queue artifact.
+- Backend `seo_intel` read-only foundation, production migration, dry-run smoke,
+  and controlled write gate.
+
+Not complete:
+
+- `SEO-BRIEF-00` SERP/content brief generator contract.
+- A read-only SERP/content brief generator.
+- A backend-owned source-of-truth contract for whether brief artifacts are only
+  advisory or may later become CMS draft inputs.
+- Any live SERP provider integration.
+- Any CMS draft creation from briefs.
+- Any automatic content generation or publishing.
+
+## Recommended next tasks
+
+### 1. Ledger reconciliation for `SEO-DASH-COLLECTOR-02`
+
+`fap-api` PR #1883 is merged, but the merged PR content records the task as
+`pr_open` because the final merge happened after the PR branch was merged. The
+next small hygiene PR should reconcile the ledger:
+
+- PR id: `SEO-DASH-COLLECTOR-02-RECONCILE`
+- Title: `docs(seo): reconcile collector write gate ledger`
+- Scope: `docs/codex/pr-train-state.json` only.
+- Record merge commit: `949b623976499b9c36010fd618bdd9cfbd0aa0dc`.
+- No runtime, API, migration, scheduler, production write, external API, CMS,
+  search submission, deployment, or env changes.
+
+### 2. `SEO-BRIEF-00`: SERP/content brief generator contract
+
+This should be the next substantive task for the URL/issue/brief line.
+
+Suggested PR:
+
+- PR id: `SEO-BRIEF-00`
+- Title: `docs(seo): define SERP content brief generator contract`
+- Suggested repo: `fap-web` for the first docs/contract artifact, unless the
+  team decides the brief contract must be backend-authoritative from day one.
+- Scope: docs/generated/focused contract test/pr-train metadata.
+- No runtime, no CMS write, no content publication, no external SERP API, no
+  search submission, no deployment.
+
+Contract should define:
+
+- Inputs:
+  - FermatMind URL Truth.
+  - Sitemap inventory.
+  - Competitor URL inventory.
+  - SEO issue queue.
+  - Existing CMS draft/release status samples.
+  - Optional manually captured SERP top-10 samples.
+- Output:
+  - JSON brief artifact.
+  - Optional Markdown brief artifact.
+  - Keyword intent.
+  - URL/page-family target.
+  - SERP table stakes.
+  - Value-add opportunities.
+  - Internal-link suggestions.
+  - Schema hints.
+  - Risk flags for claims, medical/psychological language, PII, and consent.
+- Hard boundaries:
+  - Advisory only.
+  - Does not generate publishable article copy.
+  - Does not create or mutate CMS drafts.
+  - Does not publish.
+  - Does not submit to search platforms.
+  - Does not use live external APIs until a separate approval-gated PR.
+
+### 3. `SEO-BRIEF-01`: read-only brief generator
+
+After `SEO-BRIEF-00`, add a generator that consumes existing artifacts and mock
+SERP samples:
+
+- PR id: `SEO-BRIEF-01`
+- Title: `docs(seo): add read-only SERP content brief generator`
+- Suggested repo: `fap-web` if it remains artifact/tooling only.
+- Output: `docs/seo/generated/seo-content-briefs.v1.json` and optional CSV/MD.
+- It should not call live SERP APIs, write CMS, or produce final article body
+  copy.
+
+### 4. Backend handoff contract for brief-to-CMS boundaries
+
+Before any brief can influence CMS drafts:
+
+- Define whether backend CMS treats brief artifacts as advisory metadata,
+  editorial input, or importable draft scaffolding.
+- Add approval gates for claim safety, reviewer ownership, locale parity, and
+  publication state.
+- Keep Codex out of publishable content generation by default.
+
+### 5. Approval-gated controlled collector write canary
+
+This is backend-specific and separate from the brief line. After the ledger
+reconciliation, the next backend collector task should be only a preflight for a
+bounded `url_truth_inventory` controlled write canary. It must still require an
+exact approval phrase before any production write.
+
+## Operating principle
+
+The safe sequence is:
+
+1. Observe public/runtime truth.
+2. Generate read-only artifacts.
+3. Convert artifacts into issue queues and briefs.
+4. Let humans review and approve.
+5. Only then allow bounded backend writes with exact approval.
+
+The system should not jump from competitor or SERP signals directly to CMS
+publication. SEO Intelligence is an observation and operations layer first; CMS
+and backend remain the authority for content, metadata, publication state, and
+production writes.


### PR DESCRIPTION
## What changed
- Added a backend SEO technical summary for the URL inventory, issue queue, dashboard, and future brief generator line.
- Lightened Codex workflow rules for solo GPT + Codex development: ordinary scoped PRs do not require train ids, docs/rules-only changes use lightweight validation, dirty worktrees can proceed with explicit path-limited staging, and PR-train ledger closeout should not create new train ids.

## Why
- Capture the recent cross-repo SEO operations work in backend docs.
- Reduce process overhead while preserving scope discipline and PR-train safety.

## Validation
- `git diff --check -- AGENTS.md backend/AGENTS.md backend/docs/seo/seo-url-issue-brief-program-summary-2026-06-04.md`

## Intentionally deferred
- No runtime/API/migration/scheduler changes.
- No production write, external API connection, CMS mutation, search submission, or deploy.
- No PR-train manifest/state changes.
- fap-web AGENTS changes are not included in this backend PR.