### PR TITLE
docs(seo): define article system PR train

### DIFF
--- a/backend/docs/seo/seo-article-system-pr-train-2026-06-05.md
+++ b/backend/docs/seo/seo-article-system-pr-train-2026-06-05.md
@@ -1,0 +1,62 @@
+# SEO Article System PR Train
+
+Date: 2026-06-05
+
+Train: Window 6 SEO article system
+
+Decision: CONDITIONAL. The first bilingual canary proves that the SEO article workflow can run end to end. It does not prove that articles can be batch-published without repeating the gates.
+
+## Scope
+
+This train turns the canary workflow into a repeatable article production mechanism. It covers request cards, quality review, article-specific baseline review, topic priority, internal link planning, CTA route safety, FAQ/schema smoke checks, and publish hold gates.
+
+This train does not create article body copy, article metadata copy, CMS drafts, publish actions, search submissions, URL inspections, IndexNow calls, Baidu pushes, or private URL checks.
+
+## PR Queue
+
+| Order | PR id | Purpose | Publish allowed |
+| ---: | --- | --- | --- |
+| 1 | SEO-ARTICLE-SYSTEM-TRAIN-01 | Register the train and boundaries | No |
+| 2 | SEO-ARTICLE-CANARY-QUALITY-REVIEW-01 | Review the first canary as a process template | No |
+| 3 | SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01 | Define 7-day and 14-day article baseline fields | No |
+| 4 | SEO-ARTICLE-TOPIC-PRIORITY-01 | Rank next article topics without writing content | No |
+| 5 | SEO-ARTICLE-REQUEST-CARDS-02 | Create next-batch request cards only | No |
+| 6 | ARTICLE-INTERNAL-LINK-PLAN-01 | Define public-canonical internal link matrix | No |
+| 7 | ARTICLE-CTA-ROUTE-GATE-01 | Gate article CTA route safety and tracking expectations | No |
+| 8 | ARTICLE-FAQ-SCHEMA-SMOKE-01 | Define Article, FAQ, and Breadcrumb schema smoke rules | No |
+| 9 | SEO-ARTICLE-PUBLISH-HOLD-GATE-01 | Make publish forbidden until all gates and exact approval pass | No |
+
+## Hard Boundaries
+
+- Do not write second-article body copy.
+- Do not write final title, H1, meta, FAQ, CTA, social, ad, or publication copy.
+- Do not create CMS drafts.
+- Do not publish or unpublish.
+- Do not submit to Google Search Console, Baidu, IndexNow, 360, Sogou, or Shenma.
+- Do not run GSC URL Inspection.
+- Do not access result, order, share, pay, payment, history, private, tokenized, or user-specific URLs.
+- Do not treat analytics as purchase truth.
+- Do not treat Unknown as zero.
+- Keep article authority in CMS/backend.
+
+## Sidecar Issues
+
+The train may record these issues without stopping request-card and planning work, provided the current PR did not introduce the issue and required checks pass:
+
+- ARTICLE-TO-TEST-CLICK-TRACKING-RECONCILE-01
+- ANALYTICS-SEO-P0-01 through ANALYTICS-SEO-P0-05
+- PRIVATE-URL-LIVE-REVIEW follow-up
+- CAREER-TIER-A-LINK-ELIGIBILITY
+- TEST-LANDING-PROOF-SURFACE follow-up
+
+## Exit Criteria
+
+Window 6 can close as complete when PR9 is merged and cleanup confirms:
+
+- request cards exist for the next batch,
+- topic priority recommends the next request card,
+- internal link planning is public-canonical only,
+- CTA route gate is documented,
+- FAQ/schema smoke policy is documented,
+- publish hold gate blocks CMS draft, publish, and search submission without separate exact authorization,
+- no article copy or CMS draft was created by the train.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43327,7 +43327,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-system-train-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article system PR train",
     "depends_on": [],
@@ -43369,8 +43369,8 @@
       ]
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "a3e4acae",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1887",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43386,6 +43386,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Train doc, manifest entries, and state entries passed local JSON/YAML/diff validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1887."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-04T17:04:32+08:00",
+  "updated_at": "2026-06-05T00:00:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -43322,5 +43322,431 @@
     ],
     "sidecars": [],
     "next_task": "approval-gated url_truth_inventory controlled write canary preflight"
+  },
+  "SEO-ARTICLE-SYSTEM-TRAIN-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-article-system-train-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): define article system PR train",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "This train registration item has no dependencies."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/seo/seo-article-system-pr-train-2026-06-05.md, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-article-system-pr-train-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON/YAML parse and scoped diff checks passed for docs-only train registration."
+      }
+    },
+    "result": {
+      "go_no_go": "GO for continuing to SEO-ARTICLE-CANARY-QUALITY-REVIEW-01 after PR merge; NO-GO for article copy, CMS drafts, publish, search submission, deploy, or private URL actions.",
+      "registered_tasks": [
+        "SEO-ARTICLE-CANARY-QUALITY-REVIEW-01",
+        "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01",
+        "SEO-ARTICLE-TOPIC-PRIORITY-01",
+        "SEO-ARTICLE-REQUEST-CARDS-02",
+        "ARTICLE-INTERNAL-LINK-PLAN-01",
+        "ARTICLE-CTA-ROUTE-GATE-01",
+        "ARTICLE-FAQ-SCHEMA-SMOKE-01",
+        "SEO-ARTICLE-PUBLISH-HOLD-GATE-01"
+      ]
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized and started from explicit Window 6 PR train request."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Train doc, manifest entries, and state entries passed local JSON/YAML/diff validation."
+      }
+    ]
+  },
+  "SEO-ARTICLE-CANARY-QUALITY-REVIEW-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-article-canary-quality-review-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): review article canary quality gates",
+    "depends_on": [
+      "SEO-ARTICLE-SYSTEM-TRAIN-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on SEO-ARTICLE-SYSTEM-TRAIN-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-article-performance-baseline-template-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): add article performance baseline template",
+    "depends_on": [
+      "SEO-ARTICLE-CANARY-QUALITY-REVIEW-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on SEO-ARTICLE-CANARY-QUALITY-REVIEW-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "SEO-ARTICLE-TOPIC-PRIORITY-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-article-topic-priority-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): rank next article topics",
+    "depends_on": [
+      "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "SEO-ARTICLE-REQUEST-CARDS-02": {
+    "repo": "fap-api",
+    "branch": "codex/seo-article-request-cards-02",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): add next article request cards",
+    "depends_on": [
+      "SEO-ARTICLE-TOPIC-PRIORITY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on SEO-ARTICLE-TOPIC-PRIORITY-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "ARTICLE-INTERNAL-LINK-PLAN-01": {
+    "repo": "fap-api",
+    "branch": "codex/article-internal-link-plan-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): define article internal link plan",
+    "depends_on": [
+      "SEO-ARTICLE-REQUEST-CARDS-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on SEO-ARTICLE-REQUEST-CARDS-02."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "ARTICLE-CTA-ROUTE-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/article-cta-route-gate-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): gate article CTA routes",
+    "depends_on": [
+      "ARTICLE-INTERNAL-LINK-PLAN-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on ARTICLE-INTERNAL-LINK-PLAN-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "ARTICLE-FAQ-SCHEMA-SMOKE-01": {
+    "repo": "fap-api",
+    "branch": "codex/article-faq-schema-smoke-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): define article FAQ schema smoke",
+    "depends_on": [
+      "ARTICLE-CTA-ROUTE-GATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on ARTICLE-CTA-ROUTE-GATE-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
+  },
+  "SEO-ARTICLE-PUBLISH-HOLD-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/seo-article-publish-hold-gate-01",
+    "base": "main",
+    "status": "planned",
+    "train_scope": "seo_article_system_window_6",
+    "title": "docs(seo): define article publish hold gate",
+    "depends_on": [
+      "ARTICLE-FAQ-SCHEMA-SMOKE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Depends on ARTICLE-FAQ-SCHEMA-SMOKE-01."
+      },
+      "scope_validation": {
+        "status": "not_started",
+        "evidence": null
+      },
+      "local": {
+        "status": "not_started",
+        "commands": [],
+        "notes": null
+      }
+    },
+    "result": null,
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "missing_from_manifest",
+        "to": "planned",
+        "notes": "Initialized as a planned Window 6 SEO article system task."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21075,3 +21075,359 @@ prs:
     content_authority: backend
     repository_rule_impact: backend commerce/report policy authority now includes locale freemium policy source and frontend consumption contract.
     next_task: fap-web consume backend locale freemium policy without frontend-inferred commercial rules
+
+  - id: SEO-ARTICLE-SYSTEM-TRAIN-01
+    repo: fap-api
+    branch: codex/seo-article-system-train-01
+    title: "docs(seo): define article system PR train"
+    train_scope: seo_article_system_window_6
+    status: executing
+    depends_on: []
+    scope:
+      - Register Window 6 SEO article system tasks and boundaries.
+      - Define the docs/contracts-only queue that turns the first canary into a repeatable production mechanism.
+      - Initialize planned entries for canary quality review, baseline template, topic priority, request cards, internal links, CTA route gate, FAQ/schema smoke, and publish hold gate.
+    allowed_paths:
+      - backend/docs/seo/seo-article-system-pr-train-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Write second-article body copy, title, H1, meta, FAQ, CTA, social, ad, or publication copy.
+      - Create CMS drafts, publish, unpublish, submit search, run GSC URL Inspection, call Baidu, call IndexNow, or deploy.
+      - Access result, order, share, pay, payment, history, private, tokenized, or user-specific URLs.
+    validation:
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-article-system-pr-train-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy:
+      github_checks_required: true
+      squash: true
+      auto_merge: true
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-CANARY-QUALITY-REVIEW-01
+
+  - id: SEO-ARTICLE-CANARY-QUALITY-REVIEW-01
+    repo: fap-api
+    branch: codex/seo-article-canary-quality-review-01
+    title: "docs(seo): review article canary quality gates"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - SEO-ARTICLE-SYSTEM-TRAIN-01
+    scope:
+      - Review the first bilingual canary as a process template, not a content template.
+      - Inspect public pages, Article/FAQ/Breadcrumb schema, CTA targets, internal links, sitemap/llms inclusion, title duplication, claim boundaries, public API, and SEO API.
+      - Record what is reusable and what is not reusable.
+    allowed_paths:
+      - backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md
+      - backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite content, create CMS drafts, publish, submit search, or access private URLs.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01
+
+  - id: SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01
+    repo: fap-api
+    branch: codex/seo-article-performance-baseline-template-01
+    title: "docs(seo): add article performance baseline template"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - SEO-ARTICLE-CANARY-QUALITY-REVIEW-01
+    scope:
+      - Create an article-specific 7-day and 14-day baseline template.
+      - Preserve Unknown as Unknown, mark private_url_seen=Yes as P0, and keep purchase truth backend-only.
+    allowed_paths:
+      - backend/docs/seo/seo-article-performance-baseline-template-2026-06-05.md
+      - backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Query private URLs, dashboard secrets, CMS data mutations, publish actions, or search submission surfaces.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-article-performance-baseline-template-2026-06-05.md backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-TOPIC-PRIORITY-01
+
+  - id: SEO-ARTICLE-TOPIC-PRIORITY-01
+    repo: fap-api
+    branch: codex/seo-article-topic-priority-01
+    title: "docs(seo): rank next article topics"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01
+    scope:
+      - Rank next article topics without writing article content.
+      - Compare RIASEC explanation, career uncertainty, Big Five career use, MBTI vs RIASEC vs Big Five, and result/career-library internal-link article candidates.
+    allowed_paths:
+      - backend/docs/seo/seo-article-topic-priority-2026-06-05.md
+      - backend/docs/seo/generated/seo-article-topic-priority-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Write final title, H1, meta, body, FAQ, CTA, ad, social, or publication copy.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/seo-article-topic-priority-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-article-topic-priority-2026-06-05.md backend/docs/seo/generated/seo-article-topic-priority-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-REQUEST-CARDS-02
+
+  - id: SEO-ARTICLE-REQUEST-CARDS-02
+    repo: fap-api
+    branch: codex/seo-article-request-cards-02
+    title: "docs(seo): add next article request cards"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - SEO-ARTICLE-TOPIC-PRIORITY-01
+    scope:
+      - Add next-batch request cards only for RIASEC explanation, career uncertainty, Big Five career use, and article/career internal linking.
+      - Keep request cards as routing, measurement, CMS-field, and boundary inputs for GPT content packages.
+    allowed_paths:
+      - backend/docs/seo/seo-article-request-cards-02-2026-06-05.md
+      - backend/docs/seo/generated/seo-article-request-cards-02.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Include final title, H1, meta copy, outline, body copy, FAQ copy, CTA copy, or publishable article text.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/seo-article-request-cards-02.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-article-request-cards-02-2026-06-05.md backend/docs/seo/generated/seo-article-request-cards-02.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: ARTICLE-INTERNAL-LINK-PLAN-01
+
+  - id: ARTICLE-INTERNAL-LINK-PLAN-01
+    repo: fap-api
+    branch: codex/article-internal-link-plan-01
+    title: "docs(seo): define article internal link plan"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - SEO-ARTICLE-REQUEST-CARDS-02
+    scope:
+      - Create an internal link matrix, allowed target registry, blocked target registry, and sidecar dependencies for career Tier A and hub strategy.
+      - Restrict link targets to public canonical routes.
+    allowed_paths:
+      - backend/docs/seo/article-internal-link-plan-2026-06-05.md
+      - backend/docs/seo/generated/article-internal-link-plan-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Link to result, order, share, pay, payment, history, private take/session/result/order/payment/share, or tokenized URLs.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/article-internal-link-plan-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/article-internal-link-plan-2026-06-05.md backend/docs/seo/generated/article-internal-link-plan-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: ARTICLE-CTA-ROUTE-GATE-01
+
+  - id: ARTICLE-CTA-ROUTE-GATE-01
+    repo: fap-api
+    branch: codex/article-cta-route-gate-01
+    title: "docs(seo): gate article CTA routes"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - ARTICLE-INTERNAL-LINK-PLAN-01
+    scope:
+      - Verify that article CTA targets are public canonical routes and do not point to private or user-specific routes.
+      - Document article_to_test_click tracking expectation and record a sidecar issue if runtime uses start_attempt plus attribution.
+    allowed_paths:
+      - backend/docs/seo/article-cta-route-gate-2026-06-05.md
+      - backend/docs/seo/generated/article-cta-route-gate-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+      - docs/codex/sidecar/**
+    do_not:
+      - Mutate CMS, publish, refactor runtime event tracking, or generate article content.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/article-cta-route-gate-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/article-cta-route-gate-2026-06-05.md backend/docs/seo/generated/article-cta-route-gate-01.v1.json docs/codex docs/codex/sidecar
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: ARTICLE-FAQ-SCHEMA-SMOKE-01
+
+  - id: ARTICLE-FAQ-SCHEMA-SMOKE-01
+    repo: fap-api
+    branch: codex/article-faq-schema-smoke-01
+    title: "docs(seo): define article FAQ schema smoke"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - ARTICLE-CTA-ROUTE-GATE-01
+    scope:
+      - Define smoke checks for Article, FAQ, and Breadcrumb schema consistency.
+      - Require FAQ schema only when visible FAQ is CMS/backend sourced and prevent generated fallback FAQ from becoming SEO authority.
+    allowed_paths:
+      - backend/docs/seo/article-faq-schema-smoke-2026-06-05.md
+      - backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Generate article content, mutate CMS, publish, submit search, or add frontend fallback authority.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/article-faq-schema-smoke-2026-06-05.md backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-PUBLISH-HOLD-GATE-01
+
+  - id: SEO-ARTICLE-PUBLISH-HOLD-GATE-01
+    repo: fap-api
+    branch: codex/seo-article-publish-hold-gate-01
+    title: "docs(seo): define article publish hold gate"
+    train_scope: seo_article_system_window_6
+    status: planned
+    depends_on:
+      - ARTICLE-FAQ-SCHEMA-SMOKE-01
+    scope:
+      - Define publish hold checklist and exact next authorization prompt for GPT content package intake.
+      - Keep publish forbidden unless all gates pass and the user gives separate exact approval.
+    allowed_paths:
+      - backend/docs/seo/seo-article-publish-hold-gate-2026-06-05.md
+      - backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, create CMS drafts, generate article content, submit search, call IndexNow, call Baidu, or inspect private URLs.
+    validation:
+      - python3 -m json.tool backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/seo/seo-article-publish-hold-gate-2026-06-05.md backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: GPT-5.5 Pro content package request for RIASEC article after separate authorization


### PR DESCRIPTION
## What changed
- Added the Window 6 SEO article system PR train definition.
- Registered the current train item plus the next eight planned docs/contracts-only tasks in `docs/codex/pr-train.yaml`.
- Initialized PR train state entries for the Window 6 queue.

## Why
The first bilingual SEO article canary proved the article workflow can run end to end, but it should be converted into a repeatable production mechanism before planning the next drafts or publishing any additional article.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo/seo-article-system-pr-train-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No second article copy.
- No title, H1, meta, FAQ, CTA, ad, social, or publication copy.
- No CMS draft creation.
- No publish or unpublish.
- No search submission, GSC URL Inspection, Baidu push, or IndexNow.
- No deploy.
- No private result/order/share/pay/payment/history/private/tokenized/user-specific URL access.

## Repository rule impact
Docs-only train registration. CMS/backend remains the article authority; frontend fallback content remains forbidden.
