### PR TITLE
docs(codex): add Help review preflight train entry

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -34731,7 +34731,7 @@
     "branch": "codex/detail-ready-1048-replacement-authority-source-controlled-import-01",
     "base": "main",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01 controlled replacement authority source import path",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [
       "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01"
     ],
@@ -44384,11 +44384,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "6783dea9ac604a8d964a8120c559b5ed3ed3f2bd",
+    "commit_sha": "1796232f0f89f379d2ad1a0e0c6227e1ff8accb5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1903",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T02:15:35Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "planned_outputs": {
       "generated_artifact": "backend/docs/help/generated/help-content-draft-postcheck-01.v1.json",
       "operations_report": "backend/docs/operations/help-content-draft-postcheck-2026-06-05.md",
@@ -44477,6 +44477,91 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "PR #1903 GitHub checks passed and PR was CLEAN/MERGEABLE with four scoped files."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "Reconciled after PR #1903 squash merge; origin/main contains merge commit d2fbf99e2e2439ddbb0789b4207ff42c4a13d642, remote task branch is absent, and local cleanup was executed."
+      }
+    ],
+    "merge_commit": "d2fbf99e2e2439ddbb0789b4207ff42c4a13d642",
+    "merge_commit_sha": "d2fbf99e2e2439ddbb0789b4207ff42c4a13d642"
+  },
+  "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-review-preflight-01",
+    "base": "origin/main",
+    "status": "pending",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): prepare Help CMS draft editorial review preflight",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-POSTCHECK-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding the HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01 manifest/state entries."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-POSTCHECK-01 is merged as PR #1903; origin/main contains merge commit d2fbf99e2e2439ddbb0789b4207ff42c4a13d642."
+      },
+      "scope_preflight": {
+        "status": "pass",
+        "evidence": "Review preflight scope is read-only readiness and handoff only; no Operator editorial approval, CMS mutation, publish, deploy, private URL access, payment/refund flow, or secret/env/cookie/token read is allowed."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "planned_outputs": {
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md",
+      "operator_review_allowed_now": false,
+      "publish_allowed": false,
+      "cms_mutation_allowed": false
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "editorial_approval_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-SUPPORT-CONTACT-FIELD",
+        "status": "open_from_postcheck",
+        "note": "Postcheck found support@fermatmind.com in the import package, but not in production ContentPage rows and no first-class support_contact field was verified."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-OPERATOR-APPROVAL",
+        "status": "blocked_until_operator_review",
+        "note": "Codex may prepare review handoff only; Operator editorial approval must be explicit and separate."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish, indexability, sitemap/llms inclusion, and search submission remain forbidden without separate explicit approval."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "manifest_state_authorized",
+        "note": "User authorized supplementing manifest/state entries for HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pending",
+        "note": "Manifest/state entry added; implementation must run as a separate scoped read-only review-preflight PR."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21522,7 +21522,7 @@ prs:
     branch: codex/help-content-draft-postcheck-01
     title: "docs(help): archive Help CMS draft postcheck"
     train_scope: window_9_help_service_content
-    status: postcheck_passed_publish_blocked
+    status: merged
     depends_on:
       - HELP-CONTENT-DRAFT-CREATE-01
     scope:
@@ -21556,6 +21556,46 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01
+
+  - id: HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01
+    repo: fap-api
+    branch: codex/help-content-draft-review-preflight-01
+    title: "docs(help): prepare Help CMS draft editorial review preflight"
+    train_scope: window_9_help_service_content
+    status: pending
+    depends_on:
+      - HELP-CONTENT-DRAFT-POSTCHECK-01
+    scope:
+      - Run read-only preflight over Help service draft/postcheck artifacts before Operator editorial review.
+      - Archive the review-readiness checklist, support-contact sidecar status, publish/search/deploy hard gates, and exact Operator review handoff requirements.
+      - Keep editorial approval, CMS mutation, publish, deployment, search submission, and private URL access out of scope.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json
+      - backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Approve editorial review, publish, mutate CMS, create/update/delete drafts, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01
 
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added the missing `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01` PR-train manifest entry.
- Added the matching pending state entry with read-only review-preflight scope and hard no-publish/no-CMS-mutation boundaries.
- Reconciled `HELP-CONTENT-DRAFT-POSTCHECK-01` as merged after PR #1903, including merge commit and cleanup facts.

## Why
The Help service content train was blocked because `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01` existed only as `next_task`, not as an executable manifest/state entry. This PR makes the next read-only review preflight executable under normal PR-train discipline.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Does not run `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01`.
- Does not approve editorial review.
- Does not create, update, delete, publish, index, or expose CMS content.
- Does not deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, or run payment/refund flows.

## Repository rule impact
This is PR-train bookkeeping only. Content authority remains CMS/backend; frontend fallback authority remains false.
