### PR TITLE
docs(seo): rank next article topics

### DIFF
--- a/backend/docs/seo/generated/seo-article-topic-priority-01.v1.json
+++ b/backend/docs/seo/generated/seo-article-topic-priority-01.v1.json
@@ -1,0 +1,132 @@
+{
+  "artifact_id": "seo-article-topic-priority-01",
+  "artifact_version": "v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "scope": "topic_priority_without_article_copy",
+  "content_generation": false,
+  "cms_mutation": false,
+  "publish_action": false,
+  "search_submission": false,
+  "private_url_access": false,
+  "decision": {
+    "recommended_next_topic_direction": "RIASEC explanation",
+    "recommendation_status": "GO for request-card planning",
+    "default_confirmed": true
+  },
+  "topics": [
+    {
+      "priority": 1,
+      "topic_direction": "RIASEC explanation",
+      "search_intent": "explanation / career exploration",
+      "user_problem": "understand what RIASEC is for before taking or interpreting a career-interest test",
+      "primary_cta": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/en/tests/holland-career-interest-test-riasec"
+      ],
+      "secondary_cta": [
+        "MBTI public test route",
+        "Big Five public test route"
+      ],
+      "internal_links": [
+        "first_canary",
+        "riasec_test_page",
+        "mbti_test_page",
+        "big_five_test_page"
+      ],
+      "claim_boundary": "interest_exploration_only",
+      "publish_risk": "low_medium"
+    },
+    {
+      "priority": 2,
+      "topic_direction": "Career uncertainty",
+      "search_intent": "career guidance",
+      "user_problem": "feels stuck choosing majors, jobs, or career direction",
+      "primary_cta": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/en/tests/holland-career-interest-test-riasec"
+      ],
+      "secondary_cta": [
+        "MBTI or Big Five public test route"
+      ],
+      "internal_links": [
+        "first_canary",
+        "future_riasec_explanation",
+        "approved_public_career_hub_if_available"
+      ],
+      "claim_boundary": "exploration_support_only",
+      "publish_risk": "medium"
+    },
+    {
+      "priority": 3,
+      "topic_direction": "Big Five career use",
+      "search_intent": "personality-to-work-style explanation",
+      "user_problem": "understand how Big Five traits can inform work-style reflection",
+      "primary_cta": [
+        "/zh/tests/big-five-personality-test-ocean-model",
+        "/en/tests/big-five-personality-test-ocean-model"
+      ],
+      "secondary_cta": [
+        "RIASEC public test route"
+      ],
+      "internal_links": [
+        "first_canary",
+        "future_riasec_explanation",
+        "big_five_test_page"
+      ],
+      "claim_boundary": "work_style_tendency_only",
+      "publish_risk": "medium"
+    },
+    {
+      "priority": 4,
+      "topic_direction": "MBTI vs RIASEC vs Big Five",
+      "search_intent": "comparison / framework selection",
+      "user_problem": "choose which assessment to use for career exploration",
+      "primary_cta": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/en/tests/holland-career-interest-test-riasec"
+      ],
+      "secondary_cta": [
+        "MBTI public test route",
+        "Big Five public test route"
+      ],
+      "internal_links": [
+        "first_canary",
+        "future_riasec_explanation",
+        "future_big_five_career_use"
+      ],
+      "claim_boundary": "limited_use_cases_no_framework_superiority",
+      "publish_risk": "medium"
+    },
+    {
+      "priority": 5,
+      "topic_direction": "Result/career-library internal-link article",
+      "search_intent": "navigation / next-step guidance",
+      "user_problem": "needs safe next steps after public article/test discovery",
+      "primary_cta": [
+        "public_canonical_article_test_or_career_route_only"
+      ],
+      "secondary_cta": [
+        "Unknown"
+      ],
+      "internal_links": [
+        "approved_public_articles",
+        "approved_public_tests",
+        "career_pages_only_after_tier_a_or_hub_eligibility"
+      ],
+      "claim_boundary": "no_private_result_or_career_certainty",
+      "publish_risk": "medium_high"
+    }
+  ],
+  "forbidden_confirmed": {
+    "final_title_generated": false,
+    "h1_generated": false,
+    "meta_copy_generated": false,
+    "body_copy_generated": false,
+    "faq_copy_generated": false,
+    "cta_copy_generated": false,
+    "cms_draft_created": false,
+    "publish_performed": false,
+    "search_submit_performed": false
+  },
+  "next_task": "SEO-ARTICLE-REQUEST-CARDS-02"
+}

--- a/backend/docs/seo/seo-article-topic-priority-2026-06-05.md
+++ b/backend/docs/seo/seo-article-topic-priority-2026-06-05.md
@@ -1,0 +1,50 @@
+# SEO Article Topic Priority
+
+Date: 2026-06-05
+
+PR train item: SEO-ARTICLE-TOPIC-PRIORITY-01
+
+Scope: rank next article topic directions without writing article content.
+
+## Boundary
+
+This document does not provide final titles, H1, meta copy, body copy, FAQ copy, CTA copy, ad copy, social copy, or publishable article text. It does not create CMS drafts, publish, submit search, inspect private URLs, or mutate runtime data.
+
+## Decision
+
+Recommended next request-card priority: RIASEC explanation.
+
+Reason: it is the lowest-risk bridge from the first comparison canary into a durable test-explanation and career-guidance article cluster. It supports the public RIASEC test route, strengthens internal links from the canary, and avoids overexpanding comparison-style articles before the baseline and link plan are mature.
+
+## Topic Matrix
+
+| Priority | Topic direction | Search intent | User problem | Primary CTA | Secondary CTA | Internal links | Claim boundary | Publish risk | Reason |
+| ---: | --- | --- | --- | --- | --- | --- | --- | --- | --- |
+| 1 | RIASEC explanation | explanation / career exploration | User needs to understand what the RIASEC framework is for before taking or interpreting a career-interest test | `/zh/tests/holland-career-interest-test-riasec` and `/en/tests/holland-career-interest-test-riasec` | MBTI and Big Five public test routes where relevant | first canary, RIASEC test page, MBTI test page, Big Five test page | Interest exploration only; no diagnosis, hiring fit, guaranteed career outcome, or ability claim | Low-Medium | Directly fills the test-explanation asset gap and is easier to claim-bound than advice-heavy topics |
+| 2 | Career uncertainty | career guidance | User feels stuck choosing majors, jobs, or career direction | RIASEC public test route | MBTI or Big Five public test route based on request card | first canary, future RIASEC explanation, approved public career hub if available | Exploration support only; no deterministic career advice, counseling replacement, or guaranteed outcome | Medium | High user pain and search potential, but higher claim risk and needs stronger link-plan boundaries |
+| 3 | Big Five career use | personality-to-work-style explanation | User wants to understand how Big Five traits can inform work-style reflection | Big Five public test route | RIASEC public test route | first canary, RIASEC explanation, Big Five test page | Work-style tendency only; no job performance, hiring, competency, or clinical claim | Medium | Clear request-card gap and useful cluster expansion after RIASEC explanation |
+| 4 | MBTI vs RIASEC vs Big Five | comparison / framework selection | User wants to choose which assessment to use for career exploration | RIASEC public test route unless request card says otherwise | MBTI and Big Five public test routes | first canary, RIASEC explanation, Big Five career use | Each framework has limited use cases; no framework superiority or outcome guarantee | Medium | Useful later, but too close to the first canary if done immediately |
+| 5 | Result/career-library internal-link article | navigation / next-step guidance | User needs safe next steps after public article/test discovery | Public canonical article/test/career routes only | Unknown until career Tier A/hub eligibility is approved | Approved public articles, tests, and career pages only | No private result URL, personalized report URL, order/payment/share/history route, or career certainty claim | Medium-High | Needs ARTICLE-INTERNAL-LINK-PLAN-01 and career eligibility decisions before content package intake |
+
+## Topic Recommendation
+
+Proceed to request-card planning in this order:
+
+1. RIASEC explanation.
+2. Career uncertainty.
+3. Big Five career use.
+4. Article/career internal linking request.
+
+Do not prioritize another comparison article until the explanation and guidance assets exist.
+
+## Gate Dependencies
+
+- SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01 must remain the review template for published articles.
+- SEO-ARTICLE-REQUEST-CARDS-02 must define request cards before GPT content packages.
+- ARTICLE-INTERNAL-LINK-PLAN-01 must decide which career routes are eligible for public canonical links.
+- ARTICLE-CTA-ROUTE-GATE-01 must settle the article CTA route and tracking expectation before draft/publish planning.
+- ARTICLE-FAQ-SCHEMA-SMOKE-01 must define the visible CMS/backend FAQ schema rule before publish.
+
+## Next Task
+
+Proceed to SEO-ARTICLE-REQUEST-CARDS-02 after this PR merges. Do not write article copy or create CMS drafts.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43484,7 +43484,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-performance-baseline-template-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): add article performance baseline template",
     "depends_on": [
@@ -43520,11 +43520,11 @@
       "next_task": "SEO-ARTICLE-TOPIC-PRIORITY-01"
     },
     "failure_reason": null,
-    "commit_sha": "06c06b2c",
+    "commit_sha": "c3afcd9a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1890",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:03:47Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43549,6 +43549,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1890."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1890 merged with squash merge commit 073ba146a3909a0dadb09cb57900500fab29ec12; continued from detached origin/main because main is owned by another worktree."
       }
     ]
   },
@@ -43556,7 +43562,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-topic-priority-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): rank next article topics",
     "depends_on": [
@@ -43568,20 +43574,29 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01 merged as PR #1890 with merge commit 073ba146a3909a0dadb09cb57900500fab29ec12."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the topic priority doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/seo-article-topic-priority-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-article-topic-priority-2026-06-05.md backend/docs/seo/generated/seo-article-topic-priority-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for next request-card planning; recommended next topic direction is RIASEC explanation.",
+      "next_task": "SEO-ARTICLE-REQUEST-CARDS-02"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43594,6 +43609,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR3 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Topic priority doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43562,7 +43562,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-topic-priority-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): rank next article topics",
     "depends_on": [
@@ -43598,8 +43598,8 @@
       "next_task": "SEO-ARTICLE-REQUEST-CARDS-02"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "94d4e02a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1891",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43621,6 +43621,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Topic priority doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1891."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20594,7 +20594,7 @@ prs:
     branch: codex/seo-dash-00-reconcile-schema-api-contract
     title: "docs(seo): reconcile seo_intel schema and read-only API contract"
     train_scope: search_intelligence_schema_api_contract
-    status: executing
+    status: merged
     scope:
       - Reconcile existing seo_intel foundation docs into one schema, PII, consent, source-of-truth, and read-only API contract.
       - Lock the distinction between CMS/backend authority, seo_intel observation, and fap-web dashboard shell.
@@ -21202,7 +21202,7 @@ prs:
     branch: codex/seo-article-topic-priority-01
     title: "docs(seo): rank next article topics"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - SEO-ARTICLE-PERFORMANCE-BASELINE-TEMPLATE-01
     scope:


### PR DESCRIPTION
## What changed
- Added a topic priority matrix for the next SEO article request-card batch.
- Added a generated JSON artifact with the same ranked topic directions and guardrails.
- Reconciled PR3 as merged and advanced PR4 state in the train ledger.

## Why
The next article should be selected as a request-card direction before any GPT content package, CMS draft, or publish action. The recommended next direction is RIASEC explanation.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/seo-article-topic-priority-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo/seo-article-topic-priority-2026-06-05.md backend/docs/seo/generated/seo-article-topic-priority-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No final article title, H1, meta, outline, body, FAQ, or CTA copy.
- No CMS draft creation.
- No publish or unpublish.
- No search submission, GSC URL Inspection, Baidu push, or IndexNow.
- No private URL access.
- No deploy.

## Repository rule impact
Docs/artifact-only topic planning. CMS/backend remains article authority; this PR only chooses request-card priority.
