### PR TITLE
test(seo): validate RIASEC explanation package v2 boundaries

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json
+++ b/backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json
@@ -1,0 +1,153 @@
+{
+  "task_id": "SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01",
+  "source_task_id": "SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01",
+  "source_package_version": "v2_truity_density_revision",
+  "generated_at": "2026-06-05",
+  "decision": "GO for reference/source review",
+  "content_safe": true,
+  "content_blocked": false,
+  "cms_draft_created": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "codex_content_rewrite_performed": false,
+  "checks": {
+    "package_contains_zh_en": true,
+    "locale_field_checks": [
+      {
+        "locale": "zh",
+        "title_exists": true,
+        "slug_exists": true,
+        "slug_length": 45,
+        "slug_length_pass": true,
+        "h1_exists": true,
+        "seo_title_length": 22,
+        "seo_title_length_pass": true,
+        "seo_description_length": 53,
+        "seo_description_length_pass": true,
+        "body_markdown_exists": true,
+        "faq_count": 6,
+        "visible_faq_count": 6,
+        "expected_faq_schema_mainEntity_count": 6,
+        "body_visible_faq_heading_count": 6,
+        "faq_count_matches_schema": true,
+        "primary_cta_href": "/zh/tests/holland-career-interest-test-riasec",
+        "primary_cta_public_canonical_pass": true,
+        "internal_links": [
+          {
+            "href": "/zh/articles/mbti-vs-holland-career-choice",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/zh/tests/holland-career-interest-test-riasec",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/zh/tests/mbti-personality-test-16-personality-types",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/zh/tests/big-five-personality-test-ocean-model",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/zh/career/jobs",
+            "status": "conditional",
+            "validation": "conditional"
+          }
+        ],
+        "internal_links_pass": true,
+        "conditional_links": [
+          "/zh/career/jobs"
+        ],
+        "references_required": true,
+        "unresolved_references": [
+          "primary_model_background",
+          "holland_hexagon",
+          "career_information_systems",
+          "comparison_context",
+          "claim_boundary"
+        ],
+        "unknown_preserved": true
+      },
+      {
+        "locale": "en",
+        "title_exists": true,
+        "slug_exists": true,
+        "slug_length": 48,
+        "slug_length_pass": true,
+        "h1_exists": true,
+        "seo_title_length": 40,
+        "seo_title_length_pass": true,
+        "seo_description_length": 139,
+        "seo_description_length_pass": true,
+        "body_markdown_exists": true,
+        "faq_count": 6,
+        "visible_faq_count": 6,
+        "expected_faq_schema_mainEntity_count": 6,
+        "body_visible_faq_heading_count": 6,
+        "faq_count_matches_schema": true,
+        "primary_cta_href": "/en/tests/holland-career-interest-test-riasec",
+        "primary_cta_public_canonical_pass": true,
+        "internal_links": [
+          {
+            "href": "/en/articles/mbti-vs-holland-code-career-choice",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/en/tests/holland-career-interest-test-riasec",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/en/tests/mbti-personality-test-16-personality-types",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/en/tests/big-five-personality-test-ocean-model",
+            "status": "allowed",
+            "validation": "allowed"
+          },
+          {
+            "href": "/en/career/jobs",
+            "status": "conditional",
+            "validation": "conditional"
+          }
+        ],
+        "internal_links_pass": true,
+        "conditional_links": [
+          "/en/career/jobs"
+        ],
+        "references_required": true,
+        "unresolved_references": [
+          "primary_model_background",
+          "holland_hexagon",
+          "career_information_systems",
+          "comparison_context",
+          "claim_boundary"
+        ],
+        "unknown_preserved": true
+      }
+    ],
+    "no_private_url": true,
+    "no_result_order_share_pay_payment_history_route": true,
+    "no_tokenized_url": true,
+    "no_raw_private_identifier": true,
+    "claim_boundary": "pass",
+    "claim_scan_notes": "Risk phrases are allowed only in explicit negation, limitation, or what-it-should-not-do contexts. General Chinese problem-diagnosis wording is not treated as medical or psychological diagnosis.",
+    "publish_hold_flags": "pass",
+    "references_required": true,
+    "unresolved_reference_fields_marked_needs_source_verification": true
+  },
+  "blockers": [],
+  "sidecar_issues": [
+    "References remain needs_source_verification and block publish until reviewed.",
+    "Career hub links are conditional and must not be activated in CMS body until route eligibility is confirmed.",
+    "Cover image remains __CMS_MEDIA_PLACEHOLDER_REQUIRED__ and needs CMS media replacement before publish."
+  ]
+}

--- a/backend/docs/seo/riasec-explanation-content-package-v2-validation.md
+++ b/backend/docs/seo/riasec-explanation-content-package-v2-validation.md
@@ -1,0 +1,31 @@
+# RIASEC Explanation Content Package V2 Validation
+
+Task: `SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01`
+
+Decision: **GO for reference/source review**
+
+## Scope
+
+This validation checks the archived GPT-5.5 Pro package mechanically. Codex did not rewrite title, H1, metadata, FAQ, CTA, or body copy. No CMS draft was created, no publish was performed, and no search submission was performed.
+
+## Checks
+
+- zh/en package files present: PASS
+- Title, slug, H1, SEO title, SEO description, body markdown: PASS
+- FAQ visible/schema count alignment: PASS
+- CTA route public canonical RIASEC only: PASS
+- Internal links allowed or conditional: PASS
+- Private/result/order/share/pay/payment/history/tokenized URL scan: PASS
+- Claim boundary scan: PASS
+- Unknown baseline values preserved: PASS
+- Draft/publish/search flags: PASS
+
+## Non-Publish Blockers
+
+- References remain `needs_source_verification`; this is acceptable for reference/source review but blocks publish.
+- Career hub links remain conditional until route eligibility is confirmed.
+- Cover image remains a CMS media placeholder and must be replaced before publish.
+
+## Result
+
+GO for SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01.

--- a/backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php
+++ b/backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecArticlePackageV2ValidationTest extends TestCase
+{
+    public function test_riasec_explanation_v2_validation_allows_reference_review_only(): void
+    {
+        $validation = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-content-package-v2.validation.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01', $validation['task_id']);
+        $this->assertSame('GO for reference/source review', $validation['decision']);
+        $this->assertTrue($validation['content_safe']);
+        $this->assertFalse($validation['content_blocked']);
+        $this->assertSame([], $validation['blockers']);
+
+        $this->assertFalse($validation['cms_draft_created']);
+        $this->assertFalse($validation['publish_allowed']);
+        $this->assertFalse($validation['search_submit_allowed']);
+        $this->assertFalse($validation['codex_content_rewrite_performed']);
+
+        $this->assertTrue($validation['checks']['no_private_url']);
+        $this->assertTrue($validation['checks']['no_result_order_share_pay_payment_history_route']);
+        $this->assertTrue($validation['checks']['no_tokenized_url']);
+        $this->assertTrue($validation['checks']['no_raw_private_identifier']);
+        $this->assertSame('pass', $validation['checks']['claim_boundary']);
+        $this->assertSame('pass', $validation['checks']['publish_hold_flags']);
+        $this->assertTrue($validation['checks']['references_required']);
+        $this->assertTrue($validation['checks']['unresolved_reference_fields_marked_needs_source_verification']);
+    }
+
+    public function test_riasec_explanation_v2_locale_validation_keeps_cta_faq_and_unknown_boundaries(): void
+    {
+        $validation = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-content-package-v2.validation.json');
+
+        $localeChecks = collect($validation['checks']['locale_field_checks'])->keyBy('locale');
+
+        $this->assertSame('/zh/tests/holland-career-interest-test-riasec', $localeChecks['zh']['primary_cta_href']);
+        $this->assertSame('/en/tests/holland-career-interest-test-riasec', $localeChecks['en']['primary_cta_href']);
+
+        foreach (['zh', 'en'] as $locale) {
+            $this->assertTrue($localeChecks[$locale]['slug_length_pass']);
+            $this->assertTrue($localeChecks[$locale]['seo_title_length_pass']);
+            $this->assertTrue($localeChecks[$locale]['seo_description_length_pass']);
+            $this->assertTrue($localeChecks[$locale]['body_markdown_exists']);
+            $this->assertSame(6, $localeChecks[$locale]['faq_count']);
+            $this->assertSame(6, $localeChecks[$locale]['visible_faq_count']);
+            $this->assertSame(6, $localeChecks[$locale]['expected_faq_schema_mainEntity_count']);
+            $this->assertSame(6, $localeChecks[$locale]['body_visible_faq_heading_count']);
+            $this->assertTrue($localeChecks[$locale]['faq_count_matches_schema']);
+            $this->assertTrue($localeChecks[$locale]['primary_cta_public_canonical_pass']);
+            $this->assertTrue($localeChecks[$locale]['internal_links_pass']);
+            $this->assertTrue($localeChecks[$locale]['unknown_preserved']);
+        }
+
+        $this->assertSame(['/zh/career/jobs'], $localeChecks['zh']['conditional_links']);
+        $this->assertSame(['/en/career/jobs'], $localeChecks['en']['conditional_links']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:15:30+08:00",
+  "updated_at": "2026-06-05T11:20:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45707,7 +45707,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-package-validation-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "test(seo): validate RIASEC explanation package v2 boundaries",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01"
@@ -45738,8 +45738,8 @@
         "notes": "Focused validation test, JSON/YAML parse, and scoped diff check passed. Codex did not rewrite article content."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "GitHub checks passed on PR #1911: Semgrep, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -45779,6 +45779,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1911."
+      },
+      {
+        "at": "2026-06-05T11:20:00+08:00",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "notes": "All required GitHub checks passed on PR #1911."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:13:30+08:00",
+  "updated_at": "2026-06-05T11:15:30+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45707,7 +45707,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-package-validation-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "title": "test(seo): validate RIASEC explanation package v2 boundaries",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01"
@@ -45760,7 +45760,7 @@
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1911",
     "transitions": [
       {
         "at": "2026-06-05T10:52:00+08:00",
@@ -45773,6 +45773,12 @@
         "from": "planned",
         "to": "local_checks_passed",
         "notes": "Validation artifact and report passed local checks. Decision is GO for reference/source review, with publish blockers retained for references, conditional career hub links, and CMS media placeholder."
+      },
+      {
+        "at": "2026-06-05T11:15:30+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1911."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:06:00+08:00",
+  "updated_at": "2026-06-05T11:13:30+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45611,11 +45611,11 @@
     "repo": "fap-api",
     "base": "main",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:12:58Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "branch": "codex/seo-article-riasec-v2-package-archive-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "docs(seo): archive RIASEC explanation article package v2",
     "depends_on": [],
     "checks": {
@@ -45664,7 +45664,7 @@
       "go_no_go": "GO for package validation; no CMS draft, publish, search submission, deploy, private URL access, or content rewrite performed."
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "89ba8ee1a64d5a7269c55402ceccee4e83198af6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1909",
     "transitions": [
       {
@@ -45690,6 +45690,12 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "notes": "All required GitHub checks passed on PR #1909."
+      },
+      {
+        "at": "2026-06-05T11:13:30+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled in PR2 after GitHub showed PR #1909 merged at 2026-06-05T03:12:58Z with merge commit 89ba8ee1a64d5a7269c55402ceccee4e83198af6; origin/main contains the merge commit; remote task branch is deleted; local task branch is absent."
       }
     ]
   },
@@ -45701,7 +45707,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-package-validation-01",
-    "status": "planned",
+    "status": "local_checks_passed",
     "title": "test(seo): validate RIASEC explanation package v2 boundaries",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01"
@@ -45712,23 +45718,46 @@
         "evidence": "User provided an explicit /goal for the RIASEC explanation V2 SEO article PR train, including PR ids, branches, titles, scopes, allowed paths, and hard gates. Default execution is allowed only through CMS draft preflight."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01 to merge."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01 merged as PR #1909 at 2026-06-05T03:12:58Z; origin/main contains merge commit 89ba8ee1a64d5a7269c55402ceccee4e83198af6."
       },
       "scope_validation": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json, backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php, backend/docs/seo/riasec-explanation-content-package-v2-validation.md, and docs/codex PR-train metadata."
       },
       "local": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecArticlePackageV2ValidationTest --no-ansi",
+          "git diff --check -- backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php backend/docs/seo/riasec-explanation-content-package-v2-validation.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "Focused validation test, JSON/YAML parse, and scoped diff check passed. Codex did not rewrite article content."
       },
       "github": {
         "status": "pending",
         "evidence": null
       }
     },
-    "result": {},
+    "result": {
+      "validation_path": "backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json",
+      "report_path": "backend/docs/seo/riasec-explanation-content-package-v2-validation.md",
+      "decision": "GO for reference/source review",
+      "content_safe": true,
+      "content_blocked": false,
+      "blockers": [],
+      "sidecar_issues": [
+        "References remain needs_source_verification and block publish until reviewed.",
+        "Career hub links are conditional and must not be activated in CMS body until route eligibility is confirmed.",
+        "Cover image remains __CMS_MEDIA_PLACEHOLDER_REQUIRED__ and needs CMS media replacement before publish."
+      ],
+      "cms_draft_created": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -45738,6 +45767,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01 /goal. No CMS mutation, publish, search submission, deploy, private URL access, or content rewrite authorized."
+      },
+      {
+        "at": "2026-06-05T11:13:30+08:00",
+        "from": "planned",
+        "to": "local_checks_passed",
+        "notes": "Validation artifact and report passed local checks. Decision is GO for reference/source review, with publish blockers retained for references, conditional career hub links, and CMS media placeholder."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21896,7 +21896,7 @@ prs:
     branch: codex/seo-article-riasec-v2-package-archive-01
     title: "docs(seo): archive RIASEC explanation article package v2"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: in_progress
+    status: merged
     scope:
       - Archive the uploaded GPT-5.5 Pro RIASEC explanation V2 content package as draft-only CMS input.
       - Preserve package files exactly without creating CMS drafts, publishing, search submission, deploy, or article copy edits.
@@ -21942,7 +21942,7 @@ prs:
     branch: codex/seo-article-riasec-v2-package-validation-01
     title: "test(seo): validate RIASEC explanation package v2 boundaries"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: planned
+    status: in_progress
     scope:
       - Validate the archived package against request-card, CTA route, FAQ/schema, publish-hold, claim-boundary, and privacy route restrictions.
       - Produce generated validation evidence and a short validation report.


### PR DESCRIPTION
## What changed
- Added a generated validation artifact for the archived RIASEC explanation V2 package.
- Added a short validation report with GO for reference/source review and retained non-publish blockers.
- Added focused validation coverage for CTA, FAQ/schema counts, Unknown placeholders, draft/publish/search flags, and private-route boundaries.
- Reconciled PR1 package archive as merged in the PR train ledger.

## Why
This gates the GPT-5.5 Pro package before source review and CMS import-package preparation without rewriting article content or creating CMS records.

## Validation
- php -l backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php
- python3 -m json.tool backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecArticlePackageV2ValidationTest --no-ansi
- git diff --check -- backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json backend/tests/Feature/SEO/RiasecArticlePackageV2ValidationTest.php backend/docs/seo/riasec-explanation-content-package-v2-validation.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS draft creation.
- No publish.
- No search submission.
- No deploy.
- No article body/title/H1/meta/FAQ/CTA rewrite by Codex.
- References remain needs_source_verification and block publish.
- Conditional career hub links must not be activated in CMS body until route eligibility is confirmed.

## Repository rule impact
Content authority remains CMS/backend. This PR validates a non-publishable package and does not introduce frontend editorial fallback, runtime API changes, CMS mutation, or public SEO enumeration changes.