### PR TITLE
feat(benefit): gate DailyGiving proof storage fields

### DIFF
--- a/backend/app/Models/DailyGivingRecord.php
+++ b/backend/app/Models/DailyGivingRecord.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
@@ -110,6 +111,17 @@ class DailyGivingRecord extends Model
         ];
     }
 
+    protected static function booted(): void
+    {
+        self::saving(function (self $record): void {
+            $violations = $record->proofStorageGateViolations();
+
+            if ($violations !== []) {
+                throw new InvalidArgumentException('DailyGiving proof storage gate failed: '.implode('; ', $violations));
+            }
+        });
+    }
+
     public function scopePublishedPublic(Builder $query): Builder
     {
         return $query
@@ -197,5 +209,80 @@ class DailyGivingRecord extends Model
             'public_notes' => $this->public_notes,
             'published_at' => $this->published_at?->toDateTimeString(),
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function proofStorageGateViolations(): array
+    {
+        $violations = [];
+        $privatePath = trim((string) ($this->proof_private_path ?? ''));
+        $publicUrl = trim((string) ($this->proof_public_url ?? ''));
+        $proofStatus = trim((string) ($this->proof_status ?? ''));
+
+        if ($privatePath !== '' && ! $this->looksLikePrivateProofPath($privatePath)) {
+            $violations[] = 'proof_private_path must point to a private disk/bucket path, not a public URL/path';
+        }
+
+        if ($publicUrl !== '' && ! $this->looksLikeReviewedPublicProofUrl($publicUrl)) {
+            $violations[] = 'proof_public_url must point to reviewed redacted public proof only';
+        }
+
+        if ($privatePath !== '' && $publicUrl !== '' && hash_equals($privatePath, $publicUrl)) {
+            $violations[] = 'proof_public_url must not equal proof_private_path';
+        }
+
+        if ($publicUrl !== '' && $proofStatus !== self::PROOF_REDACTED_AVAILABLE) {
+            $violations[] = 'proof_public_url requires proof_status=redacted_available';
+        }
+
+        if ($proofStatus === self::PROOF_WITHHELD && trim((string) ($this->proof_redaction_notes ?? '')) === '') {
+            $violations[] = 'withheld proof requires admin-only proof_redaction_notes reviewer reason';
+        }
+
+        return $violations;
+    }
+
+    private function looksLikePrivateProofPath(string $path): bool
+    {
+        $normalized = strtolower(trim($path));
+
+        if ($normalized === '') {
+            return false;
+        }
+
+        foreach (['http://', 'https://', '/storage/', 'storage/app/public/', 'public/', 'media/'] as $publicPrefix) {
+            if (str_starts_with($normalized, $publicPrefix)) {
+                return false;
+            }
+        }
+
+        foreach (['private://', 'private/', 'daily-giving/private/', 'foundation/private/', 'proofs/private/', 's3://private/', 'r2://private/'] as $privatePrefix) {
+            if (str_starts_with($normalized, $privatePrefix)) {
+                return true;
+            }
+        }
+
+        return str_contains($normalized, '/private/');
+    }
+
+    private function looksLikeReviewedPublicProofUrl(string $url): bool
+    {
+        $normalized = strtolower(trim($url));
+
+        if (! str_starts_with($normalized, 'https://')) {
+            return false;
+        }
+
+        foreach (['/private/', 'proof_private_path', 'receipt_reference_private', 'internal_notes', 'auth_token', 'session_id', 'raw-receipt', 'raw_receipt'] as $forbidden) {
+            if (str_contains($normalized, $forbidden)) {
+                return false;
+            }
+        }
+
+        return str_contains($normalized, 'redacted')
+            || str_contains($normalized, '/public/')
+            || str_contains($normalized, '/media/');
     }
 }

--- a/backend/docs/operations/daily-giving-proof-storage-gate.md
+++ b/backend/docs/operations/daily-giving-proof-storage-gate.md
@@ -1,0 +1,35 @@
+# DailyGiving Proof Storage Gate
+
+Date: 2026-06-05
+
+PR train item: `DAILY-GIVING-PROOF-STORAGE-GATE-01`
+
+Mode: scoped backend contract and tests. This PR does not create records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, or deploy.
+
+## Decision
+
+DailyGiving records now have a model-level proof storage gate. Any save path must reject obvious raw-proof/public-proof boundary violations before a record can be persisted.
+
+## Enforced Rules
+
+- `proof_private_path` must look like a private disk or private bucket path.
+- `proof_private_path` must not be a public URL or public media path.
+- `proof_public_url` must be an HTTPS reviewed public proof URL.
+- `proof_public_url` must not contain private/admin/raw receipt indicators.
+- `proof_public_url` must not equal `proof_private_path`.
+- `proof_public_url` requires `proof_status=redacted_available`.
+- `proof_status=withheld` requires admin-only `proof_redaction_notes`.
+
+## Public Projection Boundary
+
+The public array must not expose:
+
+- `proof_private_path`
+- `proof_redaction_notes`
+- `receipt_reference_private`
+- `internal_notes`
+- admin user ids
+
+## Still Deferred
+
+This gate does not upload or inspect real proof files. Storage-level private disk/bucket confirmation remains a deployment/configuration prerequisite for the later first-record authorization step.

--- a/backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json
+++ b/backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json
@@ -1,0 +1,30 @@
+{
+  "version": "daily_giving_proof_storage_gate.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "backend_contract",
+  "record_created": false,
+  "proof_uploaded": false,
+  "proof_processed": false,
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "enforced_rules": [
+    "proof_private_path_requires_private_disk_or_bucket_shape",
+    "proof_private_path_rejects_public_url_or_public_media_path",
+    "proof_public_url_requires_https_reviewed_public_proof_shape",
+    "proof_public_url_rejects_private_or_raw_receipt_indicators",
+    "proof_public_url_must_not_equal_proof_private_path",
+    "proof_public_url_requires_redacted_available_status",
+    "withheld_proof_requires_admin_redaction_notes_reason"
+  ],
+  "public_projection_forbidden_fields": [
+    "proof_private_path",
+    "proof_redaction_notes",
+    "receipt_reference_private",
+    "internal_notes",
+    "created_by_admin_user_id",
+    "updated_by_admin_user_id"
+  ],
+  "storage_private_confirmed": false,
+  "storage_private_confirmation_deferred": true,
+  "trust_badge_allowed": false
+}

--- a/backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
@@ -1,0 +1,73 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use App\Models\DailyGivingRecord;
+use Tests\TestCase;
+
+final class DailyGivingProofStorageGateTest extends TestCase
+{
+    public function test_storage_gate_accepts_private_raw_proof_and_reviewed_redacted_public_proof(): void
+    {
+        $record = new DailyGivingRecord([
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+        ]);
+
+        $this->assertSame([], $record->proofStorageGateViolations());
+    }
+
+    public function test_storage_gate_rejects_public_raw_proof_paths_and_private_public_urls(): void
+    {
+        $record = new DailyGivingRecord([
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_private_path' => 'https://media.fermatmind.com/raw-receipt.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/private/raw-receipt.pdf',
+        ]);
+
+        $violations = $record->proofStorageGateViolations();
+
+        $this->assertContains('proof_private_path must point to a private disk/bucket path, not a public URL/path', $violations);
+        $this->assertContains('proof_public_url must point to reviewed redacted public proof only', $violations);
+    }
+
+    public function test_public_url_requires_redacted_available_and_withheld_requires_reason(): void
+    {
+        $recordWithPublicUrl = new DailyGivingRecord([
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_PENDING,
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+        ]);
+
+        $this->assertContains('proof_public_url requires proof_status=redacted_available', $recordWithPublicUrl->proofStorageGateViolations());
+
+        $withheld = new DailyGivingRecord([
+            'proof_status' => DailyGivingRecord::PROOF_WITHHELD,
+        ]);
+
+        $this->assertContains('withheld proof requires admin-only proof_redaction_notes reviewer reason', $withheld->proofStorageGateViolations());
+    }
+
+    public function test_public_projection_never_returns_private_proof_fields(): void
+    {
+        $record = new DailyGivingRecord([
+            'record_code' => 'FM-GIVING-2026-06-001',
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+            'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
+            'proof_redaction_notes' => 'Private reviewer note.',
+            'receipt_reference_private' => 'private-receipt-id',
+            'internal_notes' => 'Private internal note.',
+            'created_by_admin_user_id' => 1,
+            'updated_by_admin_user_id' => 1,
+        ]);
+
+        $public = $record->toPublicArray();
+
+        foreach (['proof_private_path', 'proof_redaction_notes', 'receipt_reference_private', 'internal_notes', 'created_by_admin_user_id', 'updated_by_admin_user_id'] as $field) {
+            $this->assertArrayNotHasKey($field, $public);
+        }
+    }
+}

--- a/backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
@@ -125,7 +125,7 @@ class DailyGivingRecordPublicApiTest extends TestCase
     public function test_show_exposes_allowed_public_fields(): void
     {
         $record = DailyGivingRecord::factory()->completed()->create([
-            'proof_public_url' => 'https://example.com/proof',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
             'receipt_reference_redacted' => 'REF-REDACTED',
             'social_x_url' => 'https://x.com/fermatmind/status/123',
             'social_linkedin_url' => 'https://linkedin.com/feed/update/456',

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:20:00+08:00",
+  "updated_at": "2026-06-05T03:21:09Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45616,7 +45616,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-proof-storage-gate-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "feat(benefit): gate DailyGiving proof storage fields",
     "depends_on": [
@@ -45652,7 +45652,7 @@
       },
       "github": {
         "status": "pending",
-        "commands": []
+        "evidence": "PR #1912 opened; GitHub checks pending."
       }
     },
     "result": {
@@ -45667,8 +45667,8 @@
       "existing_public_api_fixture_aligned": true
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "956ac7faa821598cca19efff05e5edc05b30a9e0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1912",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45707,6 +45707,12 @@
         "from": "local_checks_passed",
         "to": "local_checks_passed",
         "notes": "Broader DailyGivingRecord test filter passed after aligning the existing public API proof_public_url fixture with the redacted public media gate."
+      },
+      {
+        "at": "2026-06-05T03:21:09Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened PR #1912 for DailyGiving proof storage gate. No production writes or record/proof mutations performed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35103,7 +35103,7 @@
     "branch": "codex/detail-ready-1046-rollout-apply-preflight-01",
     "base": "main",
     "title": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 production preflight for clean 1046 rollout apply",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [],
     "commit_sha": "67e95aac7a4344a407c5c1b563c4131a27d2d7aa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1748",
@@ -45551,11 +45551,11 @@
       "next_pr_supported": "DAILY-GIVING-PROOF-STORAGE-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "7c20a2e5d952b9c34139e2f9a294830a71be41b2",
+    "commit_sha": "4a75168e5e14aa7d5717752beeb5ea6f700ab10d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1910",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:08:32Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -45604,6 +45604,109 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1910."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "PR #1910 squash-merged at 4a75168e5e14aa7d5717752beeb5ea6f700ab10d; remote branch absent; local branch deleted after detached origin/main sync."
+      }
+    ]
+  },
+  "DAILY-GIVING-PROOF-STORAGE-GATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-proof-storage-gate-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "feat(benefit): gate DailyGiving proof storage fields",
+    "depends_on": [
+      "DAILY-GIVING-PROOF-REDACTION-SOP-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User requested DailyGiving proof storage gate and forbade record/proof mutations, deployment, and publish actions."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "DAILY-GIVING-PROOF-REDACTION-SOP-01 merged as PR #1910 at 4a75168e5e14aa7d5717752beeb5ea6f700ab10d."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to DailyGivingRecord model storage gate, proof storage docs/generated artifact, new storage gate test, existing DailyGivingRecordPublicApiTest fixture alignment, and docs/codex ledger paths. No record/proof/CMS/publish/deploy/search mutation was performed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Models/DailyGivingRecord.php",
+          "php -l backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php",
+          "php -l backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php",
+          "python3 -m json.tool backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingProofStorageGateTest --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRecord --no-ansi",
+          "git diff --check -- backend/app/Models/DailyGivingRecord.php backend/docs/operations/daily-giving-proof-storage-gate.md backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "All commands exited 0. PHPUnit reported warnings from the temporary checkout missing backend/.env; DailyGivingProofStorageGateTest passed 11 assertions and the broader DailyGivingRecord filter passed 110 assertions."
+      },
+      "github": {
+        "status": "pending",
+        "commands": []
+      }
+    },
+    "result": {
+      "storage_gate_added": true,
+      "public_projection_private_fields_blocked": true,
+      "record_created": false,
+      "proof_uploaded": false,
+      "proof_processed": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "next_pr_supported": "DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01",
+      "existing_public_api_fixture_aligned": true
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Scope remained within PR8 model/docs/generated/test/ledger paths after adding existing public API fixture alignment for the new proof_public_url gate."
+    },
+    "sidecars": [
+      {
+        "id": "STORAGE_LEVEL_PRIVATE_DISK",
+        "status": "deferred",
+        "note": "The model gate rejects unsafe field shapes; deployment/configuration proof of private disk/bucket remains deferred."
+      }
+    ],
+    "next_task": "DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Initialized after PR7 merge for DailyGiving proof storage gate."
+      },
+      {
+        "at": "2026-06-05T03:17:36Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Local syntax, JSON/YAML, scoped diff, and focused PHPUnit checks passed. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T03:20:00Z",
+        "from": "local_checks_passed",
+        "to": "local_checks_passed",
+        "notes": "Broader DailyGivingRecord test filter passed after aligning the existing public API proof_public_url fixture with the redacted public media gate."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T03:21:09Z",
+  "updated_at": "2026-06-05T03:26:07Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45616,7 +45616,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-proof-storage-gate-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "feat(benefit): gate DailyGiving proof storage fields",
     "depends_on": [
@@ -45651,8 +45651,8 @@
         "notes": "All commands exited 0. PHPUnit reported warnings from the temporary checkout missing backend/.env; DailyGivingProofStorageGateTest passed 11 assertions and the broader DailyGivingRecord filter passed 110 assertions."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #1912 opened; GitHub checks pending."
+        "status": "pass",
+        "evidence": "PR #1912 checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -45667,7 +45667,7 @@
       "existing_public_api_fixture_aligned": true
     },
     "failure_reason": null,
-    "commit_sha": "956ac7faa821598cca19efff05e5edc05b30a9e0",
+    "commit_sha": "f01bdfafeadf4567fa4c283904f2323181bd9a25",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1912",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -45713,6 +45713,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened PR #1912 for DailyGiving proof storage gate. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T03:26:07Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed for PR #1912; ready for squash merge. No production writes or record/proof mutations performed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21891,6 +21891,54 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: DAILY-GIVING-PROOF-STORAGE-GATE-01
+
+  - id: DAILY-GIVING-PROOF-STORAGE-GATE-01
+    repo: fap-api
+    depends_on:
+      - DAILY-GIVING-PROOF-REDACTION-SOP-01
+    branch: codex/daily-giving-proof-storage-gate-01
+    title: "feat(benefit): gate DailyGiving proof storage fields"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Add a model-level storage gate for DailyGiving proof private/public field boundaries.
+      - Verify public projection never returns private proof/admin fields.
+      - Add generated storage-gate artifact and focused tests.
+    allowed_paths:
+      - backend/app/Models/DailyGivingRecord.php
+      - backend/docs/operations/daily-giving-proof-storage-gate.md
+      - backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json
+      - backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
+      - backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, deploy, or read secrets.
+    validation:
+      - php -l backend/app/Models/DailyGivingRecord.php
+      - php -l backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
+      - python3 -m json.tool backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingProofStorageGateTest --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRecord --no-ansi
+      - git diff --check -- backend/app/Models/DailyGivingRecord.php backend/docs/operations/daily-giving-proof-storage-gate.md backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01
+
   - id: SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01
     repo: fap-api
     branch: codex/seo-article-riasec-v2-package-archive-01


### PR DESCRIPTION
## What changed
- Added a DailyGivingRecord model-level proof storage gate for private raw proof paths and redacted public proof URLs.
- Added a generated storage-gate artifact and focused regression coverage.
- Aligned an existing public API fixture with the new redacted public proof URL gate.

## Why
- DailyGiving public release needs a backend guard before any real record/proof workflow can be considered.
- Raw proof must remain private and public API projection must never expose private proof/admin fields.

## Validation
- php -l backend/app/Models/DailyGivingRecord.php
- php -l backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
- php -l backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
- python3 -m json.tool backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingProofStorageGateTest --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRecord --no-ansi
- git diff --check -- backend/app/Models/DailyGivingRecord.php backend/docs/operations/daily-giving-proof-storage-gate.md backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

Note: PHPUnit emitted warnings because the temp worktree has no backend/.env; commands exited 0 and assertions passed.

## Intentionally deferred
- No DailyGiving record creation.
- No proof upload or proof processing.
- No CMS mutation, publish, indexing, trust badge, search submission, or deploy.
- Storage-level private disk/bucket proof remains a follow-up gate.