### PR TITLE
docs(codex): add Help editorial review train entry

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44491,7 +44491,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-review-preflight-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review preflight",
     "depends_on": [
@@ -44566,9 +44566,9 @@
     "failure_reason": null,
     "commit_sha": "f7dcd33b8832feb0c8da0bd18a96700158c04814",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1908",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:01:45Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "planned_outputs": {
       "generated_artifact": "backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json",
       "operations_report": "backend/docs/operations/help-content-draft-review-preflight-2026-06-05.md",
@@ -44644,6 +44644,92 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "PR #1908 GitHub checks passed and PR was CLEAN/MERGEABLE with four scoped files."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "Reconciled after PR #1908 squash merge; origin/main contains merge commit 012b2e8f28f5ab338b21a306b921a1560767ffa5, remote task branch is absent, and local cleanup was executed."
+      }
+    ],
+    "merge_commit": "012b2e8f28f5ab338b21a306b921a1560767ffa5",
+    "merge_commit_sha": "012b2e8f28f5ab338b21a306b921a1560767ffa5"
+  },
+  "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-editorial-review-01",
+    "base": "origin/main",
+    "status": "pending_operator_review_request",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): prepare Help CMS draft editorial review request",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding the HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01 manifest/state entries."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01 is merged as PR #1908; origin/main contains merge commit 012b2e8f28f5ab338b21a306b921a1560767ffa5."
+      },
+      "scope_preflight": {
+        "status": "pass",
+        "evidence": "Editorial-review PR scope is review request and decision-capture only; Codex must not claim Operator editorial approval, mutate CMS, publish, deploy, access private URLs, run payment/refund flows, or read secrets/env/cookies/tokens."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "planned_outputs": {
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md",
+      "operator_review_request_allowed": true,
+      "operator_approval_allowed_for_codex": false,
+      "publish_allowed": false,
+      "cms_mutation_allowed": false
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "editorial_approval_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-OPERATOR-APPROVAL",
+        "status": "hard_gate",
+        "note": "Operator editorial approval must be explicit and separate; Codex may only prepare the review request and capture the required decision contract."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish, indexability, sitemap/llms inclusion, search submission, and deployment remain forbidden without separate explicit approval."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-SUPPORT-CONTACT-FIELD",
+        "status": "open",
+        "note": "support@fermatmind.com exists in the import package, but prior postcheck did not verify a first-class support_contact field on production ContentPage rows."
+      }
+    ],
+    "next_task": null,
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "manifest_state_authorized",
+        "note": "User authorized supplementing manifest/state entries for HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pending_operator_review_request",
+        "note": "Manifest/state entry added; implementation must run as a separate scoped PR and stop before claiming Operator editorial approval."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21562,7 +21562,7 @@ prs:
     branch: codex/help-content-draft-review-preflight-01
     title: "docs(help): prepare Help CMS draft editorial review preflight"
     train_scope: window_9_help_service_content
-    status: review_preflight_passed_operator_review_required
+    status: merged
     depends_on:
       - HELP-CONTENT-DRAFT-POSTCHECK-01
     scope:
@@ -21596,6 +21596,47 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01
+
+  - id: HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01
+    repo: fap-api
+    branch: codex/help-content-draft-editorial-review-01
+    title: "docs(help): prepare Help CMS draft editorial review request"
+    train_scope: window_9_help_service_content
+    status: pending_operator_review_request
+    depends_on:
+      - HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01
+    scope:
+      - Prepare the Operator editorial review request and decision-capture artifact for the 12 Help service CMS drafts.
+      - Archive the review checklist, source package identity, support-contact sidecar status, non-diagnostic/privacy/payment/refund/result-recovery coverage, and publish/search/deploy hard gates.
+      - Stop before claiming Operator editorial approval; approval must be explicit and separate from Codex-generated artifacts.
+      - Keep CMS mutation, publish, deployment, search submission, private URL access, and payment/refund operations out of scope.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json
+      - backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Approve editorial review on Operator's behalf, publish, mutate CMS, create/update/delete drafts, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: null
 
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added the authorized `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01` manifest/state entry.
- Reconciled `HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01` as merged after PR #1908 so the new dependency is unblocked.

## Why
- The Help service content train needs an explicit next PR entry before Codex can prepare the Operator editorial review request.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No editorial approval was performed.
- No CMS mutation, publish, deploy, search submission, private URL access, payment/refund flow, or secret/env/cookie/token read was performed.
- Actual `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01` implementation must run in a separate scoped PR and stop before claiming Operator approval.

## Repository rule impact
- Help content remains CMS/backend-authoritative. This PR only updates PR-train metadata and does not introduce frontend fallback content.