### PR TITLE
docs(benefit): map Foundation CMS fields

### DIFF
--- a/backend/docs/operations/foundation-cms-field-map.md
+++ b/backend/docs/operations/foundation-cms-field-map.md
@@ -1,0 +1,89 @@
+# Foundation CMS Field Map
+
+Date: 2026-06-05
+
+PR train item: `FOUNDATION-CMS-FIELD-MAP-01`
+
+Mode: documentation, generated artifact, and contract test only. This PR does not change the `content_pages` schema, mutate CMS records, create Foundation copy, create DailyGiving records, process proof files, publish, submit search URLs, or deploy.
+
+## Decision
+
+Foundation can be prepared through existing CMS `content_pages` fields, but the current schema does not contain dedicated governance fields for claim-boundary version, public-benefit policy version, proof-policy summary, or FAQ/schema gates.
+
+The next content-production step should use existing fields for the page body and review state, while keeping missing governance fields explicit in the request card and operator checklist. Do not hide these requirements inside frontend fallback content.
+
+## Existing `content_pages` Field Coverage
+
+| Requirement | Existing field | Status |
+| --- | --- | --- |
+| public route identity | `slug`, `path`, `locale`, `canonical_path` | available |
+| page classification | `kind`, `page_type`, `template`, `animation_profile` | available |
+| visible page body | `title`, `kicker`, `summary`, `content_md`, `content_html`, `headings_json` | available |
+| SEO metadata | `seo_title`, `meta_description`, `seo_description`, `canonical_path` | available |
+| public/index state | `status`, `is_public`, `is_indexable`, `published_at`, `effective_at` | available |
+| translation workflow | `translation_group_id`, `source_locale`, `translation_status`, `source_content_id`, `source_version_hash`, `translated_from_version_hash` | available |
+| review workflow | `review_state`, `owner`, `legal_review_required`, `science_review_required`, `last_reviewed_at`, `source_doc`, `source_updated_at` | available |
+
+## Required Foundation Mapping
+
+| Foundation need | Map now | Required rule |
+| --- | --- | --- |
+| plan explanation modules | `content_md` or `content_html` | CMS/backend authority only |
+| module headings | `headings_json` and visible body | no frontend editorial fallback |
+| review owner | `owner` | required before publish |
+| claim review state | `review_state`, `legal_review_required`, `last_reviewed_at` | approved before public expansion |
+| route | `slug=foundation`, localized `path`, localized `locale` | canonical public route only |
+| indexability | `is_indexable=true` only for Foundation | DailyGiving remains separate and noindex |
+| source package trace | `source_doc` | point to internal asset/request-card reference, not public proof |
+| SEO | `seo_title`, `meta_description`, `seo_description` | no final metadata in this PR |
+
+## Explicit Missing Governance Fields
+
+These are not dedicated `content_pages` columns today:
+
+- `claim_boundary_version`
+- `public_benefit_policy_version`
+- `proof_policy_summary`
+- `daily_giving_state_summary`
+- `faq_items`
+- `faq_schema_enabled`
+- `faq_schema_review_state`
+- `operator_review_checklist`
+
+Until a later schema or metadata container exists, these requirements must remain in internal docs/request cards and must be operator-reviewed before CMS publish. They must not be approximated through frontend static content.
+
+## DailyGiving Dependency Boundary
+
+Foundation may reference DailyGiving only as a gated future ledger concept and record-review process. DailyGiving fields stay in `daily_giving_records`, not `content_pages`.
+
+Relevant existing DailyGiving fields:
+
+- `donation_status`
+- `proof_status`
+- `proof_public_url`
+- `proof_private_path`
+- `proof_redaction_notes`
+- `receipt_reference_redacted`
+- `receipt_reference_private`
+- `public_notes`
+- `internal_notes`
+- `is_public`
+- `is_indexable`
+- `published_at`
+- manual social URL fields
+
+Foundation CMS content must not claim a public DailyGiving ledger, public proof, stable daily operation, or trust badge unless later release gates pass.
+
+## GPT Input Implications
+
+GPT should receive this field map before preparing content inputs. GPT should:
+
+- request module-level CMS fields and review notes;
+- preserve governance-field gaps as explicit operator requirements;
+- keep FAQ as question inventory only unless CMS-approved answers exist;
+- keep DailyGiving noindex and zero-public-record state visible in the evidence table;
+- avoid final H1, metadata, FAQ answers, CTA, social copy, and trust badge copy.
+
+## Codex Follow-up Implications
+
+Codex may later add schema or metadata support only under a separate authorized PR. Until then, Codex should validate that Foundation content stays CMS-backed and that DailyGiving proof/record/index gates are not bypassed through Foundation page copy.

--- a/backend/docs/operations/generated/foundation-cms-field-map.v1.json
+++ b/backend/docs/operations/generated/foundation-cms-field-map.v1.json
@@ -1,0 +1,125 @@
+{
+  "version": "foundation_cms_field_map.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "field_map_only",
+  "schema_change_performed": false,
+  "cms_mutation_performed": false,
+  "publishable_copy_created": false,
+  "content_authority": "CMS/backend content_pages",
+  "content_pages_existing_fields": {
+    "route_identity": [
+      "slug",
+      "path",
+      "locale",
+      "canonical_path"
+    ],
+    "classification": [
+      "kind",
+      "page_type",
+      "template",
+      "animation_profile"
+    ],
+    "visible_body": [
+      "title",
+      "kicker",
+      "summary",
+      "content_md",
+      "content_html",
+      "headings_json"
+    ],
+    "seo": [
+      "seo_title",
+      "meta_description",
+      "seo_description",
+      "canonical_path"
+    ],
+    "visibility": [
+      "status",
+      "is_public",
+      "is_indexable",
+      "published_at",
+      "effective_at"
+    ],
+    "translation": [
+      "translation_group_id",
+      "source_locale",
+      "translation_status",
+      "source_content_id",
+      "source_version_hash",
+      "translated_from_version_hash"
+    ],
+    "review": [
+      "review_state",
+      "owner",
+      "legal_review_required",
+      "science_review_required",
+      "last_reviewed_at",
+      "source_doc",
+      "source_updated_at"
+    ]
+  },
+  "foundation_mapping": {
+    "route": {
+      "slug": "foundation",
+      "path": "localized_public_canonical",
+      "locale": "en_or_zh-CN"
+    },
+    "plan_modules": "content_md_or_content_html",
+    "module_headings": "headings_json_and_visible_body",
+    "review_owner": "owner",
+    "claim_review_state": [
+      "review_state",
+      "legal_review_required",
+      "last_reviewed_at"
+    ],
+    "foundation_indexability": "is_indexable_true_only_for_foundation",
+    "source_trace": "source_doc",
+    "seo": [
+      "seo_title",
+      "meta_description",
+      "seo_description"
+    ]
+  },
+  "missing_dedicated_governance_fields": [
+    "claim_boundary_version",
+    "public_benefit_policy_version",
+    "proof_policy_summary",
+    "daily_giving_state_summary",
+    "faq_items",
+    "faq_schema_enabled",
+    "faq_schema_review_state",
+    "operator_review_checklist"
+  ],
+  "daily_giving_boundary": {
+    "stored_in_content_pages": false,
+    "record_authority": "daily_giving_records",
+    "relevant_fields": [
+      "donation_status",
+      "proof_status",
+      "proof_public_url",
+      "proof_private_path",
+      "proof_redaction_notes",
+      "receipt_reference_redacted",
+      "receipt_reference_private",
+      "public_notes",
+      "internal_notes",
+      "is_public",
+      "is_indexable",
+      "published_at",
+      "manual_social_url_fields"
+    ],
+    "foundation_may_claim_public_ledger_now": false,
+    "foundation_may_claim_trust_badge_now": false
+  },
+  "gpt_constraints": {
+    "preserve_missing_fields_as_operator_requirements": true,
+    "faq_questions_only_until_cms_approved_answers_exist": true,
+    "daily_giving_noindex_state_required": true,
+    "zero_public_record_state_required": true,
+    "final_h1_allowed": false,
+    "final_metadata_allowed": false,
+    "cta_copy_allowed": false,
+    "social_copy_allowed": false,
+    "trust_badge_copy_allowed": false
+  }
+}

--- a/backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php
+++ b/backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php
@@ -1,0 +1,74 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use Tests\TestCase;
+
+final class FoundationCmsFieldMapTest extends TestCase
+{
+    private function artifact(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/operations/generated/foundation-cms-field-map.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function test_existing_content_page_fields_cover_foundation_page_basics(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('foundation_cms_field_map.v1', $artifact['version']);
+        $this->assertFalse($artifact['schema_change_performed']);
+        $this->assertFalse($artifact['cms_mutation_performed']);
+        $this->assertFalse($artifact['publishable_copy_created']);
+
+        foreach (['slug', 'path', 'locale', 'canonical_path'] as $field) {
+            $this->assertContains($field, $artifact['content_pages_existing_fields']['route_identity']);
+        }
+
+        foreach (['content_md', 'content_html', 'headings_json'] as $field) {
+            $this->assertContains($field, $artifact['content_pages_existing_fields']['visible_body']);
+        }
+
+        foreach (['review_state', 'owner', 'legal_review_required', 'last_reviewed_at'] as $field) {
+            $this->assertContains($field, $artifact['content_pages_existing_fields']['review']);
+        }
+    }
+
+    public function test_governance_gaps_remain_explicit_operator_requirements(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'claim_boundary_version',
+            'public_benefit_policy_version',
+            'proof_policy_summary',
+            'daily_giving_state_summary',
+            'faq_schema_enabled',
+            'operator_review_checklist',
+        ] as $field) {
+            $this->assertContains($field, $artifact['missing_dedicated_governance_fields']);
+        }
+
+        $this->assertTrue($artifact['gpt_constraints']['preserve_missing_fields_as_operator_requirements']);
+        $this->assertTrue($artifact['gpt_constraints']['faq_questions_only_until_cms_approved_answers_exist']);
+    }
+
+    public function test_daily_giving_boundary_blocks_ledger_and_badge_claims(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertFalse($artifact['daily_giving_boundary']['stored_in_content_pages']);
+        $this->assertSame('daily_giving_records', $artifact['daily_giving_boundary']['record_authority']);
+        $this->assertContains('proof_private_path', $artifact['daily_giving_boundary']['relevant_fields']);
+        $this->assertContains('proof_redaction_notes', $artifact['daily_giving_boundary']['relevant_fields']);
+        $this->assertFalse($artifact['daily_giving_boundary']['foundation_may_claim_public_ledger_now']);
+        $this->assertFalse($artifact['daily_giving_boundary']['foundation_may_claim_trust_badge_now']);
+        $this->assertTrue($artifact['gpt_constraints']['daily_giving_noindex_state_required']);
+        $this->assertTrue($artifact['gpt_constraints']['zero_public_record_state_required']);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35526,7 +35526,7 @@
   "CONTENT-PACKS-INDEX-ARTIFACT-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-index-artifact-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "commit_sha": "7e0cc715e03b105e51c9556596212c48bb962868",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1763",
     "checks": {
@@ -45075,8 +45075,21 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1905 --watch --interval 15"
+        ],
+        "jobs": [
+          "Semgrep OSS",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ]
       }
     },
     "result": {
@@ -45138,6 +45151,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1905."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1905."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45089,7 +45089,7 @@
       "next_pr_supported": "FOUNDATION-FAQ-SCHEMA-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "29402eea664022f2e988098ed3afb07d974801cf",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -45128,6 +45128,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Foundation CMS field map validated with focused PHPUnit, JSON/YAML parse, scoped diff check, and allowed-path review."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "commit_recorded",
+        "note": "Implementation commit 29402eea664022f2e988098ed3afb07d974801cf recorded before push."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35199,7 +35199,7 @@
     "branch": "codex/detail-ready-1046-rollout-no-audit-dry-run-01",
     "base": "main",
     "title": "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01 no-write career rollout dry-run",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [],
     "commit_sha": "09ec7f599b05d7d555ad186af81633010f5c47f3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1749",
@@ -44961,11 +44961,11 @@
       "next_pr_supported": "FOUNDATION-CMS-FIELD-MAP-01"
     },
     "failure_reason": null,
-    "commit_sha": "4ecb0a435fbf61d30f10df34ca2c5b6590f9b9f5",
+    "commit_sha": "8c772dc1d06de475f34982e4cf56e3e2dd5fd0b9",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1904",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T02:22:52Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -45014,6 +45014,120 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1904."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1904 squash-merged at 8c772dc1d06de475f34982e4cf56e3e2dd5fd0b9; remote branch absent; local branch deleted after detached origin/main sync."
+      }
+    ]
+  },
+  "FOUNDATION-CMS-FIELD-MAP-01": {
+    "repo": "fap-api",
+    "branch": "codex/foundation-cms-field-map-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): map Foundation CMS fields",
+    "depends_on": [
+      "FOUNDATION-CONTENT-REQUEST-CARD-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized the Window 7 train through PR12 and requested evidence-backed GPT/CMS input requirements."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FOUNDATION-CONTENT-REQUEST-CARD-01 merged as PR #1904 at 8c772dc1d06de475f34982e4cf56e3e2dd5fd0b9."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed paths are confined to PR5 field-map docs, generated artifact, focused test, and codex ledger paths."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "php -l backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/operations/generated/foundation-cms-field-map.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationCmsFieldMapTest --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/operations/foundation-cms-field-map.md backend/docs/operations/generated/foundation-cms-field-map.v1.json backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "commands": []
+      }
+    },
+    "result": {
+      "existing_content_page_fields_mapped": true,
+      "missing_governance_fields_identified": true,
+      "schema_change_performed": false,
+      "cms_mutation_performed": false,
+      "publishable_copy_created": false,
+      "daily_giving_record_created": false,
+      "next_pr_supported": "FOUNDATION-FAQ-SCHEMA-GATE-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "schema_change_performed": false,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Changed files are intended to stay within PR5 docs/generated/test/ledger paths."
+    },
+    "sidecars": [
+      {
+        "id": "DEDICATED_GOVERNANCE_FIELDS",
+        "status": "missing",
+        "note": "Claim/proof/FAQ governance fields are documented as missing dedicated content_pages fields; no schema change in PR5."
+      },
+      {
+        "id": "FOUNDATION_CMS_COPY",
+        "status": "not_created",
+        "note": "PR5 does not create CMS copy or drafts."
+      }
+    ],
+    "next_task": "FOUNDATION-FAQ-SCHEMA-GATE-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR4 merge for Foundation CMS field mapping."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Foundation CMS field map validated with focused PHPUnit, JSON/YAML parse, scoped diff check, and allowed-path review."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45026,7 +45026,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-cms-field-map-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): map Foundation CMS fields",
     "depends_on": [
@@ -45090,7 +45090,7 @@
     },
     "failure_reason": null,
     "commit_sha": "29402eea664022f2e988098ed3afb07d974801cf",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1905",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45133,6 +45133,11 @@
         "at": "2026-06-05",
         "status": "commit_recorded",
         "note": "Implementation commit 29402eea664022f2e988098ed3afb07d974801cf recorded before push."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1905."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21690,7 +21690,7 @@ prs:
     branch: codex/foundation-content-request-card-01
     title: "docs(benefit): add Foundation content request card"
     train_scope: window_7_public_benefit_trust_gate
-    status: in_progress
+    status: merged
     scope:
       - Add a GPT input request card for Foundation plan-page content preparation.
       - Ground the request card in scanned Foundation, DailyGiving, operator-decision, proof-policy, and claim-boundary evidence.
@@ -21722,3 +21722,46 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: FOUNDATION-CMS-FIELD-MAP-01
+
+  - id: FOUNDATION-CMS-FIELD-MAP-01
+    repo: fap-api
+    depends_on:
+      - FOUNDATION-CONTENT-REQUEST-CARD-01
+    branch: codex/foundation-cms-field-map-01
+    title: "docs(benefit): map Foundation CMS fields"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Map Foundation plan-page requirements to existing CMS content_pages fields.
+      - Identify missing dedicated governance fields without changing schema.
+      - Add generated field-map artifact and focused contract coverage.
+    allowed_paths:
+      - backend/docs/operations/foundation-cms-field-map.md
+      - backend/docs/operations/generated/foundation-cms-field-map.v1.json
+      - backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change schema, mutate CMS records, create publishable copy, create DailyGiving records, process proof files, publish, submit search URLs, make runtime changes, or deploy.
+    validation:
+      - php -l backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php
+      - python3 -m json.tool backend/docs/operations/generated/foundation-cms-field-map.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationCmsFieldMapTest --no-ansi
+      - git diff --check -- backend/docs/operations/foundation-cms-field-map.md backend/docs/operations/generated/foundation-cms-field-map.v1.json backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: FOUNDATION-FAQ-SCHEMA-GATE-01


### PR DESCRIPTION
## What changed
- Added a Foundation CMS field map for existing content_pages coverage and explicit governance-field gaps.
- Added a generated JSON artifact for the field map.
- Added focused PHPUnit coverage for existing field coverage, missing governance requirements, and DailyGiving boundary constraints.
- Recorded PR5 in the codex train ledger and reconciled PR4 merge facts.

## Why
This keeps Foundation content preparation CMS/backend-authoritative while making claim/proof/FAQ governance requirements explicit before any CMS publish.

## Validation
- php -l backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php
- python3 -m json.tool backend/docs/operations/generated/foundation-cms-field-map.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationCmsFieldMapTest --no-ansi
- git diff --check -- backend/docs/operations/foundation-cms-field-map.md backend/docs/operations/generated/foundation-cms-field-map.v1.json backend/tests/Feature/Foundation/FoundationCmsFieldMapTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No schema change.
- No CMS mutation or publish.
- No Foundation public copy, final SEO metadata, FAQ answers, CTA, social copy, or trust badge copy.
- No DailyGiving records, proof files, search submission, runtime changes, or deploy.