### PR TITLE
docs(benefit): define DailyGiving public release prerequisites

### DIFF
--- a/backend/docs/operations/daily-giving-public-release-prereq.md
+++ b/backend/docs/operations/daily-giving-public-release-prereq.md
@@ -1,0 +1,32 @@
+# DailyGiving Public Release Prerequisites
+
+Date: 2026-06-05
+
+PR train item: `DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01`
+
+Mode: prerequisite contract only. This PR does not create records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, run social distribution, or deploy.
+
+## Decision
+
+DailyGiving is not ready for public trust amplification until the public release prerequisites are met and verified by smoke checks. The page must remain `noindex`, and DailyGiving must stay out of sitemap and llms surfaces while first real records are created and reviewed.
+
+## Required Release Gates
+
+- Public records API returns at least one public record.
+- Public months API returns at least one month.
+- At least one public record is completed or verified.
+- At least one public record is verified before any trust badge or high-amplification claim is considered.
+- Public records remain `is_indexable=false` during first-record review.
+- Each public record has a reviewed proof state: redacted public proof URL, or withheld proof with admin-only reviewer reason.
+- Public API never returns raw proof paths, private receipt references, redaction notes, internal notes, or admin user ids.
+- DailyGiving pages remain `noindex`.
+- DailyGiving routes remain absent from sitemap, `llms.txt`, and `llms-full.txt`.
+- Claim lint remains clean for official-partner, endorsement, certification, guaranteed-impact, and unsupported stable-operation claims.
+
+## Trust Boundary
+
+The release gate allows only controlled public record visibility after review. It does not allow a DailyGiving trust badge, public amplification, paid-page trust claim, search submission, social distribution, or official endorsement implication.
+
+## Deferred Until First Record Authorization
+
+The first real record requires a separate private-ledger authorization. Raw receipt storage, redacted proof creation, record review, and public record activation are intentionally outside this PR.

--- a/backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json
+++ b/backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json
@@ -1,0 +1,56 @@
+{
+  "version": "daily_giving_public_release_prereq.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "prerequisite_contract",
+  "record_created": false,
+  "proof_uploaded": false,
+  "proof_processed": false,
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "required_public_api_gates": {
+    "records_api_min_count": 1,
+    "months_api_min_count": 1,
+    "completed_or_verified_public_records_min_count": 1,
+    "verified_public_records_min_count_for_trust_badge_consideration": 1,
+    "forbidden_public_fields": [
+      "proof_private_path",
+      "proof_redaction_notes",
+      "receipt_reference_private",
+      "internal_notes",
+      "created_by_admin_user_id",
+      "updated_by_admin_user_id"
+    ]
+  },
+  "required_record_gates": {
+    "is_public": true,
+    "is_indexable": false,
+    "donation_status_allowed": [
+      "completed",
+      "verified"
+    ],
+    "proof_status_allowed": [
+      "redacted_available",
+      "withheld"
+    ],
+    "withheld_requires_admin_redaction_notes": true,
+    "redacted_public_proof_requires_proof_public_url": true
+  },
+  "required_indexability_gates": {
+    "daily_giving_page_noindex": true,
+    "daily_giving_sitemap_inclusion_allowed": false,
+    "daily_giving_llms_inclusion_allowed": false
+  },
+  "required_claim_lint_forbidden_claims": [
+    "UN official partner",
+    "联合国官方合作",
+    "official certification",
+    "official endorsement",
+    "guaranteed impact",
+    "stable daily giving operation without public records"
+  ],
+  "trust_badge_allowed_now": false,
+  "public_amplification_allowed_now": false,
+  "next_authorization_required": "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01"
+}

--- a/backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use Tests\TestCase;
+
+final class DailyGivingPublicReleasePrereqTest extends TestCase
+{
+    public function test_release_prereq_artifact_keeps_execution_non_mutating(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'record_created',
+            'proof_uploaded',
+            'proof_processed',
+            'cms_mutation_performed',
+            'publish_performed',
+            'search_submission_performed',
+            'deploy_performed',
+            'trust_badge_allowed_now',
+            'public_amplification_allowed_now',
+        ] as $field) {
+            $this->assertFalse($artifact[$field], $field);
+        }
+
+        $this->assertSame('DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01', $artifact['next_authorization_required']);
+    }
+
+    public function test_public_release_requires_records_months_and_safe_public_projection(): void
+    {
+        $artifact = $this->artifact();
+        $api = $artifact['required_public_api_gates'];
+
+        $this->assertSame(1, $api['records_api_min_count']);
+        $this->assertSame(1, $api['months_api_min_count']);
+        $this->assertSame(1, $api['completed_or_verified_public_records_min_count']);
+        $this->assertSame(1, $api['verified_public_records_min_count_for_trust_badge_consideration']);
+
+        foreach (['proof_private_path', 'proof_redaction_notes', 'receipt_reference_private', 'internal_notes', 'created_by_admin_user_id', 'updated_by_admin_user_id'] as $field) {
+            $this->assertContains($field, $api['forbidden_public_fields']);
+        }
+    }
+
+    public function test_release_requires_noindex_and_sitemap_llms_exclusion(): void
+    {
+        $indexability = $this->artifact()['required_indexability_gates'];
+
+        $this->assertTrue($indexability['daily_giving_page_noindex']);
+        $this->assertFalse($indexability['daily_giving_sitemap_inclusion_allowed']);
+        $this->assertFalse($indexability['daily_giving_llms_inclusion_allowed']);
+    }
+
+    public function test_claim_lint_forbids_endorsement_and_guaranteed_impact_claims(): void
+    {
+        $forbidden = $this->artifact()['required_claim_lint_forbidden_claims'];
+
+        foreach (['UN official partner', '联合国官方合作', 'official endorsement', 'guaranteed impact'] as $claim) {
+            $this->assertContains($claim, $forbidden);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/operations/generated/daily-giving-public-release-prereq.v1.json');
+        $payload = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45616,7 +45616,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-proof-storage-gate-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "feat(benefit): gate DailyGiving proof storage fields",
     "depends_on": [
@@ -45667,11 +45667,11 @@
       "existing_public_api_fixture_aligned": true
     },
     "failure_reason": null,
-    "commit_sha": "f01bdfafeadf4567fa4c283904f2323181bd9a25",
+    "commit_sha": "ab13f978d804ec75b8f1c5842fa9823b80d6fd55",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1912",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:37:40Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -45719,6 +45719,12 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed for PR #1912; ready for squash merge. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T03:40:24Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "PR #1912 squash-merged at ab13f978d804ec75b8f1c5842fa9823b80d6fd55; origin/main contains merge commit; remote and local task branches are absent."
       }
     ]
   },
@@ -46090,6 +46096,90 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01 /goal. No CMS mutation, publish, search submission, deploy, private URL access, or content rewrite authorized."
+      }
+    ]
+  },
+  "DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-public-release-prereq-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): define DailyGiving public release prerequisites",
+    "depends_on": [
+      "DAILY-GIVING-PROOF-STORAGE-GATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized Window 7 Public Benefit / Foundation / DailyGiving Trust Gate PR train through PR12 and required stopping before record/proof mutation steps."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "DAILY-GIVING-PROOF-STORAGE-GATE-01 merged as PR #1912 at ab13f978d804ec75b8f1c5842fa9823b80d6fd55."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to DailyGiving public release prerequisite docs/generated artifact/test and docs/codex ledger paths. No record/proof/CMS/publish/deploy/search/social/index/trust badge action was performed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php",
+          "python3 -m json.tool backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingPublicReleasePrereqTest --no-ansi",
+          "git diff --check -- backend/docs/operations/daily-giving-public-release-prereq.md backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "All commands exited 0. PHPUnit reported four warnings from the temporary checkout missing backend/.env; 31 assertions passed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "result": {
+      "record_created": false,
+      "proof_uploaded": false,
+      "proof_processed": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "trust_badge_allowed_now": false,
+      "public_amplification_allowed_now": false,
+      "next_pr_supported": "DAILY-GIVING-PUBLIC-API-SMOKE-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Scope stayed within PR9 docs/generated/test/ledger paths. First real record remains blocked until separate authorization."
+    },
+    "next_task": "DAILY-GIVING-PUBLIC-API-SMOKE-01",
+    "transitions": [
+      {
+        "at": "2026-06-05T03:40:24Z",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized PR9 after PR8 merge. No record/proof/CMS/publish/deploy/search/social/index/trust badge action authorized."
+      },
+      {
+        "at": "2026-06-05T03:41:08Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Local syntax, JSON/YAML, focused PHPUnit, and scoped diff checks passed. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T11:35:00+08:00",
+  "updated_at": "2026-06-05T03:41:48Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -46103,7 +46103,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-public-release-prereq-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving public release prerequisites",
     "depends_on": [
@@ -46136,7 +46136,7 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #1914 opened; GitHub checks pending."
       }
     },
     "result": {
@@ -46152,8 +46152,8 @@
       "next_pr_supported": "DAILY-GIVING-PUBLIC-API-SMOKE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "c832ce3c426fc4c1e51471e8207931a6944340d4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1914",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -46180,6 +46180,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Local syntax, JSON/YAML, focused PHPUnit, and scoped diff checks passed. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T03:41:48Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened PR #1914 for DailyGiving public release prerequisite contract. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T03:41:48Z",
+  "updated_at": "2026-06-05T03:46:56Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -46103,7 +46103,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-public-release-prereq-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving public release prerequisites",
     "depends_on": [
@@ -46135,8 +46135,8 @@
         "notes": "All commands exited 0. PHPUnit reported four warnings from the temporary checkout missing backend/.env; 31 assertions passed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #1914 opened; GitHub checks pending."
+        "status": "pass",
+        "evidence": "PR #1914 checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -46152,7 +46152,7 @@
       "next_pr_supported": "DAILY-GIVING-PUBLIC-API-SMOKE-01"
     },
     "failure_reason": null,
-    "commit_sha": "c832ce3c426fc4c1e51471e8207931a6944340d4",
+    "commit_sha": "53f289827d75c981dc1c568a4e727280e0c7dd86",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1914",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -46186,6 +46186,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened PR #1914 for DailyGiving public release prerequisite contract. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T03:46:56Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed for PR #1914; ready for squash merge. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21899,7 +21899,7 @@ prs:
     branch: codex/daily-giving-proof-storage-gate-01
     title: "feat(benefit): gate DailyGiving proof storage fields"
     train_scope: window_7_public_benefit_trust_gate
-    status: in_progress
+    status: merged
     scope:
       - Add a model-level storage gate for DailyGiving proof private/public field boundaries.
       - Verify public projection never returns private proof/admin fields.
@@ -21938,6 +21938,49 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01
+
+  - id: DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01
+    repo: fap-api
+    depends_on:
+      - DAILY-GIVING-PROOF-STORAGE-GATE-01
+    branch: codex/daily-giving-public-release-prereq-01
+    title: "docs(benefit): define DailyGiving public release prerequisites"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Define DailyGiving public release prerequisites for records API, months API, proof review, noindex, sitemap/llms exclusion, and claim lint.
+      - Add generated prerequisite artifact and focused contract coverage.
+      - Keep all record, proof, CMS, publish, index, trust badge, search, social, and deploy actions non-mutating.
+    allowed_paths:
+      - backend/docs/operations/daily-giving-public-release-prereq.md
+      - backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json
+      - backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, run social distribution, deploy, or read secrets.
+    validation:
+      - php -l backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php
+      - python3 -m json.tool backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingPublicReleasePrereqTest --no-ansi
+      - git diff --check -- backend/docs/operations/daily-giving-public-release-prereq.md backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: DAILY-GIVING-PUBLIC-API-SMOKE-01
 
   - id: SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added a DailyGiving public release prerequisite contract.
- Added a generated release-prereq artifact and focused coverage.
- Reconciled PR8 merge facts in the PR-train ledger.

## Why
- DailyGiving must not be treated as a scalable trust asset until records API, months API, proof review, noindex, sitemap/llms exclusion, and claim lint gates are proven.

## Validation
- php -l backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php
- python3 -m json.tool backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingPublicReleasePrereqTest --no-ansi
- git diff --check -- backend/docs/operations/daily-giving-public-release-prereq.md backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json backend/tests/Feature/Foundation/DailyGivingPublicReleasePrereqTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

Note: PHPUnit emitted warnings because the temp worktree has no backend/.env; command exited 0 and 31 assertions passed.

## Intentionally deferred
- No DailyGiving record creation.
- No proof upload or processing.
- No CMS mutation, publish, indexing, trust badge, search submission, social distribution, or deploy.
- First real record remains blocked until DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01 authorization.