### PR TITLE
ops(cms): create Help service content drafts

### DIFF
--- a/backend/docs/help/generated/help-content-draft-create-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-create-01.v1.json
@@ -1,0 +1,71 @@
+{
+  "schema_version": "help-content-draft-create-01.v1",
+  "task": "HELP-CONTENT-DRAFT-CREATE-01",
+  "decision": "CMS_DRAFT_CREATE_COMPLETED_WITH_SIDECARS",
+  "ssh_alias": "fap-api-prod",
+  "password_used": false,
+  "secret_env_cookie_token_read": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "private_url_access_performed": false,
+  "payment_or_refund_performed": false,
+  "payment_provider_changed": false,
+  "source": {
+    "package": "HELP-SERVICE-CONTENT-DRAFTS-01",
+    "local_source_file": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "remote_temp_source_dir": "/tmp/fm-help-drafts.nnYsTB",
+    "remote_temp_source_removed": true
+  },
+  "dry_run": {
+    "passed": true,
+    "files_found": 1,
+    "pages_found": 12,
+    "will_create": 12,
+    "will_update": 0,
+    "will_skip": 0
+  },
+  "import": {
+    "performed": true,
+    "status_mode": "draft",
+    "upsert": false,
+    "files_found": 1,
+    "pages_found": 12,
+    "will_create": 12,
+    "will_update": 0,
+    "will_skip": 0
+  },
+  "created_records": [
+    {"id": 31, "slug": "help-unlock-failure", "locale": "zh-CN", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/unlock-failure", "canonical_path": "/help/unlock-failure", "review_state": "owner_review", "translation_group_id": "content-page-help-unlock-failure"},
+    {"id": 32, "slug": "help-unlock-failure", "locale": "en", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/unlock-failure", "canonical_path": "/help/unlock-failure", "review_state": "owner_review", "translation_group_id": "content-page-help-unlock-failure"},
+    {"id": 33, "slug": "help-payment-refund", "locale": "zh-CN", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/payment-refund", "canonical_path": "/help/payment-refund", "review_state": "owner_review", "translation_group_id": "content-page-help-payment-refund"},
+    {"id": 34, "slug": "help-payment-refund", "locale": "en", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/payment-refund", "canonical_path": "/help/payment-refund", "review_state": "owner_review", "translation_group_id": "content-page-help-payment-refund"},
+    {"id": 35, "slug": "help-result-recovery", "locale": "zh-CN", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/result-recovery", "canonical_path": "/help/result-recovery", "review_state": "owner_review", "translation_group_id": "content-page-help-result-recovery"},
+    {"id": 36, "slug": "help-result-recovery", "locale": "en", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/result-recovery", "canonical_path": "/help/result-recovery", "review_state": "owner_review", "translation_group_id": "content-page-help-result-recovery"},
+    {"id": 37, "slug": "help-privacy-data", "locale": "zh-CN", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/privacy-data", "canonical_path": "/help/privacy-data", "review_state": "owner_review", "translation_group_id": "content-page-help-privacy-data"},
+    {"id": 38, "slug": "help-privacy-data", "locale": "en", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/privacy-data", "canonical_path": "/help/privacy-data", "review_state": "owner_review", "translation_group_id": "content-page-help-privacy-data"},
+    {"id": 39, "slug": "help-use-boundaries", "locale": "zh-CN", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/use-boundaries", "canonical_path": "/help/use-boundaries", "review_state": "owner_review", "translation_group_id": "content-page-help-use-boundaries"},
+    {"id": 40, "slug": "help-use-boundaries", "locale": "en", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/use-boundaries", "canonical_path": "/help/use-boundaries", "review_state": "owner_review", "translation_group_id": "content-page-help-use-boundaries"},
+    {"id": 41, "slug": "help-data-deletion", "locale": "zh-CN", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/data-deletion", "canonical_path": "/help/data-deletion", "review_state": "owner_review", "translation_group_id": "content-page-help-data-deletion"},
+    {"id": 42, "slug": "help-data-deletion", "locale": "en", "status": "draft", "is_public": false, "is_indexable": false, "published_revision_id": null, "published_at": null, "path": "/help/data-deletion", "canonical_path": "/help/data-deletion", "review_state": "owner_review", "translation_group_id": "content-page-help-data-deletion"}
+  ],
+  "public_surface": {
+    "all_target_routes_404": true,
+    "sitemap_target_hits": 0,
+    "llms_target_hits": 0,
+    "llms_full_target_hits": 0
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-CREATE-SUPPORT-CONTACT-FIELD",
+      "status": "needs_postcheck",
+      "note": "ContentPage has no first-class support_contact field; import package contains support@fermatmind.com, but CMS row-level support-contact authority needs PR5/PR6 verification before publish."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-CREATE-TEMP-SOURCE",
+      "status": "closed",
+      "note": "Production release did not contain PR3 package files, so temporary source-dir import was used and removed. No deploy was performed."
+    }
+  ],
+  "next_task": "HELP-CONTENT-DRAFT-POSTCHECK-01"
+}

--- a/backend/docs/operations/help-content-draft-create-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-create-2026-06-05.md
@@ -1,0 +1,106 @@
+# HELP-CONTENT-DRAFT-CREATE-01
+
+## Decision
+
+`CMS_DRAFT_CREATE_COMPLETED_WITH_SIDECARS`
+
+Six bilingual Help service `ContentPage` draft pairs were created in the target CMS by using the existing controlled importer in draft mode. No publish, search submission, deploy, private URL access, payment/refund action, payment-provider change, secret/env/cookie/token read, or public amplification was performed.
+
+The server password pasted in the chat was not used. Execution used the approved SSH alias `fap-api-prod` with non-interactive key/alias access.
+
+## Source
+
+- Source package: `HELP-SERVICE-CONTENT-DRAFTS-01`
+- Source adapter copied to a temporary server source directory from:
+  - `backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json`
+- Temporary source directory:
+  - `/tmp/fm-help-drafts.nnYsTB`
+- Temporary source cleanup:
+  - removed after import
+
+## Dry Run
+
+Command:
+
+```text
+php artisan content-pages:import-local-baseline --dry-run --status=draft --source-dir=/tmp/fm-help-drafts.nnYsTB --no-ansi
+```
+
+Result:
+
+```text
+files_found=1
+pages_found=12
+will_create=12
+will_update=0
+will_skip=0
+dry-run complete
+```
+
+## Draft Create
+
+Command:
+
+```text
+php artisan content-pages:import-local-baseline --status=draft --source-dir=/tmp/fm-help-drafts.nnYsTB --no-ansi
+```
+
+Result:
+
+```text
+files_found=1
+pages_found=12
+will_create=12
+will_update=0
+will_skip=0
+import complete
+```
+
+## Created Draft Records
+
+| ID | Locale | Slug | Status | Public | Indexable | Published revision | Published at |
+| ---: | --- | --- | --- | --- | --- | --- | --- |
+| 31 | zh-CN | `help-unlock-failure` | draft | false | false | null | null |
+| 32 | en | `help-unlock-failure` | draft | false | false | null | null |
+| 33 | zh-CN | `help-payment-refund` | draft | false | false | null | null |
+| 34 | en | `help-payment-refund` | draft | false | false | null | null |
+| 35 | zh-CN | `help-result-recovery` | draft | false | false | null | null |
+| 36 | en | `help-result-recovery` | draft | false | false | null | null |
+| 37 | zh-CN | `help-privacy-data` | draft | false | false | null | null |
+| 38 | en | `help-privacy-data` | draft | false | false | null | null |
+| 39 | zh-CN | `help-use-boundaries` | draft | false | false | null | null |
+| 40 | en | `help-use-boundaries` | draft | false | false | null | null |
+| 41 | zh-CN | `help-data-deletion` | draft | false | false | null | null |
+| 42 | en | `help-data-deletion` | draft | false | false | null | null |
+
+## Public Surface Checks
+
+All public routes returned 404:
+
+- `/zh/help/unlock-failure`
+- `/en/help/unlock-failure`
+- `/zh/help/payment-refund`
+- `/en/help/payment-refund`
+- `/zh/help/result-recovery`
+- `/en/help/result-recovery`
+- `/zh/help/privacy-data`
+- `/en/help/privacy-data`
+- `/zh/help/use-boundaries`
+- `/en/help/use-boundaries`
+- `/zh/help/data-deletion`
+- `/en/help/data-deletion`
+
+Enumeration checks:
+
+- `sitemap.xml`: 0 target hits
+- `llms.txt`: 0 target hits
+- `llms-full.txt`: 0 target hits
+
+## Sidecars
+
+- `ContentPage` does not currently expose a first-class `support_contact` field. The import package records `support_contact=support@fermatmind.com`, but the created CMS draft rows do not have a dedicated support-contact column. PR5/PR6 must verify whether this is acceptable for editorial review or whether a backend field/schema follow-up is required before publish.
+- The current production release did not contain the PR3 package files, so this task used a temporary `/tmp` source directory instead of deploying. No deployment was performed.
+
+## Next Task
+
+`HELP-CONTENT-DRAFT-POSTCHECK-01`

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44039,6 +44039,156 @@
     "merge_commit": "8dcb7f38db21000271dee7ac45a92ca293c38a9d",
     "merge_commit_sha": "8dcb7f38db21000271dee7ac45a92ca293c38a9d"
   },
+  "HELP-CONTENT-DRAFT-CREATE-01": {
+    "status": "local_checks_passed",
+    "branch": "codex/help-content-draft-create-01",
+    "repo": "fap-api",
+    "title": "ops(cms): create Help service content drafts",
+    "commit_sha": null,
+    "pr_url": null,
+    "checks": [
+      {
+        "command": "ssh -o BatchMode=yes fap-api-prod ... content-pages:import-local-baseline --dry-run --status=draft --source-dir=/tmp/fm-help-drafts.nnYsTB --no-ansi",
+        "status": "passed",
+        "details": "files_found=1 pages_found=12 will_create=12 will_update=0 will_skip=0"
+      },
+      {
+        "command": "ssh -o BatchMode=yes fap-api-prod ... content-pages:import-local-baseline --status=draft --source-dir=/tmp/fm-help-drafts.nnYsTB --no-ansi",
+        "status": "passed",
+        "details": "files_found=1 pages_found=12 will_create=12 will_update=0 will_skip=0"
+      },
+      {
+        "command": "read-only ContentPage metadata query for target slugs",
+        "status": "passed",
+        "details": "12 records found; IDs 31-42; all draft, non-public, non-indexable, published_revision_id=null, published_at=null"
+      },
+      {
+        "command": "public route absence checks for 12 localized target routes",
+        "status": "passed",
+        "details": "all 12 routes returned 404"
+      },
+      {
+        "command": "sitemap.xml / llms.txt / llms-full.txt target absence checks",
+        "status": "passed",
+        "details": "0 target hits"
+      },
+      {
+        "command": "remote temporary source cleanup",
+        "status": "passed",
+        "details": "/tmp/fm-help-drafts.nnYsTB removed"
+      },
+      {
+        "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-create-01.v1.json >/dev/null",
+        "status": "passed"
+      },
+      {
+        "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+        "status": "passed"
+      },
+      {
+        "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+        "status": "passed"
+      },
+      {
+        "command": "git diff --check -- backend/docs/help/generated/help-content-draft-create-01.v1.json backend/docs/operations/help-content-draft-create-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+        "status": "passed"
+      },
+      {
+        "command": "git diff --cached --check",
+        "status": "passed"
+      }
+    ],
+    "failure_reason": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "drafts": {
+      "created_count": 12,
+      "ids": [
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42
+      ],
+      "slugs": [
+        "help-unlock-failure",
+        "help-payment-refund",
+        "help-result-recovery",
+        "help-privacy-data",
+        "help-use-boundaries",
+        "help-data-deletion"
+      ],
+      "locales": [
+        "zh-CN",
+        "en"
+      ],
+      "status": "draft",
+      "is_public": false,
+      "is_indexable": false,
+      "published_revision_id": null,
+      "published_at": null
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": true,
+      "cms_write_scope": "create 12 ContentPage draft rows only",
+      "publish_performed": false,
+      "private_url_access_performed": false,
+      "payment_provider_changed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "secret_env_cookie_token_read": false,
+      "password_used": false
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-CREATE-SUPPORT-CONTACT-FIELD",
+        "status": "needs_postcheck",
+        "note": "ContentPage has no first-class support_contact field; import package contains support@fermatmind.com, but CMS row-level support-contact authority needs PR5/PR6 verification before publish."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-CREATE-TEMP-SOURCE",
+        "status": "closed",
+        "note": "Production release did not contain PR3 package files, so temporary source-dir import was used and removed. No deploy was performed."
+      },
+      {
+        "id": "SERVER-PASSWORD-ROTATION-RECOMMENDED",
+        "status": "operator_followup",
+        "note": "A server password was pasted in chat. Codex did not use it; operator should rotate it if valid."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-POSTCHECK-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized Codex to use SSH alias fap-api-prod for HELP-CONTENT-DRAFT-CREATE-01 with strict no-publish/no-search/no-secret/no-private-url boundaries."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "draft_create_completed",
+        "note": "Controlled ContentPage importer created 12 draft-only Help records after dry-run passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "post_import_absence_passed",
+        "note": "Read-only metadata check passed; public routes returned 404 and sitemap/llms/llms-full had zero target hits."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Docs/generated/state validation passed; changed paths limited to PR4 allowed paths."
+      }
+    ]
+  },
   "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01": {
     "repo": "fap-api",
     "branch": "codex/public-benefit-asset-packages-archive-01",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44040,12 +44040,12 @@
     "merge_commit_sha": "8dcb7f38db21000271dee7ac45a92ca293c38a9d"
   },
   "HELP-CONTENT-DRAFT-CREATE-01": {
-    "status": "local_checks_passed",
+    "status": "ready_to_merge",
     "branch": "codex/help-content-draft-create-01",
     "repo": "fap-api",
     "title": "ops(cms): create Help service content drafts",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "734404e332b3c0c00648589ceca4064d47aa2151",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1896",
     "checks": [
       {
         "command": "ssh -o BatchMode=yes fap-api-prod ... content-pages:import-local-baseline --dry-run --status=draft --source-dir=/tmp/fm-help-drafts.nnYsTB --no-ansi",
@@ -44186,6 +44186,16 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Docs/generated/state validation passed; changed paths limited to PR4 allowed paths."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open_rebased",
+        "note": "PR #1896 was opened and rebased onto latest origin/main after resolving docs/codex ledger conflicts."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "Ledger records PR URL and rebased implementation commit; merge remains gated on post-rebase GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21477,6 +21477,46 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-CREATE-01
 
+  - id: HELP-CONTENT-DRAFT-CREATE-01
+    repo: fap-api
+    branch: codex/help-content-draft-create-01
+    title: "ops(cms): create Help service content drafts"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    depends_on:
+      - HELP-CMS-IMPORT-PACKAGE-01
+    scope:
+      - Create six bilingual Help service CMS drafts only through the controlled ContentPage importer.
+      - Keep every draft non-public, non-indexable, unpublished, and excluded from public routes, sitemap, llms, and search submission.
+      - Archive draft IDs, import output, public absence checks, and sidecar issues.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-create-01.v1.json
+      - backend/docs/operations/help-content-draft-create-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, make indexable, submit search URLs, deploy, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-create-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-create-01.v1.json backend/docs/operations/help-content-draft-create-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    database_mutation: true
+    payment_provider_call: false
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-POSTCHECK-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Ran HELP-CONTENT-DRAFT-CREATE-01 with the approved SSH alias fap-api-prod.
- Created 12 ContentPage CMS drafts for six Help service pages across zh-CN and en.
- Archived draft IDs, dry-run/import outputs, public route absence, sitemap/llms absence, and sidecars.

## Draft records
- IDs 31-42
- Slugs: help-unlock-failure, help-payment-refund, help-result-recovery, help-privacy-data, help-use-boundaries, help-data-deletion
- Locales: zh-CN and en
- State: status=draft, is_public=false, is_indexable=false, published_revision_id=null, published_at=null

## Validation
- Controlled dry-run: files_found=1, pages_found=12, will_create=12, will_update=0, will_skip=0
- Controlled import: files_found=1, pages_found=12, will_create=12, will_update=0, will_skip=0
- Read-only ContentPage metadata query: 12 draft records found
- Public route checks: all 12 target routes returned 404
- sitemap.xml / llms.txt / llms-full.txt: 0 target hits
- python3 -m json.tool backend/docs/help/generated/help-content-draft-create-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/help/generated/help-content-draft-create-01.v1.json backend/docs/operations/help-content-draft-create-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No publish, no make-indexable, no sitemap/llms inclusion, no search submission, no deploy, no private URL access, no secret/env/cookie/token read, no payment/refund, and no payment-provider change.
- ContentPage has no first-class support_contact field; PR5/PR6 must verify support-contact authority before publish.
- The server password pasted in chat was not used and should be rotated by the operator if valid.