### PR TITLE
docs(help): archive Help CMS draft postcheck

### DIFF
--- a/backend/docs/help/generated/help-content-draft-postcheck-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-postcheck-01.v1.json
@@ -1,0 +1,183 @@
+{
+  "schema": "help-content-draft-postcheck-01.v1",
+  "task": "HELP-CONTENT-DRAFT-POSTCHECK-01",
+  "generated_at": "2026-06-05",
+  "decision": "POSTCHECK_PASS_WITH_PUBLISH_BLOCKED_SIDECARS",
+  "source_package": {
+    "required_uploaded_zip": "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01.zip",
+    "zip_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+    "zip_file_count": 14,
+    "yaml_package_count": 6,
+    "index_schema_version": "help_service_content_drafts.v1",
+    "archive_import_package": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "content_page_source": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json"
+  },
+  "expected_drafts": {
+    "count": 12,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ]
+  },
+  "cms_readonly_postcheck": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly_artisan_tinker",
+    "cms_mutation_performed": false,
+    "secret_env_cookie_token_read": false,
+    "private_url_access_performed": false,
+    "record_count": 12,
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true,
+    "all_review_state_owner_review": true,
+    "all_public_help_paths": true,
+    "private_route_pattern_seen": false,
+    "rows": [
+      {
+        "id": 42,
+        "locale": "en",
+        "slug": "help-data-deletion",
+        "path": "/help/data-deletion",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01"
+      },
+      {
+        "id": 41,
+        "locale": "zh-CN",
+        "slug": "help-data-deletion",
+        "path": "/help/data-deletion",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01"
+      },
+      {
+        "id": 34,
+        "locale": "en",
+        "slug": "help-payment-refund",
+        "path": "/help/payment-refund",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 33,
+        "locale": "zh-CN",
+        "slug": "help-payment-refund",
+        "path": "/help/payment-refund",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 38,
+        "locale": "en",
+        "slug": "help-privacy-data",
+        "path": "/help/privacy-data",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 37,
+        "locale": "zh-CN",
+        "slug": "help-privacy-data",
+        "path": "/help/privacy-data",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 36,
+        "locale": "en",
+        "slug": "help-result-recovery",
+        "path": "/help/result-recovery",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01"
+      },
+      {
+        "id": 35,
+        "locale": "zh-CN",
+        "slug": "help-result-recovery",
+        "path": "/help/result-recovery",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01"
+      },
+      {
+        "id": 32,
+        "locale": "en",
+        "slug": "help-unlock-failure",
+        "path": "/help/unlock-failure",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01"
+      },
+      {
+        "id": 31,
+        "locale": "zh-CN",
+        "slug": "help-unlock-failure",
+        "path": "/help/unlock-failure",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01"
+      },
+      {
+        "id": 40,
+        "locale": "en",
+        "slug": "help-use-boundaries",
+        "path": "/help/use-boundaries",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01"
+      },
+      {
+        "id": 39,
+        "locale": "zh-CN",
+        "slug": "help-use-boundaries",
+        "path": "/help/use-boundaries",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01"
+      }
+    ]
+  },
+  "public_surface_checks": {
+    "localized_routes": {
+      "checked_count": 12,
+      "all_404": true,
+      "private_pattern_seen": false
+    },
+    "sitemap_xml": {
+      "status": 200,
+      "target_hits": 0
+    },
+    "llms_txt": {
+      "status": 200,
+      "target_hits": 0
+    },
+    "llms_full_txt": {
+      "status": 200,
+      "target_hits": 0
+    }
+  },
+  "support_contact_check": {
+    "operator_contact": "support@fermatmind.com",
+    "import_package_contains_support_contact": true,
+    "content_page_rows_contain_support_contact": false,
+    "cms_first_class_support_contact_field_verified": false,
+    "status": "sidecar_required"
+  },
+  "publish_gates": {
+    "publish_performed": false,
+    "publish_allowed_now": false,
+    "operator_editorial_approval_present": false,
+    "search_submission_performed": false,
+    "deploy_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-POSTCHECK-SUPPORT-CONTACT-FIELD",
+      "status": "open",
+      "note": "support@fermatmind.com exists in the import package, but the production ContentPage rows do not contain it and no first-class support_contact field was verified."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POSTCHECK-EDITORIAL-APPROVAL",
+      "status": "blocked_until_operator_review",
+      "note": "Operator editorial approval remains required before publish."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POSTCHECK-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Draft rows are hidden from public routes, sitemap, and llms surfaces; publish/search submission remains forbidden without separate explicit approval."
+    }
+  ],
+  "next_task": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01"
+}

--- a/backend/docs/operations/help-content-draft-postcheck-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-postcheck-2026-06-05.md
@@ -1,0 +1,39 @@
+# HELP-CONTENT-DRAFT-POSTCHECK-01
+
+Decision: `POSTCHECK_PASS_WITH_PUBLISH_BLOCKED_SIDECARS`.
+
+This read-only postcheck used the uploaded package at `/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01.zip` and the archived import package in this repository. It did not publish, deploy, submit search URLs, mutate CMS rows, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+
+## Evidence
+
+- Uploaded zip present: `fermatmind-help-service-content-drafts-01.zip`.
+- Zip SHA-256: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6`.
+- Zip contents: 14 files, including 6 markdown drafts, 6 YAML metadata files, `index.json`, and `README.md`.
+- Archived ContentPage source contains 12 intended rows for 6 slugs across `zh-CN` and `en`.
+- Production read-only CMS query found 12 matching ContentPage rows: IDs 31-42.
+- All 12 rows are `draft`, non-public, non-indexable, unpublished, and `owner_review`.
+- All 12 rows use public canonical help paths under `/help/...`.
+- No private result/order/share/pay/payment/history URL pattern was found in the queried CMS row metadata/body fields.
+- Public checks returned 404 for all 12 localized target routes.
+- `sitemap.xml`, `llms.txt`, and `llms-full.txt` had zero target hits.
+
+## Verified Drafts
+
+| slug | locales | ids | state |
+| --- | --- | --- | --- |
+| `help-unlock-failure` | `zh-CN`, `en` | 31, 32 | draft, hidden |
+| `help-payment-refund` | `zh-CN`, `en` | 33, 34 | draft, hidden |
+| `help-result-recovery` | `zh-CN`, `en` | 35, 36 | draft, hidden |
+| `help-privacy-data` | `zh-CN`, `en` | 37, 38 | draft, hidden |
+| `help-use-boundaries` | `zh-CN`, `en` | 39, 40 | draft, hidden |
+| `help-data-deletion` | `zh-CN`, `en` | 41, 42 | draft, hidden |
+
+## Sidecars
+
+- `HELP-CONTENT-DRAFT-POSTCHECK-SUPPORT-CONTACT-FIELD`: `support@fermatmind.com` exists in the import package, but the production ContentPage rows do not contain it and no first-class `support_contact` field was verified. This must be resolved or explicitly accepted before publish.
+- `HELP-CONTENT-DRAFT-POSTCHECK-EDITORIAL-APPROVAL`: Operator editorial approval remains required. Codex did not approve content.
+- `HELP-CONTENT-DRAFT-POSTCHECK-PUBLISH-BLOCK`: Publish, indexability, sitemap/llms inclusion, and search submission remain blocked until separate explicit approval.
+
+## Next Task
+
+`HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01`

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44311,7 +44311,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-postcheck-01",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): archive Help CMS draft postcheck",
     "depends_on": [
@@ -44366,10 +44366,25 @@
             "status": "passed"
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1903 --watch --interval 15"
+        ],
+        "jobs": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep blocking secrets"
+        ]
       }
     },
     "failure_reason": null,
-    "commit_sha": "2ce4ffbc710b0bd01d371cc12aa8e1b4a0583a46",
+    "commit_sha": "6783dea9ac604a8d964a8120c559b5ed3ed3f2bd",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1903",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -44457,6 +44472,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1903 with implementation commit 2ce4ffbc710b0bd01d371cc12aa8e1b4a0583a46; GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "PR #1903 GitHub checks passed and PR was CLEAN/MERGEABLE with four scoped files."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44311,7 +44311,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-postcheck-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): archive Help CMS draft postcheck",
     "depends_on": [
@@ -44369,8 +44369,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "2ce4ffbc710b0bd01d371cc12aa8e1b4a0583a46",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1903",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44452,6 +44452,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Generated artifact, state JSON, manifest YAML, and scoped diff checks passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1903 with implementation commit 2ce4ffbc710b0bd01d371cc12aa8e1b4a0583a46; GitHub checks are pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44311,7 +44311,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-postcheck-01",
     "base": "origin/main",
-    "status": "pending",
+    "status": "local_checks_passed",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): archive Help CMS draft postcheck",
     "depends_on": [
@@ -44329,6 +44329,43 @@
       "scope_preflight": {
         "status": "pass",
         "evidence": "POSTCHECK scope is read-only archive and verification only; no CMS mutation, publish, deploy, private URL access, payment/refund flow, or secret/env/cookie/token read is allowed."
+      },
+      "source_package": {
+        "status": "pass",
+        "evidence": "Uploaded zip /Users/rainie/Desktop/fermatmind-help-service-content-drafts-01.zip exists; SHA-256 2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6; zip contains 14 files including six md/yaml draft packages, README, and index.json."
+      },
+      "cms_readonly_postcheck": {
+        "status": "pass",
+        "evidence": "Read-only CMS query found 12 target ContentPage rows; all are draft, non-public, non-indexable, unpublished, owner_review, and on public /help/... paths."
+      },
+      "public_surface": {
+        "status": "pass",
+        "evidence": "All 12 localized public target routes returned 404; sitemap.xml, llms.txt, and llms-full.txt had zero target hits."
+      },
+      "support_contact": {
+        "status": "sidecar_open",
+        "evidence": "support@fermatmind.com exists in the import package, but production ContentPage rows do not contain it and no first-class support_contact field was verified."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-postcheck-01.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-postcheck-01.v1.json backend/docs/operations/help-content-draft-postcheck-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
       }
     },
     "failure_reason": null,
@@ -44345,6 +44382,29 @@
       "publish_allowed": false,
       "cms_mutation_allowed": false
     },
+    "result": {
+      "decision": "POSTCHECK_PASS_WITH_PUBLISH_BLOCKED_SIDECARS",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-postcheck-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-postcheck-2026-06-05.md",
+      "draft_count_found": 12,
+      "draft_ids": [
+        31,
+        32,
+        33,
+        34,
+        35,
+        36,
+        37,
+        38,
+        39,
+        40,
+        41,
+        42
+      ],
+      "publish_allowed_now": false,
+      "operator_editorial_approval_present": false,
+      "next_pr_supported": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01"
+    },
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -44357,8 +44417,8 @@
     "sidecars": [
       {
         "id": "HELP-CONTENT-DRAFT-POSTCHECK-SUPPORT-CONTACT-FIELD",
-        "status": "must_verify",
-        "note": "Postcheck must verify how support_contact is represented because ContentPage has no first-class support_contact field."
+        "status": "open",
+        "note": "support@fermatmind.com exists in the import package, but the production ContentPage rows do not contain it and no first-class support_contact field was verified."
       },
       {
         "id": "HELP-CONTENT-DRAFT-POSTCHECK-EDITORIAL-APPROVAL",
@@ -44382,6 +44442,16 @@
         "at": "2026-06-05",
         "status": "pending",
         "note": "Manifest/state entry added; implementation must run as a separate scoped read-only postcheck PR."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "postcheck_passed_publish_blocked",
+        "note": "Read-only postcheck passed for draft state, public absence, sitemap/llms absence, and private URL safety. Publish remains blocked by sidecars and Operator editorial approval."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Generated artifact, state JSON, manifest YAML, and scoped diff checks passed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21522,7 +21522,7 @@ prs:
     branch: codex/help-content-draft-postcheck-01
     title: "docs(help): archive Help CMS draft postcheck"
     train_scope: window_9_help_service_content
-    status: pending
+    status: postcheck_passed_publish_blocked
     depends_on:
       - HELP-CONTENT-DRAFT-CREATE-01
     scope:


### PR DESCRIPTION
## What changed
- Archived `HELP-CONTENT-DRAFT-POSTCHECK-01` generated evidence and operations report.
- Verified the uploaded `fermatmind-help-service-content-drafts-01.zip` was present and used as the source package reference.
- Recorded read-only CMS draft postcheck evidence for 12 Help service ContentPage drafts.
- Updated PR-train manifest/state to mark postcheck passed with publish blocked sidecars.

## Why
The Help service content train needed a read-only postcheck after CMS draft creation before Operator editorial review or publish preflight can proceed.

## Validation
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-postcheck-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/help/generated/help-content-draft-postcheck-01.v1.json backend/docs/operations/help-content-draft-postcheck-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- Read-only public route/sitemap/llms absence checks
- Read-only CMS metadata check via `fap-api-prod` SSH alias; no secret/env/cookie/token read

## Intentionally deferred
- No publish, deployment, search submission, CMS mutation, payment/refund flow, payment-provider change, or private result/order/share/pay/payment/history URL access.
- Operator editorial approval remains blocked and was not performed.
- Support contact remains a sidecar because the import package contains the support email, but production ContentPage rows do not contain it and no first-class `support_contact` field was verified.

## Repository rule impact
Content authority remains CMS/backend. Frontend fallback authority remains false. This PR archives postcheck evidence only and keeps publish blocked.
