### PR TITLE
test(benefit): add DailyGiving public API smoke gate

### DIFF
--- a/backend/docs/operations/daily-giving-public-api-smoke.md
+++ b/backend/docs/operations/daily-giving-public-api-smoke.md
@@ -1,0 +1,23 @@
+# DailyGiving Public API Smoke
+
+Date: 2026-06-05
+
+PR train item: `DAILY-GIVING-PUBLIC-API-SMOKE-01`
+
+Mode: backend smoke contract and test fixtures only. This PR does not create real DailyGiving records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, run social distribution, or deploy.
+
+## Smoke Coverage
+
+- A test fixture public record makes `/api/v0.5/foundation/giving-records` return at least one item.
+- The months endpoint returns at least one month for the fixture public record.
+- The show endpoint returns the fixture record by public `record_code`.
+- Public responses exclude private proof paths, private receipt references, redaction notes, internal notes, and admin user ids.
+- The fixture remains `is_indexable=false`.
+
+## Boundary
+
+This smoke test proves backend public API projection behavior with controlled test data. It does not prove production has real public records, does not upload or redact proof, and does not authorize indexing or trust badges.
+
+## Next Gate
+
+DailyGiving indexability remains blocked until page-level noindex, sitemap, and llms gates are verified separately.

--- a/backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json
+++ b/backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json
@@ -1,0 +1,36 @@
+{
+  "version": "daily_giving_public_api_smoke.v1",
+  "generated_at": "2026-06-05T00:00:00+08:00",
+  "mode": "backend_test_fixture_smoke",
+  "production_record_created": false,
+  "proof_uploaded": false,
+  "proof_processed": false,
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "smoke_endpoints": [
+    "/api/v0.5/foundation/giving-records",
+    "/api/v0.5/foundation/giving-records/months",
+    "/api/v0.5/foundation/giving-records/{record_code}"
+  ],
+  "fixture_expectations": {
+    "records_api_min_count": 1,
+    "months_api_min_count": 1,
+    "show_api_status": 200,
+    "fixture_is_indexable": false,
+    "fixture_donation_status": "verified",
+    "fixture_proof_status": "redacted_available"
+  },
+  "forbidden_public_fields": [
+    "proof_private_path",
+    "proof_redaction_notes",
+    "receipt_reference_private",
+    "internal_notes",
+    "created_by_admin_user_id",
+    "updated_by_admin_user_id"
+  ],
+  "trust_badge_allowed_now": false,
+  "public_amplification_allowed_now": false,
+  "next_pr": "DAILY-GIVING-INDEXABILITY-GATE-01"
+}

--- a/backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use App\Models\DailyGivingRecord;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class DailyGivingPublicApiSmokeTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_public_api_smoke_returns_fixture_record_month_and_no_private_fields(): void
+    {
+        $record = DailyGivingRecord::factory()->verified()->create([
+            'record_code' => 'FM-GIVING-2026-06-SMOKE',
+            'donation_date' => '2026-06-05',
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-smoke-2026-06-05.pdf',
+            'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt-smoke.pdf',
+            'proof_redaction_notes' => 'Test fixture reviewer note.',
+            'receipt_reference_private' => 'PRIVATE-SMOKE-REF',
+            'internal_notes' => 'Test fixture internal note.',
+            'created_by_admin_user_id' => 1,
+            'updated_by_admin_user_id' => 2,
+            'is_public' => true,
+            'is_indexable' => false,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $index = $this->getJson('/api/v0.5/foundation/giving-records');
+        $index->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.record_code', $record->record_code);
+
+        $months = $this->getJson('/api/v0.5/foundation/giving-records/months');
+        $months->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('months.0', '2026-06');
+
+        $show = $this->getJson("/api/v0.5/foundation/giving-records/{$record->record_code}");
+        $show->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('record.record_code', $record->record_code)
+            ->assertJsonPath('record.donation_status', DailyGivingRecord::DONATION_VERIFIED)
+            ->assertJsonPath('record.proof_status', DailyGivingRecord::PROOF_REDACTED_AVAILABLE);
+
+        $publicRecord = $show->json('record');
+
+        foreach ($this->forbiddenPublicFields() as $field) {
+            $this->assertArrayNotHasKey($field, $publicRecord);
+        }
+    }
+
+    public function test_public_api_smoke_artifact_keeps_runtime_actions_blocked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_record_created',
+            'proof_uploaded',
+            'proof_processed',
+            'cms_mutation_performed',
+            'publish_performed',
+            'search_submission_performed',
+            'deploy_performed',
+            'trust_badge_allowed_now',
+            'public_amplification_allowed_now',
+        ] as $field) {
+            $this->assertFalse($artifact[$field], $field);
+        }
+
+        $this->assertSame('DAILY-GIVING-INDEXABILITY-GATE-01', $artifact['next_pr']);
+    }
+
+    public function test_public_api_smoke_artifact_matches_private_field_contract(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ($this->forbiddenPublicFields() as $field) {
+            $this->assertContains($field, $artifact['forbidden_public_fields']);
+        }
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function forbiddenPublicFields(): array
+    {
+        return [
+            'proof_private_path',
+            'proof_redaction_notes',
+            'receipt_reference_private',
+            'internal_notes',
+            'created_by_admin_user_id',
+            'updated_by_admin_user_id',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/operations/generated/daily-giving-public-api-smoke.v1.json');
+        $payload = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T04:02:50Z",
+  "updated_at": "2026-06-05T04:07:42Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -46205,7 +46205,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-public-api-smoke-01",
     "base": "main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "test(benefit): add DailyGiving public API smoke gate",
     "depends_on": [
@@ -46237,8 +46237,8 @@
         "notes": "All commands exited 0. PHPUnit reported three warnings from the temporary checkout missing backend/.env; 36 assertions passed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #1917 opened; GitHub checks pending."
+        "status": "pass",
+        "evidence": "PR #1917 checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -46254,7 +46254,7 @@
       "next_pr_supported": "DAILY-GIVING-INDEXABILITY-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": "92c97fd62d95ea2a13680c5e63e400ed3761ccca",
+    "commit_sha": "cac138c18d4573e9ae9f7d15e884f6fdb0f19aa0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1917",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -46288,6 +46288,12 @@
         "from": "local_checks_passed",
         "to": "pr_open",
         "notes": "Opened PR #1917 for DailyGiving public API smoke gate. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T04:07:42Z",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed for PR #1917; ready for squash merge. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T04:01:49Z",
+  "updated_at": "2026-06-05T04:02:50Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -46205,7 +46205,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-public-api-smoke-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "test(benefit): add DailyGiving public API smoke gate",
     "depends_on": [
@@ -46238,7 +46238,7 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR #1917 opened; GitHub checks pending."
       }
     },
     "result": {
@@ -46254,8 +46254,8 @@
       "next_pr_supported": "DAILY-GIVING-INDEXABILITY-GATE-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "92c97fd62d95ea2a13680c5e63e400ed3761ccca",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1917",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -46282,6 +46282,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Local syntax, JSON/YAML, focused PHPUnit, and scoped diff checks passed. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T04:02:50Z",
+        "from": "local_checks_passed",
+        "to": "pr_open",
+        "notes": "Opened PR #1917 for DailyGiving public API smoke gate. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T03:46:56Z",
+  "updated_at": "2026-06-05T04:01:49Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -46103,7 +46103,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-public-release-prereq-01",
     "base": "main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving public release prerequisites",
     "depends_on": [
@@ -46152,11 +46152,11 @@
       "next_pr_supported": "DAILY-GIVING-PUBLIC-API-SMOKE-01"
     },
     "failure_reason": null,
-    "commit_sha": "53f289827d75c981dc1c568a4e727280e0c7dd86",
+    "commit_sha": "b8b77dfb8af895be3a13f9f8880a1e9cf41aabca",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1914",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:58:37Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -46192,6 +46192,96 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed for PR #1914; ready for squash merge. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T04:00:51Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "PR #1914 squash-merged at b8b77dfb8af895be3a13f9f8880a1e9cf41aabca; origin/main contains merge commit; remote and local task branches are absent."
+      }
+    ]
+  },
+  "DAILY-GIVING-PUBLIC-API-SMOKE-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-public-api-smoke-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "test(benefit): add DailyGiving public API smoke gate",
+    "depends_on": [
+      "DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized Window 7 Public Benefit / Foundation / DailyGiving Trust Gate PR train through PR12 and required stopping before record/proof mutation steps."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01 merged as PR #1914 at b8b77dfb8af895be3a13f9f8880a1e9cf41aabca."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to DailyGiving public API smoke docs/generated artifact/test and docs/codex ledger paths. Test records are sqlite fixtures only; no production record/proof/CMS/publish/deploy/search/social/index/trust badge action was performed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php",
+          "python3 -m json.tool backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingPublicApiSmokeTest --no-ansi",
+          "git diff --check -- backend/docs/operations/daily-giving-public-api-smoke.md backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "All commands exited 0. PHPUnit reported three warnings from the temporary checkout missing backend/.env; 36 assertions passed."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "result": {
+      "production_record_created": false,
+      "proof_uploaded": false,
+      "proof_processed": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "trust_badge_allowed_now": false,
+      "public_amplification_allowed_now": false,
+      "next_pr_supported": "DAILY-GIVING-INDEXABILITY-GATE-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Scope stayed within PR10 docs/generated/test/ledger paths. API smoke uses sqlite fixtures only."
+    },
+    "next_task": "DAILY-GIVING-INDEXABILITY-GATE-01",
+    "transitions": [
+      {
+        "at": "2026-06-05T04:00:51Z",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized PR10 after PR9 merge. No production record/proof/CMS/publish/deploy/search/social/index/trust badge action authorized."
+      },
+      {
+        "at": "2026-06-05T04:01:49Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Local syntax, JSON/YAML, focused PHPUnit, and scoped diff checks passed. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21946,7 +21946,7 @@ prs:
     branch: codex/daily-giving-public-release-prereq-01
     title: "docs(benefit): define DailyGiving public release prerequisites"
     train_scope: window_7_public_benefit_trust_gate
-    status: in_progress
+    status: merged
     scope:
       - Define DailyGiving public release prerequisites for records API, months API, proof review, noindex, sitemap/llms exclusion, and claim lint.
       - Add generated prerequisite artifact and focused contract coverage.
@@ -21981,6 +21981,49 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: DAILY-GIVING-PUBLIC-API-SMOKE-01
+
+  - id: DAILY-GIVING-PUBLIC-API-SMOKE-01
+    repo: fap-api
+    depends_on:
+      - DAILY-GIVING-PUBLIC-RELEASE-PREREQ-01
+    branch: codex/daily-giving-public-api-smoke-01
+    title: "test(benefit): add DailyGiving public API smoke gate"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Add DailyGiving public API smoke coverage for records, months, show, and private-field exclusion using test fixtures only.
+      - Add generated public API smoke artifact.
+      - Keep real records, proof, CMS, publish, index, trust badge, search, social, and deploy actions non-mutating.
+    allowed_paths:
+      - backend/docs/operations/daily-giving-public-api-smoke.md
+      - backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json
+      - backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create production records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, run social distribution, deploy, or read secrets.
+    validation:
+      - php -l backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
+      - python3 -m json.tool backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingPublicApiSmokeTest --no-ansi
+      - git diff --check -- backend/docs/operations/daily-giving-public-api-smoke.md backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: DAILY-GIVING-INDEXABILITY-GATE-01
 
   - id: SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added DailyGiving public API smoke coverage for records, months, and show endpoints using sqlite test fixtures only.
- Added generated public API smoke artifact.
- Reconciled PR9 merge facts in the PR-train ledger.

## Why
- Public release needs a repeatable backend smoke proving public API projection returns records/months when fixture records exist and never exposes private proof/admin fields.

## Validation
- php -l backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
- python3 -m json.tool backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingPublicApiSmokeTest --no-ansi
- git diff --check -- backend/docs/operations/daily-giving-public-api-smoke.md backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

Note: PHPUnit emitted warnings because the temp worktree has no backend/.env; command exited 0 and 36 assertions passed.

## Intentionally deferred
- No production DailyGiving record creation.
- No proof upload or processing.
- No CMS mutation, publish, indexing, trust badge, search submission, social distribution, or deploy.