### PR TITLE
ARTICLE-FAQ-SCHEMA-SMOKE-01: Add article FAQ schema smoke

### DIFF
--- a/backend/docs/seo/article-faq-schema-smoke-2026-06-05.md
+++ b/backend/docs/seo/article-faq-schema-smoke-2026-06-05.md
@@ -1,0 +1,104 @@
+# Article FAQ Schema Smoke
+
+Date: 2026-06-05
+
+PR train item: ARTICLE-FAQ-SCHEMA-SMOKE-01
+
+Scope: repeatable smoke gate for Article, BreadcrumbList, and FAQPage structured data on SEO articles.
+
+## Boundary
+
+This smoke gate does not write FAQ questions, FAQ answers, article copy, title, H1, meta, CTA copy, ad copy, or social copy. It does not mutate CMS, create a draft, publish, submit search, deploy, or inspect private URLs.
+
+## Decision
+
+GO for Article and BreadcrumbList schema smoke as a required check on every published article.
+
+GO for FAQPage schema only when FAQ items are visibly rendered from CMS/backend article answer-surface data.
+
+NO-GO for hidden FAQ schema, generated fallback FAQ, frontend-local FAQ authority, or FAQPage schema when no visible FAQ block exists.
+
+## Required Smoke Checks
+
+| Schema type | Required when | Source authority | Smoke expectation |
+| --- | --- | --- | --- |
+| Article | public article detail is published and indexable | CMS article or approved CMS SEO JSON-LD | one Article JSON-LD object with canonical URL, headline, description, language, author, published/modified dates, and mainEntityOfPage |
+| BreadcrumbList | public article detail is rendered | public locale route and article title | one BreadcrumbList object matching Home -> Articles -> article |
+| FAQPage | visible article FAQ exists | `answer_surface_v1.faq_blocks` or approved CMS/backend visible FAQ authority | FAQPage mainEntity count equals visible FAQ count |
+
+## FAQ Schema Rules
+
+- FAQPage may be emitted only from visible FAQ content.
+- The visible FAQ source must be CMS/backend-owned.
+- FAQPage must not be inferred from hidden HTML, frontend fallback copy, article body heuristics, or GPT-only package notes.
+- If visible FAQ is absent, the correct result is no FAQPage schema.
+- If FAQ content exists in a draft package but is not visible in the rendered draft/public page, FAQPage is NO-GO.
+- If FAQ visibility or source authority is Unknown, FAQPage is NO-GO until reviewed.
+
+## Read-only Runtime Evidence
+
+Read-only fap-web evidence found:
+
+- `app/(localized)/[locale]/articles/[slug]/page.tsx` builds Article JSON-LD and BreadcrumbList for article details.
+- The same article page maps `article.answerSurface.faqBlocks` into FAQPage only when question and answer values exist.
+- `tests/contracts/article-answer-surface.contract.test.ts` verifies FAQPage is emitted from visible answer-surface FAQ and not emitted when visible FAQ is absent.
+- `tests/contracts/fixtures/discoverability-foundation/structured-data-contract.v1.json` records article_detail authority as `cms_article_visible_content` and allows only Article, BreadcrumbList, and FAQPage.
+
+This PR records the smoke gate only. It does not change fap-web runtime.
+
+## CMS Package Requirements
+
+Every future article content package should carry these non-copy fields before CMS draft planning:
+
+- article locale,
+- article slug placeholder,
+- schema intent for Article and BreadcrumbList,
+- FAQ intended state: `none`, `visible_cms_faq`, or `Unknown`,
+- FAQ source authority,
+- visible FAQ count,
+- expected FAQPage mainEntity count,
+- Article schema source: CMS SEO JSON-LD or article-derived fallback,
+- Breadcrumb canonical path,
+- claim-boundary notes,
+- unresolved Unknown fields.
+
+The package must not carry final FAQ copy in Codex-produced planning artifacts.
+
+## Draft And Publish Gate
+
+For drafts:
+
+- draft route should remain noindex or absent from sitemap/llms,
+- schema smoke can be recorded from authorized preview/dry-run output only if preview access is approved,
+- if preview access is not approved, record draft schema as Unknown rather than 0.
+
+For published articles:
+
+- public page returns 200,
+- Article JSON-LD exists unless explicitly blocked by article authority,
+- BreadcrumbList exists,
+- FAQPage exists only when visible FAQ exists,
+- FAQPage `mainEntity` count matches visible FAQ count,
+- sitemap/llms inclusion is checked only after publish,
+- no private or tokenized URL is used during smoke.
+
+## Failure Conditions
+
+Block publish or follow-up expansion when:
+
+- FAQPage exists without visible FAQ,
+- visible FAQ exists but FAQPage count differs,
+- schema contains private/result/order/share/pay/payment/history URLs,
+- schema contains frontend-local editorial fallback content,
+- Article/Breadcrumb schema is missing from a published indexable article,
+- schema source authority is Unknown.
+
+## Result
+
+This smoke gate is reusable for the second and third SEO articles.
+
+It keeps FAQ/schema stable by separating structure and authority checks from publishable FAQ copy.
+
+## Next Task
+
+Proceed to SEO-ARTICLE-PUBLISH-HOLD-GATE-01 after this PR merges.

--- a/backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json
+++ b/backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json
@@ -1,0 +1,94 @@
+{
+  "artifact_id": "ARTICLE-FAQ-SCHEMA-SMOKE-01",
+  "date": "2026-06-05",
+  "scope": "seo_article_faq_schema_smoke",
+  "boundaries": {
+    "faq_copy_written": false,
+    "article_copy_written": false,
+    "title_h1_meta_cta_copy_written": false,
+    "cms_draft_created": false,
+    "publish_executed": false,
+    "search_submission_executed": false,
+    "private_url_accessed": false,
+    "runtime_changed": false
+  },
+  "decision": {
+    "article_schema": "GO",
+    "breadcrumb_schema": "GO",
+    "faq_schema_with_visible_cms_faq": "GO",
+    "faq_schema_without_visible_cms_faq": "NO-GO",
+    "hidden_or_frontend_fallback_faq_schema": "NO-GO"
+  },
+  "required_smoke_checks": [
+    {
+      "schema_type": "Article",
+      "required_when": "published_indexable_article_detail",
+      "source_authority": "cms_article_or_approved_cms_seo_jsonld",
+      "expectation": "one Article JSON-LD object with canonical URL, headline, description, language, author, dates, and mainEntityOfPage"
+    },
+    {
+      "schema_type": "BreadcrumbList",
+      "required_when": "article_detail_rendered",
+      "source_authority": "public_locale_route_and_article_title",
+      "expectation": "one BreadcrumbList matching Home > Articles > article"
+    },
+    {
+      "schema_type": "FAQPage",
+      "required_when": "visible_article_faq_exists",
+      "source_authority": "answer_surface_v1.faq_blocks_or_approved_cms_backend_visible_faq",
+      "expectation": "mainEntity count equals visible FAQ count"
+    }
+  ],
+  "faq_schema_rules": [
+    "faq_schema_only_from_visible_content",
+    "visible_faq_source_must_be_cms_backend_owned",
+    "no_hidden_html_schema",
+    "no_frontend_fallback_faq_authority",
+    "no_article_body_heuristic_faq",
+    "no_faq_schema_when_visible_faq_absent",
+    "unknown_source_or_visibility_blocks_faq_schema"
+  ],
+  "runtime_evidence": [
+    "fap-web app/(localized)/[locale]/articles/[slug]/page.tsx builds Article and BreadcrumbList JSON-LD",
+    "fap-web app/(localized)/[locale]/articles/[slug]/page.tsx maps article.answerSurface.faqBlocks into FAQPage only when question and answer exist",
+    "fap-web tests/contracts/article-answer-surface.contract.test.ts verifies FAQPage is emitted only from visible answer-surface FAQ",
+    "fap-web tests/contracts/fixtures/discoverability-foundation/structured-data-contract.v1.json limits article_detail schema to Article, BreadcrumbList, and FAQPage"
+  ],
+  "cms_package_required_fields": [
+    "article_locale",
+    "article_slug_placeholder",
+    "schema_intent_article",
+    "schema_intent_breadcrumb",
+    "faq_intended_state",
+    "faq_source_authority",
+    "visible_faq_count",
+    "expected_faqpage_main_entity_count",
+    "article_schema_source",
+    "breadcrumb_canonical_path",
+    "claim_boundary_notes",
+    "unresolved_unknown_fields"
+  ],
+  "draft_rules": [
+    "draft_route_noindex_or_absent_from_sitemap_llms",
+    "authorized_preview_required_for_draft_schema_smoke",
+    "preview_not_authorized_means_unknown_not_zero"
+  ],
+  "publish_smoke": [
+    "public_page_200",
+    "article_jsonld_exists_unless_authority_blocks",
+    "breadcrumb_jsonld_exists",
+    "faqpage_exists_only_when_visible_faq_exists",
+    "faqpage_main_entity_count_matches_visible_faq_count",
+    "sitemap_llms_checked_after_publish",
+    "no_private_or_tokenized_url_used"
+  ],
+  "failure_conditions": [
+    "faqpage_without_visible_faq",
+    "faqpage_count_mismatch",
+    "schema_contains_private_url",
+    "schema_contains_frontend_local_editorial_fallback",
+    "article_or_breadcrumb_missing_on_published_indexable_article",
+    "schema_source_authority_unknown"
+  ],
+  "next_task": "SEO-ARTICLE-PUBLISH-HOLD-GATE-01"
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -33392,7 +33392,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-POST-PUBLISH-SMOKE-01": {
-    "status": "pr_open",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-post-publish-smoke-01",
     "base": "main",
@@ -43839,11 +43839,11 @@
       "next_task": "ARTICLE-FAQ-SCHEMA-SMOKE-01"
     },
     "failure_reason": null,
-    "commit_sha": "12f36b3b3c168caa6ce052a670aa243e21781934",
+    "commit_sha": "d16e14083c6354736445212f984e651f5e0a58b6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1897",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:41:29Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43868,6 +43868,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1897."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1897 merged with squash merge commit ff12145afc415d0d79370d5f3e5020962f2939b3 and cleanup completed."
       }
     ]
   },
@@ -43875,7 +43881,7 @@
     "repo": "fap-api",
     "branch": "codex/article-faq-schema-smoke-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article FAQ schema smoke",
     "depends_on": [
@@ -43887,20 +43893,29 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on ARTICLE-CTA-ROUTE-GATE-01."
+        "status": "pass",
+        "evidence": "ARTICLE-CTA-ROUTE-GATE-01 merged as PR #1897 with merge commit ff12145afc415d0d79370d5f3e5020962f2939b3."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the FAQ/schema smoke doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/article-faq-schema-smoke-2026-06-05.md backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "GO for Article/Breadcrumb smoke; GO for FAQPage only when visible CMS/backend FAQ exists; NO-GO for hidden or fallback FAQ schema.",
+      "next_task": "SEO-ARTICLE-PUBLISH-HOLD-GATE-01"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43913,6 +43928,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR7 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "FAQ/schema smoke doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43881,7 +43881,7 @@
     "repo": "fap-api",
     "branch": "codex/article-faq-schema-smoke-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article FAQ schema smoke",
     "depends_on": [
@@ -43917,8 +43917,8 @@
       "next_task": "SEO-ARTICLE-PUBLISH-HOLD-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "ac333a83ddda76f0b10b40ecb92bdca3707fdcbd",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1899",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -43940,6 +43940,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "FAQ/schema smoke doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1899."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20824,7 +20824,7 @@ prs:
     branch: codex/seo-dash-collector-01-smoke-reconcile
     title: "docs(seo): record collector dry-run smoke evidence"
     train_scope: seo_intel_collector_dry_run_smoke_evidence
-    status: executing
+    status: merged
     depends_on:
       - SEO-DASH-COLLECTOR-01
     scope:
@@ -21359,7 +21359,7 @@ prs:
     branch: codex/article-faq-schema-smoke-01
     title: "docs(seo): define article FAQ schema smoke"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - ARTICLE-CTA-ROUTE-GATE-01
     scope:


### PR DESCRIPTION
What changed
- Added the reusable article FAQ/schema smoke gate.
- Added the generated JSON artifact for downstream publish-gate and QA use.
- Reconciled ARTICLE-CTA-ROUTE-GATE-01 as merged and advanced ARTICLE-FAQ-SCHEMA-SMOKE-01 in PR train metadata.

Why
- Makes Article, BreadcrumbList, and FAQPage checks repeatable for every SEO article.
- Requires FAQPage only from visible CMS/backend FAQ authority and blocks hidden/fallback FAQ schema.

Validation
- python3 -m json.tool backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/seo/article-faq-schema-smoke-2026-06-05.md backend/docs/seo/generated/article-faq-schema-smoke-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA copy.
- No CMS draft, publish, unpublish, search submission, or deploy.
- No frontend runtime change.
- Draft schema remains Unknown unless an authorized preview/dry-run is available.