### PR TITLE
docs(seo): add next article request cards

### DIFF
--- a/backend/docs/seo/generated/seo-article-request-cards-02.v1.json
+++ b/backend/docs/seo/generated/seo-article-request-cards-02.v1.json
@@ -1,0 +1,200 @@
+{
+  "artifact_id": "seo-article-request-cards-02",
+  "artifact_version": "v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "scope": "request_cards_only_no_article_copy",
+  "content_generation": false,
+  "cms_mutation": false,
+  "publish_action": false,
+  "search_submission": false,
+  "private_url_access": false,
+  "shared_forbidden_routes": [
+    "/result/**",
+    "/orders/**",
+    "/share/**",
+    "/pay/**",
+    "/payment/**",
+    "/history/**",
+    "private_take_session_result_order_payment_share_urls",
+    "tokenized_urls",
+    "user_specific_urls"
+  ],
+  "shared_required_measurement_events": [
+    "article_to_test_click_or_approved_article_attribution_equivalent",
+    "start_test",
+    "complete_test",
+    "view_result"
+  ],
+  "request_cards": [
+    {
+      "request_id": "RIASEC-EXPLANATION-ARTICLE-REQ-01",
+      "topic_direction": "RIASEC explanation",
+      "business_goal": "Expand from the first canary into a test-explanation asset that supports career-interest discovery",
+      "target_user_problem": "Understand what RIASEC is for before taking or interpreting a career-interest assessment",
+      "primary_search_intent": "explanation / career exploration",
+      "target_page_placeholder": "/{locale}/articles/{gpt-proposed-slug-after-review}",
+      "primary_cta_target": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/en/tests/holland-career-interest-test-riasec"
+      ],
+      "secondary_cta_target": [
+        "MBTI public test route",
+        "Big Five public test route"
+      ],
+      "required_internal_links": [
+        "first canary",
+        "RIASEC public test page",
+        "MBTI public test page",
+        "Big Five public test page"
+      ],
+      "required_claim_boundaries": [
+        "interest exploration only",
+        "no diagnosis",
+        "no hiring fit",
+        "no guaranteed career outcome",
+        "no ability claim"
+      ]
+    },
+    {
+      "request_id": "CAREER-UNCERTAINTY-ARTICLE-REQ-02",
+      "topic_direction": "Career uncertainty",
+      "business_goal": "Support broad career-direction uncertainty and route users to public career-interest exploration",
+      "target_user_problem": "Feels stuck choosing majors, jobs, or career direction",
+      "primary_search_intent": "career guidance / exploration",
+      "target_page_placeholder": "/{locale}/articles/{gpt-proposed-slug-after-review}",
+      "primary_cta_target": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/en/tests/holland-career-interest-test-riasec"
+      ],
+      "secondary_cta_target": [
+        "MBTI or Big Five public test route"
+      ],
+      "required_internal_links": [
+        "first canary",
+        "future RIASEC explanation",
+        "public test pages",
+        "approved public career hub only after link-plan approval"
+      ],
+      "required_claim_boundaries": [
+        "exploration support only",
+        "no deterministic advice",
+        "no counseling replacement",
+        "no guaranteed outcome"
+      ]
+    },
+    {
+      "request_id": "BIG-FIVE-CAREER-ARTICLE-REQ-01",
+      "topic_direction": "Big Five career use",
+      "business_goal": "Fill the Big Five career-use asset gap without making job-performance or hiring claims",
+      "target_user_problem": "Understand how Big Five traits can inform work-style reflection",
+      "primary_search_intent": "personality-to-work-style explanation",
+      "target_page_placeholder": "/{locale}/articles/{gpt-proposed-slug-after-review}",
+      "primary_cta_target": [
+        "/zh/tests/big-five-personality-test-ocean-model",
+        "/en/tests/big-five-personality-test-ocean-model"
+      ],
+      "secondary_cta_target": [
+        "RIASEC public test route"
+      ],
+      "required_internal_links": [
+        "first canary",
+        "future RIASEC explanation",
+        "Big Five public test page",
+        "RIASEC public test page"
+      ],
+      "required_claim_boundaries": [
+        "work-style tendency only",
+        "no job performance prediction",
+        "no hiring fit",
+        "no competency claim",
+        "no clinical claim"
+      ]
+    },
+    {
+      "request_id": "ARTICLE-CAREER-INTERNAL-LINKING-REQ-01",
+      "topic_direction": "Article and career internal-linking support",
+      "business_goal": "Plan safe public-canonical article-to-test and article-to-career discovery",
+      "target_user_problem": "Needs safe next steps after discovering an article or public test page",
+      "primary_search_intent": "navigation / next-step guidance",
+      "target_page_placeholder": "/{locale}/articles/{gpt-proposed-slug-after-review}",
+      "primary_cta_target": [
+        "public canonical test route selected by approved package"
+      ],
+      "secondary_cta_target": [
+        "public canonical career route only after ARTICLE-INTERNAL-LINK-PLAN-01 approval"
+      ],
+      "required_internal_links": [
+        "approved public articles",
+        "approved public tests",
+        "career hub or Tier A career pages only after eligibility is recorded"
+      ],
+      "required_claim_boundaries": [
+        "no private result reference",
+        "no personalized report URL",
+        "no career certainty",
+        "no guaranteed outcome"
+      ]
+    }
+  ],
+  "cms_fields_gpt_must_fill_later": [
+    "title",
+    "slug",
+    "locale",
+    "excerpt",
+    "body_markdown",
+    "seo_title",
+    "meta_description",
+    "FAQ items",
+    "CTA slot labels",
+    "CTA slot hrefs",
+    "claim boundary notes",
+    "references",
+    "category",
+    "tags",
+    "cover metadata"
+  ],
+  "publish_prerequisites": [
+    "content package review",
+    "CMS draft authorization",
+    "draft noindex",
+    "sitemap and llms absence before publish",
+    "CTA route gate",
+    "FAQ schema smoke",
+    "baseline owner",
+    "controlled publish preflight",
+    "exact publish approval"
+  ],
+  "metrics": {
+    "day_7": [
+      "in_sitemap",
+      "indexed_google",
+      "indexed_baidu",
+      "google_impressions",
+      "google_clicks",
+      "landing_pv",
+      "article_to_test_click",
+      "start_test",
+      "complete_test",
+      "view_result",
+      "private_url_seen"
+    ],
+    "day_14": [
+      "day_7_fields",
+      "internal_link_clicks",
+      "content_update_decision"
+    ]
+  },
+  "forbidden_confirmed": {
+    "final_title_generated": false,
+    "h1_generated": false,
+    "meta_copy_generated": false,
+    "outline_generated": false,
+    "body_copy_generated": false,
+    "faq_copy_generated": false,
+    "cta_copy_generated": false,
+    "cms_draft_created": false,
+    "publish_performed": false,
+    "search_submit_performed": false
+  },
+  "next_task": "ARTICLE-INTERNAL-LINK-PLAN-01"
+}

--- a/backend/docs/seo/seo-article-request-cards-02-2026-06-05.md
+++ b/backend/docs/seo/seo-article-request-cards-02-2026-06-05.md
@@ -1,0 +1,122 @@
+# SEO Article Request Cards 02
+
+Date: 2026-06-05
+
+PR train item: SEO-ARTICLE-REQUEST-CARDS-02
+
+Scope: next-batch request cards only. These cards are routing, measurement, CMS-field, and boundary inputs for later GPT content packages.
+
+## Boundary
+
+No final title, H1, meta copy, outline, body copy, FAQ copy, CTA copy, ad copy, social copy, or publishable article text is included. No CMS draft is created. No publish, search submission, GSC URL Inspection, Baidu push, IndexNow call, deploy, or private URL access is performed.
+
+## Shared Forbidden Routes
+
+All request cards forbid:
+
+- `/result/**`
+- `/orders/**`
+- `/share/**`
+- `/pay/**`
+- `/payment/**`
+- `/history/**`
+- private take/session/result/order/payment/share URLs
+- tokenized URLs
+- user-specific URLs
+
+## Shared Required Measurement Events
+
+- `article_to_test_click`, or an explicitly documented article attribution equivalent after ARTICLE-CTA-ROUTE-GATE-01.
+- `start_test`.
+- `complete_test`.
+- `view_result`.
+
+These events are observation signals only. Purchase truth remains backend-only.
+
+## Request Card: RIASEC-EXPLANATION-ARTICLE-REQ-01
+
+| Field | Value |
+| --- | --- |
+| request_id | RIASEC-EXPLANATION-ARTICLE-REQ-01 |
+| topic_direction | RIASEC explanation |
+| business_goal | Expand from the first canary into a test-explanation asset that supports career-interest discovery |
+| target_user_problem | User wants to understand what RIASEC is for before taking or interpreting a career-interest assessment |
+| primary_search_intent | explanation / career exploration |
+| target_page placeholder | `/{locale}/articles/{gpt-proposed-slug-after-review}` |
+| primary_cta_target | `/zh/tests/holland-career-interest-test-riasec` and `/en/tests/holland-career-interest-test-riasec` |
+| secondary_cta_target | MBTI and Big Five public test routes when relevant |
+| required_internal_links | first canary, RIASEC public test page, MBTI public test page, Big Five public test page |
+| forbidden_routes | shared forbidden routes |
+| required_claim_boundaries | interest exploration only; no diagnosis, no hiring fit, no guaranteed career outcome, no ability claim |
+| required_measurement_events | shared required measurement events |
+| CMS fields GPT must fill later | title, slug, locale, excerpt, body_markdown, seo_title, meta_description, FAQ items, CTA slot labels, CTA slot hrefs, claim boundary notes, references, category, tags, cover metadata |
+| publish prerequisites | content package review, CMS draft authorization, draft noindex, sitemap/llms absence, CTA route gate, FAQ/schema smoke, baseline owner, controlled publish preflight, exact publish approval |
+| 7-day metrics | in_sitemap, indexed_google, indexed_baidu, google_impressions, google_clicks, landing_pv, article_to_test_click, start_test, complete_test, view_result, private_url_seen |
+| 14-day metrics | same as 7-day plus internal_link_clicks and content_update_decision |
+
+## Request Card: CAREER-UNCERTAINTY-ARTICLE-REQ-02
+
+| Field | Value |
+| --- | --- |
+| request_id | CAREER-UNCERTAINTY-ARTICLE-REQ-02 |
+| topic_direction | Career uncertainty |
+| business_goal | Support users who arrive with broad career-direction uncertainty and route them to public career-interest exploration |
+| target_user_problem | User feels stuck choosing majors, jobs, or career direction |
+| primary_search_intent | career guidance / exploration |
+| target_page placeholder | `/{locale}/articles/{gpt-proposed-slug-after-review}` |
+| primary_cta_target | `/zh/tests/holland-career-interest-test-riasec` and `/en/tests/holland-career-interest-test-riasec` |
+| secondary_cta_target | MBTI or Big Five public test route if the approved package supports it |
+| required_internal_links | first canary, future RIASEC explanation, public test pages, approved public career hub only after link-plan approval |
+| forbidden_routes | shared forbidden routes |
+| required_claim_boundaries | exploration support only; no deterministic advice, no counseling replacement, no guaranteed outcome |
+| required_measurement_events | shared required measurement events |
+| CMS fields GPT must fill later | title, slug, locale, excerpt, body_markdown, seo_title, meta_description, FAQ items, CTA slot labels, CTA slot hrefs, claim boundary notes, references, category, tags, cover metadata |
+| publish prerequisites | content package review, CMS draft authorization, draft noindex, sitemap/llms absence, CTA route gate, FAQ/schema smoke, baseline owner, controlled publish preflight, exact publish approval |
+| 7-day metrics | in_sitemap, indexed_google, indexed_baidu, google_impressions, google_clicks, landing_pv, article_to_test_click, start_test, complete_test, view_result, private_url_seen |
+| 14-day metrics | same as 7-day plus internal_link_clicks and content_update_decision |
+
+## Request Card: BIG-FIVE-CAREER-ARTICLE-REQ-01
+
+| Field | Value |
+| --- | --- |
+| request_id | BIG-FIVE-CAREER-ARTICLE-REQ-01 |
+| topic_direction | Big Five career use |
+| business_goal | Fill the Big Five career-use asset gap without making job-performance or hiring claims |
+| target_user_problem | User wants to understand how Big Five traits can inform work-style reflection |
+| primary_search_intent | personality-to-work-style explanation |
+| target_page placeholder | `/{locale}/articles/{gpt-proposed-slug-after-review}` |
+| primary_cta_target | `/zh/tests/big-five-personality-test-ocean-model` and `/en/tests/big-five-personality-test-ocean-model` |
+| secondary_cta_target | RIASEC public test route |
+| required_internal_links | first canary, future RIASEC explanation, Big Five public test page, RIASEC public test page |
+| forbidden_routes | shared forbidden routes |
+| required_claim_boundaries | work-style tendency only; no job performance prediction, no hiring fit, no competency claim, no clinical claim |
+| required_measurement_events | shared required measurement events |
+| CMS fields GPT must fill later | title, slug, locale, excerpt, body_markdown, seo_title, meta_description, FAQ items, CTA slot labels, CTA slot hrefs, claim boundary notes, references, category, tags, cover metadata |
+| publish prerequisites | content package review, CMS draft authorization, draft noindex, sitemap/llms absence, CTA route gate, FAQ/schema smoke, baseline owner, controlled publish preflight, exact publish approval |
+| 7-day metrics | in_sitemap, indexed_google, indexed_baidu, google_impressions, google_clicks, landing_pv, article_to_test_click, start_test, complete_test, view_result, private_url_seen |
+| 14-day metrics | same as 7-day plus internal_link_clicks and content_update_decision |
+
+## Request Card: ARTICLE-CAREER-INTERNAL-LINKING-REQ-01
+
+| Field | Value |
+| --- | --- |
+| request_id | ARTICLE-CAREER-INTERNAL-LINKING-REQ-01 |
+| topic_direction | Article and career internal-linking support |
+| business_goal | Plan safe public-canonical article-to-test and article-to-career discovery without linking private result or payment surfaces |
+| target_user_problem | User needs safe next steps after discovering an article or public test page |
+| primary_search_intent | navigation / next-step guidance |
+| target_page placeholder | `/{locale}/articles/{gpt-proposed-slug-after-review}` |
+| primary_cta_target | public canonical test route selected by the approved package |
+| secondary_cta_target | public canonical career route only after ARTICLE-INTERNAL-LINK-PLAN-01 approval |
+| required_internal_links | approved public articles, approved public tests, career hub or Tier A career pages only after eligibility is recorded |
+| forbidden_routes | shared forbidden routes |
+| required_claim_boundaries | no private result reference, no personalized report URL, no career certainty, no guaranteed outcome |
+| required_measurement_events | shared required measurement events |
+| CMS fields GPT must fill later | title, slug, locale, excerpt, body_markdown, seo_title, meta_description, FAQ items if approved, CTA slot labels, CTA slot hrefs, claim boundary notes, references, category, tags, cover metadata |
+| publish prerequisites | ARTICLE-INTERNAL-LINK-PLAN-01, CTA route gate, FAQ/schema smoke if FAQ is present, content package review, CMS draft authorization, draft noindex, sitemap/llms absence, baseline owner, controlled publish preflight, exact publish approval |
+| 7-day metrics | in_sitemap, indexed_google, indexed_baidu, google_impressions, google_clicks, landing_pv, article_to_test_click, start_test, complete_test, view_result, private_url_seen |
+| 14-day metrics | same as 7-day plus internal_link_clicks and content_update_decision |
+
+## Next Task
+
+Proceed to ARTICLE-INTERNAL-LINK-PLAN-01 after this PR merges.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43640,7 +43640,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-request-cards-02",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): add next article request cards",
     "depends_on": [
@@ -43682,8 +43682,8 @@
       "next_task": "ARTICLE-INTERNAL-LINK-PLAN-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "28363822",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1894",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43705,6 +43705,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Request cards doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1894."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43562,7 +43562,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-topic-priority-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): rank next article topics",
     "depends_on": [
@@ -43598,11 +43598,11 @@
       "next_task": "SEO-ARTICLE-REQUEST-CARDS-02"
     },
     "failure_reason": null,
-    "commit_sha": "94d4e02a",
+    "commit_sha": "3479f8f5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1891",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:12:42Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43627,6 +43627,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1891."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1891 merged with squash merge commit 5456a909bfc97b7640df46ddc9f6957aff46b337 and cleanup completed."
       }
     ]
   },
@@ -43634,7 +43640,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-request-cards-02",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): add next article request cards",
     "depends_on": [
@@ -43646,20 +43652,35 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on SEO-ARTICLE-TOPIC-PRIORITY-01."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-TOPIC-PRIORITY-01 merged as PR #1891 with merge commit 5456a909bfc97b7640df46ddc9f6957aff46b337."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the request cards doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/seo-article-request-cards-02.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-article-request-cards-02-2026-06-05.md backend/docs/seo/generated/seo-article-request-cards-02.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for next-batch request cards as input only; NO-GO for article copy, CMS drafts, publish, or search submission.",
+      "request_cards": [
+        "RIASEC-EXPLANATION-ARTICLE-REQ-01",
+        "CAREER-UNCERTAINTY-ARTICLE-REQ-02",
+        "BIG-FIVE-CAREER-ARTICLE-REQ-01",
+        "ARTICLE-CAREER-INTERNAL-LINKING-REQ-01"
+      ],
+      "next_task": "ARTICLE-INTERNAL-LINK-PLAN-01"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43672,6 +43693,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR4 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Request cards doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20652,7 +20652,7 @@ prs:
     branch: codex/seo-dash-api-01-readonly-contract
     title: "feat(seo): add seo_intel read-only dashboard API contract"
     train_scope: seo_intel_read_only_dashboard_api
-    status: executing
+    status: merged
     scope:
       - Implement the authorized seo_intel read-only API route family from SEO-DASH-00-RECONCILE.
       - Add the narrow admin.seo_intel.read permission while preserving admin.owner and admin.ops.read compatibility.
@@ -21241,7 +21241,7 @@ prs:
     branch: codex/seo-article-request-cards-02
     title: "docs(seo): add next article request cards"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - SEO-ARTICLE-TOPIC-PRIORITY-01
     scope:


### PR DESCRIPTION
## What changed
- Added four next-batch SEO article request cards as routing/measurement/CMS-field inputs only.
- Added a generated JSON artifact for the request cards.
- Reconciled PR4 as merged and advanced PR5 state in the train ledger.

## Why
The next article batch should start from explicit request cards before GPT content packages, CMS drafts, or publish planning. These cards preserve public canonical routes and claim boundaries.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/seo-article-request-cards-02.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/seo/seo-article-request-cards-02-2026-06-05.md backend/docs/seo/generated/seo-article-request-cards-02.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No final title, H1, meta, outline, body, FAQ, CTA, ad, social, or publication copy.
- No CMS draft creation.
- No publish or unpublish.
- No search submission, GSC URL Inspection, Baidu push, or IndexNow.
- No private URL access.
- No deploy.

## Repository rule impact
Docs/artifact-only request cards. CMS/backend remains article authority; GPT content packages and CMS draft authorization are separate future gates.
