### PR TITLE
docs(benefit): define Foundation public benefit claim boundary

### DIFF
--- a/backend/docs/operations/foundation-claim-boundary-contract.md
+++ b/backend/docs/operations/foundation-claim-boundary-contract.md
@@ -1,0 +1,111 @@
+# Foundation Public Benefit Claim Boundary Contract
+
+Date: 2026-06-05
+
+PR train item: `FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01`
+
+Mode: contract and docs only. This PR does not create Foundation public copy, DailyGiving promotional copy, CMS records, DailyGiving records, proof files, social posts, trust badges, search submissions, or deploys.
+
+## Decision
+
+Foundation and DailyGiving public-benefit language must stay record-backed and boundary-first.
+
+Foundation may describe an independent public-benefit plan and operator-reviewed record system. DailyGiving may not be described as a public trust asset, trust badge, paid-page proof, search/social amplification asset, or stable daily operation until public records and proof gates pass.
+
+## Allowed Claim Categories
+
+- Independent public-benefit plan.
+- Operator-reviewed DailyGiving record process.
+- Redacted proof when available and reviewed.
+- Public ledger when release gates are met.
+- DailyGiving remains noindex until release gates pass.
+- United Nations Foundation may be referenced only as the recipient named in reviewed records.
+- Proof can be withheld only with an approved reviewer reason.
+
+## Forbidden Claim Categories
+
+- `UN official partner`
+- `联合国官方合作`
+- `official endorsement`
+- `官方背书`
+- `certified by`
+- `官方认证`
+- `guaranteed impact`
+- `formal affiliation`
+- `authorized by UN`
+- `approved by the UN`
+- `fundraising for UN`
+- `official fundraising partner`
+- `registered foundation`
+- `nonprofit` unless legal status is separately documented
+- stable daily giving operation before public records exist
+- all records are public
+- trust badge claim without separate readiness
+
+## Evidence-Required Claim Categories
+
+| Claim category | Required evidence before use |
+| --- | --- |
+| Daily donation is active | Private receipt exists, date verified, recipient verified, amount verified or variance explained |
+| Public ledger exists | Public API returns at least one completed or verified public record |
+| Public proof available | Redacted public proof URL is reviewed and private proof is not public |
+| Amount donated | Record amount matches operator policy or variance is documented |
+| Continuous streak | Multiple dated records exist and public API supports the streak without gaps |
+| Recipient confirmation | Recipient-side public confirmation exists; otherwise do not imply it |
+| Social sync claim | Manual social URL exists and was reviewed for claim safety |
+
+## Before Public Records Exist
+
+Allowed:
+
+- Plan language.
+- Governance and review language.
+- Proof readiness language.
+- Noindex and gated-ledger language.
+- Statement that public records are not yet available if needed in internal docs or request cards.
+
+Forbidden:
+
+- Public DailyGiving ledger is live.
+- Verified daily donation record exists.
+- Stable daily giving operation.
+- Trust badge.
+- Public amplification proof.
+- Search submission proof.
+
+## After Public Records Exist
+
+Allowed only if gates pass:
+
+- A public record is available.
+- The record was reviewed under the release gate.
+- Public proof is redacted and available, or proof is withheld with approved reviewer reason.
+- DailyGiving remains noindex unless a later indexability preflight is separately approved.
+
+Still forbidden:
+
+- Official partnership.
+- Official endorsement.
+- Certification.
+- Authorization by United Nations Foundation or UN.
+- Guaranteed impact.
+- Trust badge without separate readiness.
+- Search submission without separate authorization.
+
+## Social Sync Constraints
+
+Social sync is manual only. Stored social URLs may point to human-reviewed public posts, but the system must not create automatic posts, handle credentials, run scheduled posting, or infer social URLs from record text.
+
+Social content must not imply official partnership, endorsement, certification, authorization, guaranteed impact, fundraising authority, or trust badge readiness.
+
+## Proof Withheld Constraints
+
+Withheld proof is allowed only as a privacy or safety exception with reviewer reason. Withheld proof cannot power trust badges, high-amplification claims, paid-page proof, search submission claims, or guaranteed-impact claims.
+
+## GPT And Codex Boundaries
+
+GPT may produce request cards, module inventories, CMS field needs, claim matrix drafts, SOP inputs, and review templates.
+
+Codex may implement docs, generated artifacts, contract tests, public API smoke, noindex gates, and storage gates.
+
+Neither GPT nor Codex may write final publishable Foundation copy, CTA copy, social copy, trust badge copy, or unsupported DailyGiving promotional copy in this train.

--- a/backend/docs/operations/generated/foundation-claim-boundary.v1.json
+++ b/backend/docs/operations/generated/foundation-claim-boundary.v1.json
@@ -1,0 +1,125 @@
+{
+  "version": "foundation_claim_boundary.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "contract_only",
+  "publishable_copy_created": false,
+  "allowed_claims": [
+    "independent public-benefit plan",
+    "operator-reviewed record",
+    "redacted proof when available",
+    "public ledger when ready",
+    "DailyGiving remains noindex until release gates pass",
+    "recipient-only United Nations Foundation reference",
+    "proof withheld only with approved reviewer reason"
+  ],
+  "forbidden_claims": [
+    "UN official partner",
+    "联合国官方合作",
+    "official endorsement",
+    "官方背书",
+    "certified by",
+    "官方认证",
+    "guaranteed impact",
+    "formal affiliation",
+    "authorized by UN",
+    "approved by the UN",
+    "fundraising for UN",
+    "official fundraising partner",
+    "registered foundation",
+    "nonprofit unless legally confirmed",
+    "stable daily giving before public records exist",
+    "all records are public",
+    "trust badge without separate readiness"
+  ],
+  "evidence_required_claims": {
+    "daily_donation_is_active": [
+      "private_receipt_exists",
+      "date_verified",
+      "recipient_verified",
+      "amount_verified_or_variance_explained"
+    ],
+    "public_ledger_exists": [
+      "public_api_records_count_greater_than_zero",
+      "completed_or_verified_public_record_exists"
+    ],
+    "public_proof_available": [
+      "redacted_public_proof_url_reviewed",
+      "private_proof_not_public",
+      "proof_gate_passed"
+    ],
+    "amount_donated": [
+      "record_amount_matches_operator_policy_or_variance_documented"
+    ],
+    "continuous_streak": [
+      "multiple_dated_records_exist",
+      "public_api_supports_streak_without_gaps"
+    ],
+    "recipient_confirmation": [
+      "recipient_side_public_confirmation_exists"
+    ],
+    "social_sync_claim": [
+      "manual_social_url_exists",
+      "claim_lint_passed"
+    ]
+  },
+  "before_public_records": {
+    "allowed": [
+      "plan language",
+      "governance language",
+      "proof readiness language",
+      "noindex gated status"
+    ],
+    "forbidden": [
+      "public daily giving ledger is live",
+      "verified daily donation record",
+      "stable daily giving operation",
+      "trust badge",
+      "public amplification proof"
+    ]
+  },
+  "after_public_records": {
+    "allowed": [
+      "public record is available",
+      "record reviewed under release gate",
+      "public proof is redacted or withheld with approved reason",
+      "DailyGiving remains noindex until later indexability preflight"
+    ],
+    "still_forbidden": [
+      "official partnership",
+      "official endorsement",
+      "certification",
+      "authorization by United Nations Foundation or UN",
+      "guaranteed impact",
+      "trust badge without separate readiness",
+      "search submission without separate authorization"
+    ]
+  },
+  "social_sync_constraints": {
+    "mode": "manual_only",
+    "automatic_posting_allowed": false,
+    "credential_handling_allowed": false,
+    "safe_only_after_human_review": true,
+    "forbidden_implications": [
+      "official partnership",
+      "endorsement",
+      "certification",
+      "authorization",
+      "guaranteed impact",
+      "fundraising authority",
+      "trust badge readiness"
+    ]
+  },
+  "proof_withheld_constraints": {
+    "withheld_allowed": true,
+    "reviewer_reason_required": true,
+    "can_power_trust_badge": false,
+    "can_support_high_amplification": false,
+    "can_support_paid_page_proof": false
+  },
+  "validation": {
+    "no_publishable_copy": true,
+    "no_social_copy": true,
+    "no_trust_badge_copy": true,
+    "daily_giving_noindex_retained": true
+  }
+}

--- a/backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php
+++ b/backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php
@@ -1,0 +1,69 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use Tests\TestCase;
+
+class FoundationClaimBoundaryTest extends TestCase
+{
+    private function artifact(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/operations/generated/foundation-claim-boundary.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function test_foundation_claim_boundary_blocks_official_relationship_and_impact_claims(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('foundation_claim_boundary.v1', $artifact['version']);
+        $this->assertFalse($artifact['publishable_copy_created']);
+
+        foreach ([
+            'UN official partner',
+            '联合国官方合作',
+            'official endorsement',
+            '官方背书',
+            'certified by',
+            '官方认证',
+            'guaranteed impact',
+            'formal affiliation',
+            'authorized by UN',
+            'fundraising for UN',
+            'registered foundation',
+            'stable daily giving before public records exist',
+        ] as $claim) {
+            $this->assertContains($claim, $artifact['forbidden_claims']);
+        }
+    }
+
+    public function test_claims_require_evidence_before_public_records_can_be_amplified(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertContains('public_api_records_count_greater_than_zero', $artifact['evidence_required_claims']['public_ledger_exists']);
+        $this->assertContains('proof_gate_passed', $artifact['evidence_required_claims']['public_proof_available']);
+        $this->assertContains('stable daily giving operation', $artifact['before_public_records']['forbidden']);
+        $this->assertContains('trust badge', $artifact['before_public_records']['forbidden']);
+        $this->assertContains('trust badge without separate readiness', $artifact['after_public_records']['still_forbidden']);
+    }
+
+    public function test_social_sync_and_withheld_proof_do_not_unlock_badges_or_amplification(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('manual_only', $artifact['social_sync_constraints']['mode']);
+        $this->assertFalse($artifact['social_sync_constraints']['automatic_posting_allowed']);
+        $this->assertFalse($artifact['social_sync_constraints']['credential_handling_allowed']);
+        $this->assertTrue($artifact['proof_withheld_constraints']['withheld_allowed']);
+        $this->assertTrue($artifact['proof_withheld_constraints']['reviewer_reason_required']);
+        $this->assertFalse($artifact['proof_withheld_constraints']['can_power_trust_badge']);
+        $this->assertFalse($artifact['proof_withheld_constraints']['can_support_high_amplification']);
+        $this->assertTrue($artifact['validation']['daily_giving_noindex_retained']);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44509,7 +44509,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-claim-boundary-contract-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define Foundation public benefit claim boundary",
     "depends_on": [
@@ -44570,8 +44570,8 @@
       "next_pr_supported": "FOUNDATION-CONTENT-REQUEST-CARD-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "60736dc9f079db642907cd8003f34c4e022402e9",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1901",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44608,6 +44608,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Claim-boundary contract validated locally with focused PHPUnit, JSON/YAML parse, and scoped diff check."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1901."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44509,7 +44509,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-claim-boundary-contract-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define Foundation public benefit claim boundary",
     "depends_on": [
@@ -44555,6 +44555,22 @@
             "command": "git diff --check -- backend/docs/operations/foundation-claim-boundary-contract.md backend/docs/operations/generated/foundation-claim-boundary.v1.json backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
             "status": "passed"
           }
+        ]
+      },
+      "github": {
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1901 --watch --interval 15"
+        ],
+        "jobs": [
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
         ]
       }
     },
@@ -44613,6 +44629,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1901."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1901."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44371,7 +44371,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-trust-page-asset-inventory-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): inventory Foundation trust page assets",
     "depends_on": [
@@ -44444,11 +44444,11 @@
       "next_pr_supported": "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01"
     },
     "failure_reason": null,
-    "commit_sha": "9a55fe83a813f28d053ddf9ad0f0dfa19b91b6f8",
+    "commit_sha": "79f38edf8bfaf5ff996f73fb7902db430a2eb790",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1898",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:47:10Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -44497,6 +44497,117 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1898."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1898 squash-merged at 79f38edf8bfaf5ff996f73fb7902db430a2eb790; remote branch deleted; local worktree fast-forwarded to origin/main."
+      }
+    ]
+  },
+  "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01": {
+    "repo": "fap-api",
+    "branch": "codex/foundation-claim-boundary-contract-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): define Foundation public benefit claim boundary",
+    "depends_on": [
+      "FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided PR3 id, branch, title, allowed paths, and required claim taxonomy in the Window 7 PR train request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01 merged as PR #1898 at 79f38edf8bfaf5ff996f73fb7902db430a2eb790."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed paths are confined to PR3 allowed docs/generated/test/ledger paths."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "php -l backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/operations/generated/foundation-claim-boundary.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationClaimBoundaryTest --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/operations/foundation-claim-boundary-contract.md backend/docs/operations/generated/foundation-claim-boundary.v1.json backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
+      }
+    },
+    "result": {
+      "forbidden_claims_defined": true,
+      "evidence_required_claims_defined": true,
+      "before_public_records_rules_defined": true,
+      "after_public_records_rules_defined": true,
+      "social_sync_constraints_defined": true,
+      "proof_withheld_constraints_defined": true,
+      "publishable_copy_created": false,
+      "trust_badge_copy_created": false,
+      "next_pr_supported": "FOUNDATION-CONTENT-REQUEST-CARD-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Changed files are limited to the PR3 claim-boundary doc, generated artifact, focused test, and codex ledger paths."
+    },
+    "sidecars": [
+      {
+        "id": "PUBLIC_DAILY_GIVING_RECORD",
+        "status": "still_missing",
+        "note": "Claim contract does not create records."
+      },
+      {
+        "id": "TRUST_BADGE",
+        "status": "blocked",
+        "note": "Trust badge remains blocked by claim boundary."
+      }
+    ],
+    "next_task": "FOUNDATION-CONTENT-REQUEST-CARD-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR2 merge for claim-boundary contract."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Claim-boundary contract validated locally with focused PHPUnit, JSON/YAML parse, and scoped diff check."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21599,3 +21599,46 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01
+
+  - id: FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01
+    repo: fap-api
+    depends_on:
+      - FOUNDATION-TRUST-PAGE-ASSET-INVENTORY-01
+    branch: codex/foundation-claim-boundary-contract-01
+    title: "docs(benefit): define Foundation public benefit claim boundary"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Define allowed, forbidden, and evidence-required claim categories for Foundation and DailyGiving public-benefit language.
+      - Cover before-public-record and after-public-record rules, social sync constraints, and proof-withheld constraints.
+      - Add focused contract coverage without creating publishable copy.
+    allowed_paths:
+      - backend/docs/operations/foundation-claim-boundary-contract.md
+      - backend/docs/operations/generated/foundation-claim-boundary.v1.json
+      - backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create publishable copy, social copy, trust badge copy, CMS records, DailyGiving records, proof files, search submissions, runtime changes, or deploys.
+    validation:
+      - php -l backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php
+      - python3 -m json.tool backend/docs/operations/generated/foundation-claim-boundary.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationClaimBoundaryTest --no-ansi
+      - git diff --check -- backend/docs/operations/foundation-claim-boundary-contract.md backend/docs/operations/generated/foundation-claim-boundary.v1.json backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: FOUNDATION-CONTENT-REQUEST-CARD-01


### PR DESCRIPTION
## What changed
- Added a Foundation/DailyGiving public-benefit claim boundary contract.
- Added machine-readable allowed, forbidden, and evidence-required claim categories.
- Added focused coverage for official relationship, endorsement, certification, guaranteed impact, before-record, after-record, social sync, and proof-withheld gates.
- Updated Window 7 PR train manifest/state and reconciled PR2 as merged.

## Why
Foundation can continue as a conditional brand trust page, but DailyGiving cannot be amplified until record, proof, API, noindex, and claim gates pass. This contract gives GPT and Codex a testable boundary without writing publishable copy.

## Validation
- `php -l backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php`
- `python3 -m json.tool backend/docs/operations/generated/foundation-claim-boundary.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationClaimBoundaryTest --no-ansi`
- `git diff --check -- backend/docs/operations/foundation-claim-boundary-contract.md backend/docs/operations/generated/foundation-claim-boundary.v1.json backend/tests/Feature/Foundation/FoundationClaimBoundaryTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No publishable Foundation copy.
- No social copy or trust badge copy.
- No CMS mutation.
- No DailyGiving record creation.
- No proof upload or processing.
- No search submission or deploy.
