### PR TITLE
docs(cms): prepare RIASEC explanation CMS import package

### DIFF
--- a/backend/docs/seo/cms-import-packages/riasec-explanation-v2/README.md
+++ b/backend/docs/seo/cms-import-packages/riasec-explanation-v2/README.md
@@ -1,0 +1,38 @@
+# RIASEC Explanation CMS Import Package
+
+Task: `SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01`
+
+Decision: **GO for CMS draft preflight; NO-GO for CMS draft creation without exact draft-only authorization.**
+
+## Scope
+
+This package mechanically maps the validated GPT-5.5 Pro RIASEC V2 content package into CMS import-package fields. Codex did not rewrite article copy, create CMS records, publish, submit search URLs, deploy, or access private URLs.
+
+## Targets
+
+- zh: `/zh/articles/riasec-holland-career-interest-test-explained`
+- en: `/en/articles/what-is-riasec-holland-code-career-interest-test`
+
+## Draft Defaults
+
+- status=draft
+- is_public=false
+- is_indexable=false
+- robots=noindex,nofollow
+- published_at=null
+- published_revision_id=null
+- publish_allowed=false
+- search_submit_allowed=false
+- schema_enabled=false until visible FAQ preview is verified
+- requires_operator_review=true
+
+## Retained Blockers
+
+- References require operator/editor source acceptance before publish.
+- Psychometrics review is required before publish.
+- Career hub links remain conditional.
+- Cover image remains `__CMS_MEDIA_PLACEHOLDER_REQUIRED__`.
+
+## Result
+
+GO for `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-PREFLIGHT-01`.

--- a/backend/docs/seo/cms-import-packages/riasec-explanation-v2/en.article-target.json
+++ b/backend/docs/seo/cms-import-packages/riasec-explanation-v2/en.article-target.json
@@ -1,0 +1,218 @@
+{
+  "locale": "en",
+  "canonical_path": "/en/articles/what-is-riasec-holland-code-career-interest-test",
+  "package_version": "editorial_package.v1",
+  "translation_group_id": "riasec-explanation-article-2026-06-v2",
+  "title": "What Is RIASEC? Understanding Holland Code Career Interests",
+  "slug": "what-is-riasec-holland-code-career-interest-test",
+  "h1": "What Is RIASEC? How the Holland Code Supports Career Exploration",
+  "seo_title": "What Is RIASEC? Holland Code Career Test",
+  "seo_description": "Learn what RIASEC means, how Holland Code interests combine, and how the model can support career exploration without deciding your future.",
+  "excerpt": "RIASEC is a career-interest model that organizes work preferences into six areas. It can help you explore career environments, but it is not a career verdict.",
+  "category": "career_exploration",
+  "tags": [
+    "RIASEC",
+    "Holland Code",
+    "career interests",
+    "career exploration",
+    "vocational interests"
+  ],
+  "content_track": "evergreen_knowledge",
+  "audience_intent": "career_decision",
+  "signal_source": "RIASEC",
+  "signal_type": "interest",
+  "decision_domains": [
+    "career",
+    "self"
+  ],
+  "target_tests": [
+    "holland-career-interest-test-riasec"
+  ],
+  "target_topics": [
+    {
+      "topic": "career-interest",
+      "requires_operator_mapping": true
+    },
+    {
+      "topic": "riasec",
+      "requires_operator_mapping": true
+    },
+    {
+      "topic": "holland-code",
+      "requires_operator_mapping": true
+    },
+    {
+      "topic": "career-exploration",
+      "requires_operator_mapping": true
+    }
+  ],
+  "claim_level": "exploratory",
+  "sensitivity_level": "career_sensitive",
+  "medical_disclaimer_required": false,
+  "ability_disclaimer_required": false,
+  "external_references_required": true,
+  "review_required_by": [
+    "editor",
+    "psychometrics"
+  ],
+  "cover_image": "__CMS_MEDIA_PLACEHOLDER_REQUIRED__",
+  "cover_image_alt": "RIASEC hexagon showing six Holland Code career-interest areas",
+  "cover_image_prompt": "A restrained editorial infographic showing a Holland RIASEC hexagon with six career-interest domains, subtle arrows for consistency/differentiation/congruence, dark grid, no people, no logos, no certification badges.",
+  "cover_image_style_tag": "editorial_infographic_dark_grid",
+  "body_markdown": "# What Is RIASEC? How the Holland Code Supports Career Exploration\n\n> Some work is something you *can* do, but it drains you over time. Other work may take practice, yet still feels worth returning to. RIASEC focuses on that difference. It is not an ability diagnosis; it is a way to examine vocational interests and work environments.\n\n## 1. The core definition of RIASEC\n\nRIASEC is a model of career interests. It organizes preferences for work activities, problem types, and occupational environments into six areas: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional.\n\nThe model is commonly associated with the Holland Code. Its purpose is not to give you a fixed identity label or decide your career for you. It is better understood as a map for exploration: it helps you notice which work activities may draw your sustained attention and which environments may drain you over time.\n\nIf MBTI is often used to describe preference style, and Big Five is often used to describe broad trait tendencies, RIASEC is more directly about career interests:\n\n- What kinds of work activities tend to attract you?\n- What kinds of environments may fit your interests better?\n- Which career directions should you explore first instead of guessing randomly?\n\n## 2. How the RIASEC / Holland Code model works\n\nThe most useful part of RIASEC is not a single letter. It is the combination of interests.\n\nMany results show two or three high-scoring areas. A person may not be simply Social; they may be Social + Enterprising, or Social + Artistic. The first combination may point toward training, organizing, persuading, or activating teams. The second may point toward education, experience design, human-centered communication, or creative support.\n\nSo the better questions are not “Which type am I?” but:\n\n1. Which interest areas are strongest?\n2. Are the strongest areas close together, complementary, or in tension?\n3. Is there a clear difference between the strongest and weakest areas?\n4. Does my current study, work, or career target fit these interest patterns?\n\nThese questions are more useful than memorizing six labels.\n\n## 3. The six interest areas: definitions and combinations\n\n### 3.1 Realistic: working with concrete systems\n\nRealistic interests are often related to tools, equipment, physical systems, outdoor environments, machines, construction, repair, and practical outcomes. People with stronger Realistic interests may prefer work where something visible gets built, fixed, tested, or operated.\n\nIf this interest is strong but the work environment is mostly abstract meetings, vague planning, or intangible output, the person may feel drained. This is not an ability judgment. It is an interest-environment signal.\n\nExample combinations:\n\n- **RI**: Realistic + Investigative. May point toward technical research, engineering analysis, system architecture, or experimental problem-solving.\n- **RE**: Realistic + Enterprising. May point toward engineering project coordination, operational leadership, field execution, or business work with concrete systems.\n\nThese are not prescriptions. They are starting points for exploration.\n\n### 3.2 Investigative: understanding systems and causes\n\nInvestigative interests are often related to analysis, reasoning, observation, research, data, experimentation, and problem-solving. People with stronger Investigative interests may enjoy asking why something works the way it does.\n\nIf this interest is strong, an environment that demands quick conclusions without analysis may feel frustrating.\n\nExample combinations:\n\n- **IA**: Investigative + Artistic. May point toward conceptual design, interaction research, creative technology, or open-ended problem exploration.\n- **IC**: Investigative + Conventional. May point toward data governance, audit, quality control, system validation, or compliance-oriented analysis.\n\nInvestigative does not mean “higher ability.” It only describes the kind of work activity that may be engaging.\n\n### 3.3 Artistic: expression, design, and open-ended problems\n\nArtistic interests are often related to expression, creation, language, design, visuals, storytelling, and problems without one fixed answer. People with stronger Artistic interests may need room to interpret, create, and reframe.\n\nIf this interest is strong but the environment is highly scripted and rigid, the person may feel constrained.\n\nExample combinations:\n\n- **AI**: Artistic + Investigative. May point toward conceptual research, early-stage product exploration, knowledge design, or creative modeling.\n- **AS**: Artistic + Social. May point toward user experience, educational content, human-centered design, narrative communication, or supportive creative work.\n\nArtistic does not only mean art careers. It may appear in product, content, research communication, design, teaching, and brand strategy.\n\n### 3.4 Social: work directed toward people\n\nSocial interests are often related to helping, teaching, communication, collaboration, support, training, and understanding others. People with stronger Social interests often want their work to affect real people, not just systems.\n\nIf this interest is strong but the work is almost entirely mechanical, isolated, or detached from human feedback, the person may feel a lack of meaning.\n\nExample combinations:\n\n- **SA**: Social + Artistic. May point toward education, experience design, human-centered communication, coaching-like support, or narrative work.\n- **SE**: Social + Enterprising. May point toward training, team activation, organizational communication, client success, or people-centered leadership.\n\nSocial does not mean every people-facing job will fit. Conflict load, emotional labor, and pressure still need to be evaluated.\n\n### 3.5 Enterprising: influence, resources, and outcomes\n\nEnterprising interests are often related to influence, persuasion, organizing people, coordinating resources, business goals, leadership, and project movement. People with stronger Enterprising interests may want action, feedback, and visible outcomes.\n\nIf this interest is strong, a very stable environment with little autonomy or feedback may feel unengaging. This does not mean the person must become an entrepreneur or manager.\n\nExample combinations:\n\n- **EI**: Enterprising + Investigative. May point toward business strategy, investment research, market analysis, growth decisions, or complex judgment work.\n- **EC**: Enterprising + Conventional. May point toward operations management, process improvement, project delivery, organizational control, or structured execution.\n\nEnterprising is not simply “liking to lead.” It is often about being drawn to goals, influence, resources, and outcomes.\n\n### 3.6 Conventional: building order in complex systems\n\nConventional interests are often related to structure, procedures, order, data management, detail, standards, and reliable execution. People with stronger Conventional interests may prefer systems that are trackable, repeatable, and organized.\n\nIf this interest is strong but the environment is chaotic, ambiguous, and constantly changing without standards, stress may rise.\n\nExample combinations:\n\n- **CI**: Conventional + Investigative. May point toward actuarial work, financial analysis, compliance audit, data security, or system verification.\n- **CE**: Conventional + Enterprising. May point toward operations, business process management, organizational controls, project standards, or execution systems.\n\nConventional does not mean “uncreative.” It can be a strong systems skill: turning complexity into reliability.\n\n## 4. Why compound interest codes matter\n\nA RIASEC result is rarely explained well by one sentence. The first two or three letters often matter more.\n\nFor example:\n\n- **RI** and **IR** both involve Realistic and Investigative interests, but their order may imply different emphasis. RI may lean toward concrete systems and technical delivery; IR may lean toward analysis and research.\n- **SA** and **SE** both include Social interests. One may lean toward expression, education, and human-centered experience; the other may lean toward activation, training, and influence.\n- **IC** and **IA** both include Investigative interests. One may lean toward validation and structure; the other toward exploration and creative concept-building.\n\nA useful RIASEC interpretation should look at order, distance, score differences, and current work context.\n\n## 5. The Holland hexagon: consistency, differentiation, and congruence\n\nRIASEC is often shown as a hexagon. The shape is not decoration. It is a way to think about relationships among interests.\n\n### 5.1 Consistency\n\nConsistency asks whether your strongest interest areas are close together on the hexagon. Nearby interests may form a more coherent exploration pattern. Distant interests may suggest that you are drawn to different kinds of activities at the same time.\n\nFor example, Social and Enterprising are neighbors and may point toward communication, training, organizing, or influence. Realistic and Social are farther apart; that does not mean conflict, but it may suggest the need for a hybrid environment that combines concrete systems with human interaction.\n\n### 5.2 Differentiation\n\nDifferentiation looks at the distance between your highest scores and the rest. High differentiation suggests that some interests stand out clearly. Low differentiation may mean broad interests, or it may mean you have not had enough real exposure to separate your preferences yet.\n\nLow differentiation is not a bad result. It simply suggests that your next step may be to gather more evidence through courses, projects, interviews, internships, or real tasks.\n\n### 5.3 Congruence\n\nCongruence asks how well your interest pattern fits your current study, work, or target environment. If there is a large gap, you may feel drained, underused, or disconnected from the work.\n\nCongruence is still not destiny. Skills, role design, team context, career stage, and opportunity all matter. RIASEC helps you notice possible misfit; it does not decide the answer.\n\n## 6. RIASEC vs MBTI vs Big Five in career exploration\n\n| Self-exploration question | RIASEC / Holland career interests | MBTI / 16 types | Big Five / OCEAN |\n|---|---|---|---|\n| What does it mainly answer? | What work activities and environments tend to interest me? | How do I tend to process information, decide, and interact? | What are my broad behavioral tendencies and stress boundaries? |\n| Main target | Career interests, work activities, environment preference | Preference style, interaction pattern, cognitive orientation | Continuous traits such as openness, conscientiousness, extraversion, agreeableness, and emotional stability |\n| Career use | Narrow career directions, compare work environments, plan exploration | Understand communication style and team friction | Observe long-term work habits, stress patterns, and behavioral consistency |\n| Best role in a career journey | Direct career-exploration starting point | Self-style reflection tool | Behavioral tendency reference layer |\n| What it should not do | Guarantee a career fit | Decide your career fate | Replace professional evaluation or real performance evidence |\n\nIf your question is “Which career direction should I explore first?”, RIASEC is often the more direct starting point. If your question is “How do I communicate and make decisions?”, MBTI may help. If your question is “What are my long-term behavioral tendencies?”, Big Five may add useful context.\n\n## 7. How to use RIASEC for career exploration\n\nYou can use RIASEC as a set of exploration filters.\n\nFirst, look at your strongest interest areas. They suggest the types of activities that may draw your attention.\n\nSecond, look at whether those interests cluster together. If your top two areas are close, your exploration path may be more focused. If they are far apart, you may need to look for hybrid environments.\n\nThird, look at differentiation. If one or two interests stand out clearly, you may start exploration there. If the scores are flat, you may need more real-world exposure before drawing conclusions.\n\nFourth, compare interests with reality. Interest is not the same as skill, and skill is not the same as interest. Career decisions also involve learning cost, industry opportunity, work location, economic pressure, and long-term goals.\n\n## 8. What should a full report help you examine?\n\nIf you complete a RIASEC assessment, the most useful result is not just “your type.” A stronger report should help you examine:\n\n- the distribution of all six interest areas;\n- the meaning of your first two or three Holland Code letters;\n- the consistency of your interest pattern on the hexagon;\n- the differentiation between stronger and weaker interests;\n- the congruence between your interests and current or target environments;\n- career environments worth exploring, not guaranteed career conclusions;\n- next steps for testing your interests through real tasks, courses, projects, or interviews.\n\nThe value of this kind of report is not that it decides for you. It helps turn vague career uncertainty into a structure you can investigate.\n\n## 9. Limits of RIASEC\n\nRIASEC is not a medical or psychological diagnosis. It does not evaluate ability, predict career success, or guarantee that an occupation will fit.\n\nIt is best used for exploratory questions:\n\n- What types of activities may interest me?\n- Which work environments should I compare first?\n- Which directions are worth testing with real experience?\n- Could my current sense of work fatigue be related to interest-environment misfit?\n\nCareer decisions still require skills, experience, industry information, local opportunity, and feedback from real situations. RIASEC is a map, not a verdict.\n\n## 10. What to do next\n\nIf you are choosing a major, considering a career change, or trying to understand your work interests more clearly, you can start with a Holland / RIASEC career-interest test.\n\nIf you are still comparing tools, you can read the MBTI vs Holland comparison first. For career interests, RIASEC is usually the more direct tool. For preference style, MBTI can add context. For continuous behavioral tendencies, Big Five may be useful.\n\n## Frequently Asked Questions\n\n### Is RIASEC a career test?\n\nRIASEC is a career-interest model often used in career-interest assessments. It helps you understand preferred activities and work environments, but it does not decide your career outcome.\n\n### Is the Holland Code the same as RIASEC?\n\nIn common use, they are closely related. RIASEC refers to the six interest areas in the Holland career-interest model: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional.\n\n### Can RIASEC tell me my best career?\n\nNo. It can help narrow your exploration, but it cannot guarantee that a specific career is right for you. Career decisions also require skills, experience, industry research, and real feedback.\n\n### What are consistency and differentiation in the Holland Code?\n\nConsistency looks at whether your strongest interests are close together on the RIASEC hexagon. Differentiation looks at whether your highest interests stand out clearly from the rest.\n\n### Is RIASEC or MBTI better for career choice?\n\nIf your question is about career interests and work environments, RIASEC is usually more direct. If your question is about personality preference and interaction style, MBTI offers another angle.\n\n### Should I use Big Five together with RIASEC?\n\nNot always. RIASEC can stand on its own for career-interest exploration. Big Five can add information about broader behavioral tendencies such as conscientiousness, extraversion, or emotional stability.\n",
+  "faq_entries": [
+    {
+      "question": "Is RIASEC a career test?",
+      "answer": "RIASEC is a career-interest model often used in career-interest assessments. It helps you understand preferred activities and work environments, but it does not decide your career outcome."
+    },
+    {
+      "question": "Is the Holland Code the same as RIASEC?",
+      "answer": "In common use, they are closely related. RIASEC refers to the six interest areas in the Holland career-interest model: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional."
+    },
+    {
+      "question": "Can RIASEC tell me my best career?",
+      "answer": "No. It can help narrow your exploration, but it cannot guarantee that a specific career is right for you. Career decisions also require skills, experience, industry research, and real feedback."
+    },
+    {
+      "question": "What are consistency and differentiation in the Holland Code?",
+      "answer": "Consistency looks at whether your strongest interests are close together on the RIASEC hexagon. Differentiation looks at whether your highest interests stand out clearly from the rest."
+    },
+    {
+      "question": "Is RIASEC or MBTI better for career choice?",
+      "answer": "If your question is about career interests and work environments, RIASEC is usually more direct. If your question is about personality preference and interaction style, MBTI offers another angle."
+    },
+    {
+      "question": "Should I use Big Five together with RIASEC?",
+      "answer": "Not always. RIASEC can stand on its own for career-interest exploration. Big Five can add information about broader behavioral tendencies such as conscientiousness, extraversion, or emotional stability."
+    }
+  ],
+  "cta_suggestions": {
+    "primary_cta_label_suggestion": "Start the Holland / RIASEC career-interest test",
+    "primary_cta_href": "/en/tests/holland-career-interest-test-riasec",
+    "cta_intent": "start_career_interest_assessment",
+    "target_test_slug": "holland-career-interest-test-riasec",
+    "tracking_expectation": "article_to_test_click",
+    "safety_check": "public canonical route only"
+  },
+  "internal_link_plan": [
+    {
+      "anchor_suggestion": "MBTI vs Holland Code for career choice",
+      "href": "/en/articles/mbti-vs-holland-code-career-choice",
+      "purpose": "Connect to existing comparison canary.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "Holland / RIASEC career-interest test",
+      "href": "/en/tests/holland-career-interest-test-riasec",
+      "purpose": "Primary test path.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "MBTI personality test",
+      "href": "/en/tests/mbti-personality-test-16-personality-types",
+      "purpose": "Comparison context for personality preference.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "Big Five personality test",
+      "href": "/en/tests/big-five-personality-test-ocean-model",
+      "purpose": "Complementary behavioral-trait context.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "career library",
+      "href": "/en/career/jobs",
+      "purpose": "Conditional career exploration path.",
+      "status": "conditional",
+      "note": "Route eligibility and career hub strategy require operator/Codex confirmation before use in CMS body."
+    }
+  ],
+  "answer_surface_schema_alignment": {
+    "answer_surface_policy": "editor_supplied",
+    "answer_surface_visibility_suggestion": "Use excerpt or a visible editor summary near the top; do not duplicate a Quick Answer heading inside body_markdown.",
+    "quick_answer_summary": "RIASEC is a career-interest model that describes six areas of work preference: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional. It can support career exploration, but it does not decide a career outcome.",
+    "visible_faq_count": 6,
+    "expected_faq_schema_mainEntity_count": 6,
+    "Article_schema_source": "CMS article fields",
+    "Breadcrumb_canonical_path": "/en/articles/what-is-riasec-holland-code-career-interest-test"
+  },
+  "claim_boundary_checklist": {
+    "no_career_guarantee": "pass",
+    "no_diagnosis": "pass",
+    "no_official_certification_implication": "pass",
+    "no_deterministic_matching_claim": "pass",
+    "no_private_url": "pass",
+    "references_needed": true,
+    "unresolved_Unknown_fields": [
+      "target_topics mapping",
+      "cover_image CMS media asset",
+      "career hub eligibility",
+      "exact external references",
+      "final report module availability in product"
+    ]
+  },
+  "references_needs": [
+    {
+      "category": "primary_model_background",
+      "suggestion": "Sources explaining Holland's vocational-interest theory and the RIASEC model.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "holland_hexagon",
+      "suggestion": "Sources explaining consistency, differentiation, and congruence in Holland Code interpretation.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "career_information_systems",
+      "suggestion": "Public career-information systems that classify work interests or occupations using RIASEC-related dimensions.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "comparison_context",
+      "suggestion": "Neutral sources explaining how vocational interests differ from personality-style and trait models.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "claim_boundary",
+      "suggestion": "Sources clarifying that career-interest tests support exploration and should not be treated as deterministic career-selection tools.",
+      "status": "needs_source_verification"
+    }
+  ],
+  "baseline_placeholders": {
+    "publish_date": "Unknown",
+    "indexed_status": "Unknown",
+    "sitemap_seen": "Unknown",
+    "llms_seen": "Unknown",
+    "impressions_7d": "Unknown",
+    "clicks_7d": "Unknown",
+    "ctr_7d": "Unknown",
+    "average_position_7d": "Unknown",
+    "article_to_test_clicks_7d": "Unknown",
+    "impressions_14d": "Unknown",
+    "clicks_14d": "Unknown",
+    "ctr_14d": "Unknown",
+    "average_position_14d": "Unknown",
+    "article_to_test_clicks_14d": "Unknown",
+    "notes_for_operator": [
+      "Confirm CMS slug and canonical before draft creation.",
+      "Verify CTA target remains the public RIASEC test route.",
+      "Verify career hub link eligibility before using career hub link in body.",
+      "Confirm external references before publish.",
+      "Confirm final report module availability before using report-preview language as product promise.",
+      "Run article CTA route gate, FAQ/schema smoke, and publish hold gate before publish."
+    ]
+  },
+  "draft_defaults": {
+    "status": "draft",
+    "is_public": false,
+    "is_indexable": false,
+    "robots": "noindex,nofollow",
+    "published_at": null,
+    "published_revision_id": null,
+    "publish_allowed": false,
+    "search_submit_allowed": false,
+    "schema_enabled": false,
+    "schema_enabled_reason": "disabled until visible FAQ preview and CMS draft postcheck verify FAQ/schema alignment",
+    "requires_operator_review": true
+  }
+}

--- a/backend/docs/seo/cms-import-packages/riasec-explanation-v2/zh.article-target.json
+++ b/backend/docs/seo/cms-import-packages/riasec-explanation-v2/zh.article-target.json
@@ -1,0 +1,219 @@
+{
+  "locale": "zh",
+  "canonical_path": "/zh/articles/riasec-holland-career-interest-test-explained",
+  "package_version": "editorial_package.v1",
+  "translation_group_id": "riasec-explanation-article-2026-06-v2",
+  "title": "RIASEC 是什么？用霍兰德职业兴趣看懂职业动力",
+  "slug": "riasec-holland-career-interest-test-explained",
+  "h1": "RIASEC 是什么？霍兰德职业兴趣测试如何辅助职业探索",
+  "seo_title": "RIASEC 是什么？霍兰德职业兴趣测试解释",
+  "seo_description": "系统了解 RIASEC 六型、霍兰德代码、组合兴趣、六角形指标，以及它如何辅助职业探索而不是决定职业结果。",
+  "excerpt": "RIASEC 是一种职业兴趣模型，用六类兴趣方向帮助你理解自己更偏好的活动、环境和职业探索路径。它能辅助决策，但不能替你决定职业结果。",
+  "category": "career_exploration",
+  "tags": [
+    "RIASEC",
+    "Holland Code",
+    "霍兰德职业兴趣测试",
+    "职业探索",
+    "职业兴趣",
+    "职业动力"
+  ],
+  "content_track": "evergreen_knowledge",
+  "audience_intent": "career_decision",
+  "signal_source": "RIASEC",
+  "signal_type": "interest",
+  "decision_domains": [
+    "career",
+    "self"
+  ],
+  "target_tests": [
+    "holland-career-interest-test-riasec"
+  ],
+  "target_topics": [
+    {
+      "topic": "career-interest",
+      "requires_operator_mapping": true
+    },
+    {
+      "topic": "riasec",
+      "requires_operator_mapping": true
+    },
+    {
+      "topic": "holland-code",
+      "requires_operator_mapping": true
+    },
+    {
+      "topic": "career-exploration",
+      "requires_operator_mapping": true
+    }
+  ],
+  "claim_level": "exploratory",
+  "sensitivity_level": "career_sensitive",
+  "medical_disclaimer_required": false,
+  "ability_disclaimer_required": false,
+  "external_references_required": true,
+  "review_required_by": [
+    "editor",
+    "psychometrics"
+  ],
+  "cover_image": "__CMS_MEDIA_PLACEHOLDER_REQUIRED__",
+  "cover_image_alt": "RIASEC 六角形与六种职业兴趣方向示意图",
+  "cover_image_prompt": "A restrained editorial infographic showing a Holland RIASEC hexagon with six career-interest domains, subtle arrows for consistency/differentiation/congruence, dark grid, no people, no logos, no official certification symbols.",
+  "cover_image_style_tag": "editorial_infographic_dark_grid",
+  "body_markdown": "# RIASEC 是什么？霍兰德职业兴趣测试如何辅助职业探索\n\n> 有些工作你“能做”，但做久了会明显消耗；有些工作你不一定一开始就熟练，却会让你愿意持续投入。RIASEC 关注的不是能力诊断，而是职业兴趣与工作环境之间的关系：你更容易被哪类活动、问题和场景吸引。\n\n## 1. RIASEC 的核心定义\n\nRIASEC 是一种职业兴趣模型。它把人们对工作活动、问题类型和职业环境的偏好整理成六个方向：现实型、研究型、艺术型、社会型、企业型和常规型。\n\n它也常被称为霍兰德职业兴趣模型，英文里经常用 Holland Code 表示。RIASEC 不是用来给你贴一个固定标签，也不是替你决定“应该做什么职业”。它更像一张职业探索地图：帮助你看清哪些活动更能激发你的持续投入，哪些环境可能让你长期消耗。\n\n如果 MBTI 更常被用来描述认知风格和互动偏好，Big Five 更常被用来观察连续的人格特质倾向，那么 RIASEC 更直接地回答职业问题：\n\n- 我更喜欢处理什么类型的任务？\n- 我更愿意待在什么样的工作环境里？\n- 我应该先探索哪些职业方向，而不是盲目试错？\n\n## 2. RIASEC / Holland Code 的方法逻辑\n\nRIASEC 的重要价值不是单看某一个字母，而是看兴趣组合。多数人的结果不是单一类型，而是两到三个高分方向共同构成职业兴趣代码。\n\n例如，一个人可能不是单纯的 Social，也可能是 Social + Enterprising，或者 Social + Artistic。前者可能更关注组织、说服、训练和团队激活，后者可能更关注人文表达、陪伴、教育和创意沟通。\n\n所以，RIASEC 最值得看的不是“我是不是某一型”，而是：\n\n1. 哪几个兴趣方向排在前面？\n2. 这些方向彼此是否相邻、互补，还是存在张力？\n3. 最高分和其他分数之间差距是否明显？\n4. 我现在的学习、工作或转行方向，是否和这些兴趣方向接近？\n\n这四个问题，会比单纯记住六个字母更有用。\n\n## 3. 六个兴趣方向：不只看定义，也看组合\n\n### 3.1 现实型 Realistic：把问题落到具体系统里\n\n现实型通常与工具、设备、空间、身体操作、机械系统、工程结构、户外或具体交付有关。偏现实型的人往往不满足于停留在抽象讨论里，更希望看到一个东西被修好、搭好、测好或运行起来。\n\n如果这个方向长期缺席，一个人可能会在过度抽象、会议密集、产出不具体的环境中感到消耗。但这不是能力判断，只是兴趣和环境偏好的线索。\n\n常见组合示例：\n\n- **RI**：现实型 + 研究型。可能更关注技术研发、系统分析、工程问题、架构设计或实验验证。\n- **RE**：现实型 + 企业型。可能更关注工程项目推进、实业运营、资源调度或现场管理。\n\n这些组合不是职业推荐清单，而是提醒你观察自己更容易被什么样的工作活动吸引。\n\n### 3.2 研究型 Investigative：向问题底层寻找结构\n\n研究型通常与分析、推理、观察、数据、实验、诊断问题、理解规律有关。偏研究型的人往往习惯问“为什么”，也更愿意把复杂问题拆开推演。\n\n如果这个方向强，而工作却长期要求快速表态、重复执行、很少允许分析过程，用户可能会感觉自己的思考方式没有被使用。\n\n常见组合示例：\n\n- **IA**：研究型 + 艺术型。可能更关注概念设计、交互研究、创意技术或开放式问题探索。\n- **IC**：研究型 + 常规型。可能更关注数据治理、审计、质量控制、系统验证和流程安全。\n\n研究型不等于能力高低，它只是说明你可能更愿意处理需要理解、分析和验证的任务。\n\n### 3.3 艺术型 Artistic：在开放问题中表达和重组\n\n艺术型通常与表达、创作、语言、视觉、设计、叙事、开放式问题和不固定流程有关。偏艺术型的人往往更需要表达空间，不喜欢完全被标准答案和僵硬流程锁住。\n\n如果这个方向强，却长期处在高度 SOP 化、没有解释空间和创作空间的环境中，可能会感到表达受限。\n\n常见组合示例：\n\n- **AI**：艺术型 + 研究型。可能更关注概念探索、产品前期研究、创意算法、知识表达或新问题建模。\n- **AS**：艺术型 + 社会型。可能更关注用户体验、教育内容、人文叙事、表达支持和面向人的设计。\n\n艺术型不等于必须从事艺术职业。它也可能体现在产品、内容、设计、品牌、研究表达或教学方式中。\n\n### 3.4 社会型 Social：把工作指向具体的人\n\n社会型通常与帮助、教学、沟通、协作、支持、训练、理解他人有关。偏社会型的人往往不只是想完成任务，也希望工作能对具体的人产生影响。\n\n如果这个方向强，而工作长期是纯机器、纯流程、纯数字，且几乎没有人与人之间的反馈，可能会感到意义感不足。\n\n常见组合示例：\n\n- **SA**：社会型 + 艺术型。可能更关注教育表达、组织发展、人文沟通、体验设计或陪伴型服务。\n- **SE**：社会型 + 企业型。可能更关注培训、团队激活、组织沟通、客户成功或以人为中心的推动工作。\n\n社会型不意味着适合所有人际工作。高强度冲突、销售压力或情绪劳动仍然需要结合其他维度继续判断。\n\n### 3.5 企业型 Enterprising：推动资源、影响他人、看见结果\n\n企业型通常与影响、说服、组织、资源协调、商业目标、领导、项目推动有关。偏企业型的人往往希望看到行动后的反馈，不喜欢长期停在无决策、无资源、无结果的状态。\n\n如果这个方向强，过度稳定但缺少自主度和结果反馈的环境可能会显得乏味。但这不代表必须创业，也不代表一定适合管理岗位。\n\n常见组合示例：\n\n- **EI**：企业型 + 研究型。可能更关注商业策略分析、投资研究、增长判断、市场洞察或复杂决策。\n- **EC**：企业型 + 常规型。可能更关注运营管理、流程改进、组织效率、项目交付或制度化推进。\n\n企业型的关键不是“爱管人”，而是更容易被资源、目标、机会和结果牵引。\n\n### 3.6 常规型 Conventional：为混乱系统建立秩序\n\n常规型通常与规则、流程、秩序、数据管理、细节、标准化和稳定执行有关。偏常规型的人往往不喜欢边界长期模糊，更愿意把事情整理成可追踪、可复核、可执行的系统。\n\n如果这个方向强，而环境长期混乱、责任不清、标准频繁变化，可能会带来较高压力。\n\n常见组合示例：\n\n- **CI**：常规型 + 研究型。可能更关注精算、财务分析、合规审计、数据安全和系统验证。\n- **CE**：常规型 + 企业型。可能更关注流程管理、运营制度、企业控制、项目规范和组织执行。\n\n常规型不是“保守”的同义词。它也可以是一种强系统能力：帮助组织把复杂事务变得可靠。\n\n## 4. 复合兴趣代码为什么重要？\n\nRIASEC 的职业兴趣结果，通常不是一句“你是某一型”就能解释清楚。更有价值的是前两位或前三位代码。\n\n例如：\n\n- **RI** 和 **IR** 都涉及现实型与研究型，但主次不同。前者可能更偏向具体系统和技术交付，后者可能更偏向研究分析和问题理解。\n- **SA** 和 **SE** 都有社会型，但一个更接近表达、体验、教育和支持，另一个更接近组织推动、培训和影响。\n- **IC** 和 **IA** 都有研究型，但一个更重视系统验证和规范，一个更重视开放问题和创意探索。\n\n因此，完整的 RIASEC 解读不应只看最高分，而应该看组合顺序、分数差距和兴趣之间的关系。\n\n## 5. 六角形模型：一致性、区分度与适配度\n\nRIASEC 常用六角形来表示六个兴趣方向的关系。这个六角形不是装饰图，而是理解职业兴趣结构的工具。\n\n### 5.1 一致性 Consistency\n\n一致性关注你的高分兴趣是否在六角形上彼此接近。相邻的兴趣方向通常更容易形成清晰的职业探索线索；距离较远的兴趣方向，可能说明你同时被不同类型的工作活动吸引。\n\n例如，社会型和企业型相邻，可能共同指向沟通、组织、训练或影响他人的环境。现实型和社会型距离较远，并不代表冲突，而是提示你可能需要寻找同时包含具体系统和人与人互动的复合环境。\n\n### 5.2 区分度 Differentiation\n\n区分度关注最高分和其他分数之间的差距。高区分度说明某些兴趣方向非常突出，探索路径可能更集中。低区分度说明多个方向都差不多，可能代表兴趣广泛，也可能代表你当前还没有足够体验来分辨偏好。\n\n低区分度不是坏结果。它只是提示你：下一步可能不应该急着下结论，而应该用课程、项目、访谈、实习或真实任务继续收集证据。\n\n### 5.3 适配度 Congruence\n\n适配度关注你的兴趣代码与当前学习、工作或目标环境之间的关系。如果你长期处在与兴趣差异较大的环境中，可能更容易感觉耗竭、分心或意义感不足。\n\n但适配度仍然不是命运判断。一个人可以通过技能补充、岗位调整、团队环境、职业阶段变化来改变体验。RIASEC 只能帮助你看见问题，不替你决定答案。\n\n## 6. RIASEC、MBTI 和 Big Five 的职场防区\n\n| 自我探索问题 | RIASEC / 霍兰德职业兴趣 | MBTI / 16 型人格 | Big Five / 大五人格 |\n|---|---|---|---|\n| 它主要回答什么？ | 我更容易被什么工作活动和环境吸引？ | 我倾向于如何获取信息、做决定和互动？ | 我的行为倾向和情绪稳定边界在哪里？ |\n| 核心观察对象 | 职业兴趣、工作活动、环境偏好 | 偏好风格、沟通方式、认知取向 | 连续人格特质，如开放性、尽责性、外向性等 |\n| 在职业探索中怎么用？ | 缩小职业方向、比较工作环境、规划验证路径 | 理解协作风格、决策偏好和沟通冲突 | 观察长期工作习惯、压力边界和执行稳定性 |\n| 最适合作为什么入口？ | 职业探索和选方向的起点 | 自我风格理解的辅助工具 | 行为倾向复核和长期自我观察工具 |\n| 不能做什么？ | 不能保证某职业一定适合 | 不能决定职业命运 | 不能替代专业评估或实际表现 |\n\n如果你的问题是“我到底该先探索什么职业方向”，RIASEC 往往更直接。 如果你的问题是“我为什么会用这种方式沟通和决策”，MBTI 可能有帮助。 如果你的问题是“我长期行为倾向和压力反应怎样”，Big Five 可以补充另一个角度。\n\n## 7. 如何把 RIASEC 用在职业探索中？\n\n你可以把 RIASEC 当作一套筛选问题，而不是答案本身。\n\n第一步，先看你的高分兴趣方向。它们提示你更容易被哪些活动吸引。\n\n第二步，看这些兴趣之间是否聚拢。如果前两位兴趣相邻，说明探索方向可能更集中；如果跨度大，说明你可能需要寻找复合型场景。\n\n第三步，看区分度。如果最高分明显高于其他方向，可以优先探索相应职业环境；如果分数很平，可以先多做真实任务，而不是立刻下结论。\n\n第四步，把兴趣和现实条件放在一起看。兴趣不是能力，能力也不等于兴趣。职业选择还要考虑技能、学习成本、行业机会、工作地点、经济压力和长期目标。\n\n## 8. 完整报告应该帮你看什么？\n\n如果你完成 RIASEC 测试，真正值得看的不是“你是哪一型”这一句话，而是更细的结构：\n\n- 六个兴趣方向的相对分布；\n- 前两位或前三位 Holland Code 的组合含义；\n- 你的兴趣代码在六角形上的一致性；\n- 最高分和其他分数之间的区分度；\n- 当前职业或目标方向与兴趣代码之间的适配度；\n- 适合继续探索的职业环境，而不是保证适合的职业结论；\n- 下一步可以用哪些真实任务、课程或访谈继续验证。\n\n这类报告的价值不在于替你做决定，而在于把模糊的职业焦虑拆成可以观察和验证的结构。\n\n## 9. RIASEC 的边界\n\nRIASEC 不诊断心理状态，不评估医学问题，也不判断能力高低。它不应该用于招聘筛选，也不能保证某个职业一定适合你。\n\n它适合回答的是探索性问题：\n\n- 我可能对哪些活动更有兴趣？\n- 我应该先比较哪些职业环境？\n- 哪些方向值得进一步体验？\n- 我现在的工作消耗感，是否可能和兴趣环境不匹配有关？\n\n职业决策仍然需要结合技能、经验、行业信息、地区机会和真实反馈。RIASEC 是地图，不是判决书。\n\n## 10. 下一步可以怎么做？\n\n如果你正在选专业、考虑转行，或者只是想更系统地理解自己的职业兴趣，可以先完成霍兰德 / RIASEC 职业兴趣测试。\n\n如果你还在比较工具，可以先读 MBTI 与霍兰德的区别，再根据问题选择测试：想看职业兴趣，优先从 RIASEC 开始；想看人格偏好，可以结合 MBTI；想看连续行为倾向，可以参考 Big Five。\n\n## 常见问题\n\n### RIASEC 是职业测试吗？\n\nRIASEC 是职业兴趣模型，常用于职业探索和职业兴趣测试。它帮助你理解自己更偏好的活动和工作环境，但不决定你的职业结果。\n\n### 霍兰德职业兴趣测试和 RIASEC 是一回事吗？\n\n通常可以这样理解。RIASEC 是霍兰德职业兴趣模型中的六个兴趣方向：现实型、研究型、艺术型、社会型、企业型和常规型。\n\n### RIASEC 能告诉我最适合的职业吗？\n\n不能直接保证某个职业最适合你。它可以帮助你缩小探索范围，但职业选择仍要结合技能、经验、行业信息和真实反馈。\n\n### 什么是 Holland Code 的一致性和区分度？\n\n一致性关注你的高分兴趣是否彼此接近，区分度关注最高兴趣和其他兴趣之间差距是否明显。它们可以帮助你理解结果结构，但不能单独决定职业方向。\n\n### RIASEC 和 MBTI 哪个更适合选职业？\n\n如果你的问题是职业兴趣和工作环境，RIASEC 通常更直接。如果你想理解人格偏好和互动风格，MBTI 可以提供另一个角度。\n\n### RIASEC 测试结果需要和 Big Five 一起看吗？\n\n不一定。RIASEC 可以单独用于职业兴趣探索。Big Five 更适合补充观察行为倾向，例如尽责性、外向性或情绪稳定性。\n",
+  "faq_entries": [
+    {
+      "question": "RIASEC 是职业测试吗？",
+      "answer": "RIASEC 是职业兴趣模型，常用于职业探索和职业兴趣测试。它帮助你理解自己更偏好的活动和工作环境，但不决定你的职业结果。"
+    },
+    {
+      "question": "霍兰德职业兴趣测试和 RIASEC 是一回事吗？",
+      "answer": "通常可以这样理解。RIASEC 是霍兰德职业兴趣模型中的六个兴趣方向：现实型、研究型、艺术型、社会型、企业型和常规型。"
+    },
+    {
+      "question": "RIASEC 能告诉我最适合的职业吗？",
+      "answer": "不能直接保证某个职业最适合你。它可以帮助你缩小探索范围，但职业选择仍要结合技能、经验、行业信息和真实反馈。"
+    },
+    {
+      "question": "什么是 Holland Code 的一致性和区分度？",
+      "answer": "一致性关注你的高分兴趣是否彼此接近，区分度关注最高兴趣和其他兴趣之间差距是否明显。它们可以帮助你理解结果结构，但不能单独决定职业方向。"
+    },
+    {
+      "question": "RIASEC 和 MBTI 哪个更适合选职业？",
+      "answer": "如果你的问题是职业兴趣和工作环境，RIASEC 通常更直接。如果你想理解人格偏好和互动风格，MBTI 可以提供另一个角度。"
+    },
+    {
+      "question": "RIASEC 测试结果需要和 Big Five 一起看吗？",
+      "answer": "不一定。RIASEC 可以单独用于职业兴趣探索。Big Five 更适合补充观察行为倾向，例如尽责性、外向性或情绪稳定性。"
+    }
+  ],
+  "cta_suggestions": {
+    "primary_cta_label_suggestion": "开始霍兰德 / RIASEC 职业兴趣测试",
+    "primary_cta_href": "/zh/tests/holland-career-interest-test-riasec",
+    "cta_intent": "start_career_interest_assessment",
+    "target_test_slug": "holland-career-interest-test-riasec",
+    "tracking_expectation": "article_to_test_click",
+    "safety_check": "public canonical route only"
+  },
+  "internal_link_plan": [
+    {
+      "anchor_suggestion": "MBTI 和霍兰德的区别",
+      "href": "/zh/articles/mbti-vs-holland-career-choice",
+      "purpose": "Connect to existing comparison canary.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "霍兰德 / RIASEC 职业兴趣测试",
+      "href": "/zh/tests/holland-career-interest-test-riasec",
+      "purpose": "Primary test path.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "MBTI 性格测试",
+      "href": "/zh/tests/mbti-personality-test-16-personality-types",
+      "purpose": "Comparison context for personality preference.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "大五人格测试",
+      "href": "/zh/tests/big-five-personality-test-ocean-model",
+      "purpose": "Complementary behavioral-trait context.",
+      "status": "allowed"
+    },
+    {
+      "anchor_suggestion": "职业库",
+      "href": "/zh/career/jobs",
+      "purpose": "Conditional career exploration path.",
+      "status": "conditional",
+      "note": "Route eligibility and career hub strategy require operator/Codex confirmation before use in CMS body."
+    }
+  ],
+  "answer_surface_schema_alignment": {
+    "answer_surface_policy": "editor_supplied",
+    "answer_surface_visibility_suggestion": "Use excerpt or a visible editor summary near the top; do not duplicate a Quick Answer heading inside body_markdown.",
+    "quick_answer_summary": "RIASEC 是一种职业兴趣模型，用现实型、研究型、艺术型、社会型、企业型和常规型六个方向帮助用户理解更偏好的活动和工作环境。它适合辅助职业探索，但不决定职业结果。",
+    "visible_faq_count": 6,
+    "expected_faq_schema_mainEntity_count": 6,
+    "Article_schema_source": "CMS article fields",
+    "Breadcrumb_canonical_path": "/zh/articles/riasec-holland-career-interest-test-explained"
+  },
+  "claim_boundary_checklist": {
+    "no_career_guarantee": "pass",
+    "no_diagnosis": "pass",
+    "no_official_certification_implication": "pass",
+    "no_deterministic_matching_claim": "pass",
+    "no_private_url": "pass",
+    "references_needed": true,
+    "unresolved_Unknown_fields": [
+      "target_topics mapping",
+      "cover_image CMS media asset",
+      "career hub eligibility",
+      "exact external references",
+      "final report module availability in product"
+    ]
+  },
+  "references_needs": [
+    {
+      "category": "primary_model_background",
+      "suggestion": "Sources explaining Holland's vocational-interest theory and the RIASEC model.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "holland_hexagon",
+      "suggestion": "Sources explaining consistency, differentiation, and congruence in Holland Code interpretation.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "career_information_systems",
+      "suggestion": "Public career-information systems that classify work interests or occupations using RIASEC-related dimensions.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "comparison_context",
+      "suggestion": "Neutral sources explaining how vocational interests differ from personality-style and trait models.",
+      "status": "needs_source_verification"
+    },
+    {
+      "category": "claim_boundary",
+      "suggestion": "Sources clarifying that career-interest tests support exploration and should not be treated as deterministic career-selection tools.",
+      "status": "needs_source_verification"
+    }
+  ],
+  "baseline_placeholders": {
+    "publish_date": "Unknown",
+    "indexed_status": "Unknown",
+    "sitemap_seen": "Unknown",
+    "llms_seen": "Unknown",
+    "impressions_7d": "Unknown",
+    "clicks_7d": "Unknown",
+    "ctr_7d": "Unknown",
+    "average_position_7d": "Unknown",
+    "article_to_test_clicks_7d": "Unknown",
+    "impressions_14d": "Unknown",
+    "clicks_14d": "Unknown",
+    "ctr_14d": "Unknown",
+    "average_position_14d": "Unknown",
+    "article_to_test_clicks_14d": "Unknown",
+    "notes_for_operator": [
+      "Confirm CMS slug and canonical before draft creation.",
+      "Verify CTA target remains the public RIASEC test route.",
+      "Verify career hub link eligibility before using career hub link in body.",
+      "Confirm external references before publish.",
+      "Confirm final report module availability before using report-preview language as product promise.",
+      "Run article CTA route gate, FAQ/schema smoke, and publish hold gate before publish."
+    ]
+  },
+  "draft_defaults": {
+    "status": "draft",
+    "is_public": false,
+    "is_indexable": false,
+    "robots": "noindex,nofollow",
+    "published_at": null,
+    "published_revision_id": null,
+    "publish_allowed": false,
+    "search_submit_allowed": false,
+    "schema_enabled": false,
+    "schema_enabled_reason": "disabled until visible FAQ preview and CMS draft postcheck verify FAQ/schema alignment",
+    "requires_operator_review": true
+  }
+}

--- a/backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json
@@ -1,0 +1,476 @@
+{
+  "task_id": "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01",
+  "source_task_id": "SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01",
+  "source_package_version": "v2_truity_density_revision",
+  "source_package_path": "backend/docs/seo/article-packages/riasec-explanation-v2/riasec-explanation-v2.cms-import.json",
+  "validation_artifact": "backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json",
+  "reference_review_artifact": "backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json",
+  "generated_at": "2026-06-05",
+  "cms_draft_created": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "content_rewrite_performed": false,
+  "importer_mode": "draft_package_only_no_cms_write",
+  "import_targets": [
+    {
+      "locale": "zh",
+      "canonical_path": "/zh/articles/riasec-holland-career-interest-test-explained",
+      "package_version": "editorial_package.v1",
+      "translation_group_id": "riasec-explanation-article-2026-06-v2",
+      "title": "RIASEC 是什么？用霍兰德职业兴趣看懂职业动力",
+      "slug": "riasec-holland-career-interest-test-explained",
+      "h1": "RIASEC 是什么？霍兰德职业兴趣测试如何辅助职业探索",
+      "seo_title": "RIASEC 是什么？霍兰德职业兴趣测试解释",
+      "seo_description": "系统了解 RIASEC 六型、霍兰德代码、组合兴趣、六角形指标，以及它如何辅助职业探索而不是决定职业结果。",
+      "excerpt": "RIASEC 是一种职业兴趣模型，用六类兴趣方向帮助你理解自己更偏好的活动、环境和职业探索路径。它能辅助决策，但不能替你决定职业结果。",
+      "category": "career_exploration",
+      "tags": [
+        "RIASEC",
+        "Holland Code",
+        "霍兰德职业兴趣测试",
+        "职业探索",
+        "职业兴趣",
+        "职业动力"
+      ],
+      "content_track": "evergreen_knowledge",
+      "audience_intent": "career_decision",
+      "signal_source": "RIASEC",
+      "signal_type": "interest",
+      "decision_domains": [
+        "career",
+        "self"
+      ],
+      "target_tests": [
+        "holland-career-interest-test-riasec"
+      ],
+      "target_topics": [
+        {
+          "topic": "career-interest",
+          "requires_operator_mapping": true
+        },
+        {
+          "topic": "riasec",
+          "requires_operator_mapping": true
+        },
+        {
+          "topic": "holland-code",
+          "requires_operator_mapping": true
+        },
+        {
+          "topic": "career-exploration",
+          "requires_operator_mapping": true
+        }
+      ],
+      "claim_level": "exploratory",
+      "sensitivity_level": "career_sensitive",
+      "medical_disclaimer_required": false,
+      "ability_disclaimer_required": false,
+      "external_references_required": true,
+      "review_required_by": [
+        "editor",
+        "psychometrics"
+      ],
+      "cover_image": "__CMS_MEDIA_PLACEHOLDER_REQUIRED__",
+      "cover_image_alt": "RIASEC 六角形与六种职业兴趣方向示意图",
+      "cover_image_prompt": "A restrained editorial infographic showing a Holland RIASEC hexagon with six career-interest domains, subtle arrows for consistency/differentiation/congruence, dark grid, no people, no logos, no official certification symbols.",
+      "cover_image_style_tag": "editorial_infographic_dark_grid",
+      "body_markdown": "# RIASEC 是什么？霍兰德职业兴趣测试如何辅助职业探索\n\n> 有些工作你“能做”，但做久了会明显消耗；有些工作你不一定一开始就熟练，却会让你愿意持续投入。RIASEC 关注的不是能力诊断，而是职业兴趣与工作环境之间的关系：你更容易被哪类活动、问题和场景吸引。\n\n## 1. RIASEC 的核心定义\n\nRIASEC 是一种职业兴趣模型。它把人们对工作活动、问题类型和职业环境的偏好整理成六个方向：现实型、研究型、艺术型、社会型、企业型和常规型。\n\n它也常被称为霍兰德职业兴趣模型，英文里经常用 Holland Code 表示。RIASEC 不是用来给你贴一个固定标签，也不是替你决定“应该做什么职业”。它更像一张职业探索地图：帮助你看清哪些活动更能激发你的持续投入，哪些环境可能让你长期消耗。\n\n如果 MBTI 更常被用来描述认知风格和互动偏好，Big Five 更常被用来观察连续的人格特质倾向，那么 RIASEC 更直接地回答职业问题：\n\n- 我更喜欢处理什么类型的任务？\n- 我更愿意待在什么样的工作环境里？\n- 我应该先探索哪些职业方向，而不是盲目试错？\n\n## 2. RIASEC / Holland Code 的方法逻辑\n\nRIASEC 的重要价值不是单看某一个字母，而是看兴趣组合。多数人的结果不是单一类型，而是两到三个高分方向共同构成职业兴趣代码。\n\n例如，一个人可能不是单纯的 Social，也可能是 Social + Enterprising，或者 Social + Artistic。前者可能更关注组织、说服、训练和团队激活，后者可能更关注人文表达、陪伴、教育和创意沟通。\n\n所以，RIASEC 最值得看的不是“我是不是某一型”，而是：\n\n1. 哪几个兴趣方向排在前面？\n2. 这些方向彼此是否相邻、互补，还是存在张力？\n3. 最高分和其他分数之间差距是否明显？\n4. 我现在的学习、工作或转行方向，是否和这些兴趣方向接近？\n\n这四个问题，会比单纯记住六个字母更有用。\n\n## 3. 六个兴趣方向：不只看定义，也看组合\n\n### 3.1 现实型 Realistic：把问题落到具体系统里\n\n现实型通常与工具、设备、空间、身体操作、机械系统、工程结构、户外或具体交付有关。偏现实型的人往往不满足于停留在抽象讨论里，更希望看到一个东西被修好、搭好、测好或运行起来。\n\n如果这个方向长期缺席，一个人可能会在过度抽象、会议密集、产出不具体的环境中感到消耗。但这不是能力判断，只是兴趣和环境偏好的线索。\n\n常见组合示例：\n\n- **RI**：现实型 + 研究型。可能更关注技术研发、系统分析、工程问题、架构设计或实验验证。\n- **RE**：现实型 + 企业型。可能更关注工程项目推进、实业运营、资源调度或现场管理。\n\n这些组合不是职业推荐清单，而是提醒你观察自己更容易被什么样的工作活动吸引。\n\n### 3.2 研究型 Investigative：向问题底层寻找结构\n\n研究型通常与分析、推理、观察、数据、实验、诊断问题、理解规律有关。偏研究型的人往往习惯问“为什么”，也更愿意把复杂问题拆开推演。\n\n如果这个方向强，而工作却长期要求快速表态、重复执行、很少允许分析过程，用户可能会感觉自己的思考方式没有被使用。\n\n常见组合示例：\n\n- **IA**：研究型 + 艺术型。可能更关注概念设计、交互研究、创意技术或开放式问题探索。\n- **IC**：研究型 + 常规型。可能更关注数据治理、审计、质量控制、系统验证和流程安全。\n\n研究型不等于能力高低，它只是说明你可能更愿意处理需要理解、分析和验证的任务。\n\n### 3.3 艺术型 Artistic：在开放问题中表达和重组\n\n艺术型通常与表达、创作、语言、视觉、设计、叙事、开放式问题和不固定流程有关。偏艺术型的人往往更需要表达空间，不喜欢完全被标准答案和僵硬流程锁住。\n\n如果这个方向强，却长期处在高度 SOP 化、没有解释空间和创作空间的环境中，可能会感到表达受限。\n\n常见组合示例：\n\n- **AI**：艺术型 + 研究型。可能更关注概念探索、产品前期研究、创意算法、知识表达或新问题建模。\n- **AS**：艺术型 + 社会型。可能更关注用户体验、教育内容、人文叙事、表达支持和面向人的设计。\n\n艺术型不等于必须从事艺术职业。它也可能体现在产品、内容、设计、品牌、研究表达或教学方式中。\n\n### 3.4 社会型 Social：把工作指向具体的人\n\n社会型通常与帮助、教学、沟通、协作、支持、训练、理解他人有关。偏社会型的人往往不只是想完成任务，也希望工作能对具体的人产生影响。\n\n如果这个方向强，而工作长期是纯机器、纯流程、纯数字，且几乎没有人与人之间的反馈，可能会感到意义感不足。\n\n常见组合示例：\n\n- **SA**：社会型 + 艺术型。可能更关注教育表达、组织发展、人文沟通、体验设计或陪伴型服务。\n- **SE**：社会型 + 企业型。可能更关注培训、团队激活、组织沟通、客户成功或以人为中心的推动工作。\n\n社会型不意味着适合所有人际工作。高强度冲突、销售压力或情绪劳动仍然需要结合其他维度继续判断。\n\n### 3.5 企业型 Enterprising：推动资源、影响他人、看见结果\n\n企业型通常与影响、说服、组织、资源协调、商业目标、领导、项目推动有关。偏企业型的人往往希望看到行动后的反馈，不喜欢长期停在无决策、无资源、无结果的状态。\n\n如果这个方向强，过度稳定但缺少自主度和结果反馈的环境可能会显得乏味。但这不代表必须创业，也不代表一定适合管理岗位。\n\n常见组合示例：\n\n- **EI**：企业型 + 研究型。可能更关注商业策略分析、投资研究、增长判断、市场洞察或复杂决策。\n- **EC**：企业型 + 常规型。可能更关注运营管理、流程改进、组织效率、项目交付或制度化推进。\n\n企业型的关键不是“爱管人”，而是更容易被资源、目标、机会和结果牵引。\n\n### 3.6 常规型 Conventional：为混乱系统建立秩序\n\n常规型通常与规则、流程、秩序、数据管理、细节、标准化和稳定执行有关。偏常规型的人往往不喜欢边界长期模糊，更愿意把事情整理成可追踪、可复核、可执行的系统。\n\n如果这个方向强，而环境长期混乱、责任不清、标准频繁变化，可能会带来较高压力。\n\n常见组合示例：\n\n- **CI**：常规型 + 研究型。可能更关注精算、财务分析、合规审计、数据安全和系统验证。\n- **CE**：常规型 + 企业型。可能更关注流程管理、运营制度、企业控制、项目规范和组织执行。\n\n常规型不是“保守”的同义词。它也可以是一种强系统能力：帮助组织把复杂事务变得可靠。\n\n## 4. 复合兴趣代码为什么重要？\n\nRIASEC 的职业兴趣结果，通常不是一句“你是某一型”就能解释清楚。更有价值的是前两位或前三位代码。\n\n例如：\n\n- **RI** 和 **IR** 都涉及现实型与研究型，但主次不同。前者可能更偏向具体系统和技术交付，后者可能更偏向研究分析和问题理解。\n- **SA** 和 **SE** 都有社会型，但一个更接近表达、体验、教育和支持，另一个更接近组织推动、培训和影响。\n- **IC** 和 **IA** 都有研究型，但一个更重视系统验证和规范，一个更重视开放问题和创意探索。\n\n因此，完整的 RIASEC 解读不应只看最高分，而应该看组合顺序、分数差距和兴趣之间的关系。\n\n## 5. 六角形模型：一致性、区分度与适配度\n\nRIASEC 常用六角形来表示六个兴趣方向的关系。这个六角形不是装饰图，而是理解职业兴趣结构的工具。\n\n### 5.1 一致性 Consistency\n\n一致性关注你的高分兴趣是否在六角形上彼此接近。相邻的兴趣方向通常更容易形成清晰的职业探索线索；距离较远的兴趣方向，可能说明你同时被不同类型的工作活动吸引。\n\n例如，社会型和企业型相邻，可能共同指向沟通、组织、训练或影响他人的环境。现实型和社会型距离较远，并不代表冲突，而是提示你可能需要寻找同时包含具体系统和人与人互动的复合环境。\n\n### 5.2 区分度 Differentiation\n\n区分度关注最高分和其他分数之间的差距。高区分度说明某些兴趣方向非常突出，探索路径可能更集中。低区分度说明多个方向都差不多，可能代表兴趣广泛，也可能代表你当前还没有足够体验来分辨偏好。\n\n低区分度不是坏结果。它只是提示你：下一步可能不应该急着下结论，而应该用课程、项目、访谈、实习或真实任务继续收集证据。\n\n### 5.3 适配度 Congruence\n\n适配度关注你的兴趣代码与当前学习、工作或目标环境之间的关系。如果你长期处在与兴趣差异较大的环境中，可能更容易感觉耗竭、分心或意义感不足。\n\n但适配度仍然不是命运判断。一个人可以通过技能补充、岗位调整、团队环境、职业阶段变化来改变体验。RIASEC 只能帮助你看见问题，不替你决定答案。\n\n## 6. RIASEC、MBTI 和 Big Five 的职场防区\n\n| 自我探索问题 | RIASEC / 霍兰德职业兴趣 | MBTI / 16 型人格 | Big Five / 大五人格 |\n|---|---|---|---|\n| 它主要回答什么？ | 我更容易被什么工作活动和环境吸引？ | 我倾向于如何获取信息、做决定和互动？ | 我的行为倾向和情绪稳定边界在哪里？ |\n| 核心观察对象 | 职业兴趣、工作活动、环境偏好 | 偏好风格、沟通方式、认知取向 | 连续人格特质，如开放性、尽责性、外向性等 |\n| 在职业探索中怎么用？ | 缩小职业方向、比较工作环境、规划验证路径 | 理解协作风格、决策偏好和沟通冲突 | 观察长期工作习惯、压力边界和执行稳定性 |\n| 最适合作为什么入口？ | 职业探索和选方向的起点 | 自我风格理解的辅助工具 | 行为倾向复核和长期自我观察工具 |\n| 不能做什么？ | 不能保证某职业一定适合 | 不能决定职业命运 | 不能替代专业评估或实际表现 |\n\n如果你的问题是“我到底该先探索什么职业方向”，RIASEC 往往更直接。 如果你的问题是“我为什么会用这种方式沟通和决策”，MBTI 可能有帮助。 如果你的问题是“我长期行为倾向和压力反应怎样”，Big Five 可以补充另一个角度。\n\n## 7. 如何把 RIASEC 用在职业探索中？\n\n你可以把 RIASEC 当作一套筛选问题，而不是答案本身。\n\n第一步，先看你的高分兴趣方向。它们提示你更容易被哪些活动吸引。\n\n第二步，看这些兴趣之间是否聚拢。如果前两位兴趣相邻，说明探索方向可能更集中；如果跨度大，说明你可能需要寻找复合型场景。\n\n第三步，看区分度。如果最高分明显高于其他方向，可以优先探索相应职业环境；如果分数很平，可以先多做真实任务，而不是立刻下结论。\n\n第四步，把兴趣和现实条件放在一起看。兴趣不是能力，能力也不等于兴趣。职业选择还要考虑技能、学习成本、行业机会、工作地点、经济压力和长期目标。\n\n## 8. 完整报告应该帮你看什么？\n\n如果你完成 RIASEC 测试，真正值得看的不是“你是哪一型”这一句话，而是更细的结构：\n\n- 六个兴趣方向的相对分布；\n- 前两位或前三位 Holland Code 的组合含义；\n- 你的兴趣代码在六角形上的一致性；\n- 最高分和其他分数之间的区分度；\n- 当前职业或目标方向与兴趣代码之间的适配度；\n- 适合继续探索的职业环境，而不是保证适合的职业结论；\n- 下一步可以用哪些真实任务、课程或访谈继续验证。\n\n这类报告的价值不在于替你做决定，而在于把模糊的职业焦虑拆成可以观察和验证的结构。\n\n## 9. RIASEC 的边界\n\nRIASEC 不诊断心理状态，不评估医学问题，也不判断能力高低。它不应该用于招聘筛选，也不能保证某个职业一定适合你。\n\n它适合回答的是探索性问题：\n\n- 我可能对哪些活动更有兴趣？\n- 我应该先比较哪些职业环境？\n- 哪些方向值得进一步体验？\n- 我现在的工作消耗感，是否可能和兴趣环境不匹配有关？\n\n职业决策仍然需要结合技能、经验、行业信息、地区机会和真实反馈。RIASEC 是地图，不是判决书。\n\n## 10. 下一步可以怎么做？\n\n如果你正在选专业、考虑转行，或者只是想更系统地理解自己的职业兴趣，可以先完成霍兰德 / RIASEC 职业兴趣测试。\n\n如果你还在比较工具，可以先读 MBTI 与霍兰德的区别，再根据问题选择测试：想看职业兴趣，优先从 RIASEC 开始；想看人格偏好，可以结合 MBTI；想看连续行为倾向，可以参考 Big Five。\n\n## 常见问题\n\n### RIASEC 是职业测试吗？\n\nRIASEC 是职业兴趣模型，常用于职业探索和职业兴趣测试。它帮助你理解自己更偏好的活动和工作环境，但不决定你的职业结果。\n\n### 霍兰德职业兴趣测试和 RIASEC 是一回事吗？\n\n通常可以这样理解。RIASEC 是霍兰德职业兴趣模型中的六个兴趣方向：现实型、研究型、艺术型、社会型、企业型和常规型。\n\n### RIASEC 能告诉我最适合的职业吗？\n\n不能直接保证某个职业最适合你。它可以帮助你缩小探索范围，但职业选择仍要结合技能、经验、行业信息和真实反馈。\n\n### 什么是 Holland Code 的一致性和区分度？\n\n一致性关注你的高分兴趣是否彼此接近，区分度关注最高兴趣和其他兴趣之间差距是否明显。它们可以帮助你理解结果结构，但不能单独决定职业方向。\n\n### RIASEC 和 MBTI 哪个更适合选职业？\n\n如果你的问题是职业兴趣和工作环境，RIASEC 通常更直接。如果你想理解人格偏好和互动风格，MBTI 可以提供另一个角度。\n\n### RIASEC 测试结果需要和 Big Five 一起看吗？\n\n不一定。RIASEC 可以单独用于职业兴趣探索。Big Five 更适合补充观察行为倾向，例如尽责性、外向性或情绪稳定性。\n",
+      "faq_entries": [
+        {
+          "question": "RIASEC 是职业测试吗？",
+          "answer": "RIASEC 是职业兴趣模型，常用于职业探索和职业兴趣测试。它帮助你理解自己更偏好的活动和工作环境，但不决定你的职业结果。"
+        },
+        {
+          "question": "霍兰德职业兴趣测试和 RIASEC 是一回事吗？",
+          "answer": "通常可以这样理解。RIASEC 是霍兰德职业兴趣模型中的六个兴趣方向：现实型、研究型、艺术型、社会型、企业型和常规型。"
+        },
+        {
+          "question": "RIASEC 能告诉我最适合的职业吗？",
+          "answer": "不能直接保证某个职业最适合你。它可以帮助你缩小探索范围，但职业选择仍要结合技能、经验、行业信息和真实反馈。"
+        },
+        {
+          "question": "什么是 Holland Code 的一致性和区分度？",
+          "answer": "一致性关注你的高分兴趣是否彼此接近，区分度关注最高兴趣和其他兴趣之间差距是否明显。它们可以帮助你理解结果结构，但不能单独决定职业方向。"
+        },
+        {
+          "question": "RIASEC 和 MBTI 哪个更适合选职业？",
+          "answer": "如果你的问题是职业兴趣和工作环境，RIASEC 通常更直接。如果你想理解人格偏好和互动风格，MBTI 可以提供另一个角度。"
+        },
+        {
+          "question": "RIASEC 测试结果需要和 Big Five 一起看吗？",
+          "answer": "不一定。RIASEC 可以单独用于职业兴趣探索。Big Five 更适合补充观察行为倾向，例如尽责性、外向性或情绪稳定性。"
+        }
+      ],
+      "cta_suggestions": {
+        "primary_cta_label_suggestion": "开始霍兰德 / RIASEC 职业兴趣测试",
+        "primary_cta_href": "/zh/tests/holland-career-interest-test-riasec",
+        "cta_intent": "start_career_interest_assessment",
+        "target_test_slug": "holland-career-interest-test-riasec",
+        "tracking_expectation": "article_to_test_click",
+        "safety_check": "public canonical route only"
+      },
+      "internal_link_plan": [
+        {
+          "anchor_suggestion": "MBTI 和霍兰德的区别",
+          "href": "/zh/articles/mbti-vs-holland-career-choice",
+          "purpose": "Connect to existing comparison canary.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "霍兰德 / RIASEC 职业兴趣测试",
+          "href": "/zh/tests/holland-career-interest-test-riasec",
+          "purpose": "Primary test path.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "MBTI 性格测试",
+          "href": "/zh/tests/mbti-personality-test-16-personality-types",
+          "purpose": "Comparison context for personality preference.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "大五人格测试",
+          "href": "/zh/tests/big-five-personality-test-ocean-model",
+          "purpose": "Complementary behavioral-trait context.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "职业库",
+          "href": "/zh/career/jobs",
+          "purpose": "Conditional career exploration path.",
+          "status": "conditional",
+          "note": "Route eligibility and career hub strategy require operator/Codex confirmation before use in CMS body."
+        }
+      ],
+      "answer_surface_schema_alignment": {
+        "answer_surface_policy": "editor_supplied",
+        "answer_surface_visibility_suggestion": "Use excerpt or a visible editor summary near the top; do not duplicate a Quick Answer heading inside body_markdown.",
+        "quick_answer_summary": "RIASEC 是一种职业兴趣模型，用现实型、研究型、艺术型、社会型、企业型和常规型六个方向帮助用户理解更偏好的活动和工作环境。它适合辅助职业探索，但不决定职业结果。",
+        "visible_faq_count": 6,
+        "expected_faq_schema_mainEntity_count": 6,
+        "Article_schema_source": "CMS article fields",
+        "Breadcrumb_canonical_path": "/zh/articles/riasec-holland-career-interest-test-explained"
+      },
+      "claim_boundary_checklist": {
+        "no_career_guarantee": "pass",
+        "no_diagnosis": "pass",
+        "no_official_certification_implication": "pass",
+        "no_deterministic_matching_claim": "pass",
+        "no_private_url": "pass",
+        "references_needed": true,
+        "unresolved_Unknown_fields": [
+          "target_topics mapping",
+          "cover_image CMS media asset",
+          "career hub eligibility",
+          "exact external references",
+          "final report module availability in product"
+        ]
+      },
+      "references_needs": [
+        {
+          "category": "primary_model_background",
+          "suggestion": "Sources explaining Holland's vocational-interest theory and the RIASEC model.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "holland_hexagon",
+          "suggestion": "Sources explaining consistency, differentiation, and congruence in Holland Code interpretation.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "career_information_systems",
+          "suggestion": "Public career-information systems that classify work interests or occupations using RIASEC-related dimensions.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "comparison_context",
+          "suggestion": "Neutral sources explaining how vocational interests differ from personality-style and trait models.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "claim_boundary",
+          "suggestion": "Sources clarifying that career-interest tests support exploration and should not be treated as deterministic career-selection tools.",
+          "status": "needs_source_verification"
+        }
+      ],
+      "baseline_placeholders": {
+        "publish_date": "Unknown",
+        "indexed_status": "Unknown",
+        "sitemap_seen": "Unknown",
+        "llms_seen": "Unknown",
+        "impressions_7d": "Unknown",
+        "clicks_7d": "Unknown",
+        "ctr_7d": "Unknown",
+        "average_position_7d": "Unknown",
+        "article_to_test_clicks_7d": "Unknown",
+        "impressions_14d": "Unknown",
+        "clicks_14d": "Unknown",
+        "ctr_14d": "Unknown",
+        "average_position_14d": "Unknown",
+        "article_to_test_clicks_14d": "Unknown",
+        "notes_for_operator": [
+          "Confirm CMS slug and canonical before draft creation.",
+          "Verify CTA target remains the public RIASEC test route.",
+          "Verify career hub link eligibility before using career hub link in body.",
+          "Confirm external references before publish.",
+          "Confirm final report module availability before using report-preview language as product promise.",
+          "Run article CTA route gate, FAQ/schema smoke, and publish hold gate before publish."
+        ]
+      },
+      "draft_defaults": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "robots": "noindex,nofollow",
+        "published_at": null,
+        "published_revision_id": null,
+        "publish_allowed": false,
+        "search_submit_allowed": false,
+        "schema_enabled": false,
+        "schema_enabled_reason": "disabled until visible FAQ preview and CMS draft postcheck verify FAQ/schema alignment",
+        "requires_operator_review": true
+      }
+    },
+    {
+      "locale": "en",
+      "canonical_path": "/en/articles/what-is-riasec-holland-code-career-interest-test",
+      "package_version": "editorial_package.v1",
+      "translation_group_id": "riasec-explanation-article-2026-06-v2",
+      "title": "What Is RIASEC? Understanding Holland Code Career Interests",
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "h1": "What Is RIASEC? How the Holland Code Supports Career Exploration",
+      "seo_title": "What Is RIASEC? Holland Code Career Test",
+      "seo_description": "Learn what RIASEC means, how Holland Code interests combine, and how the model can support career exploration without deciding your future.",
+      "excerpt": "RIASEC is a career-interest model that organizes work preferences into six areas. It can help you explore career environments, but it is not a career verdict.",
+      "category": "career_exploration",
+      "tags": [
+        "RIASEC",
+        "Holland Code",
+        "career interests",
+        "career exploration",
+        "vocational interests"
+      ],
+      "content_track": "evergreen_knowledge",
+      "audience_intent": "career_decision",
+      "signal_source": "RIASEC",
+      "signal_type": "interest",
+      "decision_domains": [
+        "career",
+        "self"
+      ],
+      "target_tests": [
+        "holland-career-interest-test-riasec"
+      ],
+      "target_topics": [
+        {
+          "topic": "career-interest",
+          "requires_operator_mapping": true
+        },
+        {
+          "topic": "riasec",
+          "requires_operator_mapping": true
+        },
+        {
+          "topic": "holland-code",
+          "requires_operator_mapping": true
+        },
+        {
+          "topic": "career-exploration",
+          "requires_operator_mapping": true
+        }
+      ],
+      "claim_level": "exploratory",
+      "sensitivity_level": "career_sensitive",
+      "medical_disclaimer_required": false,
+      "ability_disclaimer_required": false,
+      "external_references_required": true,
+      "review_required_by": [
+        "editor",
+        "psychometrics"
+      ],
+      "cover_image": "__CMS_MEDIA_PLACEHOLDER_REQUIRED__",
+      "cover_image_alt": "RIASEC hexagon showing six Holland Code career-interest areas",
+      "cover_image_prompt": "A restrained editorial infographic showing a Holland RIASEC hexagon with six career-interest domains, subtle arrows for consistency/differentiation/congruence, dark grid, no people, no logos, no certification badges.",
+      "cover_image_style_tag": "editorial_infographic_dark_grid",
+      "body_markdown": "# What Is RIASEC? How the Holland Code Supports Career Exploration\n\n> Some work is something you *can* do, but it drains you over time. Other work may take practice, yet still feels worth returning to. RIASEC focuses on that difference. It is not an ability diagnosis; it is a way to examine vocational interests and work environments.\n\n## 1. The core definition of RIASEC\n\nRIASEC is a model of career interests. It organizes preferences for work activities, problem types, and occupational environments into six areas: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional.\n\nThe model is commonly associated with the Holland Code. Its purpose is not to give you a fixed identity label or decide your career for you. It is better understood as a map for exploration: it helps you notice which work activities may draw your sustained attention and which environments may drain you over time.\n\nIf MBTI is often used to describe preference style, and Big Five is often used to describe broad trait tendencies, RIASEC is more directly about career interests:\n\n- What kinds of work activities tend to attract you?\n- What kinds of environments may fit your interests better?\n- Which career directions should you explore first instead of guessing randomly?\n\n## 2. How the RIASEC / Holland Code model works\n\nThe most useful part of RIASEC is not a single letter. It is the combination of interests.\n\nMany results show two or three high-scoring areas. A person may not be simply Social; they may be Social + Enterprising, or Social + Artistic. The first combination may point toward training, organizing, persuading, or activating teams. The second may point toward education, experience design, human-centered communication, or creative support.\n\nSo the better questions are not “Which type am I?” but:\n\n1. Which interest areas are strongest?\n2. Are the strongest areas close together, complementary, or in tension?\n3. Is there a clear difference between the strongest and weakest areas?\n4. Does my current study, work, or career target fit these interest patterns?\n\nThese questions are more useful than memorizing six labels.\n\n## 3. The six interest areas: definitions and combinations\n\n### 3.1 Realistic: working with concrete systems\n\nRealistic interests are often related to tools, equipment, physical systems, outdoor environments, machines, construction, repair, and practical outcomes. People with stronger Realistic interests may prefer work where something visible gets built, fixed, tested, or operated.\n\nIf this interest is strong but the work environment is mostly abstract meetings, vague planning, or intangible output, the person may feel drained. This is not an ability judgment. It is an interest-environment signal.\n\nExample combinations:\n\n- **RI**: Realistic + Investigative. May point toward technical research, engineering analysis, system architecture, or experimental problem-solving.\n- **RE**: Realistic + Enterprising. May point toward engineering project coordination, operational leadership, field execution, or business work with concrete systems.\n\nThese are not prescriptions. They are starting points for exploration.\n\n### 3.2 Investigative: understanding systems and causes\n\nInvestigative interests are often related to analysis, reasoning, observation, research, data, experimentation, and problem-solving. People with stronger Investigative interests may enjoy asking why something works the way it does.\n\nIf this interest is strong, an environment that demands quick conclusions without analysis may feel frustrating.\n\nExample combinations:\n\n- **IA**: Investigative + Artistic. May point toward conceptual design, interaction research, creative technology, or open-ended problem exploration.\n- **IC**: Investigative + Conventional. May point toward data governance, audit, quality control, system validation, or compliance-oriented analysis.\n\nInvestigative does not mean “higher ability.” It only describes the kind of work activity that may be engaging.\n\n### 3.3 Artistic: expression, design, and open-ended problems\n\nArtistic interests are often related to expression, creation, language, design, visuals, storytelling, and problems without one fixed answer. People with stronger Artistic interests may need room to interpret, create, and reframe.\n\nIf this interest is strong but the environment is highly scripted and rigid, the person may feel constrained.\n\nExample combinations:\n\n- **AI**: Artistic + Investigative. May point toward conceptual research, early-stage product exploration, knowledge design, or creative modeling.\n- **AS**: Artistic + Social. May point toward user experience, educational content, human-centered design, narrative communication, or supportive creative work.\n\nArtistic does not only mean art careers. It may appear in product, content, research communication, design, teaching, and brand strategy.\n\n### 3.4 Social: work directed toward people\n\nSocial interests are often related to helping, teaching, communication, collaboration, support, training, and understanding others. People with stronger Social interests often want their work to affect real people, not just systems.\n\nIf this interest is strong but the work is almost entirely mechanical, isolated, or detached from human feedback, the person may feel a lack of meaning.\n\nExample combinations:\n\n- **SA**: Social + Artistic. May point toward education, experience design, human-centered communication, coaching-like support, or narrative work.\n- **SE**: Social + Enterprising. May point toward training, team activation, organizational communication, client success, or people-centered leadership.\n\nSocial does not mean every people-facing job will fit. Conflict load, emotional labor, and pressure still need to be evaluated.\n\n### 3.5 Enterprising: influence, resources, and outcomes\n\nEnterprising interests are often related to influence, persuasion, organizing people, coordinating resources, business goals, leadership, and project movement. People with stronger Enterprising interests may want action, feedback, and visible outcomes.\n\nIf this interest is strong, a very stable environment with little autonomy or feedback may feel unengaging. This does not mean the person must become an entrepreneur or manager.\n\nExample combinations:\n\n- **EI**: Enterprising + Investigative. May point toward business strategy, investment research, market analysis, growth decisions, or complex judgment work.\n- **EC**: Enterprising + Conventional. May point toward operations management, process improvement, project delivery, organizational control, or structured execution.\n\nEnterprising is not simply “liking to lead.” It is often about being drawn to goals, influence, resources, and outcomes.\n\n### 3.6 Conventional: building order in complex systems\n\nConventional interests are often related to structure, procedures, order, data management, detail, standards, and reliable execution. People with stronger Conventional interests may prefer systems that are trackable, repeatable, and organized.\n\nIf this interest is strong but the environment is chaotic, ambiguous, and constantly changing without standards, stress may rise.\n\nExample combinations:\n\n- **CI**: Conventional + Investigative. May point toward actuarial work, financial analysis, compliance audit, data security, or system verification.\n- **CE**: Conventional + Enterprising. May point toward operations, business process management, organizational controls, project standards, or execution systems.\n\nConventional does not mean “uncreative.” It can be a strong systems skill: turning complexity into reliability.\n\n## 4. Why compound interest codes matter\n\nA RIASEC result is rarely explained well by one sentence. The first two or three letters often matter more.\n\nFor example:\n\n- **RI** and **IR** both involve Realistic and Investigative interests, but their order may imply different emphasis. RI may lean toward concrete systems and technical delivery; IR may lean toward analysis and research.\n- **SA** and **SE** both include Social interests. One may lean toward expression, education, and human-centered experience; the other may lean toward activation, training, and influence.\n- **IC** and **IA** both include Investigative interests. One may lean toward validation and structure; the other toward exploration and creative concept-building.\n\nA useful RIASEC interpretation should look at order, distance, score differences, and current work context.\n\n## 5. The Holland hexagon: consistency, differentiation, and congruence\n\nRIASEC is often shown as a hexagon. The shape is not decoration. It is a way to think about relationships among interests.\n\n### 5.1 Consistency\n\nConsistency asks whether your strongest interest areas are close together on the hexagon. Nearby interests may form a more coherent exploration pattern. Distant interests may suggest that you are drawn to different kinds of activities at the same time.\n\nFor example, Social and Enterprising are neighbors and may point toward communication, training, organizing, or influence. Realistic and Social are farther apart; that does not mean conflict, but it may suggest the need for a hybrid environment that combines concrete systems with human interaction.\n\n### 5.2 Differentiation\n\nDifferentiation looks at the distance between your highest scores and the rest. High differentiation suggests that some interests stand out clearly. Low differentiation may mean broad interests, or it may mean you have not had enough real exposure to separate your preferences yet.\n\nLow differentiation is not a bad result. It simply suggests that your next step may be to gather more evidence through courses, projects, interviews, internships, or real tasks.\n\n### 5.3 Congruence\n\nCongruence asks how well your interest pattern fits your current study, work, or target environment. If there is a large gap, you may feel drained, underused, or disconnected from the work.\n\nCongruence is still not destiny. Skills, role design, team context, career stage, and opportunity all matter. RIASEC helps you notice possible misfit; it does not decide the answer.\n\n## 6. RIASEC vs MBTI vs Big Five in career exploration\n\n| Self-exploration question | RIASEC / Holland career interests | MBTI / 16 types | Big Five / OCEAN |\n|---|---|---|---|\n| What does it mainly answer? | What work activities and environments tend to interest me? | How do I tend to process information, decide, and interact? | What are my broad behavioral tendencies and stress boundaries? |\n| Main target | Career interests, work activities, environment preference | Preference style, interaction pattern, cognitive orientation | Continuous traits such as openness, conscientiousness, extraversion, agreeableness, and emotional stability |\n| Career use | Narrow career directions, compare work environments, plan exploration | Understand communication style and team friction | Observe long-term work habits, stress patterns, and behavioral consistency |\n| Best role in a career journey | Direct career-exploration starting point | Self-style reflection tool | Behavioral tendency reference layer |\n| What it should not do | Guarantee a career fit | Decide your career fate | Replace professional evaluation or real performance evidence |\n\nIf your question is “Which career direction should I explore first?”, RIASEC is often the more direct starting point. If your question is “How do I communicate and make decisions?”, MBTI may help. If your question is “What are my long-term behavioral tendencies?”, Big Five may add useful context.\n\n## 7. How to use RIASEC for career exploration\n\nYou can use RIASEC as a set of exploration filters.\n\nFirst, look at your strongest interest areas. They suggest the types of activities that may draw your attention.\n\nSecond, look at whether those interests cluster together. If your top two areas are close, your exploration path may be more focused. If they are far apart, you may need to look for hybrid environments.\n\nThird, look at differentiation. If one or two interests stand out clearly, you may start exploration there. If the scores are flat, you may need more real-world exposure before drawing conclusions.\n\nFourth, compare interests with reality. Interest is not the same as skill, and skill is not the same as interest. Career decisions also involve learning cost, industry opportunity, work location, economic pressure, and long-term goals.\n\n## 8. What should a full report help you examine?\n\nIf you complete a RIASEC assessment, the most useful result is not just “your type.” A stronger report should help you examine:\n\n- the distribution of all six interest areas;\n- the meaning of your first two or three Holland Code letters;\n- the consistency of your interest pattern on the hexagon;\n- the differentiation between stronger and weaker interests;\n- the congruence between your interests and current or target environments;\n- career environments worth exploring, not guaranteed career conclusions;\n- next steps for testing your interests through real tasks, courses, projects, or interviews.\n\nThe value of this kind of report is not that it decides for you. It helps turn vague career uncertainty into a structure you can investigate.\n\n## 9. Limits of RIASEC\n\nRIASEC is not a medical or psychological diagnosis. It does not evaluate ability, predict career success, or guarantee that an occupation will fit.\n\nIt is best used for exploratory questions:\n\n- What types of activities may interest me?\n- Which work environments should I compare first?\n- Which directions are worth testing with real experience?\n- Could my current sense of work fatigue be related to interest-environment misfit?\n\nCareer decisions still require skills, experience, industry information, local opportunity, and feedback from real situations. RIASEC is a map, not a verdict.\n\n## 10. What to do next\n\nIf you are choosing a major, considering a career change, or trying to understand your work interests more clearly, you can start with a Holland / RIASEC career-interest test.\n\nIf you are still comparing tools, you can read the MBTI vs Holland comparison first. For career interests, RIASEC is usually the more direct tool. For preference style, MBTI can add context. For continuous behavioral tendencies, Big Five may be useful.\n\n## Frequently Asked Questions\n\n### Is RIASEC a career test?\n\nRIASEC is a career-interest model often used in career-interest assessments. It helps you understand preferred activities and work environments, but it does not decide your career outcome.\n\n### Is the Holland Code the same as RIASEC?\n\nIn common use, they are closely related. RIASEC refers to the six interest areas in the Holland career-interest model: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional.\n\n### Can RIASEC tell me my best career?\n\nNo. It can help narrow your exploration, but it cannot guarantee that a specific career is right for you. Career decisions also require skills, experience, industry research, and real feedback.\n\n### What are consistency and differentiation in the Holland Code?\n\nConsistency looks at whether your strongest interests are close together on the RIASEC hexagon. Differentiation looks at whether your highest interests stand out clearly from the rest.\n\n### Is RIASEC or MBTI better for career choice?\n\nIf your question is about career interests and work environments, RIASEC is usually more direct. If your question is about personality preference and interaction style, MBTI offers another angle.\n\n### Should I use Big Five together with RIASEC?\n\nNot always. RIASEC can stand on its own for career-interest exploration. Big Five can add information about broader behavioral tendencies such as conscientiousness, extraversion, or emotional stability.\n",
+      "faq_entries": [
+        {
+          "question": "Is RIASEC a career test?",
+          "answer": "RIASEC is a career-interest model often used in career-interest assessments. It helps you understand preferred activities and work environments, but it does not decide your career outcome."
+        },
+        {
+          "question": "Is the Holland Code the same as RIASEC?",
+          "answer": "In common use, they are closely related. RIASEC refers to the six interest areas in the Holland career-interest model: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional."
+        },
+        {
+          "question": "Can RIASEC tell me my best career?",
+          "answer": "No. It can help narrow your exploration, but it cannot guarantee that a specific career is right for you. Career decisions also require skills, experience, industry research, and real feedback."
+        },
+        {
+          "question": "What are consistency and differentiation in the Holland Code?",
+          "answer": "Consistency looks at whether your strongest interests are close together on the RIASEC hexagon. Differentiation looks at whether your highest interests stand out clearly from the rest."
+        },
+        {
+          "question": "Is RIASEC or MBTI better for career choice?",
+          "answer": "If your question is about career interests and work environments, RIASEC is usually more direct. If your question is about personality preference and interaction style, MBTI offers another angle."
+        },
+        {
+          "question": "Should I use Big Five together with RIASEC?",
+          "answer": "Not always. RIASEC can stand on its own for career-interest exploration. Big Five can add information about broader behavioral tendencies such as conscientiousness, extraversion, or emotional stability."
+        }
+      ],
+      "cta_suggestions": {
+        "primary_cta_label_suggestion": "Start the Holland / RIASEC career-interest test",
+        "primary_cta_href": "/en/tests/holland-career-interest-test-riasec",
+        "cta_intent": "start_career_interest_assessment",
+        "target_test_slug": "holland-career-interest-test-riasec",
+        "tracking_expectation": "article_to_test_click",
+        "safety_check": "public canonical route only"
+      },
+      "internal_link_plan": [
+        {
+          "anchor_suggestion": "MBTI vs Holland Code for career choice",
+          "href": "/en/articles/mbti-vs-holland-code-career-choice",
+          "purpose": "Connect to existing comparison canary.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "Holland / RIASEC career-interest test",
+          "href": "/en/tests/holland-career-interest-test-riasec",
+          "purpose": "Primary test path.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "MBTI personality test",
+          "href": "/en/tests/mbti-personality-test-16-personality-types",
+          "purpose": "Comparison context for personality preference.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "Big Five personality test",
+          "href": "/en/tests/big-five-personality-test-ocean-model",
+          "purpose": "Complementary behavioral-trait context.",
+          "status": "allowed"
+        },
+        {
+          "anchor_suggestion": "career library",
+          "href": "/en/career/jobs",
+          "purpose": "Conditional career exploration path.",
+          "status": "conditional",
+          "note": "Route eligibility and career hub strategy require operator/Codex confirmation before use in CMS body."
+        }
+      ],
+      "answer_surface_schema_alignment": {
+        "answer_surface_policy": "editor_supplied",
+        "answer_surface_visibility_suggestion": "Use excerpt or a visible editor summary near the top; do not duplicate a Quick Answer heading inside body_markdown.",
+        "quick_answer_summary": "RIASEC is a career-interest model that describes six areas of work preference: Realistic, Investigative, Artistic, Social, Enterprising, and Conventional. It can support career exploration, but it does not decide a career outcome.",
+        "visible_faq_count": 6,
+        "expected_faq_schema_mainEntity_count": 6,
+        "Article_schema_source": "CMS article fields",
+        "Breadcrumb_canonical_path": "/en/articles/what-is-riasec-holland-code-career-interest-test"
+      },
+      "claim_boundary_checklist": {
+        "no_career_guarantee": "pass",
+        "no_diagnosis": "pass",
+        "no_official_certification_implication": "pass",
+        "no_deterministic_matching_claim": "pass",
+        "no_private_url": "pass",
+        "references_needed": true,
+        "unresolved_Unknown_fields": [
+          "target_topics mapping",
+          "cover_image CMS media asset",
+          "career hub eligibility",
+          "exact external references",
+          "final report module availability in product"
+        ]
+      },
+      "references_needs": [
+        {
+          "category": "primary_model_background",
+          "suggestion": "Sources explaining Holland's vocational-interest theory and the RIASEC model.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "holland_hexagon",
+          "suggestion": "Sources explaining consistency, differentiation, and congruence in Holland Code interpretation.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "career_information_systems",
+          "suggestion": "Public career-information systems that classify work interests or occupations using RIASEC-related dimensions.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "comparison_context",
+          "suggestion": "Neutral sources explaining how vocational interests differ from personality-style and trait models.",
+          "status": "needs_source_verification"
+        },
+        {
+          "category": "claim_boundary",
+          "suggestion": "Sources clarifying that career-interest tests support exploration and should not be treated as deterministic career-selection tools.",
+          "status": "needs_source_verification"
+        }
+      ],
+      "baseline_placeholders": {
+        "publish_date": "Unknown",
+        "indexed_status": "Unknown",
+        "sitemap_seen": "Unknown",
+        "llms_seen": "Unknown",
+        "impressions_7d": "Unknown",
+        "clicks_7d": "Unknown",
+        "ctr_7d": "Unknown",
+        "average_position_7d": "Unknown",
+        "article_to_test_clicks_7d": "Unknown",
+        "impressions_14d": "Unknown",
+        "clicks_14d": "Unknown",
+        "ctr_14d": "Unknown",
+        "average_position_14d": "Unknown",
+        "article_to_test_clicks_14d": "Unknown",
+        "notes_for_operator": [
+          "Confirm CMS slug and canonical before draft creation.",
+          "Verify CTA target remains the public RIASEC test route.",
+          "Verify career hub link eligibility before using career hub link in body.",
+          "Confirm external references before publish.",
+          "Confirm final report module availability before using report-preview language as product promise.",
+          "Run article CTA route gate, FAQ/schema smoke, and publish hold gate before publish."
+        ]
+      },
+      "draft_defaults": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "robots": "noindex,nofollow",
+        "published_at": null,
+        "published_revision_id": null,
+        "publish_allowed": false,
+        "search_submit_allowed": false,
+        "schema_enabled": false,
+        "schema_enabled_reason": "disabled until visible FAQ preview and CMS draft postcheck verify FAQ/schema alignment",
+        "requires_operator_review": true
+      }
+    }
+  ],
+  "package_decision": "GO for reference/source review",
+  "source_review_decision": "GO for CMS import package preparation; NO-GO for publish until operator/editor source review accepts or resolves listed sources.",
+  "publish_blockers": [
+    "operator_source_review_not_complete",
+    "psychometrics_review_not_complete",
+    "holland_hexagon_source_acceptance_needed",
+    "mbti_big_five_comparison_review_needed",
+    "report_preview_product_availability_unknown",
+    "cover_image_cms_media_placeholder_unresolved"
+  ],
+  "preflight_readiness": {
+    "go_for_draft_preflight": true,
+    "go_for_draft_create": false,
+    "draft_create_requires_exact_user_authorization": true,
+    "go_for_publish": false
+  },
+  "global_safety": {
+    "private_url_seen": false,
+    "route_gate": "pass_for_public_cta_and_allowed_or_conditional_internal_links",
+    "career_hub_links": "conditional_until_route_eligibility_confirmed",
+    "references": "publish_blocking_until_operator_source_review",
+    "cover_image": "__CMS_MEDIA_PLACEHOLDER_REQUIRED__"
+  }
+}

--- a/backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php
@@ -1,0 +1,81 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationCmsImportPackageTest extends TestCase
+{
+    public function test_cms_import_package_is_draft_only_for_two_locales(): void
+    {
+        $package = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-import-package.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01', $package['task_id']);
+        $this->assertFalse($package['cms_draft_created']);
+        $this->assertFalse($package['publish_allowed']);
+        $this->assertFalse($package['search_submit_allowed']);
+        $this->assertFalse($package['content_rewrite_performed']);
+        $this->assertSame('draft_package_only_no_cms_write', $package['importer_mode']);
+        $this->assertTrue($package['preflight_readiness']['go_for_draft_preflight']);
+        $this->assertFalse($package['preflight_readiness']['go_for_draft_create']);
+        $this->assertTrue($package['preflight_readiness']['draft_create_requires_exact_user_authorization']);
+
+        $targets = collect($package['import_targets'])->keyBy('locale');
+
+        $this->assertSame('/zh/articles/riasec-holland-career-interest-test-explained', $targets['zh']['canonical_path']);
+        $this->assertSame('/en/articles/what-is-riasec-holland-code-career-interest-test', $targets['en']['canonical_path']);
+
+        foreach (['zh', 'en'] as $locale) {
+            $target = $targets[$locale];
+
+            $this->assertSame('draft', $target['draft_defaults']['status']);
+            $this->assertFalse($target['draft_defaults']['is_public']);
+            $this->assertFalse($target['draft_defaults']['is_indexable']);
+            $this->assertSame('noindex,nofollow', $target['draft_defaults']['robots']);
+            $this->assertNull($target['draft_defaults']['published_at']);
+            $this->assertNull($target['draft_defaults']['published_revision_id']);
+            $this->assertFalse($target['draft_defaults']['publish_allowed']);
+            $this->assertFalse($target['draft_defaults']['search_submit_allowed']);
+            $this->assertFalse($target['draft_defaults']['schema_enabled']);
+            $this->assertTrue($target['draft_defaults']['requires_operator_review']);
+            $this->assertSame('__CMS_MEDIA_PLACEHOLDER_REQUIRED__', $target['cover_image']);
+            $this->assertCount(6, $target['faq_entries']);
+            $this->assertNotEmpty($target['body_markdown']);
+        }
+    }
+
+    public function test_cms_import_package_keeps_public_cta_and_conditional_internal_links(): void
+    {
+        $package = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-import-package.v1.json');
+        $targets = collect($package['import_targets'])->keyBy('locale');
+
+        $this->assertSame('/zh/tests/holland-career-interest-test-riasec', $targets['zh']['cta_suggestions']['primary_cta_href']);
+        $this->assertSame('/en/tests/holland-career-interest-test-riasec', $targets['en']['cta_suggestions']['primary_cta_href']);
+
+        $this->assertContains('/zh/career/jobs', collect($targets['zh']['internal_link_plan'])->where('status', 'conditional')->pluck('href')->all());
+        $this->assertContains('/en/career/jobs', collect($targets['en']['internal_link_plan'])->where('status', 'conditional')->pluck('href')->all());
+        $this->assertSame('conditional_until_route_eligibility_confirmed', $package['global_safety']['career_hub_links']);
+    }
+
+    public function test_cms_import_package_contains_no_forbidden_routes_or_private_identifiers(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-import-package.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46097,7 +46097,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-cms-import-package-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "title": "docs(cms): prepare RIASEC explanation CMS import package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01"
@@ -46129,7 +46129,9 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR opened; waiting for GitHub checks.",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
+        "commit_sha": "4184d74b860c0c494765659a39209e1952de9db4"
       }
     },
     "result": {
@@ -46144,8 +46146,8 @@
       "search_submit_allowed": false
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "4184d74b860c0c494765659a39209e1952de9db4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
     "transitions": [
       {
         "at": "2026-06-05T10:52:00+08:00",
@@ -46158,6 +46160,11 @@
         "from": "planned",
         "to": "local_checks_passed",
         "notes": "CMS import package generated with zh/en targets, draft defaults, noindex/nofollow, schema disabled until preview, and retained publish blockers."
+      },
+      {
+        "status": "pr_open",
+        "evidence": "https://github.com/fermatmind/fap-api/pull/1915",
+        "commit_sha": "4184d74b860c0c494765659a39209e1952de9db4"
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46128,10 +46128,10 @@
         "notes": "CMS import package test, JSON/YAML parse, and scoped diff check passed. No CMS write performed."
       },
       "github": {
-        "status": "pass",
-        "evidence": "GitHub checks passed on PR #1915 before ready-to-merge ledger update.",
+        "status": "pending",
+        "evidence": "PR rebased onto latest origin/main; waiting for GitHub checks on rebased head.",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
-        "commit_sha": "a9b39402db0d617dd13f76d8abe738f90ef4fc1a"
+        "commit_sha": "fdb6b1e1b840fdc4ddeeefde7813d120c4b38a95"
       }
     },
     "result": {
@@ -46146,7 +46146,7 @@
       "search_submit_allowed": false
     },
     "failure_reason": null,
-    "commit_sha": "a9b39402db0d617dd13f76d8abe738f90ef4fc1a",
+    "commit_sha": "fdb6b1e1b840fdc4ddeeefde7813d120c4b38a95",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
     "transitions": [
       {
@@ -46170,6 +46170,11 @@
         "status": "ready_to_merge",
         "evidence": "GitHub checks passed; PR is ready for merge after ledger update checks pass.",
         "commit_sha": "a9b39402db0d617dd13f76d8abe738f90ef4fc1a"
+      },
+      {
+        "status": "rebased_ready_to_merge",
+        "evidence": "PR rebased onto latest origin/main after main moved during checks.",
+        "commit_sha": "fdb6b1e1b840fdc4ddeeefde7813d120c4b38a95"
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46097,7 +46097,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-cms-import-package-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "docs(cms): prepare RIASEC explanation CMS import package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01"
@@ -46128,10 +46128,10 @@
         "notes": "CMS import package test, JSON/YAML parse, and scoped diff check passed. No CMS write performed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR opened; waiting for GitHub checks.",
+        "status": "pass",
+        "evidence": "GitHub checks passed on PR #1915 before ready-to-merge ledger update.",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
-        "commit_sha": "4184d74b860c0c494765659a39209e1952de9db4"
+        "commit_sha": "a9b39402db0d617dd13f76d8abe738f90ef4fc1a"
       }
     },
     "result": {
@@ -46146,7 +46146,7 @@
       "search_submit_allowed": false
     },
     "failure_reason": null,
-    "commit_sha": "4184d74b860c0c494765659a39209e1952de9db4",
+    "commit_sha": "a9b39402db0d617dd13f76d8abe738f90ef4fc1a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
     "transitions": [
       {
@@ -46165,6 +46165,11 @@
         "status": "pr_open",
         "evidence": "https://github.com/fermatmind/fap-api/pull/1915",
         "commit_sha": "4184d74b860c0c494765659a39209e1952de9db4"
+      },
+      {
+        "status": "ready_to_merge",
+        "evidence": "GitHub checks passed; PR is ready for merge after ledger update checks pass.",
+        "commit_sha": "a9b39402db0d617dd13f76d8abe738f90ef4fc1a"
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46097,7 +46097,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-cms-import-package-01",
-    "status": "planned",
+    "status": "local_checks_passed",
     "title": "docs(cms): prepare RIASEC explanation CMS import package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01"
@@ -46108,23 +46108,41 @@
         "evidence": "User provided an explicit /goal for the RIASEC explanation V2 SEO article PR train, including PR ids, branches, titles, scopes, allowed paths, and hard gates. Default execution is allowed only through CMS draft preflight."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01 to merge."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01 merged as PR #1913 at 2026-06-05T03:45:17Z; origin/main contains merge commit c9b4052705c902f3e718520d19b588a589a183e8."
       },
       "scope_validation": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/seo/cms-import-packages/riasec-explanation-v2/**, backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json, backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php, and docs/codex PR-train metadata."
       },
       "local": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsImportPackageTest --no-ansi",
+          "git diff --check -- backend/docs/seo/cms-import-packages/riasec-explanation-v2 backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "CMS import package test, JSON/YAML parse, and scoped diff check passed. No CMS write performed."
       },
       "github": {
         "status": "pending",
         "evidence": null
       }
     },
-    "result": {},
+    "result": {
+      "import_package_path": "backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json",
+      "targets": [
+        "/zh/articles/riasec-holland-career-interest-test-explained",
+        "/en/articles/what-is-riasec-holland-code-career-interest-test"
+      ],
+      "decision": "GO for CMS draft preflight; NO-GO for CMS draft creation without exact draft-only authorization.",
+      "cms_draft_created": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -46134,6 +46152,12 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01 /goal. No CMS mutation, publish, search submission, deploy, private URL access, or content rewrite authorized."
+      },
+      {
+        "at": "2026-06-05T11:47:00+08:00",
+        "from": "planned",
+        "to": "local_checks_passed",
+        "notes": "CMS import package generated with zh/en targets, draft defaults, noindex/nofollow, schema disabled until preview, and retained publish blockers."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22114,7 +22114,7 @@ prs:
     branch: codex/seo-article-riasec-v2-reference-source-review-01
     title: "docs(seo): verify reference needs for RIASEC explanation package"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: in_progress
+    status: merged
     scope:
       - Prepare a reference/source verification ledger for the RIASEC explanation package without fabricating citations or editing article copy.
       - Record authoritative source categories, verified URLs when available, unresolved source gaps, and publish blockers.
@@ -22150,7 +22150,7 @@ prs:
     branch: codex/seo-article-riasec-v2-cms-import-package-01
     title: "docs(cms): prepare RIASEC explanation CMS import package"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: planned
+    status: in_progress
     scope:
       - Convert the validated content package into backend/CMS import package format without writing CMS records.
       - Preserve draft defaults, noindex/nofollow, operator review requirement, CTA safety, FAQ/schema alignment, and baseline placeholders.


### PR DESCRIPTION
## What changed
- Added a draft-only zh/en CMS import target package for the RIASEC explanation article content package.
- Added a generated import summary with public canonical article paths, CTA route gating, conditional internal links, and publish/search hard blocks.
- Added focused feature tests for draft-only status, public CTA routes, conditional links, and forbidden private route/id scanning.
- Updated PR-train manifest/state for this package preparation step.

## Why
- Moves the validated GPT content package into a CMS-ready import shape while preserving the operator review, noindex draft, no publish, and no search submission gates.

## Validation commands
- php -l backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php
- python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml-ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsImportPackageTest --no-ansi
- git diff --check -- backend/docs/seo/cms-import-packages/riasec-explanation-v2 backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS draft creation.
- No publish.
- No production deploy.
- No search submission.
- No article copy rewrite by Codex.
- Source-review and cover-media publish blockers remain enforced.
