### PR TITLE
docs(benefit): inventory Foundation trust page assets

### DIFF
--- a/backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md
+++ b/backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md
@@ -1,0 +1,102 @@
+# Foundation Trust Page Asset Inventory
+
+Date: 2026-06-05
+
+PR train item: `FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01`
+
+Mode: read-only inventory. No CMS mutation, content rewrite, DailyGiving record creation, proof upload, publish, search submission, social distribution, trust badge, or deploy was performed.
+
+## Decision
+
+Foundation public brand trust page: `CONDITIONAL_GO`.
+
+DailyGiving as public trust asset: `NO_GO`.
+
+Reason: Foundation has published CMS authority, public 200 routes, indexable robots, and no high-risk claim hits in the scanned live HTML. DailyGiving remains a gated ledger surface with zero public records and zero public months, so it must not be used as a trust badge, paid-page proof, search submission target, or social amplification proof.
+
+## Public Route Inventory
+
+| Surface | URL | Status | Robots | Canonical | Decision |
+| --- | --- | ---: | --- | --- | --- |
+| Foundation ZH | `https://fermatmind.com/zh/foundation` | 200 | `index, follow` | self canonical | conditional brand trust asset |
+| Foundation EN | `https://fermatmind.com/en/foundation` | 200 | `index, follow` | self canonical | conditional brand trust asset |
+| DailyGiving ZH | `https://fermatmind.com/zh/foundation/daily-giving` | 200 | `noindex, nofollow, noarchive, nocache` | self canonical | gated ledger only |
+| DailyGiving EN | `https://fermatmind.com/en/foundation/daily-giving` | 200 | `noindex, nofollow, noarchive, nocache` | self canonical | gated ledger only |
+
+## CMS Authority
+
+Production content page API checks returned:
+
+| Locale | Status | Public | Indexable | Review state | Updated at | Content evidence |
+| --- | --- | --- | --- | --- | --- | --- |
+| EN | `published` | true | true | `approved` | 2026-05-31 | `content_md`, SEO title, and meta description present |
+| ZH | `published` | true | true | `approved` | 2026-05-31 | `content_md`, SEO title, and meta description present |
+
+Authority rule: Foundation copy belongs to CMS `content_pages`. Frontend must not add publishable Foundation editorial fallback copy.
+
+## DailyGiving Public API State
+
+| API | Result |
+| --- | --- |
+| `GET /api/v0.5/foundation/giving-records?locale=en` | 200, `ok=true`, `records_count=0`, `pagination.total=0` |
+| `GET /api/v0.5/foundation/giving-records?locale=zh-CN` | 200, `ok=true`, `records_count=0`, `pagination.total=0` |
+| `GET /api/v0.5/foundation/giving-records/months?locale=en` | 200, `ok=true`, `months_count=0` |
+| `GET /api/v0.5/foundation/giving-records/months?locale=zh-CN` | 200, `ok=true`, `months_count=0` |
+
+No public API private-key leak string was observed for `proof_private_path`, `proof_redaction_notes`, `receipt_reference_private`, `internal_notes`, `created_by_admin_user_id`, or `updated_by_admin_user_id` in the empty production responses.
+
+Public truth: public records count is 0 and public months count is 0. Whether private, draft, planned, or unpublished records exist is `Unknown` from public-only checks.
+
+## Sitemap And llms
+
+| Surface | Foundation present | DailyGiving present | Status |
+| --- | --- | --- | --- |
+| `https://fermatmind.com/sitemap.xml` | true | false | expected for Foundation only |
+| `https://fermatmind.com/llms.txt` | false | false | no DailyGiving exposure |
+| `https://fermatmind.com/llms-full.txt` | false | false | no DailyGiving exposure |
+
+Interpretation: Foundation is currently discoverable through sitemap. DailyGiving is not discoverable through sitemap, `llms.txt`, or `llms-full.txt`, which is correct while records and months are empty.
+
+## Claim Lint
+
+Scanned live Foundation and DailyGiving HTML for:
+
+- `UN official partner`
+- `联合国官方合作`
+- `官方认证`
+- `官方背书`
+- `背书`
+- `guaranteed impact`
+- `official endorsement`
+- `official partner`
+- `certified by`
+- `authorized by UN`
+- `registered foundation`
+
+Result: no live HTML hits in the scanned pages.
+
+## Missing Assets
+
+- Foundation needs a reviewed page asset package that explains plan, boundaries, privacy, record generation, and non-claims without becoming publishable copy in this PR.
+- Foundation needs a claim boundary contract and CMS field map before further content expansion.
+- Foundation FAQ schema must remain blocked unless visible CMS-approved FAQ content exists and passes claim boundary.
+- DailyGiving needs proof storage gate, redaction SOP, public release prerequisites, public API smoke, indexability gate, and first-record review template before public records are created or amplified.
+- Storage-level private proof disk or bucket confirmation is `Unknown`.
+- Public DailyGiving proof is missing.
+- Public DailyGiving record is missing.
+- Trust badge remains blocked.
+
+## Safe Content Direction For GPT
+
+GPT may prepare request cards, module inventories, CMS field needs, claim-boundary inputs, FAQ question inventories, SOP inputs, and review templates.
+
+GPT must not produce final public page copy, final H1, final metadata, final FAQ answers, CTA copy, social copy, trust badge copy, UN endorsement language, official relationship claims, guaranteed impact claims, or DailyGiving active-operation claims before public records exist.
+
+## Validation Performed
+
+- Public HTTP checks for Foundation and DailyGiving pages.
+- Public CMS API checks for Foundation EN/ZH content page authority.
+- Public DailyGiving records and months API checks.
+- Public sitemap, `llms.txt`, and `llms-full.txt` scans.
+- Live high-risk claim scan on public Foundation and DailyGiving HTML.
+- JSON/YAML parse and diff checks for this PR.

--- a/backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json
+++ b/backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json
@@ -1,0 +1,149 @@
+{
+  "version": "foundation_trust_page_asset_inventory.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "read_only_inventory",
+  "decisions": {
+    "foundation_public_brand_trust_page": "CONDITIONAL_GO",
+    "daily_giving_public_trust_asset": "NO_GO",
+    "daily_giving_trust_badge_allowed": false,
+    "daily_giving_noindex_required": true
+  },
+  "foundation_routes": [
+    {
+      "locale": "zh",
+      "url": "https://fermatmind.com/zh/foundation",
+      "status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/zh/foundation",
+      "risky_claim_hits": []
+    },
+    {
+      "locale": "en",
+      "url": "https://fermatmind.com/en/foundation",
+      "status": 200,
+      "robots": "index, follow",
+      "canonical": "https://fermatmind.com/en/foundation",
+      "risky_claim_hits": []
+    }
+  ],
+  "daily_giving_routes": [
+    {
+      "locale": "zh",
+      "url": "https://fermatmind.com/zh/foundation/daily-giving",
+      "status": 200,
+      "robots": "noindex, nofollow, noarchive, nocache",
+      "canonical": "https://fermatmind.com/zh/foundation/daily-giving",
+      "risky_claim_hits": []
+    },
+    {
+      "locale": "en",
+      "url": "https://fermatmind.com/en/foundation/daily-giving",
+      "status": 200,
+      "robots": "noindex, nofollow, noarchive, nocache",
+      "canonical": "https://fermatmind.com/en/foundation/daily-giving",
+      "risky_claim_hits": []
+    }
+  ],
+  "cms_authority": [
+    {
+      "locale": "en",
+      "api_url": "https://fermatmind.com/api/v0.5/content-pages/foundation?locale=en",
+      "status": 200,
+      "slug": "foundation",
+      "cms_status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "review_state": "approved",
+      "legal_review_required": false,
+      "science_review_required": false,
+      "updated_at": "2026-05-31",
+      "has_content_md": true,
+      "has_content_html": false,
+      "has_seo_title": true,
+      "has_meta_description": true
+    },
+    {
+      "locale": "zh-CN",
+      "api_url": "https://fermatmind.com/api/v0.5/content-pages/foundation?locale=zh-CN",
+      "status": 200,
+      "slug": "foundation",
+      "cms_status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "review_state": "approved",
+      "legal_review_required": false,
+      "science_review_required": false,
+      "updated_at": "2026-05-31",
+      "has_content_md": true,
+      "has_content_html": false,
+      "has_seo_title": true,
+      "has_meta_description": true
+    }
+  ],
+  "daily_giving_public_api": {
+    "records_count": 0,
+    "months_count": 0,
+    "pagination_total": 0,
+    "private_key_leak_observed": false,
+    "private_or_draft_records_exist": "Unknown"
+  },
+  "discoverability": {
+    "sitemap": {
+      "status": 200,
+      "foundation_present": true,
+      "daily_giving_present": false
+    },
+    "llms_txt": {
+      "status": 200,
+      "foundation_present": false,
+      "daily_giving_present": false
+    },
+    "llms_full_txt": {
+      "status": 200,
+      "foundation_present": false,
+      "daily_giving_present": false
+    }
+  },
+  "claim_lint": {
+    "scanned_terms": [
+      "UN official partner",
+      "联合国官方合作",
+      "官方认证",
+      "官方背书",
+      "背书",
+      "guaranteed impact",
+      "official endorsement",
+      "official partner",
+      "certified by",
+      "authorized by UN",
+      "registered foundation"
+    ],
+    "live_html_hits": []
+  },
+  "missing_assets": [
+    "foundation_reviewed_content_asset_package",
+    "foundation_claim_boundary_contract",
+    "foundation_cms_field_map",
+    "foundation_faq_schema_gate",
+    "daily_giving_proof_storage_gate",
+    "daily_giving_public_release_prerequisites",
+    "daily_giving_public_api_smoke",
+    "daily_giving_indexability_gate",
+    "daily_giving_first_record_review_template",
+    "storage_private_confirmed",
+    "public_daily_giving_record",
+    "public_daily_giving_proof"
+  ],
+  "forbidden_in_this_pr": [
+    "content_rewrite",
+    "cms_mutation",
+    "daily_giving_record_creation",
+    "proof_upload",
+    "publish",
+    "social_distribution",
+    "trust_badge",
+    "search_submission",
+    "deploy"
+  ],
+  "next_pr_supported": "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01"
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44177,7 +44177,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-trust-page-asset-inventory-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): inventory Foundation trust page assets",
     "depends_on": [
@@ -44219,6 +44219,22 @@
             "command": "git diff --check -- backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
             "status": "passed"
           }
+        ]
+      },
+      "github": {
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1898 --watch --interval 15"
+        ],
+        "jobs": [
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
         ]
       }
     },
@@ -44282,6 +44298,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1898."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1898."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44177,7 +44177,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-trust-page-asset-inventory-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): inventory Foundation trust page assets",
     "depends_on": [
@@ -44234,8 +44234,8 @@
       "next_pr_supported": "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9a55fe83a813f28d053ddf9ad0f0dfa19b91b6f8",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1898",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44277,6 +44277,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Foundation trust page inventory validated with public checks, JSON/YAML parse, and scoped diff check."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1898."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44043,7 +44043,7 @@
     "repo": "fap-api",
     "branch": "codex/public-benefit-asset-packages-archive-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): archive public benefit content asset packages",
     "checks": {
@@ -44117,11 +44117,11 @@
       "next_pr_supported": "FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01"
     },
     "failure_reason": null,
-    "commit_sha": "e3246bb32d54f43bc12292a8eaf466ff4fa126ad",
+    "commit_sha": "ef9fb099052f05d935b15e1b30671d4ed85aa091",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1893",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:32:57Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -44165,6 +44165,118 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1893 before rebase; PR rebased after resolving ledger conflicts against latest main."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1893 squash-merged at ef9fb099052f05d935b15e1b30671d4ed85aa091; remote branch deleted; local task branch absent after merge."
+      }
+    ]
+  },
+  "FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01": {
+    "repo": "fap-api",
+    "branch": "codex/foundation-trust-page-asset-inventory-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): inventory Foundation trust page assets",
+    "depends_on": [
+      "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided PR2 id, branch, title, allowed paths, and execution order in the Window 7 PR train request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01 merged as PR #1893 at ef9fb099052f05d935b15e1b30671d4ed85aa091."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed paths are confined to PR2 allowed docs/generated/ledger paths."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "public HTTP checks for Foundation pages, DailyGiving pages, CMS content page API, giving records API, months API, sitemap, llms, and llms-full",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
+      }
+    },
+    "result": {
+      "foundation_public_brand_trust_page": "CONDITIONAL_GO",
+      "daily_giving_public_trust_asset": "NO_GO",
+      "foundation_routes_200": true,
+      "foundation_robots_index_follow": true,
+      "daily_giving_noindex": true,
+      "daily_giving_records_count": 0,
+      "daily_giving_months_count": 0,
+      "trust_badge_allowed": false,
+      "next_pr_supported": "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Changed files are limited to the PR2 inventory doc, generated artifact, and codex ledger paths."
+    },
+    "sidecars": [
+      {
+        "id": "STORAGE_PRIVATE_CONFIRMED",
+        "status": "Unknown",
+        "note": "PR2 public inventory does not prove private disk or bucket."
+      },
+      {
+        "id": "PUBLIC_DAILY_GIVING_RECORD",
+        "status": "missing",
+        "note": "Public records API returned 0 records and 0 months."
+      },
+      {
+        "id": "TRUST_BADGE",
+        "status": "blocked",
+        "note": "DailyGiving cannot be used as trust badge while records/proof gates are incomplete."
+      }
+    ],
+    "next_task": "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR1 merge for read-only Foundation trust page asset inventory."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Foundation trust page inventory validated with public checks, JSON/YAML parse, and scoped diff check."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21518,3 +21518,44 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01
+
+  - id: FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01
+    repo: fap-api
+    depends_on:
+      - PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
+    branch: codex/foundation-trust-page-asset-inventory-01
+    title: "docs(benefit): inventory Foundation trust page assets"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Inventory current `/zh/foundation` and `/en/foundation` as public brand trust assets.
+      - Verify public routes, robots, sitemap, llms, CMS authority, public API state, claim lint, and missing asset gaps.
+      - Keep DailyGiving as a noindex gated ledger and not a trust badge or amplification asset.
+    allowed_paths:
+      - backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md
+      - backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite content, mutate CMS, create DailyGiving records, process proof files, publish, distribute social content, create trust badges, submit search URLs, deploy, or read secrets.
+    validation:
+      - public HTTP checks for Foundation pages, DailyGiving pages, CMS content page API, giving records API, months API, sitemap, llms, and llms-full
+      - python3 -m json.tool backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01


### PR DESCRIPTION
## What changed
- Added a read-only Foundation trust page asset inventory for `/zh/foundation` and `/en/foundation`.
- Added machine-readable inventory evidence for CMS authority, public routes, robots, sitemap/llms state, DailyGiving public API state, and claim lint status.
- Updated Window 7 PR train manifest/state and reconciled PR1 as merged.

## Why
Foundation can be treated as a conditional public brand trust page, but DailyGiving remains a noindex gated ledger with zero public records and zero public months. This PR records the evidence and missing asset gaps without changing content, CMS, runtime, proof, records, indexability, search, or trust badges.

## Validation
- Public HTTP checks for Foundation pages, DailyGiving pages, CMS content page API, giving records API, months API, sitemap, llms, and llms-full
- `python3 -m json.tool backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/operations/foundation-trust-page-asset-inventory-2026-06-04.md backend/docs/operations/generated/foundation-trust-page-asset-inventory.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No Foundation content rewrite or publishable copy.
- No CMS mutation.
- No DailyGiving record creation.
- No proof upload or processing.
- No trust badge, search submission, social distribution, or deploy.
