### PR TITLE
docs(seo): add article performance baseline template

### DIFF
--- a/backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json
+++ b/backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json
@@ -1,0 +1,75 @@
+{
+  "artifact_id": "seo-article-performance-baseline-template-01",
+  "artifact_version": "v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "scope": "article_specific_7_14_day_baseline_template",
+  "unknown_policy": "Unknown is not zero",
+  "content_generation": false,
+  "cms_mutation": false,
+  "publish_action": false,
+  "search_submission": false,
+  "private_url_access": false,
+  "fields": [
+    "article_id",
+    "locale",
+    "slug",
+    "canonical_url",
+    "target_keyword",
+    "target_intent",
+    "primary_cta_target",
+    "secondary_cta_target",
+    "in_sitemap",
+    "indexed_google",
+    "indexed_baidu",
+    "google_impressions",
+    "google_clicks",
+    "google_ctr",
+    "google_avg_position",
+    "baidu_search_pv",
+    "landing_pv",
+    "article_to_test_click",
+    "start_test",
+    "complete_test",
+    "view_result",
+    "private_url_seen",
+    "internal_link_clicks",
+    "content_update_decision"
+  ],
+  "review_windows": [
+    "T+7",
+    "T+14"
+  ],
+  "rules": {
+    "private_url_seen_yes": "opens_P0_privacy_investigation",
+    "purchase_truth": "backend_only",
+    "analytics_purchase_truth": false,
+    "record_private_urls": false,
+    "record_raw_user_identifiers": false,
+    "search_submission_requires_separate_authorization": true
+  },
+  "allowed_content_update_decisions": [
+    "hold",
+    "update",
+    "expand",
+    "pause",
+    "rollback",
+    "Unknown"
+  ],
+  "canonical_url_policy": {
+    "allowed": [
+      "public_article_canonical_url",
+      "public_test_canonical_url",
+      "approved_public_career_url"
+    ],
+    "forbidden_fragments": [
+      "/result",
+      "/orders",
+      "/share",
+      "/pay",
+      "/payment",
+      "/history",
+      "token"
+    ]
+  },
+  "next_task": "SEO-ARTICLE-TOPIC-PRIORITY-01"
+}

--- a/backend/docs/seo/seo-article-performance-baseline-template-2026-06-05.md
+++ b/backend/docs/seo/seo-article-performance-baseline-template-2026-06-05.md
@@ -1,0 +1,100 @@
+# SEO Article Performance Baseline Template
+
+Date: 2026-06-05
+
+PR train item: SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01
+
+Scope: article-specific 7-day and 14-day baseline template only.
+
+## Boundary
+
+This template does not query dashboards, does not mutate CMS, does not create drafts, does not publish, does not submit search, does not inspect private URLs, and does not treat analytics as purchase truth.
+
+Unknown values must remain `Unknown`. They must not be recorded as `0`.
+
+## Article Identity Fields
+
+| Field | Required | Source | Rule |
+| --- | --- | --- | --- |
+| article_id | yes | CMS/backend | Numeric id or `Unknown` before CMS creation |
+| locale | yes | CMS/backend | Use canonical API locale |
+| slug | yes | CMS/backend | Public slug only |
+| canonical_url | yes | Public canonical route | No private, tokenized, result, order, share, payment, pay, or history URL |
+| target_keyword | yes | request card / Search Console | Query text is allowed; do not infer volume from absence |
+| target_intent | yes | request card | Informational, comparison, career guidance, or explanation |
+| primary_cta_target | yes | request card / CMS | Public canonical route only |
+| secondary_cta_target | optional | request card / CMS | Public canonical route only or `Unknown` |
+
+## Indexing And Search Fields
+
+| Field | T+7 | T+14 | Rule |
+| --- | --- | --- | --- |
+| in_sitemap | PASS / FAIL / Unknown | PASS / FAIL / Unknown | Public sitemap check only |
+| indexed_google | Yes / No / Unknown | Yes / No / Unknown | GSC or public search evidence only |
+| indexed_baidu | Yes / No / Unknown | Yes / No / Unknown | Baidu evidence only |
+| google_impressions | number / Unknown | number / Unknown | Search Console truth; Unknown is not 0 |
+| google_clicks | number / Unknown | number / Unknown | Search Console truth; Unknown is not 0 |
+| google_ctr | number / Unknown | number / Unknown | Derived only if impressions and clicks are known |
+| google_avg_position | number / Unknown | number / Unknown | Search Console truth |
+| baidu_search_pv | number / Unknown | number / Unknown | Baidu dashboard truth if available |
+
+## Behavior And Funnel Fields
+
+| Field | T+7 | T+14 | Rule |
+| --- | --- | --- | --- |
+| landing_pv | number / Unknown | number / Unknown | Analytics observation only |
+| article_to_test_click | number / Unknown | number / Unknown | Must use canonical event or documented attribution equivalent |
+| start_test | number / Unknown | number / Unknown | Analytics event only, not purchase truth |
+| complete_test | number / Unknown | number / Unknown | Analytics event only |
+| view_result | number / Unknown | number / Unknown | Analytics event only; no private result URL stored |
+| private_url_seen | Yes / No / Unknown | Yes / No / Unknown | `Yes` opens P0 privacy investigation |
+| internal_link_clicks | number / Unknown | number / Unknown | Only public canonical targets |
+| content_update_decision | hold / update / expand / pause / rollback / Unknown | hold / update / expand / pause / rollback / Unknown | Decision must cite evidence class |
+
+## Review Rules
+
+- `private_url_seen=Yes` opens a P0 privacy investigation and blocks scale.
+- Purchase truth is backend/order/report truth only; analytics does not prove purchase.
+- Store canonical public URLs only.
+- Do not store private result, order, share, pay, payment, history, tokenized, or user-specific URLs.
+- Do not record raw user identifiers.
+- Do not interpret missing dashboard access as zero.
+- Do not submit search during review without a separate exact authorization.
+
+## T+7 Review
+
+Purpose: decide whether the article has early crawl, index, impression, and CTA signals.
+
+Allowed decisions:
+
+- `hold`: keep observing.
+- `update`: request a human/GPT content package revision; no direct Codex copy.
+- `expand`: prepare next request card or internal link support.
+- `pause`: stop further articles in the same topic until more evidence exists.
+- `rollback`: only with separate content/CMS authorization.
+- `Unknown`: evidence is insufficient.
+
+## T+14 Review
+
+Purpose: decide whether the topic should be expanded, revised, or paused.
+
+Required evidence classes:
+
+- public URL and sitemap/llms state,
+- Search Console or Baidu evidence if available,
+- article CTA/funnel attribution evidence if available,
+- internal link evidence if available,
+- privacy route scan result,
+- claim/schema regression status.
+
+## Template Row
+
+Use this row shape for each locale-specific article review. Values shown as `Unknown` are placeholders, not zeroes.
+
+| article_id | locale | slug | canonical_url | target_keyword | target_intent | primary_cta_target | secondary_cta_target | in_sitemap | indexed_google | indexed_baidu | google_impressions | google_clicks | google_ctr | google_avg_position | baidu_search_pv | landing_pv | article_to_test_click | start_test | complete_test | view_result | private_url_seen | internal_link_clicks | content_update_decision |
+| --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown | Unknown |
+
+## Next Task
+
+Proceed to SEO-ARTICLE-TOPIC-PRIORITY-01 after this PR merges. Do not create CMS drafts, publish, submit search, or write article copy.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43484,7 +43484,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-performance-baseline-template-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): add article performance baseline template",
     "depends_on": [
@@ -43520,8 +43520,8 @@
       "next_task": "SEO-ARTICLE-TOPIC-PRIORITY-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "06c06b2c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1890",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43543,6 +43543,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Baseline template doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1890."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43405,7 +43405,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-canary-quality-review-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): review article canary quality gates",
     "depends_on": [
@@ -43442,11 +43442,11 @@
       "next_task": "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "44ad6fb7",
+    "commit_sha": "2c399095",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1888",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T00:55:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43471,6 +43471,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1888."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1888 merged with squash merge commit 6316ea37e2eb591d6e35f9a2c080b5d8aef6ebde; origin/main contains the merge and post_merge_cleanup.sh completed."
       }
     ]
   },
@@ -43478,7 +43484,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-performance-baseline-template-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): add article performance baseline template",
     "depends_on": [
@@ -43490,20 +43496,29 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on SEO-ARTICLE-CANARY-QUALITY-REVIEW-01."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-CANARY-QUALITY-REVIEW-01 merged as PR #1888 with merge commit 6316ea37e2eb591d6e35f9a2c080b5d8aef6ebde."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the article performance baseline template doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-article-performance-baseline-template-2026-06-05.md backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for using this as the article-specific T+7/T+14 baseline template; NO-GO for treating Unknown as zero or analytics as purchase truth.",
+      "next_task": "SEO-ARTICLE-TOPIC-PRIORITY-01"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43516,6 +43531,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR2 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Baseline template doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20554,7 +20554,7 @@ prs:
     branch: codex/seo-search-submission-canary-postsubmit-signals-01
     title: "docs(seo): review SEO canary post-submit signals"
     train_scope: seo_cms_canary
-    status: executing
+    status: merged
     scope:
       - Run read-only post-submit signals review after GSC sitemap submission and Baidu zh-CN manual URL submission.
       - Confirm public article pages, public article APIs, public SEO APIs, sitemap.xml, llms.txt, and llms-full.txt remain converged and indexable.
@@ -21163,7 +21163,7 @@ prs:
     branch: codex/seo-article-performance-baseline-template-01
     title: "docs(seo): add article performance baseline template"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - SEO-ARTICLE-CANARY-QUALITY-REVIEW-01
     scope:


### PR DESCRIPTION
## What changed
- Added an article-specific T+7/T+14 performance baseline template.
- Added a generated JSON artifact listing required fields and guardrails.
- Reconciled PR2 as merged and advanced PR3 state in the train ledger.

## Why
Future SEO articles need a repeatable review shape that preserves Unknown values, blocks private URL leakage, and keeps purchase truth backend-only.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo/seo-article-performance-baseline-template-2026-06-05.md backend/docs/seo/generated/seo-article-performance-baseline-template-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No article copy, title, H1, meta, FAQ, CTA, ad, social, or publication copy.
- No CMS draft creation.
- No publish or unpublish.
- No search submission, GSC URL Inspection, Baidu push, or IndexNow.
- No dashboard/private URL access.
- No deploy.

## Repository rule impact
Docs/artifact-only baseline template. It reinforces that Unknown is not zero and analytics is not purchase truth.
