### PR TITLE
SEO-ARTICLE-PUBLISH-HOLD-GATE-01: Add article publish hold gate

### DIFF
--- a/backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json
+++ b/backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json
@@ -1,0 +1,86 @@
+{
+  "artifact_id": "SEO-ARTICLE-PUBLISH-HOLD-GATE-01",
+  "date": "2026-06-05",
+  "scope": "seo_article_publish_hold_gate",
+  "boundaries": {
+    "article_copy_written": false,
+    "title_h1_meta_faq_cta_copy_written": false,
+    "cms_draft_created": false,
+    "publish_executed": false,
+    "search_submission_executed": false,
+    "private_url_accessed": false,
+    "runtime_changed": false,
+    "deploy_executed": false
+  },
+  "decision": {
+    "publish": "HOLD",
+    "cms_draft_creation": "HOLD",
+    "search_submission": "HOLD",
+    "next_gpt_content_package_request_input": "GO_AFTER_SEPARATE_AUTHORIZATION"
+  },
+  "required_gates_before_cms_draft_planning": [
+    "topic_priority_approved",
+    "request_card_complete_without_publishable_copy",
+    "claim_boundary_reviewed",
+    "cta_route_gate_pass",
+    "internal_link_plan_pass_or_explicit_conditional",
+    "faq_schema_smoke_pass",
+    "cms_field_map_known_or_unknown_marked",
+    "performance_baseline_owner_assigned",
+    "private_url_policy_pass"
+  ],
+  "required_gates_before_publish_preflight": [
+    "cms_draft_authorization",
+    "import_package_equivalence_pass",
+    "draft_non_public_non_indexable_no_published_revision",
+    "draft_public_absence_pass",
+    "editorial_review_approved",
+    "claim_warning_ack_only_when_preflight_reports_warning",
+    "media_graph_reference_cta_faq_completeness_pass_or_exception",
+    "controlled_publish_dry_run_pass_no_writes"
+  ],
+  "required_gates_before_publish_execution": [
+    "controlled_publish_preflight_ok_true",
+    "exact_article_ids_known",
+    "exact_locale_slug_list_known",
+    "target_revisions_approved",
+    "claim_warnings_acknowledged_for_affected_article_ids_only",
+    "cta_route_gate_still_pass",
+    "faq_schema_smoke_still_pass",
+    "draft_public_absence_still_pass",
+    "separate_exact_publish_authorization_after_successful_preflight"
+  ],
+  "post_publish_smoke": [
+    "public_page_200",
+    "public_article_api_200",
+    "public_seo_api_200",
+    "canonical_hreflang_present",
+    "article_breadcrumb_faq_schema_state_checked",
+    "cta_hrefs_public_canonical",
+    "sitemap_llms_llms_full_inclusion",
+    "no_private_url_exposure",
+    "baseline_row_initialized_with_unknown_preserved",
+    "t7_t14_review_owner_assigned"
+  ],
+  "next_authorization_prompt": "I authorize Codex to prepare the GPT-5.5 Pro content package request inputs for the next RIASEC explanation SEO article only. Do not create a CMS draft, do not write final article copy in Codex, do not publish, do not submit search URLs, and do not access private/result/order/share/pay/payment/history/tokenized URLs.",
+  "prompt_scope": {
+    "authorizes_request_input_preparation_only": true,
+    "authorizes_gpt_output_acceptance": false,
+    "authorizes_cms_import": false,
+    "authorizes_cms_draft_creation": false,
+    "authorizes_editorial_approval": false,
+    "authorizes_publish_preflight": false,
+    "authorizes_publish_execution": false,
+    "authorizes_search_submission": false
+  },
+  "stop_conditions": [
+    "codex_publishable_article_copy_requested",
+    "title_h1_meta_faq_cta_copy_requested_inside_codex",
+    "cms_mutation_without_separate_authorization",
+    "publish_or_search_submission_without_successful_preflight",
+    "private_or_tokenized_cta_or_canonical_url",
+    "unknown_metric_recorded_as_zero",
+    "purchase_order_payment_truth_inferred_from_analytics"
+  ],
+  "final_train_status": "ready_for_separately_authorized_gpt_content_package_request_input_not_publish"
+}

--- a/backend/docs/seo/seo-article-publish-hold-gate-2026-06-05.md
+++ b/backend/docs/seo/seo-article-publish-hold-gate-2026-06-05.md
@@ -1,0 +1,121 @@
+# SEO Article Publish Hold Gate
+
+Date: 2026-06-05
+
+PR train item: SEO-ARTICLE-PUBLISH-HOLD-GATE-01
+
+Scope: publish hold checklist and next authorization boundary for SEO article production.
+
+## Boundary
+
+This gate does not write article copy, title, H1, meta, FAQ, CTA, ad copy, social copy, or CMS content. It does not create CMS drafts, publish, unpublish, submit search URLs, call GSC, call Baidu, call IndexNow, deploy, mutate databases, or inspect private URLs.
+
+## One-line Decision
+
+HOLD for publish. GO only for a separately authorized GPT-5.5 Pro content package request for the next approved article topic.
+
+## Default State
+
+Every new SEO article remains in HOLD until all upstream and downstream gates pass.
+
+HOLD means:
+
+- no CMS draft,
+- no publish,
+- no unpublish,
+- no sitemap or search submission,
+- no public URL inspection for a non-existent draft except public absence checks,
+- no private/result/order/share/pay/payment/history/tokenized URL access,
+- no dashboard value interpreted as 0 when evidence is Unknown.
+
+## Required Gates Before CMS Draft Planning
+
+| Gate | Required status |
+| --- | --- |
+| Topic priority | approved request-card topic exists |
+| Request card | complete and contains no publishable copy |
+| Claim boundary | reviewed for the topic and locale |
+| CTA route gate | PASS for every CTA target |
+| Internal link plan | PASS or explicit CONDITIONAL entries |
+| FAQ/schema smoke | PASS for intended schema state |
+| CMS field map | required fields known or marked Unknown |
+| Performance baseline owner | assigned for T+7 and T+14 review |
+| Private URL policy | PASS; no private CTA, canonical, or stored URL |
+
+If any required gate is Unknown, CMS draft planning stays HOLD.
+
+## Required Gates Before Publish Preflight
+
+| Gate | Required status |
+| --- | --- |
+| CMS draft authorization | separate explicit authorization exists |
+| Import/package equivalence | PASS |
+| Draft state | draft, non-public, non-indexable, no published revision |
+| Draft public absence | PASS for page, API, SEO API, sitemap, llms, and llms-full |
+| Editorial review | approved by authorized operator |
+| Claim warnings | acknowledged only when preflight says they exist |
+| Media/graph/reference/CTA/FAQ completeness | PASS or approved exception |
+| Controlled publish dry-run | PASS with no writes |
+
+If any required gate is Unknown or FAIL, publish preflight stays HOLD.
+
+## Required Gates Before Publish Execution
+
+Publish execution remains forbidden unless a later task has all of:
+
+- controlled publish preflight returns `ok=true`,
+- exact article ids are known from CMS/backend,
+- exact locale and slug list is known,
+- every target revision is approved,
+- claim warnings are explicitly acknowledged only for the affected article ids,
+- CTA route gate remains PASS,
+- FAQ/schema smoke remains PASS,
+- draft public absence remains PASS before publish,
+- user gives a separate exact publish authorization after the successful preflight.
+
+This document does not issue a publish authorization phrase.
+
+## Post-publish Gate
+
+After a separately authorized publish, the post-publish smoke must check:
+
+- public page 200,
+- public article API 200,
+- public SEO API 200,
+- canonical and hreflang,
+- Article/Breadcrumb/FAQ schema state,
+- CTA hrefs remain public canonical,
+- sitemap/llms/llms-full inclusion,
+- no private URL exposure,
+- baseline row initialized with Unknown values preserved,
+- T+7 and T+14 review calendar owner assigned.
+
+Search submission remains HOLD unless a separate exact search-channel authorization is provided.
+
+## Next Authorization Prompt
+
+The only next authorization this train prepares is content-package intake, not publish:
+
+```text
+I authorize Codex to prepare the GPT-5.5 Pro content package request inputs for the next RIASEC explanation SEO article only. Do not create a CMS draft, do not write final article copy in Codex, do not publish, do not submit search URLs, and do not access private/result/order/share/pay/payment/history/tokenized URLs.
+```
+
+This prompt authorizes request-input preparation only. It does not authorize GPT output acceptance, CMS import, CMS draft creation, editorial approval, publish preflight, publish execution, or search submission.
+
+## Stop Conditions
+
+Stop and report HOLD if:
+
+- the requested action asks Codex to write publishable article copy,
+- title/H1/meta/FAQ/CTA copy is requested inside Codex,
+- CMS mutation is requested without separate explicit authorization,
+- publish or search submission is requested without successful preflight,
+- a CTA or canonical URL points to a private/tokenized route,
+- any metric or dashboard value is unavailable and someone tries to record it as 0,
+- purchase, order, or payment truth is inferred from analytics.
+
+## Result
+
+The SEO article system is ready to move from Window 6 infrastructure into the next separately authorized GPT-5.5 Pro request-card/content-package intake step.
+
+It is not authorized for CMS draft creation, publish, search submission, or content publication.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -43959,7 +43959,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-publish-hold-gate-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article publish hold gate",
     "depends_on": [
@@ -43996,8 +43996,8 @@
       "final_train_status": "ready_for_next_separately_authorized_content_package_request_input"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "bea93807c43b554338b3d9c442f52ec44252d1b9",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1902",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44019,6 +44019,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Publish hold gate doc and generated artifact passed local validation."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1902."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -34027,7 +34027,7 @@
     ]
   },
   "REPAIR-CAREER-DETAIL-READY-LIVE-ACCEPTANCE-CLOSEOUT-1": {
-    "status": "pr_open",
+    "status": "merged",
     "repo": "fap-api",
     "branch": "codex/repair-career-detail-ready-live-acceptance-closeout-1",
     "base": "main",
@@ -43917,11 +43917,11 @@
       "next_task": "SEO-ARTICLE-PUBLISH-HOLD-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "ac333a83ddda76f0b10b40ecb92bdca3707fdcbd",
+    "commit_sha": "ac4ee0d138ea422f2b26ec34890b1ecc6c7bc875",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1899",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T01:49:36Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-05T00:00:00+08:00",
@@ -43946,6 +43946,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1899."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "pr_open",
+        "to": "merged",
+        "notes": "Reconciled after PR #1899 merged with squash merge commit 73d99a26b41714bd1569b378852f756622364cae and cleanup completed."
       }
     ]
   },
@@ -43953,7 +43959,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-article-publish-hold-gate-01",
     "base": "main",
-    "status": "planned",
+    "status": "local_checks_passed",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article publish hold gate",
     "depends_on": [
@@ -43965,20 +43971,30 @@
         "evidence": "User explicitly authorized Window 6 SEO article system PR train execution with docs/contracts-only scope and no content, CMS, publish, search submission, deploy, or private URL actions."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Depends on ARTICLE-FAQ-SCHEMA-SMOKE-01."
+        "status": "pass",
+        "evidence": "ARTICLE-FAQ-SCHEMA-SMOKE-01 merged as PR #1899 with merge commit 73d99a26b41714bd1569b378852f756622364cae."
       },
       "scope_validation": {
-        "status": "not_started",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to the publish hold gate doc, generated JSON artifact, and docs/codex metadata."
       },
       "local": {
-        "status": "not_started",
-        "commands": [],
-        "notes": null
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/seo-article-publish-hold-gate-2026-06-05.md backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "JSON artifact parse, ledger parse, manifest parse, and scoped diff checks passed."
       }
     },
-    "result": null,
+    "result": {
+      "go_no_go": "HOLD for publish; GO only for separately authorized GPT-5.5 Pro content package request input preparation.",
+      "next_authorization": "GPT-5.5 Pro content package request input only; no CMS draft, no publish, no search submit.",
+      "final_train_status": "ready_for_next_separately_authorized_content_package_request_input"
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -43991,6 +44007,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized as a planned Window 6 SEO article system task."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started after PR8 merge and cleanup."
+      },
+      {
+        "at": "2026-06-05T00:00:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Publish hold gate doc and generated artifact passed local validation."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20878,7 +20878,7 @@ prs:
     branch: codex/seo-dash-collector-02-write-gate
     title: "docs(seo): define controlled collector write gate"
     train_scope: seo_intel_controlled_collector_write_gate
-    status: executing
+    status: merged
     depends_on:
       - SEO-DASH-COLLECTOR-01-SMOKE-RECONCILE
     scope:
@@ -21398,7 +21398,7 @@ prs:
     branch: codex/seo-article-publish-hold-gate-01
     title: "docs(seo): define article publish hold gate"
     train_scope: seo_article_system_window_6
-    status: planned
+    status: executing
     depends_on:
       - ARTICLE-FAQ-SCHEMA-SMOKE-01
     scope:


### PR DESCRIPTION
What changed
- Added the SEO article publish hold gate.
- Added the generated JSON artifact for final Window 6 handoff.
- Reconciled ARTICLE-FAQ-SCHEMA-SMOKE-01 as merged and advanced SEO-ARTICLE-PUBLISH-HOLD-GATE-01 in PR train metadata.

Why
- Makes publish, CMS draft, and search submission remain HOLD unless later gates and separate exact authorization exist.
- Defines the only next allowed step as separately authorized GPT-5.5 Pro content package request-input preparation, not CMS draft or publish.

Validation
- python3 -m json.tool backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/seo/seo-article-publish-hold-gate-2026-06-05.md backend/docs/seo/generated/seo-article-publish-hold-gate-01.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA copy.
- No CMS draft, publish, unpublish, search submission, GSC, Baidu, IndexNow, or deploy.
- No private/result/order/share/pay/payment/history/tokenized URL access.
- No production analytics dashboard values are converted from Unknown to 0.