### PR TITLE
docs(help): prepare Help draft review preflight

### DIFF
--- a/backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json
@@ -1,0 +1,111 @@
+{
+  "schema": "help-content-draft-review-preflight-01.v1",
+  "task": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01",
+  "generated_at": "2026-06-05",
+  "decision": "REVIEW_PREFLIGHT_PASS_OPERATOR_REVIEW_REQUIRED_PUBLISH_BLOCKED",
+  "source_package": {
+    "required_uploaded_zip": "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01.zip",
+    "zip_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+    "zip_file_count": 14,
+    "index_schema_version": "help_service_content_drafts.v1",
+    "index_publish_allowed": false,
+    "index_requires_operator_review": true,
+    "index_cms_draft_created": false
+  },
+  "postcheck_sources": {
+    "generated_artifact": "backend/docs/help/generated/help-content-draft-postcheck-01.v1.json",
+    "generated_artifact_sha256": "476ab746a4d0c162f425c1bfcc220e1cc89d11eee25f4e5c7572448551e49d61",
+    "operations_report": "backend/docs/operations/help-content-draft-postcheck-2026-06-05.md",
+    "operations_report_sha256": "4520313c62d190296771283896e8c2d3051994824bd77cd192a5c286b4805e64",
+    "postcheck_decision": "POSTCHECK_PASS_WITH_PUBLISH_BLOCKED_SIDECARS"
+  },
+  "draft_inventory": {
+    "expected_content_page_rows": 12,
+    "draft_count_found_in_postcheck": 12,
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "all_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true
+  },
+  "review_handoff": {
+    "operator_review_handoff_ready": true,
+    "operator_editorial_approval_performed": false,
+    "operator_editorial_approval_present": false,
+    "operator_review_required": true,
+    "reviewer_required": true,
+    "review_timestamp_required": true,
+    "policy_version_required": true,
+    "per_asset_decision_required": true,
+    "allowed_operator_outcomes": [
+      "approved_for_publish_preflight",
+      "revisions_required",
+      "rejected"
+    ],
+    "asset_ids_for_review": [
+      "UNLOCK-FAILURE-HELP-CARD-01",
+      "PAYMENT-REFUND-FAQ-PACKAGE-01",
+      "RESULT-RECOVERY-FAQ-01",
+      "PRIVACY-FAQ-PACKAGE-01",
+      "NONDIAGNOSTIC-HELP-COPY-01",
+      "DATA-DELETION-REQUEST-FAQ-01"
+    ],
+    "review_requirements": [
+      "Confirm each draft remains a help/service policy asset and not marketing copy.",
+      "Confirm payment, refund, unlock failure, result recovery, privacy, non-diagnostic, and deletion boundaries are acceptable for publication review.",
+      "Confirm FAQPage schema remains disabled or gated until visible FAQ and JSON-LD can be proven equivalent.",
+      "Confirm no raw order number, payment id, result token, private result/order/share/pay/payment/history URL, or public submission of private identifiers is requested.",
+      "Resolve or explicitly accept the support-contact sidecar before publish preflight.",
+      "Record reviewer, review timestamp, policy version, per-asset outcome, and any required revisions."
+    ]
+  },
+  "hard_gates": {
+    "publish_allowed_now": false,
+    "publish_performed": false,
+    "cms_mutation_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_editorial_approval_required_before_publish": true
+  },
+  "support_contact": {
+    "operator_contact": "support@fermatmind.com",
+    "import_package_contains_support_contact": true,
+    "content_page_rows_contain_support_contact": false,
+    "cms_first_class_support_contact_field_verified": false,
+    "pre_publish_resolution_required": true,
+    "status": "sidecar_open"
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-SUPPORT-CONTACT-FIELD",
+      "status": "open",
+      "note": "Postcheck found support@fermatmind.com in the import package, but not in production ContentPage rows and no first-class support_contact field was verified."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-OPERATOR-APPROVAL",
+      "status": "blocked_until_operator_review",
+      "note": "Review handoff is ready, but Codex did not perform or assert Operator editorial approval."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish, indexability, sitemap/llms inclusion, and search submission remain forbidden without separate explicit approval."
+    }
+  ],
+  "next_task": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01"
+}

--- a/backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md
@@ -1,0 +1,53 @@
+# HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01
+
+Decision: `REVIEW_PREFLIGHT_PASS_OPERATOR_REVIEW_REQUIRED_PUBLISH_BLOCKED`.
+
+This PR prepares the Help service CMS draft editorial review handoff. It does not perform Operator editorial approval, publish, mutate CMS rows, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+
+## Evidence
+
+- Required uploaded zip exists at `/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01.zip`.
+- Zip SHA-256: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6`.
+- Zip contains 14 files: six markdown drafts, six YAML metadata files, `index.json`, and `README.md`.
+- Source index says `publish_allowed=false` and `requires_operator_review=true`.
+- Postcheck artifact: `backend/docs/help/generated/help-content-draft-postcheck-01.v1.json`.
+- Postcheck decision: `POSTCHECK_PASS_WITH_PUBLISH_BLOCKED_SIDECARS`.
+- Postcheck found 12 expected ContentPage draft rows across six help slugs and two locales.
+- Postcheck confirmed draft rows are non-public, non-indexable, unpublished, and absent from public routes, sitemap, and llms surfaces.
+
+## Operator Review Handoff Requirements
+
+Operator review must record:
+
+- reviewer
+- review timestamp
+- policy version
+- per-asset decision
+- required revisions, if any
+- support-contact sidecar resolution
+- confirmation that publish/search/deploy remain blocked until a separate explicit authorization
+
+Allowed Operator outcomes:
+
+- `approved_for_publish_preflight`
+- `revisions_required`
+- `rejected`
+
+## Assets Requiring Review
+
+- `UNLOCK-FAILURE-HELP-CARD-01`
+- `PAYMENT-REFUND-FAQ-PACKAGE-01`
+- `RESULT-RECOVERY-FAQ-01`
+- `PRIVACY-FAQ-PACKAGE-01`
+- `NONDIAGNOSTIC-HELP-COPY-01`
+- `DATA-DELETION-REQUEST-FAQ-01`
+
+## Sidecars
+
+- `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-SUPPORT-CONTACT-FIELD`: `support@fermatmind.com` exists in the import package, but not in production ContentPage rows and no first-class `support_contact` field was verified.
+- `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-OPERATOR-APPROVAL`: review handoff is ready, but Codex did not perform or assert Operator editorial approval.
+- `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-PUBLISH-BLOCK`: publish, indexability, sitemap/llms inclusion, and search submission remain forbidden without separate explicit approval.
+
+## Next Task
+
+`HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01`

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44491,7 +44491,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-review-preflight-01",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review preflight",
     "depends_on": [
@@ -44546,10 +44546,25 @@
             "status": "passed"
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1908 --watch --interval 15"
+        ],
+        "jobs": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep blocking secrets"
+        ]
       }
     },
     "failure_reason": null,
-    "commit_sha": "9dc1117fb3d665439258b5378095e7f1199ea921",
+    "commit_sha": "f7dcd33b8832feb0c8da0bd18a96700158c04814",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1908",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -44624,6 +44639,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1908 with implementation commit 9dc1117fb3d665439258b5378095e7f1199ea921; GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "PR #1908 GitHub checks passed and PR was CLEAN/MERGEABLE with four scoped files."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44491,7 +44491,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-review-preflight-01",
     "base": "origin/main",
-    "status": "pending",
+    "status": "local_checks_passed",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review preflight",
     "depends_on": [
@@ -44509,6 +44509,43 @@
       "scope_preflight": {
         "status": "pass",
         "evidence": "Review preflight scope is read-only readiness and handoff only; no Operator editorial approval, CMS mutation, publish, deploy, private URL access, payment/refund flow, or secret/env/cookie/token read is allowed."
+      },
+      "source_package": {
+        "status": "pass",
+        "evidence": "Uploaded zip exists at /Users/rainie/Desktop/fermatmind-help-service-content-drafts-01.zip; SHA-256 2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6; index publish_allowed=false and requires_operator_review=true."
+      },
+      "postcheck_dependency": {
+        "status": "pass",
+        "evidence": "Postcheck artifact decision is POSTCHECK_PASS_WITH_PUBLISH_BLOCKED_SIDECARS; it found 12 hidden draft rows and public/sitemap/llms absence."
+      },
+      "review_handoff": {
+        "status": "pass",
+        "evidence": "Review handoff requirements were archived; Operator editorial approval was not performed and remains required."
+      },
+      "support_contact": {
+        "status": "sidecar_open",
+        "evidence": "support@fermatmind.com exists in the import package, but not in production ContentPage rows and no first-class support_contact field was verified."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
       }
     },
     "failure_reason": null,
@@ -44524,6 +44561,16 @@
       "publish_allowed": false,
       "cms_mutation_allowed": false
     },
+    "result": {
+      "decision": "REVIEW_PREFLIGHT_PASS_OPERATOR_REVIEW_REQUIRED_PUBLISH_BLOCKED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md",
+      "operator_review_handoff_ready": true,
+      "operator_editorial_approval_performed": false,
+      "operator_editorial_approval_present": false,
+      "publish_allowed_now": false,
+      "next_pr_supported": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01"
+    },
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -44537,7 +44584,7 @@
     "sidecars": [
       {
         "id": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-SUPPORT-CONTACT-FIELD",
-        "status": "open_from_postcheck",
+        "status": "open",
         "note": "Postcheck found support@fermatmind.com in the import package, but not in production ContentPage rows and no first-class support_contact field was verified."
       },
       {
@@ -44562,6 +44609,16 @@
         "at": "2026-06-05",
         "status": "pending",
         "note": "Manifest/state entry added; implementation must run as a separate scoped read-only review-preflight PR."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "review_preflight_passed_operator_review_required",
+        "note": "Read-only review preflight passed and handoff requirements were archived. Operator editorial approval remains unperformed; publish/search/deploy/CMS mutation remain blocked."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Generated artifact, state JSON, manifest YAML, and scoped diff checks passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44491,7 +44491,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-review-preflight-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review preflight",
     "depends_on": [
@@ -44549,8 +44549,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "7a0788e49edbbdfffbecb3546a6179e8d925803b",
-    "pr_url": null,
+    "commit_sha": "9dc1117fb3d665439258b5378095e7f1199ea921",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1908",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44619,6 +44619,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Generated artifact, state JSON, manifest YAML, and scoped diff checks passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1908 with implementation commit 9dc1117fb3d665439258b5378095e7f1199ea921; GitHub checks are pending."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21562,7 +21562,7 @@ prs:
     branch: codex/help-content-draft-review-preflight-01
     title: "docs(help): prepare Help CMS draft editorial review preflight"
     train_scope: window_9_help_service_content
-    status: pending
+    status: review_preflight_passed_operator_review_required
     depends_on:
       - HELP-CONTENT-DRAFT-POSTCHECK-01
     scope:


### PR DESCRIPTION
## What changed
- Archived `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01` generated evidence and operations report.
- Prepared the Operator editorial review handoff requirements for the Help service CMS drafts.
- Updated PR-train manifest/state to mark review preflight passed while Operator review and publish remain blocked.

## Why
The Help service content train needed a read-only preflight before any Operator editorial review can happen. This PR records the review package, required review fields, sidecars, and hard publish gates without performing approval.

## Validation
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`

## Intentionally deferred
- No Operator editorial approval was performed.
- No CMS mutation, publish, deploy, search submission, payment/refund flow, payment-provider change, private URL access, or secret/env/cookie/token read.
- Support-contact remains an open sidecar before publish preflight.

## Repository rule impact
Content authority remains CMS/backend. Frontend fallback authority remains false. This PR prepares review preflight evidence only and keeps publish blocked.
