### PR TITLE
docs(benefit): add Foundation content request card

### DIFF
--- a/backend/docs/operations/foundation-content-request-card.md
+++ b/backend/docs/operations/foundation-content-request-card.md
@@ -1,0 +1,123 @@
+# Foundation Content Request Card
+
+Date: 2026-06-05
+
+PR train item: `FOUNDATION-CONTENT-REQUEST-CARD-01`
+
+Mode: GPT input requirements only. This file is not public Foundation copy, not a CMS draft, not final metadata, not FAQ answers, not CTA copy, not social copy, not trust badge copy, and not a publish approval.
+
+## Purpose
+
+Give GPT enough source-backed context to help prepare CMS content inputs for the Foundation plan page without inventing public claims or writing publishable copy.
+
+The output expected from GPT is a structured content brief for operator review. Final content authority remains CMS/backend `content_pages`.
+
+## Evidence Inputs GPT Must Use
+
+| Evidence | Source | Current value |
+| --- | --- | --- |
+| Foundation route status | `foundation-trust-page-asset-inventory-2026-06-04.md` | EN/ZH public routes return 200 |
+| Foundation indexability | `foundation-trust-page-asset-inventory-2026-06-04.md` | Foundation is indexable and present in sitemap |
+| Foundation authority | production content page API scan | CMS `content_pages`, published, public, indexable, approved |
+| DailyGiving public state | public records and months API scan | public records count 0, public months count 0 |
+| DailyGiving indexability | public route scan | noindex/nofollow/noarchive/nocache |
+| DailyGiving discoverability | sitemap/llms scan | not present in sitemap, `llms.txt`, or `llms-full.txt` |
+| Claim boundary | `foundation-claim-boundary-contract.md` | no official partner, endorsement, certification, guaranteed impact, or trust badge claims |
+| Operator policy | archived Window 7 operator decisions | CNY 10 daily intention, United Nations Foundation recipient-only boundary |
+| Proof policy | archived proof redaction SOP input | raw proof private, public proof redacted or withheld with reviewer reason |
+
+Unknowns must stay Unknown. In particular, private draft record count, storage-level private disk configuration, and future proof availability must not be inferred from empty public APIs.
+
+## Required GPT Output Shape
+
+GPT should return a structured input package with these sections:
+
+1. `content_objective`
+2. `source_evidence_table`
+3. `module_inventory`
+4. `cms_field_requirements`
+5. `claim_boundary_matrix`
+6. `privacy_and_proof_requirements`
+7. `daily_giving_relationship`
+8. `faq_question_inventory`
+9. `operator_review_checklist`
+10. `codex_validation_handoff`
+
+## Module Inventory Requirements
+
+GPT should define module intent and required CMS fields only. It should not draft final paragraphs.
+
+Required modules:
+
+| Module key | Required planning question |
+| --- | --- |
+| `project_identity` | What public-benefit posture can Foundation explain without claiming legal foundation or nonprofit status? |
+| `independent_giving_plan` | How should the CNY 10 daily intention and recipient-only boundary be represented as policy inputs? |
+| `evidence_before_public_records` | What evidence is needed before any DailyGiving record supports a public claim? |
+| `privacy_and_proof_handling` | What is private, what may be public, and what requires redaction or withholding reason? |
+| `non_claims` | Which claims must be explicitly excluded from the content brief? |
+| `daily_giving_future_ledger` | How should the page explain DailyGiving as gated/noindex until records and proof gates pass? |
+
+## CMS Field Requirements
+
+GPT should request fields for a CMS `content_page` only. It must not ask Codex to add frontend fallback content.
+
+Required field groups:
+
+- route and locale identifiers for `foundation`
+- page status and indexability fields
+- body/module structure fields
+- claim boundary version
+- public benefit policy version
+- proof policy summary
+- review owner and review timestamp fields
+- optional FAQ question inventory
+- schema enablement gate tied to visible approved FAQ content
+
+## Claim Boundary Rules
+
+GPT must preserve these constraints:
+
+- United Nations Foundation can be referenced only as a recipient named in operator-reviewed records or policy inputs.
+- No official partnership, official cooperation, endorsement, certification, authorization, fundraising authority, or guaranteed impact wording.
+- No trust badge language.
+- No stable daily giving operation claim while public records and months are zero.
+- No public ledger claim until public API returns eligible completed or verified public records.
+- No proof availability claim until redacted public proof exists or proof is explicitly withheld with an approved reviewer reason.
+
+## FAQ Inventory Rules
+
+GPT may propose FAQ questions only. GPT must not write final FAQ answers, FAQ schema, H1, meta title, meta description, CTA copy, social copy, or trust badge copy.
+
+FAQ questions should cover:
+
+- public-benefit plan
+- recipient-only boundary
+- DailyGiving gated status
+- record review process
+- raw proof versus public proof
+- redaction and withheld proof
+- unsupported claims prevention
+- price/report boundary if needed
+
+## Codex Handoff Requirements
+
+The GPT output should give Codex enough structure to validate:
+
+- CMS/backend source of truth
+- no frontend editorial fallback
+- claim lint pass
+- DailyGiving noindex retained
+- DailyGiving absent from sitemap and llms while gated
+- FAQ schema disabled unless visible approved FAQ content exists
+- public API not used to infer private records
+
+## Explicit Non-Goals
+
+- No CMS mutation.
+- No DailyGiving record creation.
+- No proof upload or proof processing.
+- No publishable Foundation page copy.
+- No final metadata, H1, CTA, FAQ answers, social copy, or trust badge copy.
+- No search submission.
+- No deploy.

--- a/backend/docs/operations/generated/foundation-content-request-card.v1.json
+++ b/backend/docs/operations/generated/foundation-content-request-card.v1.json
@@ -1,0 +1,107 @@
+{
+  "version": "foundation_content_request_card.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "gpt_input_requirements_only",
+  "publishable_copy_created": false,
+  "cms_mutation_allowed": false,
+  "final_authority": "CMS/backend content_pages",
+  "evidence_inputs": {
+    "foundation_routes": {
+      "en_status": 200,
+      "zh_status": 200,
+      "indexable": true,
+      "sitemap_included": true
+    },
+    "daily_giving_public_state": {
+      "records_count": 0,
+      "months_count": 0,
+      "indexability": "noindex",
+      "sitemap_included": false,
+      "llms_included": false
+    },
+    "claim_boundary_version": "foundation_claim_boundary.v1",
+    "operator_policy": {
+      "daily_amount": {
+        "amount": 10,
+        "currency": "CNY",
+        "frequency": "daily"
+      },
+      "recipient": "United Nations Foundation",
+      "relationship_boundary": "recipient_only_no_official_partnership"
+    },
+    "unknowns": [
+      "private_draft_record_count",
+      "storage_level_private_disk_or_bucket_configuration",
+      "future_public_proof_availability"
+    ]
+  },
+  "required_output_sections": [
+    "content_objective",
+    "source_evidence_table",
+    "module_inventory",
+    "cms_field_requirements",
+    "claim_boundary_matrix",
+    "privacy_and_proof_requirements",
+    "daily_giving_relationship",
+    "faq_question_inventory",
+    "operator_review_checklist",
+    "codex_validation_handoff"
+  ],
+  "required_modules": [
+    "project_identity",
+    "independent_giving_plan",
+    "evidence_before_public_records",
+    "privacy_and_proof_handling",
+    "non_claims",
+    "daily_giving_future_ledger"
+  ],
+  "cms_field_groups": [
+    "route_and_locale",
+    "status_and_indexability",
+    "body_or_module_structure",
+    "claim_boundary_version",
+    "public_benefit_policy_version",
+    "proof_policy_summary",
+    "review_owner_and_timestamp",
+    "optional_faq_question_inventory",
+    "faq_schema_gate"
+  ],
+  "forbidden_outputs": [
+    "publishable_foundation_copy",
+    "final_h1",
+    "final_meta_title",
+    "final_meta_description",
+    "final_faq_answers",
+    "cta_copy",
+    "social_copy",
+    "trust_badge_copy",
+    "cms_draft_creation",
+    "daily_giving_record_creation",
+    "proof_upload",
+    "search_submission",
+    "deploy"
+  ],
+  "claim_constraints": {
+    "recipient_only_reference": true,
+    "official_partnership_allowed": false,
+    "official_cooperation_allowed": false,
+    "endorsement_allowed": false,
+    "certification_allowed": false,
+    "authorization_claim_allowed": false,
+    "fundraising_authority_claim_allowed": false,
+    "guaranteed_impact_allowed": false,
+    "trust_badge_allowed_now": false,
+    "stable_daily_giving_claim_allowed_before_public_records": false,
+    "public_ledger_claim_requires_records": true,
+    "proof_availability_claim_requires_reviewed_public_proof_or_withheld_reason": true
+  },
+  "codex_validation_handoff": [
+    "cms_backend_source_of_truth",
+    "no_frontend_editorial_fallback",
+    "claim_lint_pass",
+    "daily_giving_noindex_retained",
+    "daily_giving_absent_from_sitemap_and_llms_while_gated",
+    "faq_schema_disabled_unless_visible_approved_faq_exists",
+    "public_api_not_used_to_infer_private_records"
+  ]
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44756,7 +44756,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-claim-boundary-contract-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define Foundation public benefit claim boundary",
     "depends_on": [
@@ -44833,11 +44833,11 @@
       "next_pr_supported": "FOUNDATION-CONTENT-REQUEST-CARD-01"
     },
     "failure_reason": null,
-    "commit_sha": "60736dc9f079db642907cd8003f34c4e022402e9",
+    "commit_sha": "7bd4989ebaaf2e53b70dc6202ff821c2c4f66a36",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1901",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T02:01:14Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -44881,6 +44881,111 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1901."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1901 squash-merged at 7bd4989ebaaf2e53b70dc6202ff821c2c4f66a36; remote branch absent; local branch deleted after detached origin/main sync."
+      }
+    ]
+  },
+  "FOUNDATION-CONTENT-REQUEST-CARD-01": {
+    "repo": "fap-api",
+    "branch": "codex/foundation-content-request-card-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): add Foundation content request card",
+    "depends_on": [
+      "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly requested GPT input requirements for Foundation/DailyGiving content assets and authorized PR train execution through PR12."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01 merged as PR #1901 at 7bd4989ebaaf2e53b70dc6202ff821c2c4f66a36."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed paths are confined to PR4 request-card docs, generated artifact, and codex ledger paths."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/operations/generated/foundation-content-request-card.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/operations/foundation-content-request-card.md backend/docs/operations/generated/foundation-content-request-card.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "commands": []
+      }
+    },
+    "result": {
+      "gpt_input_requirements_created": true,
+      "publishable_copy_created": false,
+      "cms_mutation_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "trust_badge_copy_created": false,
+      "next_pr_supported": "FOUNDATION-CMS-FIELD-MAP-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Changed files are intended to stay within PR4 docs/generated/ledger paths."
+    },
+    "sidecars": [
+      {
+        "id": "FOUNDATION_PUBLIC_COPY",
+        "status": "not_created",
+        "note": "Request card defines GPT inputs only."
+      },
+      {
+        "id": "DAILY_GIVING_TRUST_BADGE",
+        "status": "blocked",
+        "note": "Trust badge remains blocked by zero public records and claim boundary."
+      }
+    ],
+    "next_task": "FOUNDATION-CMS-FIELD-MAP-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR3 merge for GPT input request-card artifact."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Request-card artifact validated with JSON/YAML parse, scoped diff check, and allowed-path review."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -34731,7 +34731,7 @@
     "branch": "codex/detail-ready-1048-replacement-authority-source-controlled-import-01",
     "base": "main",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01 controlled replacement authority source import path",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "depends_on": [
       "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01"
     ],
@@ -35103,7 +35103,7 @@
     "branch": "codex/detail-ready-1046-rollout-apply-preflight-01",
     "base": "main",
     "title": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 production preflight for clean 1046 rollout apply",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "depends_on": [],
     "commit_sha": "67e95aac7a4344a407c5c1b563c4131a27d2d7aa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1748",
@@ -44934,8 +44934,21 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1904 --watch --interval 15"
+        ],
+        "jobs": [
+          "Semgrep OSS",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ]
       }
     },
     "result": {
@@ -44948,7 +44961,7 @@
       "next_pr_supported": "FOUNDATION-CMS-FIELD-MAP-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "4ecb0a435fbf61d30f10df34ca2c5b6590f9b9f5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1904",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -44990,12 +45003,17 @@
       {
         "at": "2026-06-05",
         "status": "commit_recorded",
-        "note": "Implementation commit ca883c865ecfdd8c920c8f448b40d400213bb4e5 recorded before push."
+        "note": "Implementation commit 4ecb0a435fbf61d30f10df34ca2c5b6590f9b9f5 recorded after rebase onto origin/main."
       },
       {
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1904."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1904."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44893,7 +44893,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-content-request-card-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): add Foundation content request card",
     "depends_on": [
@@ -44949,7 +44949,7 @@
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1904",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44991,6 +44991,11 @@
         "at": "2026-06-05",
         "status": "commit_recorded",
         "note": "Implementation commit ca883c865ecfdd8c920c8f448b40d400213bb4e5 recorded before push."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1904."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44986,6 +44986,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Request-card artifact validated with JSON/YAML parse, scoped diff check, and allowed-path review."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "commit_recorded",
+        "note": "Implementation commit ca883c865ecfdd8c920c8f448b40d400213bb4e5 recorded before push."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21647,7 +21647,7 @@ prs:
     branch: codex/foundation-claim-boundary-contract-01
     title: "docs(benefit): define Foundation public benefit claim boundary"
     train_scope: window_7_public_benefit_trust_gate
-    status: in_progress
+    status: merged
     scope:
       - Define allowed, forbidden, and evidence-required claim categories for Foundation and DailyGiving public-benefit language.
       - Cover before-public-record and after-public-record rules, social sync constraints, and proof-withheld constraints.
@@ -21682,3 +21682,43 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: FOUNDATION-CONTENT-REQUEST-CARD-01
+
+  - id: FOUNDATION-CONTENT-REQUEST-CARD-01
+    repo: fap-api
+    depends_on:
+      - FOUNDATION-CLAIM-BOUNDARY-CONTRACT-01
+    branch: codex/foundation-content-request-card-01
+    title: "docs(benefit): add Foundation content request card"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Add a GPT input request card for Foundation plan-page content preparation.
+      - Ground the request card in scanned Foundation, DailyGiving, operator-decision, proof-policy, and claim-boundary evidence.
+      - Keep the artifact non-publishable and CMS/backend-authoritative.
+    allowed_paths:
+      - backend/docs/operations/foundation-content-request-card.md
+      - backend/docs/operations/generated/foundation-content-request-card.v1.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create publishable Foundation copy, final H1, final metadata, FAQ answers, CTA copy, social copy, trust badge copy, CMS records, DailyGiving records, proof files, search submissions, runtime changes, or deploys.
+    validation:
+      - python3 -m json.tool backend/docs/operations/generated/foundation-content-request-card.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/operations/foundation-content-request-card.md backend/docs/operations/generated/foundation-content-request-card.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: FOUNDATION-CMS-FIELD-MAP-01


### PR DESCRIPTION
## What changed
- Added a non-publishable Foundation content request card for GPT input requirements.
- Added a generated JSON artifact that captures evidence inputs, required output sections, forbidden outputs, and claim constraints.
- Recorded PR4 in the codex train ledger and reconciled PR3 merge facts.

## Why
This gives GPT enough source-backed context to prepare Foundation plan-page content inputs without generating final public copy or unsupported DailyGiving trust claims.

## Validation
- python3 -m json.tool backend/docs/operations/generated/foundation-content-request-card.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/operations/foundation-content-request-card.md backend/docs/operations/generated/foundation-content-request-card.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation or publish.
- No final Foundation page copy, H1, metadata, FAQ answers, CTA, social copy, or trust badge copy.
- No DailyGiving records, proof files, search submission, runtime changes, or deploy.