### PR TITLE
docs(benefit): gate Foundation FAQ schema

### DIFF
--- a/backend/docs/operations/foundation-faq-schema-gate.md
+++ b/backend/docs/operations/foundation-faq-schema-gate.md
@@ -1,0 +1,60 @@
+# Foundation FAQ Schema Gate
+
+Date: 2026-06-05
+
+PR train item: `FOUNDATION-FAQ-SCHEMA-GATE-01`
+
+Mode: documentation, generated artifact, and contract test only. This PR does not create FAQ answers, JSON-LD runtime output, CMS records, DailyGiving records, proof files, public copy, search submissions, or deploys.
+
+## Decision
+
+Foundation FAQ schema remains blocked.
+
+Reason: the current content request card permits FAQ question inventory only. A question inventory is not visible CMS-approved FAQ answer content and must not unlock `FAQPage` JSON-LD.
+
+## Gate Rules
+
+| Gate | Required before FAQPage schema | Current state |
+| --- | --- | --- |
+| visible FAQ answers | visible, CMS/backend-authoritative answers exist on the public Foundation page | not created by this train |
+| CMS approval | FAQ answers are reviewed and approved in CMS/backend authority | not created by this train |
+| claim lint | answers pass Foundation claim boundary lint | pending future content |
+| DailyGiving boundary | FAQ does not imply public ledger, stable operation, trust badge, official partnership, endorsement, certification, or guaranteed impact | required |
+| schema source | schema mirrors visible approved FAQ content | blocked |
+
+## Allowed GPT Output
+
+GPT may produce:
+
+- FAQ question inventory.
+- Risk tags for each question.
+- Required evidence per question.
+- Reviewer checklist.
+- Codex validation handoff.
+
+GPT must not produce:
+
+- final FAQ answers;
+- final `FAQPage` JSON-LD;
+- final H1, metadata, CTA, social copy, or trust badge copy;
+- official partnership, endorsement, certification, guaranteed impact, or stable DailyGiving operation claims.
+
+## Codex Validation Rule
+
+Codex should treat Foundation FAQ schema as disabled unless all conditions pass:
+
+1. visible CMS/backend-authoritative FAQ answers exist;
+2. the visible answers are approved;
+3. schema entries match the visible answers;
+4. claim lint passes;
+5. DailyGiving remains noindex while gated;
+6. DailyGiving records/proof state is not inferred from private or unknown data.
+
+## Explicit Non-Goals
+
+- No public FAQ answers.
+- No JSON-LD runtime implementation.
+- No CMS mutation.
+- No publish.
+- No search submission.
+- No deploy.

--- a/backend/docs/operations/generated/foundation-faq-schema-gate.v1.json
+++ b/backend/docs/operations/generated/foundation-faq-schema-gate.v1.json
@@ -1,0 +1,53 @@
+{
+  "version": "foundation_faq_schema_gate.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "faq_schema_gate_only",
+  "faq_schema_allowed_now": false,
+  "faq_answers_created": false,
+  "jsonld_runtime_change_performed": false,
+  "cms_mutation_performed": false,
+  "publishable_copy_created": false,
+  "gate_requirements": [
+    "visible_cms_backend_authoritative_faq_answers_exist",
+    "faq_answers_reviewed_and_approved",
+    "schema_entries_match_visible_answers",
+    "foundation_claim_lint_passed",
+    "daily_giving_noindex_retained",
+    "daily_giving_records_and_proof_not_inferred_from_unknown_private_data"
+  ],
+  "current_state": {
+    "faq_question_inventory_allowed": true,
+    "faq_answers_available_from_this_train": false,
+    "faq_schema_source_available": false,
+    "daily_giving_noindex_required": true,
+    "daily_giving_public_records_count": 0,
+    "daily_giving_public_months_count": 0
+  },
+  "gpt_allowed_outputs": [
+    "faq_question_inventory",
+    "risk_tags_per_question",
+    "required_evidence_per_question",
+    "reviewer_checklist",
+    "codex_validation_handoff"
+  ],
+  "gpt_forbidden_outputs": [
+    "final_faq_answers",
+    "final_faqpage_jsonld",
+    "final_h1",
+    "final_metadata",
+    "cta_copy",
+    "social_copy",
+    "trust_badge_copy",
+    "official_partnership_claim",
+    "endorsement_claim",
+    "certification_claim",
+    "guaranteed_impact_claim",
+    "stable_daily_giving_operation_claim"
+  ],
+  "schema_activation_policy": {
+    "question_inventory_unlocks_schema": false,
+    "frontend_fallback_unlocks_schema": false,
+    "visible_approved_cms_answers_required": true,
+    "claim_lint_required": true
+  }
+}

--- a/backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php
+++ b/backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php
@@ -1,0 +1,67 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use Tests\TestCase;
+
+final class FoundationFaqSchemaGateTest extends TestCase
+{
+    private function artifact(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/operations/generated/foundation-faq-schema-gate.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function test_faq_schema_is_blocked_without_visible_approved_answers(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('foundation_faq_schema_gate.v1', $artifact['version']);
+        $this->assertFalse($artifact['faq_schema_allowed_now']);
+        $this->assertFalse($artifact['faq_answers_created']);
+        $this->assertFalse($artifact['jsonld_runtime_change_performed']);
+        $this->assertFalse($artifact['cms_mutation_performed']);
+        $this->assertFalse($artifact['publishable_copy_created']);
+
+        $this->assertContains('visible_cms_backend_authoritative_faq_answers_exist', $artifact['gate_requirements']);
+        $this->assertContains('faq_answers_reviewed_and_approved', $artifact['gate_requirements']);
+        $this->assertContains('schema_entries_match_visible_answers', $artifact['gate_requirements']);
+    }
+
+    public function test_question_inventory_and_frontend_fallback_do_not_unlock_schema(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['current_state']['faq_question_inventory_allowed']);
+        $this->assertFalse($artifact['schema_activation_policy']['question_inventory_unlocks_schema']);
+        $this->assertFalse($artifact['schema_activation_policy']['frontend_fallback_unlocks_schema']);
+        $this->assertTrue($artifact['schema_activation_policy']['visible_approved_cms_answers_required']);
+        $this->assertTrue($artifact['schema_activation_policy']['claim_lint_required']);
+    }
+
+    public function test_gpt_outputs_are_limited_to_inventory_and_review_inputs(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertContains('faq_question_inventory', $artifact['gpt_allowed_outputs']);
+        $this->assertContains('reviewer_checklist', $artifact['gpt_allowed_outputs']);
+
+        foreach ([
+            'final_faq_answers',
+            'final_faqpage_jsonld',
+            'cta_copy',
+            'social_copy',
+            'trust_badge_copy',
+            'official_partnership_claim',
+            'guaranteed_impact_claim',
+            'stable_daily_giving_operation_claim',
+        ] as $forbidden) {
+            $this->assertContains($forbidden, $artifact['gpt_forbidden_outputs']);
+        }
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45253,7 +45253,7 @@
     "repo": "fap-api",
     "branch": "codex/foundation-faq-schema-gate-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): gate Foundation FAQ schema",
     "depends_on": [
@@ -45316,7 +45316,7 @@
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1907",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45358,6 +45358,11 @@
         "at": "2026-06-05",
         "status": "commit_recorded",
         "note": "Implementation commit 7a0788e49edbbdfffbecb3546a6179e8d925803b recorded before push."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1907."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35978,7 +35978,7 @@
   "CONTENT-PACKS-CI-ARTIFACT-CONSUMER-SPLIT-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-ci-artifact-consumer-split-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "commit_sha": "f42f3017987210b4b6ee9b002f90631ce861bc7e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1768",
     "checks": {
@@ -45302,8 +45302,21 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1907 --watch --interval 15"
+        ],
+        "jobs": [
+          "Semgrep OSS",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ]
       }
     },
     "result": {
@@ -45363,6 +45376,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1907."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1907."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44512,7 +44512,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "7a0788e49edbbdfffbecb3546a6179e8d925803b",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -45353,6 +45353,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Foundation FAQ schema gate validated with focused PHPUnit, JSON/YAML parse, scoped diff check, and allowed-path review."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "commit_recorded",
+        "note": "Implementation commit 7a0788e49edbbdfffbecb3546a6179e8d925803b recorded before push."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45187,11 +45187,11 @@
       "next_pr_supported": "FOUNDATION-FAQ-SCHEMA-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "29402eea664022f2e988098ed3afb07d974801cf",
+    "commit_sha": "624782eb52ff98cf9bcc98514de1e59168328bf8",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1905",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T02:37:48Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "schema_change_performed": false,
@@ -45241,6 +45241,118 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1905."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1905 squash-merged at 624782eb52ff98cf9bcc98514de1e59168328bf8; remote branch absent; local branch deleted after detached origin/main sync."
+      }
+    ]
+  },
+  "FOUNDATION-FAQ-SCHEMA-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/foundation-faq-schema-gate-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): gate Foundation FAQ schema",
+    "depends_on": [
+      "FOUNDATION-CMS-FIELD-MAP-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized the Window 7 train and required GPT input requirements without final FAQ copy."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FOUNDATION-CMS-FIELD-MAP-01 merged as PR #1905 at 624782eb52ff98cf9bcc98514de1e59168328bf8."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed paths are confined to PR6 FAQ schema gate docs, generated artifact, focused test, and codex ledger paths."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "php -l backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/operations/generated/foundation-faq-schema-gate.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationFaqSchemaGateTest --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/operations/foundation-faq-schema-gate.md backend/docs/operations/generated/foundation-faq-schema-gate.v1.json backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "commands": []
+      }
+    },
+    "result": {
+      "faq_schema_allowed_now": false,
+      "faq_answers_created": false,
+      "jsonld_runtime_change_performed": false,
+      "cms_mutation_performed": false,
+      "publishable_copy_created": false,
+      "next_pr_supported": "DAILY-GIVING-PROOF-REDACTION-SOP-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Changed files are intended to stay within PR6 docs/generated/test/ledger paths."
+    },
+    "sidecars": [
+      {
+        "id": "FOUNDATION_FAQ_ANSWERS",
+        "status": "not_created",
+        "note": "FAQ question inventory is allowed; final answers remain blocked."
+      },
+      {
+        "id": "FOUNDATION_FAQ_SCHEMA",
+        "status": "blocked",
+        "note": "FAQPage schema remains blocked until visible approved CMS FAQ answers exist."
+      }
+    ],
+    "next_task": "DAILY-GIVING-PROOF-REDACTION-SOP-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR5 merge for Foundation FAQ schema gate."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Foundation FAQ schema gate validated with focused PHPUnit, JSON/YAML parse, scoped diff check, and allowed-path review."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21770,7 +21770,7 @@ prs:
     branch: codex/foundation-cms-field-map-01
     title: "docs(benefit): map Foundation CMS fields"
     train_scope: window_7_public_benefit_trust_gate
-    status: in_progress
+    status: merged
     scope:
       - Map Foundation plan-page requirements to existing CMS content_pages fields.
       - Identify missing dedicated governance fields without changing schema.
@@ -21805,3 +21805,46 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: FOUNDATION-FAQ-SCHEMA-GATE-01
+
+  - id: FOUNDATION-FAQ-SCHEMA-GATE-01
+    repo: fap-api
+    depends_on:
+      - FOUNDATION-CMS-FIELD-MAP-01
+    branch: codex/foundation-faq-schema-gate-01
+    title: "docs(benefit): gate Foundation FAQ schema"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Define Foundation FAQPage schema activation gates.
+      - Keep FAQ question inventory allowed but final FAQ answers and JSON-LD blocked.
+      - Add generated gate artifact and focused contract coverage.
+    allowed_paths:
+      - backend/docs/operations/foundation-faq-schema-gate.md
+      - backend/docs/operations/generated/foundation-faq-schema-gate.v1.json
+      - backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create FAQ answers, JSON-LD runtime output, CMS records, publishable copy, DailyGiving records, proof files, search submissions, runtime changes, or deploys.
+    validation:
+      - php -l backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php
+      - python3 -m json.tool backend/docs/operations/generated/foundation-faq-schema-gate.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationFaqSchemaGateTest --no-ansi
+      - git diff --check -- backend/docs/operations/foundation-faq-schema-gate.md backend/docs/operations/generated/foundation-faq-schema-gate.v1.json backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: DAILY-GIVING-PROOF-REDACTION-SOP-01


### PR DESCRIPTION
## What changed
- Added a Foundation FAQ/schema gate that blocks FAQPage schema until visible CMS-approved FAQ answers exist.
- Added a generated JSON gate artifact.
- Added focused PHPUnit coverage for blocked schema state, question-inventory limits, and GPT forbidden outputs.
- Recorded PR6 in the codex train ledger and reconciled PR5 merge facts.

## Why
Foundation content preparation can use FAQ question inventories, but question lists or frontend fallback content must not unlock FAQPage JSON-LD or final FAQ copy.

## Validation
- php -l backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php
- python3 -m json.tool backend/docs/operations/generated/foundation-faq-schema-gate.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=FoundationFaqSchemaGateTest --no-ansi
- git diff --check -- backend/docs/operations/foundation-faq-schema-gate.md backend/docs/operations/generated/foundation-faq-schema-gate.v1.json backend/tests/Feature/Foundation/FoundationFaqSchemaGateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No FAQ answers.
- No FAQPage JSON-LD runtime output.
- No CMS mutation or publish.
- No DailyGiving records, proof files, search submission, runtime changes, or deploy.