### PR TITLE
docs(benefit): define DailyGiving proof redaction SOP

### DIFF
--- a/backend/docs/operations/daily-giving-proof-redaction-sop.md
+++ b/backend/docs/operations/daily-giving-proof-redaction-sop.md
@@ -1,0 +1,77 @@
+# DailyGiving Proof Redaction SOP
+
+Date: 2026-06-05
+
+PR train item: `DAILY-GIVING-PROOF-REDACTION-SOP-01`
+
+Mode: SOP, generated artifact, and contract test only. This PR does not create records, upload proof, process proof, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, or deploy.
+
+## Decision
+
+Raw proof must stay private. Public proof may exist only as a separate redacted public artifact after review. Withheld proof is allowed only as a reviewer-approved privacy or safety exception, and cannot power a trust badge or public amplification claim.
+
+## Storage Classes
+
+| Proof class | Storage rule | Public access |
+| --- | --- | --- |
+| raw receipt / raw proof | private disk or private bucket only | forbidden |
+| admin proof access | private storage driver or short-TTL signed admin URL | admin-only |
+| redacted public proof | public-safe media path or public signed URL after review | allowed after review |
+| withheld proof | private raw proof retained with reviewer reason | public proof unavailable |
+
+## Redaction Standard
+
+No redaction is allowed only when reviewer inspection confirms no sensitive fields exist.
+
+Fields that must be redacted if present:
+
+- donor legal name unless explicitly approved;
+- donor email, phone, address;
+- bank account, card number, payment account id;
+- full transaction number or full order number;
+- payment provider user id;
+- billing or invoice address;
+- QR payment token;
+- session id, auth token, private receipt URL, browser URL with private token;
+- internal admin comments.
+
+Fields that may remain visible after review:
+
+- recipient name;
+- donation date;
+- amount and currency;
+- non-sensitive receipt issuer name;
+- proof status;
+- short masked public reference.
+
+## Withheld Proof Rule
+
+`proof_status=withheld` requires a reviewer reason. It may support a public record only when the record itself passes public-release review and the public page/API makes clear that public proof is withheld. It must not support trust badge, paid-page proof, high-amplification claim, or guaranteed-impact claim.
+
+## Public API Rule
+
+Public API must not expose:
+
+- `proof_private_path`
+- `proof_redaction_notes`
+- `receipt_reference_private`
+- `internal_notes`
+- admin user ids
+- raw transaction ids
+- payment account details
+- private sync diagnostics
+
+Public API may expose only reviewed public fields such as recipient, date, amount, currency, proof status, redacted proof URL, redacted receipt reference, social links after review, and public notes after claim lint.
+
+## Review Checklist
+
+Before `is_public=true`:
+
+- raw proof is private;
+- public proof URL, if present, points only to redacted proof;
+- sensitive fields are redacted or reviewer confirms none exist;
+- withheld proof has reviewer reason;
+- recipient/date/amount are verified;
+- public notes pass claim lint;
+- `is_indexable=false` remains set;
+- no trust badge is enabled.

--- a/backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json
+++ b/backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json
@@ -1,0 +1,93 @@
+{
+  "version": "daily_giving_proof_redaction_sop.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "sop_only",
+  "record_created": false,
+  "proof_uploaded": false,
+  "proof_processed": false,
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "trust_badge_allowed": false,
+  "storage_classes": {
+    "raw_proof": {
+      "storage": "private_disk_or_private_bucket",
+      "public_access": false,
+      "sitemap_or_llms_allowed": false
+    },
+    "admin_access": {
+      "mode": "private_storage_driver_or_short_ttl_signed_admin_url",
+      "public_access": false
+    },
+    "redacted_public_proof": {
+      "storage": "public_safe_media_or_public_signed_url",
+      "public_access": "allowed_after_review",
+      "must_be_separate_from_raw_proof": true
+    },
+    "withheld_proof": {
+      "reviewer_reason_required": true,
+      "can_power_trust_badge": false,
+      "can_support_high_amplification": false
+    }
+  },
+  "redaction_required_fields": [
+    "donor_legal_name_unless_approved",
+    "donor_email",
+    "donor_phone",
+    "donor_address",
+    "bank_account",
+    "card_number",
+    "payment_account_id",
+    "full_transaction_number",
+    "full_order_number",
+    "payment_provider_user_id",
+    "billing_or_invoice_address",
+    "qr_payment_token",
+    "session_id",
+    "auth_token",
+    "private_receipt_url",
+    "browser_url_with_private_token",
+    "internal_admin_comments"
+  ],
+  "public_visible_after_review": [
+    "recipient_name",
+    "donation_date",
+    "amount",
+    "currency",
+    "non_sensitive_receipt_issuer_name",
+    "proof_status",
+    "short_masked_public_reference"
+  ],
+  "public_api_forbidden_fields": [
+    "proof_private_path",
+    "proof_redaction_notes",
+    "receipt_reference_private",
+    "internal_notes",
+    "created_by_admin_user_id",
+    "updated_by_admin_user_id",
+    "raw_transaction_id",
+    "payment_account",
+    "private_sync_diagnostics"
+  ],
+  "public_api_allowed_fields_after_gates": [
+    "record_code",
+    "recipient_name",
+    "recipient_official_url",
+    "donation_date",
+    "amount_minor",
+    "currency",
+    "donation_status",
+    "proof_status",
+    "proof_public_url",
+    "receipt_reference_redacted",
+    "manual_social_links_after_review",
+    "public_notes"
+  ],
+  "release_review_required": [
+    "raw_proof_private",
+    "public_proof_redacted_or_withheld_reason_present",
+    "recipient_date_amount_verified",
+    "public_notes_claim_linted",
+    "is_indexable_false_retained",
+    "trust_badge_disabled"
+  ]
+}

--- a/backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
@@ -1,0 +1,58 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use Tests\TestCase;
+
+final class DailyGivingProofRedactionSopTest extends TestCase
+{
+    private function artifact(): array
+    {
+        $path = dirname(__DIR__, 3).'/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json';
+
+        $this->assertFileExists($path);
+
+        return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+    }
+
+    public function test_raw_proof_is_private_and_public_proof_is_separate_redacted_media(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame('daily_giving_proof_redaction_sop.v1', $artifact['version']);
+        $this->assertFalse($artifact['record_created']);
+        $this->assertFalse($artifact['proof_uploaded']);
+        $this->assertFalse($artifact['proof_processed']);
+        $this->assertFalse($artifact['publish_performed']);
+
+        $this->assertSame('private_disk_or_private_bucket', $artifact['storage_classes']['raw_proof']['storage']);
+        $this->assertFalse($artifact['storage_classes']['raw_proof']['public_access']);
+        $this->assertTrue($artifact['storage_classes']['redacted_public_proof']['must_be_separate_from_raw_proof']);
+    }
+
+    public function test_sensitive_fields_and_private_api_fields_are_forbidden_publicly(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach (['donor_email', 'payment_account_id', 'full_transaction_number', 'auth_token', 'private_receipt_url'] as $field) {
+            $this->assertContains($field, $artifact['redaction_required_fields']);
+        }
+
+        foreach (['proof_private_path', 'proof_redaction_notes', 'receipt_reference_private', 'internal_notes', 'created_by_admin_user_id', 'updated_by_admin_user_id'] as $field) {
+            $this->assertContains($field, $artifact['public_api_forbidden_fields']);
+        }
+    }
+
+    public function test_withheld_proof_cannot_power_badges_or_amplification(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertTrue($artifact['storage_classes']['withheld_proof']['reviewer_reason_required']);
+        $this->assertFalse($artifact['storage_classes']['withheld_proof']['can_power_trust_badge']);
+        $this->assertFalse($artifact['storage_classes']['withheld_proof']['can_support_high_amplification']);
+        $this->assertFalse($artifact['trust_badge_allowed']);
+        $this->assertContains('is_indexable_false_retained', $artifact['release_review_required']);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45393,7 +45393,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-proof-redaction-sop-01",
     "base": "main",
-    "status": "in_progress",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving proof redaction SOP",
     "depends_on": [
@@ -45457,7 +45457,7 @@
     },
     "failure_reason": null,
     "commit_sha": "7c20a2e5d952b9c34139e2f9a294830a71be41b2",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1910",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45499,6 +45499,11 @@
         "at": "2026-06-05",
         "status": "commit_recorded",
         "note": "Implementation commit 7c20a2e5d952b9c34139e2f9a294830a71be41b2 recorded before push."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1910."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36114,7 +36114,7 @@
     "branch": "content/pr-pol-01-policies-dashboard",
     "base": "main",
     "title": "PR-POL-01 add policies dashboard content",
-    "status": "pr_open",
+    "status": "merged",
     "depends_on": [
       "PR #1767 merged"
     ],
@@ -45328,11 +45328,11 @@
       "next_pr_supported": "DAILY-GIVING-PROOF-REDACTION-SOP-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "05e1952f814bc589e6d785184e800f8d25e209b1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1907",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T02:52:42Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -45381,6 +45381,119 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1907."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1907 squash-merged at 05e1952f814bc589e6d785184e800f8d25e209b1; remote branch absent; local branch deleted after detached origin/main sync."
+      }
+    ]
+  },
+  "DAILY-GIVING-PROOF-REDACTION-SOP-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-proof-redaction-sop-01",
+    "base": "main",
+    "status": "in_progress",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): define DailyGiving proof redaction SOP",
+    "depends_on": [
+      "FOUNDATION-FAQ-SCHEMA-GATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized DailyGiving proof redaction SOP work while forbidding proof upload/processing and record creation."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "FOUNDATION-FAQ-SCHEMA-GATE-01 merged as PR #1907 at 05e1952f814bc589e6d785184e800f8d25e209b1."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed paths are confined to PR7 proof redaction SOP docs, generated artifact, focused test, and codex ledger paths."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "php -l backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingProofRedactionSopTest --no-ansi",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check -- backend/docs/operations/daily-giving-proof-redaction-sop.md backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "commands": []
+      }
+    },
+    "result": {
+      "redaction_sop_defined": true,
+      "record_created": false,
+      "proof_uploaded": false,
+      "proof_processed": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "next_pr_supported": "DAILY-GIVING-PROOF-STORAGE-GATE-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Changed files are intended to stay within PR7 docs/generated/test/ledger paths."
+    },
+    "sidecars": [
+      {
+        "id": "RAW_PROOF_STORAGE",
+        "status": "documented_private_required",
+        "note": "PR7 documents private-only raw proof handling but does not verify storage implementation."
+      },
+      {
+        "id": "TRUST_BADGE",
+        "status": "blocked",
+        "note": "Redaction SOP does not unlock trust badge."
+      }
+    ],
+    "next_task": "DAILY-GIVING-PROOF-STORAGE-GATE-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR6 merge for DailyGiving proof redaction SOP."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "DailyGiving proof redaction SOP validated with focused PHPUnit, JSON/YAML parse, scoped diff check, and allowed-path review."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45456,7 +45456,7 @@
       "next_pr_supported": "DAILY-GIVING-PROOF-STORAGE-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "7c20a2e5d952b9c34139e2f9a294830a71be41b2",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -45494,6 +45494,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "DailyGiving proof redaction SOP validated with focused PHPUnit, JSON/YAML parse, scoped diff check, and allowed-path review."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "commit_recorded",
+        "note": "Implementation commit 7c20a2e5d952b9c34139e2f9a294830a71be41b2 recorded before push."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -36707,7 +36707,7 @@
     "repo": "fap-api",
     "branch": "codex/payment-alipay-scheduler-bootstrap-02",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02 register Alipay compensation in runtime scheduler",
     "commit_sha": "fecc207643c37dba0d411eda305a376d6eb3a2db",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1774",
@@ -45442,8 +45442,21 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1910 --watch --interval 15"
+        ],
+        "jobs": [
+          "Semgrep OSS",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ]
       }
     },
     "result": {
@@ -45504,6 +45517,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1910."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1910."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21813,7 +21813,7 @@ prs:
     branch: codex/foundation-faq-schema-gate-01
     title: "docs(benefit): gate Foundation FAQ schema"
     train_scope: window_7_public_benefit_trust_gate
-    status: in_progress
+    status: merged
     scope:
       - Define Foundation FAQPage schema activation gates.
       - Keep FAQ question inventory allowed but final FAQ answers and JSON-LD blocked.
@@ -21848,3 +21848,46 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: DAILY-GIVING-PROOF-REDACTION-SOP-01
+
+  - id: DAILY-GIVING-PROOF-REDACTION-SOP-01
+    repo: fap-api
+    depends_on:
+      - FOUNDATION-FAQ-SCHEMA-GATE-01
+    branch: codex/daily-giving-proof-redaction-sop-01
+    title: "docs(benefit): define DailyGiving proof redaction SOP"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Define DailyGiving raw proof, redacted public proof, withheld proof, and public API redaction rules.
+      - Add generated SOP artifact and focused contract coverage.
+      - Keep all proof and record handling non-mutating.
+    allowed_paths:
+      - backend/docs/operations/daily-giving-proof-redaction-sop.md
+      - backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json
+      - backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create records, upload proof, process proof, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, make runtime changes, or deploy.
+    validation:
+      - php -l backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
+      - python3 -m json.tool backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingProofRedactionSopTest --no-ansi
+      - git diff --check -- backend/docs/operations/daily-giving-proof-redaction-sop.md backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: DAILY-GIVING-PROOF-STORAGE-GATE-01


### PR DESCRIPTION
## What changed
- Added a DailyGiving proof redaction SOP covering raw proof, redacted public proof, withheld proof, and public API field boundaries.
- Added a generated SOP artifact.
- Added focused PHPUnit coverage for private proof handling, public forbidden fields, and withheld-proof limits.
- Recorded PR7 in the codex train ledger and reconciled PR6 merge facts.

## Why
DailyGiving needs a proof-handling policy before any real record/proof release work. This keeps raw receipts private and blocks trust badge or amplification use.

## Validation
- php -l backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
- python3 -m json.tool backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingProofRedactionSopTest --no-ansi
- git diff --check -- backend/docs/operations/daily-giving-proof-redaction-sop.md backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No record creation.
- No proof upload or processing.
- No CMS mutation, publish, indexing, trust badge, search submission, runtime change, or deploy.