### PR TITLE
ARTICLE-CTA-ROUTE-GATE-01: Add article CTA route gate

### DIFF
--- a/backend/docs/seo/article-cta-route-gate-2026-06-05.md
+++ b/backend/docs/seo/article-cta-route-gate-2026-06-05.md
@@ -1,0 +1,130 @@
+# Article CTA Route Gate
+
+Date: 2026-06-05
+
+PR train item: ARTICLE-CTA-ROUTE-GATE-01
+
+Scope: reusable route and tracking gate for SEO article CTA targets.
+
+## Boundary
+
+This gate does not write article CTA copy, article body copy, title, H1, meta, FAQ, ad copy, social copy, or CMS content. It does not create CMS drafts, publish, unpublish, submit search URLs, inspect private URLs, or mutate runtime data.
+
+## Decision
+
+GO for article CTA targets that resolve to public canonical test or article routes.
+
+CONDITIONAL for career hub or career page CTA targets until public canonical eligibility is recorded by the internal link plan sidecars.
+
+NO-GO for private, tokenized, result, order, share, pay, payment, or history routes.
+
+## Public Canonical CTA Allowlist
+
+| Target family | Gate status | Required proof before CMS draft |
+| --- | --- | --- |
+| Public test landing pages | Allowed | Locale route is public, canonical, indexable, and not a take/result/order/payment/share/history route |
+| Published article pages | Allowed | Article is published, canonical, indexable, in sitemap/llms after publish, and not a draft/noindex surface |
+| Article index pages | Allowed for navigation only | Public index route returns 200 and is canonical for the locale |
+| Career hub | Conditional | Career hub strategy and public canonical eligibility are approved |
+| Tier A career pages | Conditional | CAREER-TIER-A-LINK-ELIGIBILITY records approved public canonical targets |
+
+## Blocked CTA Targets
+
+Always reject:
+
+- `/result/**`
+- `/orders/**`
+- `/share/**`
+- `/pay/**`
+- `/payment/**`
+- `/history/**`
+- private take/session/result/order/payment/share URLs
+- tokenized URLs
+- user-specific URLs
+- dashboard, ops, admin, preview, draft, or authenticated CMS URLs
+- noindex routes unless explicitly approved for non-SEO operational navigation outside article CTA slots
+- external competitor pages
+
+Host-aware note: an external social sharing URL that contains `/share/` is not automatically a FermatMind private route, but it must not be treated as an article CTA target. CTA route checks must evaluate both host and path.
+
+## Route Validation Contract
+
+Before a request card becomes a CMS draft, every CTA href must pass:
+
+| Check | Expected result |
+| --- | --- |
+| Locale route shape | `/{locale}/tests/{slug}` or another approved public canonical family |
+| Host | Empty relative path or FermatMind public canonical host only |
+| Private segment scan | No result/order/share/pay/payment/history/private/token/session/user-specific segment |
+| Query scan | No token, email, order, payment, attempt, result, share, session, or user identifier |
+| Indexability | Public target is indexable unless explicitly non-SEO operational |
+| Canonical match | Target canonical equals the approved public route |
+| Tracking params | Only safe attribution fields are allowed |
+
+If any field is Unknown, the CTA is not eligible for SEO article publishing until reviewed.
+
+## Tracking Expectation
+
+The preferred event for article CTA clicks into tests is `article_to_test_click`.
+
+Read-only fap-web evidence found:
+
+- `components/cta/SeoTrackedCtaLink.tsx` emits `article_to_test_click` when `sourceRouteFamily === "article_detail"`.
+- `tests/contracts/seo-ops-02-article-cta-attribution.contract.test.ts` preserves safe article CTA context across article, test detail, and RIASEC take flow.
+- `lib/tracking/events.ts` declares `ARTICLE_TO_TEST_CLICK`.
+
+Therefore no new runtime tracking sidecar is opened by this PR. Later performance reads must still verify that production analytics ingestion exposes this event; missing dashboard visibility is Unknown, not 0.
+
+## Safe Attribution Fields
+
+Allowed as article CTA attribution context:
+
+- `source_route_family`
+- `source_page_type`
+- `source_slug`
+- `target_test_slug`
+- `target_action`
+- `cta_id`
+- `utm_source`
+- `utm_medium`
+- `utm_campaign`
+- `utm_term`
+- `utm_content`
+- safe click ids only when the tracking whitelist accepts them
+
+Rejected from CTA URLs and event payloads:
+
+- email, phone, name, address, or other direct identifiers
+- order numbers
+- attempt ids
+- payment ids
+- result ids
+- share ids
+- session ids
+- auth tokens
+- arbitrary unreviewed query parameters
+
+## CMS Draft Gate
+
+CMS draft creation for any future SEO article requires a route-gate record with:
+
+- source article locale and slug placeholder,
+- primary CTA target family,
+- primary CTA href,
+- secondary CTA hrefs if present,
+- route validation result,
+- blocked-route scan result,
+- tracking event expectation,
+- safe attribution field list,
+- unresolved Unknown fields,
+- approval owner and date.
+
+## Result
+
+This gate is reusable for second and third article planning.
+
+Do not publish a new article if its CTA target has Unknown privacy, indexability, canonical, or tracking state.
+
+## Next Task
+
+Proceed to ARTICLE-FAQ-SCHEMA-SMOKE-01 after this PR merges.

--- a/backend/docs/seo/generated/article-cta-route-gate-01.v1.json
+++ b/backend/docs/seo/generated/article-cta-route-gate-01.v1.json
@@ -1,0 +1,131 @@
+{
+  "artifact_id": "ARTICLE-CTA-ROUTE-GATE-01",
+  "date": "2026-06-05",
+  "scope": "seo_article_cta_route_gate",
+  "boundaries": {
+    "article_copy_written": false,
+    "title_h1_meta_faq_cta_copy_written": false,
+    "cms_draft_created": false,
+    "publish_executed": false,
+    "search_submission_executed": false,
+    "private_url_accessed": false,
+    "runtime_changed": false
+  },
+  "decision": {
+    "public_test_and_article_ctas": "GO",
+    "career_hub_or_career_page_ctas": "CONDITIONAL",
+    "private_tokenized_or_user_specific_ctas": "NO-GO"
+  },
+  "allowed_target_families": [
+    {
+      "family": "public_test_landing_page",
+      "status": "allowed",
+      "required_proof": [
+        "public_route",
+        "canonical",
+        "indexable",
+        "not_take_result_order_payment_share_history"
+      ]
+    },
+    {
+      "family": "published_article_page",
+      "status": "allowed",
+      "required_proof": [
+        "published",
+        "canonical",
+        "indexable",
+        "sitemap_llms_after_publish"
+      ]
+    },
+    {
+      "family": "career_hub",
+      "status": "conditional",
+      "required_proof": [
+        "career_hub_strategy_approved",
+        "public_canonical_eligibility"
+      ]
+    },
+    {
+      "family": "tier_a_career_page",
+      "status": "conditional",
+      "required_proof": [
+        "CAREER-TIER-A-LINK-ELIGIBILITY"
+      ]
+    }
+  ],
+  "blocked_route_patterns": [
+    "/result/**",
+    "/orders/**",
+    "/share/**",
+    "/pay/**",
+    "/payment/**",
+    "/history/**",
+    "private_take_session_result_order_payment_share_urls",
+    "tokenized_urls",
+    "user_specific_urls",
+    "dashboard_ops_admin_preview_draft_urls",
+    "external_competitor_pages"
+  ],
+  "route_validation_contract": [
+    "locale_route_shape",
+    "host",
+    "private_segment_scan",
+    "query_scan",
+    "indexability",
+    "canonical_match",
+    "tracking_params"
+  ],
+  "tracking": {
+    "preferred_event": "article_to_test_click",
+    "runtime_evidence": [
+      "fap-web components/cta/SeoTrackedCtaLink.tsx emits article_to_test_click for article_detail",
+      "fap-web tests/contracts/seo-ops-02-article-cta-attribution.contract.test.ts preserves safe article CTA context",
+      "fap-web lib/tracking/events.ts declares ARTICLE_TO_TEST_CLICK"
+    ],
+    "new_sidecar_opened": false,
+    "production_ingestion_visibility": "Unknown until performance baseline review"
+  },
+  "safe_attribution_fields": [
+    "source_route_family",
+    "source_page_type",
+    "source_slug",
+    "target_test_slug",
+    "target_action",
+    "cta_id",
+    "utm_source",
+    "utm_medium",
+    "utm_campaign",
+    "utm_term",
+    "utm_content",
+    "safe_click_ids_when_tracking_whitelist_accepts_them"
+  ],
+  "rejected_fields": [
+    "email",
+    "phone",
+    "name",
+    "address",
+    "order_no",
+    "attempt_id",
+    "payment_id",
+    "result_id",
+    "share_id",
+    "session_id",
+    "auth_token",
+    "arbitrary_unreviewed_query_parameters"
+  ],
+  "cms_draft_gate_required_fields": [
+    "source_article_locale",
+    "source_article_slug_placeholder",
+    "primary_cta_target_family",
+    "primary_cta_href",
+    "secondary_cta_hrefs",
+    "route_validation_result",
+    "blocked_route_scan_result",
+    "tracking_event_expectation",
+    "safe_attribution_field_list",
+    "unresolved_unknown_fields",
+    "approval_owner",
+    "approval_date"
+  ],
+  "next_task": "ARTICLE-FAQ-SCHEMA-SMOKE-01"
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33311,7 +33311,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-R2": {
-    "status": "pr_open",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-human-revision-r2",
     "base": "main",
@@ -43760,11 +43760,11 @@
       "next_task": "ARTICLE-CTA-ROUTE-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "b19732a3c0d67616705c8c88ac317989f8864130",
+    "commit_sha": "cd51c29ce0c8a4bc1760ffb75a1aac2eb7f95ec0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1895",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:32:19Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43789,6 +43789,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1895."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1895 merged with squash merge commit 6e0c78e7b2a2ff258597ebf9b079ab2bf14495fb and cleanup completed."
       }
     ]
   },
@@ -43796,7 +43802,7 @@
     "repo": "fap-api",
     "branch": "codex/article-cta-route-gate-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): gate article CTA routes",
     "depends_on": [
@@ -43808,20 +43814,30 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on ARTICLE-INTERNAL-LINK-PLAN-01."
+        "status": "pass",
+        "evidence": "ARTICLE-INTERNAL-LINK-PLAN-01 merged as PR #1895 with merge commit 6e0c78e7b2a2ff258597ebf9b079ab2bf14495fb."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the CTA route gate doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/article-cta-route-gate-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/article-cta-route-gate-2026-06-05.md backend/docs/seo/generated/article-cta-route-gate-01.v1.json docs/codex docs/codex/sidecar",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for public canonical article-to-test CTAs; CONDITIONAL for career CTAs; NO-GO for private or tokenized CTA routes.",
+      "tracking": "article_to_test_click is supported by fap-web contracts; production ingestion visibility remains Unknown until baseline review.",
+      "next_task": "ARTICLE-FAQ-SCHEMA-SMOKE-01"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43834,6 +43850,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR6 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "CTA route gate doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43802,7 +43802,7 @@
     "repo": "fap-api",
     "branch": "codex/article-cta-route-gate-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): gate article CTA routes",
     "depends_on": [
@@ -43839,8 +43839,8 @@
       "next_task": "ARTICLE-FAQ-SCHEMA-SMOKE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "12f36b3b3c168caa6ce052a670aa243e21781934",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1897",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43862,6 +43862,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "CTA route gate doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1897."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20768,7 +20768,7 @@ prs:
     branch: codex/seo-dash-collector-01-readiness
     title: "docs(seo): define post-migration collector dry-run readiness"
     train_scope: seo_intel_collector_dry_run_readiness
-    status: executing
+    status: merged
     depends_on:
       - SEO-DASH-00-RECONCILE
       - SEO-DASH-API-01
@@ -21319,7 +21319,7 @@ prs:
     branch: codex/article-cta-route-gate-01
     title: "docs(seo): gate article CTA routes"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - ARTICLE-INTERNAL-LINK-PLAN-01
     scope:


### PR DESCRIPTION
What changed
- Added the reusable SEO article CTA route gate.
- Added the generated JSON artifact for downstream QA and content-package handoff.
- Reconciled ARTICLE-INTERNAL-LINK-PLAN-01 as merged and advanced ARTICLE-CTA-ROUTE-GATE-01 in PR train metadata.

Why
- Makes every future article CTA prove public canonical target safety before CMS draft or publish planning.
- Keeps result/order/share/pay/payment/history/private/tokenized/user-specific URLs out of SEO article CTA slots.
- Records the article_to_test_click tracking expectation from read-only fap-web contract evidence without changing runtime.

Validation
- python3 -m json.tool backend/docs/seo/generated/article-cta-route-gate-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/seo/article-cta-route-gate-2026-06-05.md backend/docs/seo/generated/article-cta-route-gate-01.v1.json docs/codex docs/codex/sidecar
- git diff --cached --check

Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA copy.
- No CMS draft, publish, unpublish, search submission, or deploy.
- No runtime tracking change.
- Production analytics ingestion visibility remains Unknown until the performance baseline review.