### PR TITLE
ARTICLE-INTERNAL-LINK-PLAN-01: Add article internal link plan

### DIFF
--- a/backend/docs/seo/article-internal-link-plan-2026-06-05.md
+++ b/backend/docs/seo/article-internal-link-plan-2026-06-05.md
@@ -1,0 +1,78 @@
+# Article Internal Link Plan
+
+Date: 2026-06-05
+
+PR train item: ARTICLE-INTERNAL-LINK-PLAN-01
+
+Scope: public-canonical internal link planning for the Window 6 SEO article cluster.
+
+## Boundary
+
+This plan does not write article copy, create CMS drafts, publish, submit search, inspect private URLs, or mutate runtime data. It defines link eligibility only.
+
+## Allowed Target Registry
+
+| Target type | Status | Allowed examples |
+| --- | --- | --- |
+| Published article canonical URLs | Allowed after public 200 and indexability checks | first bilingual canary URLs |
+| RIASEC public test page | Allowed | `/zh/tests/holland-career-interest-test-riasec`, `/en/tests/holland-career-interest-test-riasec` |
+| MBTI public test page | Allowed | `/zh/tests/mbti-personality-test-16-personality-types`, `/en/tests/mbti-personality-test-16-personality-types` |
+| Big Five public test page | Allowed | `/zh/tests/big-five-personality-test-ocean-model`, `/en/tests/big-five-personality-test-ocean-model` |
+| Career hub | Conditional | `/zh/career/jobs` or locale equivalent only after career hub strategy approval |
+| Tier A career pages | Conditional | only after CAREER-TIER-A-LINK-ELIGIBILITY records approved public canonical targets |
+
+## Blocked Target Registry
+
+Always blocked:
+
+- `/result/**`
+- `/orders/**`
+- `/share/**`
+- `/pay/**`
+- `/payment/**`
+- `/history/**`
+- private take/session/result/order/payment/share URLs
+- tokenized URLs
+- user-specific URLs
+- noindex pages unless explicitly approved for non-SEO operational linking
+- external competitor pages as article CTA targets
+
+## Link Matrix
+
+| Source topic | Allowed primary links | Allowed secondary links | Conditional links | Blocked links |
+| --- | --- | --- | --- | --- |
+| First canary | RIASEC public test page, MBTI public test page, Big Five public test page | future RIASEC explanation after publish | public career hub after approval | result/order/share/pay/payment/history/private URLs |
+| RIASEC explanation | first canary, RIASEC public test page | MBTI and Big Five public test pages | career hub or Tier A pages after approval | result/order/share/pay/payment/history/private URLs |
+| Career uncertainty | RIASEC explanation, RIASEC public test page | first canary, MBTI or Big Five public test page | public career hub or Tier A pages after approval | private result/report/order/payment/share/history URLs |
+| Big Five career use | Big Five public test page, RIASEC explanation | first canary, RIASEC public test page | approved public career pages only after eligibility | job-performance, hiring, private result, or payment surfaces |
+| Article/career internal-linking support | approved public articles, public test pages | approved public career hub or Tier A pages | career pages after eligibility sidecar closes | private result/order/share/pay/payment/history/tokenized URLs |
+
+## Eligibility Rules
+
+- Every target must be a public canonical route.
+- Every article target must be published, public, and indexable before it is used as an SEO internal link.
+- Every CTA target must pass ARTICLE-CTA-ROUTE-GATE-01.
+- Career targets require either an approved hub strategy or Tier A eligibility evidence.
+- If a route's privacy/indexability state is Unknown, do not link it as an SEO internal link.
+- Do not store or link user-specific result, order, payment, report, share, history, token, or session URLs.
+
+## Sidecar Dependencies
+
+| Sidecar | Reason | Blocks this plan? |
+| --- | --- | --- |
+| CAREER-TIER-A-LINK-ELIGIBILITY | Needed before linking individual career pages | No, but blocks career-page expansion |
+| TEST-LANDING-PROOF-SURFACE follow-up | Needed to improve proof surfaces on public test pages | No |
+| ARTICLE-TO-TEST-CLICK-TRACKING-RECONCILE-01 | Needed to reconcile event naming for article CTA attribution | No, but must be resolved before analytics readout is treated as stable |
+| PRIVATE-URL-LIVE-REVIEW follow-up | Needed for broader live private URL assurance | No, unless a private URL is found |
+
+## Decision
+
+GO for public article-to-test and article-to-article links inside the Window 6 cluster.
+
+CONDITIONAL for career hub or career page links until career hub strategy or Tier A link eligibility is approved.
+
+NO-GO for private, tokenized, result, order, share, pay, payment, or history links.
+
+## Next Task
+
+Proceed to ARTICLE-CTA-ROUTE-GATE-01 after this PR merges.

--- a/backend/docs/seo/generated/article-internal-link-plan-01.v1.json
+++ b/backend/docs/seo/generated/article-internal-link-plan-01.v1.json
@@ -1,0 +1,113 @@
+{
+  "artifact_id": "article-internal-link-plan-01",
+  "artifact_version": "v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "scope": "public_canonical_internal_link_plan",
+  "content_generation": false,
+  "cms_mutation": false,
+  "publish_action": false,
+  "search_submission": false,
+  "private_url_access": false,
+  "allowed_target_registry": {
+    "published_article_canonical_urls": "allowed_after_public_200_and_indexability_checks",
+    "riasec_test": [
+      "/zh/tests/holland-career-interest-test-riasec",
+      "/en/tests/holland-career-interest-test-riasec"
+    ],
+    "mbti_test": [
+      "/zh/tests/mbti-personality-test-16-personality-types",
+      "/en/tests/mbti-personality-test-16-personality-types"
+    ],
+    "big_five_test": [
+      "/zh/tests/big-five-personality-test-ocean-model",
+      "/en/tests/big-five-personality-test-ocean-model"
+    ],
+    "career_hub": "conditional_after_career_hub_strategy_approval",
+    "tier_a_career_pages": "conditional_after_CAREER_TIER_A_LINK_ELIGIBILITY"
+  },
+  "blocked_target_registry": [
+    "/result/**",
+    "/orders/**",
+    "/share/**",
+    "/pay/**",
+    "/payment/**",
+    "/history/**",
+    "private_take_session_result_order_payment_share_urls",
+    "tokenized_urls",
+    "user_specific_urls",
+    "noindex_pages_without_explicit_non_seo_approval",
+    "external_competitor_pages_as_article_cta_targets"
+  ],
+  "matrix": [
+    {
+      "source_topic": "first_canary",
+      "allowed_primary_links": [
+        "riasec_test",
+        "mbti_test",
+        "big_five_test"
+      ],
+      "conditional_links": [
+        "future_riasec_explanation",
+        "career_hub_after_approval"
+      ]
+    },
+    {
+      "source_topic": "riasec_explanation",
+      "allowed_primary_links": [
+        "first_canary",
+        "riasec_test"
+      ],
+      "allowed_secondary_links": [
+        "mbti_test",
+        "big_five_test"
+      ],
+      "conditional_links": [
+        "career_hub_after_approval",
+        "tier_a_career_pages_after_eligibility"
+      ]
+    },
+    {
+      "source_topic": "career_uncertainty",
+      "allowed_primary_links": [
+        "riasec_explanation",
+        "riasec_test"
+      ],
+      "allowed_secondary_links": [
+        "first_canary",
+        "mbti_test",
+        "big_five_test"
+      ],
+      "conditional_links": [
+        "career_hub_after_approval",
+        "tier_a_career_pages_after_eligibility"
+      ]
+    },
+    {
+      "source_topic": "big_five_career_use",
+      "allowed_primary_links": [
+        "big_five_test",
+        "riasec_explanation"
+      ],
+      "allowed_secondary_links": [
+        "first_canary",
+        "riasec_test"
+      ],
+      "conditional_links": [
+        "tier_a_career_pages_after_eligibility"
+      ]
+    }
+  ],
+  "sidecar_dependencies": [
+    "CAREER-TIER-A-LINK-ELIGIBILITY",
+    "TEST-LANDING-PROOF-SURFACE follow-up",
+    "ARTICLE-TO-TEST-CLICK-TRACKING-RECONCILE-01",
+    "PRIVATE-URL-LIVE-REVIEW follow-up"
+  ],
+  "decision": {
+    "article_to_test_links": "GO",
+    "article_to_article_links": "GO",
+    "career_links": "CONDITIONAL",
+    "private_or_tokenized_links": "NO-GO"
+  },
+  "next_task": "ARTICLE-CTA-ROUTE-GATE-01"
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43724,7 +43724,7 @@
     "repo": "fap-api",
     "branch": "codex/article-internal-link-plan-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article internal link plan",
     "depends_on": [
@@ -43760,8 +43760,8 @@
       "next_task": "ARTICLE-CTA-ROUTE-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "b19732a3c0d67616705c8c88ac317989f8864130",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1895",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43783,6 +43783,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Internal link plan doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1895."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T01:03:16Z",
+  "updated_at": "2026-06-05T00:00:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -43640,7 +43640,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-request-cards-02",
     "base": "main",
-    "status": "pr_open",
+    "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): add next article request cards",
     "depends_on": [
@@ -43682,11 +43682,11 @@
       "next_task": "ARTICLE-INTERNAL-LINK-PLAN-01"
     },
     "failure_reason": null,
-    "commit_sha": "28363822",
+    "commit_sha": "d4922cc5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1894",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:21:50Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43711,6 +43711,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1894."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1894 merged with squash merge commit 3e68f82f12c3a462e164493f576a8f747bd1418e and cleanup completed."
       }
     ]
   },
@@ -43718,7 +43724,7 @@
     "repo": "fap-api",
     "branch": "codex/article-internal-link-plan-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article internal link plan",
     "depends_on": [
@@ -43730,20 +43736,29 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on SEO-ARTICLE-REQUEST-CARDS-02."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-REQUEST-CARDS-02 merged as PR #1894 with merge commit 3e68f82f12c3a462e164493f576a8f747bd1418e."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the internal link plan doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/article-internal-link-plan-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/article-internal-link-plan-2026-06-05.md backend/docs/seo/generated/article-internal-link-plan-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for public article-to-test and article-to-article links; CONDITIONAL for career links; NO-GO for private or tokenized links.",
+      "next_task": "ARTICLE-CTA-ROUTE-GATE-01"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43756,6 +43771,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR5 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Internal link plan doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20714,7 +20714,7 @@ prs:
     branch: codex/seo-dash-migration-01-readiness
     title: "docs(seo): define seo_intel migration readiness gate"
     train_scope: seo_intel_migration_readiness_gate
-    status: executing
+    status: merged
     scope:
       - Define production seo_intel migration readiness after the read-only API contract is merged.
       - Lock dedicated migration path, pretend/status/actual command templates, human approval phrase, preflight checklist, post-migration validation, and no-go conditions.
@@ -21280,7 +21280,7 @@ prs:
     branch: codex/article-internal-link-plan-01
     title: "docs(seo): define article internal link plan"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - SEO-ARTICLE-REQUEST-CARDS-02
     scope:


### PR DESCRIPTION
What changed
- Added the Window 6 article internal link plan for SEO article production.
- Added the generated JSON artifact for Codex/GPT handoff.
- Advanced the PR train manifest/state for ARTICLE-INTERNAL-LINK-PLAN-01.

Why
- Defines reusable public-canonical internal link rules before more article request cards or drafts move forward.
- Keeps private/result/order/share/pay/payment/history/tokenized URLs out of article CTA and internal-link planning.

Validation
- python3 -m json.tool backend/docs/seo/generated/article-internal-link-plan-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/seo/article-internal-link-plan-2026-06-05.md backend/docs/seo/generated/article-internal-link-plan-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --check -- docs/codex/pr-train-state.json
- git diff --cached --check

Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA copy.
- No CMS draft, publish, unpublish, or search submission.
- No private URL inspection or user-specific route validation.
- Career-page linking remains conditional pending public canonical eligibility proof.