### PR TITLE
docs(seo): review article canary quality gates

### DIFF
--- a/backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json
+++ b/backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json
@@ -1,0 +1,83 @@
+{
+  "artifact_id": "seo-article-canary-quality-review-01",
+  "artifact_version": "v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "scope": "read_only_canary_quality_review",
+  "content_generation": false,
+  "cms_mutation": false,
+  "publish_action": false,
+  "search_submission": false,
+  "private_url_access": false,
+  "target_articles": [
+    {
+      "locale": "zh-CN",
+      "article_id": 37,
+      "slug": "mbti-vs-holland-career-choice",
+      "public_url": "https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice",
+      "page_status": 200,
+      "api_status": 200,
+      "seo_api_status": 200,
+      "published": true,
+      "indexable": true,
+      "schema_types": [
+        "Article",
+        "BreadcrumbList",
+        "FAQPage"
+      ],
+      "title_present": true,
+      "h1_present": true,
+      "title_h1_exact_duplicate": false,
+      "related_test_edges": 3,
+      "related_test_slugs": 3
+    },
+    {
+      "locale": "en",
+      "article_id": 39,
+      "slug": "mbti-vs-holland-code-career-choice",
+      "public_url": "https://fermatmind.com/en/articles/mbti-vs-holland-code-career-choice",
+      "page_status": 200,
+      "api_status": 200,
+      "seo_api_status": 200,
+      "published": true,
+      "indexable": true,
+      "schema_types": [
+        "Article",
+        "BreadcrumbList",
+        "FAQPage"
+      ],
+      "title_present": true,
+      "h1_present": true,
+      "title_h1_exact_duplicate": false,
+      "related_test_edges": 3,
+      "related_test_slugs": 3
+    }
+  ],
+  "enumeration": {
+    "sitemap_xml_contains_bilingual_canary": true,
+    "llms_txt_contains_bilingual_canary": true,
+    "llms_full_txt_contains_bilingual_canary": true
+  },
+  "route_safety": {
+    "article_cta_private_route_seen": false,
+    "page_wide_external_social_share_url_seen": true,
+    "note": "External social-share UI must be distinguished from private FermatMind result/share/order/payment routes by ARTICLE-CTA-ROUTE-GATE-01."
+  },
+  "reuse_decision": {
+    "process_template": "GO",
+    "field_completeness_template": "CONDITIONAL",
+    "copy_content_template": "NO-GO"
+  },
+  "required_followups": [
+    "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01",
+    "ARTICLE-CTA-ROUTE-GATE-01",
+    "ARTICLE-FAQ-SCHEMA-SMOKE-01"
+  ],
+  "forbidden_confirmed": {
+    "second_article_copy_written": false,
+    "title_h1_meta_faq_cta_copy_generated": false,
+    "cms_draft_created": false,
+    "publish_performed": false,
+    "search_submit_performed": false,
+    "private_url_accessed": false
+  }
+}

--- a/backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md
+++ b/backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md
@@ -1,0 +1,118 @@
+# SEO Article Canary Quality Review
+
+Date: 2026-06-05
+
+PR train item: SEO-ARTICLE-CANARY-QUALITY-REVIEW-01
+
+Scope: read-only canary quality review. This report evaluates the first bilingual canary as a process template, not a content template.
+
+## Boundary
+
+No article copy was written or edited. No title, H1, meta, FAQ, CTA, ad, social, or publication copy was generated. No CMS draft was created. No CMS data was mutated. No publish, unpublish, search submission, GSC URL Inspection, Baidu push, IndexNow call, deploy, or private URL access was performed.
+
+## Target Surfaces
+
+| Surface | Status | Decision |
+| --- | --- | --- |
+| zh public article page | 200 | PASS |
+| en public article page | 200 | PASS |
+| zh public article API | 200 | PASS |
+| en public article API | 200 | PASS |
+| zh SEO API | 200 | PASS |
+| en SEO API | 200 | PASS |
+| sitemap.xml | 200 and contains both canary URLs | PASS |
+| llms.txt | 200 and contains both canary URLs | PASS |
+| llms-full.txt | 200 and contains both canary URLs | PASS |
+
+## Structured Data
+
+Both public canary pages expose:
+
+- Article schema.
+- BreadcrumbList schema.
+- FAQPage schema.
+
+Decision: GO for using the canary structured-data flow as a process pattern. The content of FAQ items is not reused by this review.
+
+## Page Metadata Shape
+
+Both locales have a populated browser title and H1. The title and H1 are not exact duplicates in either locale. This review records only structural presence and length ranges, not copy text.
+
+| Locale | Title present | H1 present | Exact duplicate | Note |
+| --- | --- | --- | --- | --- |
+| zh-CN | yes | yes | no | compact H1, longer title |
+| en | yes | yes | no | title and H1 are close in length but not exact duplicates |
+
+Decision: GO for the canary as a metadata process pattern. NO-GO for copying the canary metadata pattern without a per-topic review.
+
+## CTA And Internal Links
+
+Public page checks found article links and test links on both canary pages. The article APIs show:
+
+- published and indexable state,
+- related test slug present,
+- three related test slugs,
+- three article test edges,
+- landing surface present,
+- answer surface present.
+
+The canary CTA process is reusable only if each future package separately verifies public canonical targets. The first canary does not remove the need for ARTICLE-CTA-ROUTE-GATE-01.
+
+Route note: a page-wide href scan can flag an external social sharing URL containing `/share/`. This is not a FermatMind private route and not an article CTA target, but it proves the later CTA route gate must be host-aware and must distinguish social-share UI from private FermatMind result/share/order/payment routes.
+
+## Claim Boundary
+
+Canary package and postcheck artifacts show claim boundary metadata, package equivalence checks, and controlled publish preflight history. The zh-CN canary previously required explicit claim-warning acknowledgement during controlled publish workflow.
+
+Decision: CONDITIONAL for reuse. The workflow is reusable, but each new topic needs its own claim boundary review and acknowledgement path when warnings exist.
+
+## Public API And SEO API
+
+The article detail APIs expose the expected article, SEO surface, landing surface, and answer surface. The SEO APIs return metadata and structured-data payload surfaces.
+
+Decision: GO for process reuse. Public API health is not a substitute for CMS package review, controlled publish dry-run, or post-publish public smoke.
+
+## Reusable Parts
+
+- Request card to content package handoff pattern.
+- Importer/package equivalence discipline.
+- Draft noindex and public absence checks before publish.
+- Controlled publish preflight and exact approval gate.
+- Post-publish public page/API/SEO API smoke.
+- Sitemap and llms inclusion checks after publish.
+- Article, Breadcrumb, and visible FAQ schema smoke pattern.
+- Public canonical test CTA target discipline.
+
+## Not Reusable As-Is
+
+- Article body copy or structure as a content template.
+- Final title, H1, meta, FAQ, or CTA copy.
+- Topic-specific claim boundaries.
+- Topic-specific FAQ decisions.
+- Topic-specific internal link graph.
+- Search submission readiness.
+- Analytics event naming assumptions without ARTICLE-CTA-ROUTE-GATE-01.
+- Reviewer/updated/freshness display policy without a separate article metadata gate.
+
+## Decision
+
+GO for using the first canary as a process template.
+
+CONDITIONAL for using it as a field-completeness template, because tracking naming, internal link graph, route-gate host awareness, and reviewer/freshness policy still need repeatable gates.
+
+NO-GO for using it as a copy/content template.
+
+## Next Required Task
+
+Proceed to SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01 after this PR merges. Do not create a CMS draft, write article copy, publish, or submit search.
+
+## Validation Commands
+
+```bash
+node inline public page/API/schema/sitemap/llms canary signal check
+python3 -m json.tool backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43327,7 +43327,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-system-train-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article system PR train",
     "depends_on": [],
@@ -43369,11 +43369,11 @@
       ]
     },
     "failure_reason": null,
-    "commit_sha": "a3e4acae",
+    "commit_sha": "933d82e204cf01930424b1635258926c9803777a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1887",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T00:46:15Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43392,6 +43392,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1887."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1887 merged with squash merge commit e8a4e76c0a47160c9a309d4eaa2dba7c033d0463; origin/main contains the merge and post_merge_cleanup.sh completed."
       }
     ]
   },
@@ -43399,7 +43405,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-canary-quality-review-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): review article canary quality gates",
     "depends_on": [
@@ -43411,20 +43417,30 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on SEO-ARTICLE-SYSTEM-TRAIN-01."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-SYSTEM-TRAIN-01 merged as PR #1887 with merge commit e8a4e76c0a47160c9a309d4eaa2dba7c033d0463."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the canary quality review doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "node inline public page/API/schema/sitemap/llms canary signal check",
+          "python3 -m json.tool backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "Read-only public canary checks, JSON/YAML parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for canary as process template; CONDITIONAL as field-completeness template; NO-GO as copy/content template.",
+      "next_task": "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43437,6 +43453,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR1 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Canary quality review doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43405,7 +43405,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-canary-quality-review-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): review article canary quality gates",
     "depends_on": [
@@ -43442,8 +43442,8 @@
       "next_task": "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "44ad6fb7",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1888",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43465,6 +43465,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Canary quality review doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1888."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21081,7 +21081,7 @@ prs:
     branch: codex/seo-article-system-train-01
     title: "docs(seo): define article system PR train"
     train_scope: seo_article_system_window_6
-    status: executing
+    status: merged
     depends_on: []
     scope:
       - Register Window 6 SEO article system tasks and boundaries.
@@ -21123,7 +21123,7 @@ prs:
     branch: codex/seo-article-canary-quality-review-01
     title: "docs(seo): review article canary quality gates"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - SEO-ARTICLE-SYSTEM-TRAIN-01
     scope:


### PR DESCRIPTION
## What changed
- Added a read-only quality review for the first bilingual SEO article canary.
- Added a generated JSON artifact summarizing structural public/API/schema/sitemap/llms evidence without article copy.
- Reconciled PR1 as merged and advanced PR2 state in the train ledger.

## Why
The canary should be used as a repeatable process template, not as reusable article copy. This PR records what can be repeated and what still needs gates before future drafts.

## Validation
- `node inline public page/API/schema/sitemap/llms canary signal check`
- `python3 -m json.tool backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo/seo-article-canary-quality-review-2026-06-05.md backend/docs/seo/generated/seo-article-canary-quality-review-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No article copy, title, H1, meta, FAQ, CTA, ad, social, or publication copy.
- No CMS draft creation.
- No publish or unpublish.
- No search submission, GSC URL Inspection, Baidu push, or IndexNow.
- No deploy.
- No private result/order/share/pay/payment/history/private/tokenized/user-specific URL access.

## Repository rule impact
Docs/artifact-only canary review. CMS/backend remains the article authority. Future article production still requires separate GPT content package and CMS/operator authorization.
