### PR TITLE
docs(seo): verify reference needs for RIASEC explanation package

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json
@@ -1,0 +1,111 @@
+{
+  "task_id": "SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01",
+  "source_package": "backend/docs/seo/article-packages/riasec-explanation-v2/riasec-explanation-v2.cms-import.json",
+  "generated_at": "2026-06-05",
+  "content_rewrite_performed": false,
+  "cms_draft_created": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "decision": "GO for CMS import package preparation; NO-GO for publish until operator/editor source review accepts or resolves listed sources.",
+  "source_verification_status": "partially_verified_public_sources_with_publish_blockers",
+  "sources": [
+    {
+      "category": "primary_model_background",
+      "status": "verified_public_source",
+      "title": "O*NET Interest Profiler Manual",
+      "url": "https://www.onetcenter.org/reports/IP_Manual.html",
+      "publisher": "National Center for O*NET Development / O*NET Resource Center",
+      "observed_support": [
+        "The O*NET Interest Profiler is described as a vocational interest inventory for educational planning, career exploration, and career guidance.",
+        "The manual states Holland’s RIASEC theoretical model is the basis of the Interest Profiler scales."
+      ],
+      "supports_article_claims": [
+        "RIASEC/Holland Code as vocational interest model background",
+        "Use as career exploration and guidance support, not deterministic career decision authority"
+      ],
+      "publish_notes": "Use as a background/reference source after editor verifies citation style. This does not imply FermatMind is affiliated with or endorsed by O*NET, DOL, Holland, or any official body."
+    },
+    {
+      "category": "six_interest_areas",
+      "status": "verified_public_source",
+      "title": "Browse by Career Interest Types",
+      "url": "https://www.onetonline.org/find/descriptor/browse/1.B.1/",
+      "publisher": "O*NET OnLine",
+      "observed_support": [
+        "O*NET describes career interest types as broad types of work users enjoy.",
+        "The page lists Realistic, Investigative, Artistic, Social, Enterprising, and Conventional interest types with work-activity descriptions."
+      ],
+      "supports_article_claims": [
+        "Six RIASEC areas exist and can be described through work activities/environments",
+        "Career interest framing for public user education"
+      ],
+      "publish_notes": "Suitable source category for six-area descriptions. Final article should not copy source wording."
+    },
+    {
+      "category": "career_information_system_context",
+      "status": "verified_public_source",
+      "title": "O*NET Services Reference Manual: O*NET Interest Profiler endpoints",
+      "url": "https://services.onetcenter.org/reference/mpp/ip/",
+      "publisher": "O*NET Web Services",
+      "observed_support": [
+        "The public services reference enumerates Interest Profiler results, matching careers, RIASEC interests, and careers related to interests as separate service surfaces."
+      ],
+      "supports_article_claims": [
+        "RIASEC interest results can be used as structured inputs for career exploration systems",
+        "Career matching/exploration should remain a system-assisted exploration path, not a promise of outcome"
+      ],
+      "publish_notes": "Use only to support system/context framing. Do not imply FermatMind uses O*NET APIs or data unless separately verified."
+    },
+    {
+      "category": "interests_vs_work_styles_context",
+      "status": "verified_public_source",
+      "title": "The O*NET Content Model",
+      "url": "https://www.onetcenter.org/content.html",
+      "publisher": "O*NET Resource Center",
+      "observed_support": [
+        "The O*NET Content Model separates Career Interests, Abilities, and Work Styles under Worker Characteristics.",
+        "The model frames Career Interests as broad work users enjoy and Work Styles as personality tendencies exhibited at work."
+      ],
+      "supports_article_claims": [
+        "Vocational interests are a different content category from work-style/personality-tendency signals",
+        "Comparison context between RIASEC and broader personality/work-style models can be framed conservatively"
+      ],
+      "publish_notes": "This supports a category distinction, not claims about MBTI or Big Five validity. MBTI/Big Five comparison wording still needs internal editorial review."
+    },
+    {
+      "category": "claim_boundary",
+      "status": "operator_review_required",
+      "title": "Claim-boundary acceptance for non-deterministic career language",
+      "url": "Unknown",
+      "publisher": "Unknown",
+      "observed_support": [
+        "The package already uses non-deterministic language and validation passed claim-boundary scan.",
+        "A source or editorial policy should still explicitly approve career exploration vs career guarantee language before publish."
+      ],
+      "supports_article_claims": [
+        "No career guarantee",
+        "No diagnosis",
+        "No official certification implication",
+        "No deterministic matching claim"
+      ],
+      "publish_notes": "Publish blocker until editor/psychometrics reviewer accepts source set and claim boundary."
+    }
+  ],
+  "unresolved_source_gaps": [
+    "Exact references for Holland hexagon concepts consistency, differentiation, and congruence need editor/psychometrics source acceptance before publish.",
+    "Comparison statements involving MBTI and Big Five should remain conservative and need internal editorial review before publish.",
+    "Report-preview language must be verified against actual FermatMind product module availability before publish.",
+    "No DOI, edition details, or exact publication facts were invented by Codex."
+  ],
+  "publish_blockers": [
+    "operator_source_review_not_complete",
+    "psychometrics_review_not_complete",
+    "holland_hexagon_source_acceptance_needed",
+    "mbti_big_five_comparison_review_needed",
+    "report_preview_product_availability_unknown",
+    "cover_image_cms_media_placeholder_unresolved"
+  ],
+  "go_for_next_pr": "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01",
+  "no_private_url_accessed": true,
+  "sources_public_only": true
+}

--- a/backend/docs/seo/riasec-explanation-reference-source-review.md
+++ b/backend/docs/seo/riasec-explanation-reference-source-review.md
@@ -1,0 +1,48 @@
+# RIASEC Explanation Reference Source Review
+
+Task: `SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01`
+
+Decision: **GO for CMS import package preparation; NO-GO for publish until source review is accepted.**
+
+## Scope
+
+This is a source-needs and public-source verification ledger for the archived GPT-5.5 Pro RIASEC explanation package. Codex did not rewrite article copy, create CMS drafts, publish, submit search URLs, deploy, or access private URLs.
+
+## Verified Public Sources
+
+1. O*NET Interest Profiler Manual - https://www.onetcenter.org/reports/IP_Manual.html
+   - Supports RIASEC/Holland model background and career-exploration/guidance framing.
+   - Does not create official endorsement or affiliation for FermatMind.
+
+2. O*NET OnLine Browse by Career Interest Types - https://www.onetonline.org/find/descriptor/browse/1.B.1/
+   - Supports the six public career-interest areas: Realistic, Investigative, Artistic, Social, Enterprising, Conventional.
+   - Final article must not copy source wording.
+
+3. O*NET Services Interest Profiler reference - https://services.onetcenter.org/reference/mpp/ip/
+   - Supports the existence of structured Interest Profiler result, matching-career, and RIASEC-interest service surfaces.
+   - Does not prove FermatMind uses O*NET services or data.
+
+4. O*NET Content Model - https://www.onetcenter.org/content.html
+   - Supports category separation between Career Interests and Work Styles/personality-like work tendencies.
+   - Does not independently validate MBTI or Big Five comparison language.
+
+## Unresolved Source Gaps
+
+- Holland hexagon terms: consistency, differentiation, and congruence need accepted source treatment before publish.
+- MBTI and Big Five comparison statements need internal editorial/psychometrics review before publish.
+- Report-preview language needs product-availability confirmation before publish.
+- Cover image remains a CMS media placeholder.
+- No DOI, edition detail, or exact publication fact was invented by Codex.
+
+## Publish Blockers
+
+- operator_source_review_not_complete
+- psychometrics_review_not_complete
+- holland_hexagon_source_acceptance_needed
+- mbti_big_five_comparison_review_needed
+- report_preview_product_availability_unknown
+- cover_image_cms_media_placeholder_unresolved
+
+## Result
+
+GO for `SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01`. Publish remains blocked.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:29:00+08:00",
+  "updated_at": "2026-06-05T11:35:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45917,7 +45917,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-reference-source-review-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "docs(seo): verify reference needs for RIASEC explanation package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01"
@@ -45946,8 +45946,8 @@
         "notes": "Public source review ledger, JSON/YAML parse, and scoped diff check passed. Codex did not rewrite article copy."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "GitHub checks passed on PR #1913: Semgrep, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -45988,6 +45988,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1913."
+      },
+      {
+        "at": "2026-06-05T11:35:00+08:00",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "notes": "All required GitHub checks passed on PR #1913."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:26:00+08:00",
+  "updated_at": "2026-06-05T11:29:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45917,7 +45917,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-reference-source-review-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "title": "docs(seo): verify reference needs for RIASEC explanation package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01"
@@ -45969,7 +45969,7 @@
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1913",
     "transitions": [
       {
         "at": "2026-06-05T10:52:00+08:00",
@@ -45982,6 +45982,12 @@
         "from": "planned",
         "to": "local_checks_passed",
         "notes": "Source review ledger recorded public O*NET sources and publish blockers. GO for CMS import package preparation only."
+      },
+      {
+        "at": "2026-06-05T11:29:00+08:00",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1913."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T03:26:07Z",
+  "updated_at": "2026-06-05T11:26:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -45818,11 +45818,11 @@
     "repo": "fap-api",
     "base": "main",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:25:13Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "branch": "codex/seo-article-riasec-v2-package-validation-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "test(seo): validate RIASEC explanation package v2 boundaries",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01"
@@ -45874,7 +45874,7 @@
       "search_submit_allowed": false
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "0d27ca62fde9a389eec97c95d9ba97b20dfc6546",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1911",
     "transitions": [
       {
@@ -45900,6 +45900,12 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "notes": "All required GitHub checks passed on PR #1911."
+      },
+      {
+        "at": "2026-06-05T11:26:00+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled in PR3 after GitHub showed PR #1911 merged at 2026-06-05T03:25:13Z with merge commit 0d27ca62fde9a389eec97c95d9ba97b20dfc6546; origin/main contains the merge commit; remote task branch is deleted; local task branch is absent."
       }
     ]
   },
@@ -45911,7 +45917,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-reference-source-review-01",
-    "status": "planned",
+    "status": "local_checks_passed",
     "title": "docs(seo): verify reference needs for RIASEC explanation package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01"
@@ -45922,23 +45928,45 @@
         "evidence": "User provided an explicit /goal for the RIASEC explanation V2 SEO article PR train, including PR ids, branches, titles, scopes, allowed paths, and hard gates. Default execution is allowed only through CMS draft preflight."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01 to merge."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01 merged as PR #1911 at 2026-06-05T03:25:13Z; origin/main contains merge commit 0d27ca62fde9a389eec97c95d9ba97b20dfc6546."
       },
       "scope_validation": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/seo/riasec-explanation-reference-source-review.md, backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json, and docs/codex PR-train metadata."
       },
       "local": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/seo/riasec-explanation-reference-source-review.md backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "Public source review ledger, JSON/YAML parse, and scoped diff check passed. Codex did not rewrite article copy."
       },
       "github": {
         "status": "pending",
         "evidence": null
       }
     },
-    "result": {},
+    "result": {
+      "review_path": "backend/docs/seo/riasec-explanation-reference-source-review.md",
+      "generated_review_path": "backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json",
+      "source_verification_status": "partially_verified_public_sources_with_publish_blockers",
+      "decision": "GO for CMS import package preparation; NO-GO for publish until source review is accepted.",
+      "publish_blockers": [
+        "operator_source_review_not_complete",
+        "psychometrics_review_not_complete",
+        "holland_hexagon_source_acceptance_needed",
+        "mbti_big_five_comparison_review_needed",
+        "report_preview_product_availability_unknown",
+        "cover_image_cms_media_placeholder_unresolved"
+      ],
+      "cms_draft_created": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -45948,6 +45976,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01 /goal. No CMS mutation, publish, search submission, deploy, private URL access, or content rewrite authorized."
+      },
+      {
+        "at": "2026-06-05T11:26:00+08:00",
+        "from": "planned",
+        "to": "local_checks_passed",
+        "notes": "Source review ledger recorded public O*NET sources and publish blockers. GO for CMS import package preparation only."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21990,7 +21990,7 @@ prs:
     branch: codex/seo-article-riasec-v2-package-validation-01
     title: "test(seo): validate RIASEC explanation package v2 boundaries"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: in_progress
+    status: merged
     scope:
       - Validate the archived package against request-card, CTA route, FAQ/schema, publish-hold, claim-boundary, and privacy route restrictions.
       - Produce generated validation evidence and a short validation report.
@@ -22030,7 +22030,7 @@ prs:
     branch: codex/seo-article-riasec-v2-reference-source-review-01
     title: "docs(seo): verify reference needs for RIASEC explanation package"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: planned
+    status: in_progress
     scope:
       - Prepare a reference/source verification ledger for the RIASEC explanation package without fabricating citations or editing article copy.
       - Record authoritative source categories, verified URLs when available, unresolved source gaps, and publish blockers.


### PR DESCRIPTION
## What changed
- Added a reference/source review ledger for the RIASEC explanation V2 package.
- Recorded public O*NET sources for RIASEC background, six interest areas, career-system context, and interests vs work-styles category separation.
- Preserved publish blockers for source acceptance, psychometrics review, Holland hexagon terms, MBTI/Big Five comparison review, report-preview product availability, and CMS media placeholder.
- Reconciled PR2 package validation as merged in the PR train ledger.

## Why
This prepares source evidence for CMS import-package planning without fabricating citations or rewriting GPT article copy.

## Validation
- python3 -m json.tool backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/seo/riasec-explanation-reference-source-review.md backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS draft creation.
- No publish.
- No search submission.
- No deploy.
- No article body/title/H1/meta/FAQ/CTA rewrite by Codex.
- Final source acceptance and psychometrics review remain publish blockers.

## Repository rule impact
Content authority remains CMS/backend. This PR adds source-review documentation only and does not introduce frontend editorial fallback, runtime API changes, CMS mutation, or public SEO enumeration changes.