### PR TITLE
docs(cms): preflight RIASEC explanation draft creation

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json
@@ -1,0 +1,238 @@
+{
+  "task_id": "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-PREFLIGHT-01",
+  "source_task_id": "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01",
+  "source_import_package_path": "backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json",
+  "generated_at": "2026-06-05",
+  "cms_draft_created": false,
+  "cms_draft_create_allowed": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "deploy_allowed": false,
+  "content_rewrite_performed": false,
+  "private_url_accessed": false,
+  "production_write_performed": false,
+  "preflight_decision": "NO-GO for CMS draft creation; GO for documenting draft preflight blockers.",
+  "stop_reason": "Controlled importer dry-run fails for both locales, hidden CMS slug and translation-group collisions remain Unknown, and operator write permission is Unknown.",
+  "targets": [
+    {
+      "locale": "zh",
+      "slug": "riasec-holland-career-interest-test-explained",
+      "canonical_path": "/zh/articles/riasec-holland-career-interest-test-explained",
+      "translation_group_id": "riasec-explanation-article-2026-06-v2",
+      "draft_defaults": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "robots": "noindex,nofollow",
+        "published_at": null,
+        "published_revision_id": null,
+        "publish_allowed": false,
+        "search_submit_allowed": false,
+        "schema_enabled": false,
+        "schema_enabled_reason": "disabled until visible FAQ preview and CMS draft postcheck verify FAQ/schema alignment",
+        "requires_operator_review": true
+      },
+      "package_shape": {
+        "package_version": "editorial_package.v1",
+        "body_markdown_present": true,
+        "body_markdown_chars": 5788,
+        "faq_count": 6,
+        "internal_link_count": 5,
+        "conditional_internal_links": [
+          "/zh/career/jobs"
+        ],
+        "title_chars": 25,
+        "h1_chars": 28,
+        "seo_title_chars": 22,
+        "seo_description_chars": 53,
+        "excerpt_chars": 67
+      },
+      "cta_route_gate": {
+        "status": "pass",
+        "primary_cta_href": "/zh/tests/holland-career-interest-test-riasec",
+        "public_canonical_route_only": true,
+        "forbidden_private_route_seen": false
+      },
+      "faq_schema_gate": {
+        "status": "conditional_pass_for_preflight",
+        "faq_visible_ready_count": 6,
+        "schema_enabled_before_preview": false,
+        "requirement": "Enable FAQ/schema only after visible FAQ preview matches schema entries."
+      },
+      "public_exposure_absence": {
+        "article_api_status": 404,
+        "article_seo_api_status": 404,
+        "web_route_status": 404,
+        "sitemap_xml": "absent",
+        "llms_txt": "absent",
+        "llms_full_txt": "absent"
+      },
+      "draft_create_preflight": {
+        "status": "blocked",
+        "hidden_cms_slug_collision": "Unknown",
+        "hidden_translation_group_collision": "Unknown",
+        "operator_write_permission": "Unknown",
+        "importer_dry_run_status": "fail",
+        "importer_dry_run_error": "Array to string conversion",
+        "importer_dry_run_would_write": false
+      }
+    },
+    {
+      "locale": "en",
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "canonical_path": "/en/articles/what-is-riasec-holland-code-career-interest-test",
+      "translation_group_id": "riasec-explanation-article-2026-06-v2",
+      "draft_defaults": {
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "robots": "noindex,nofollow",
+        "published_at": null,
+        "published_revision_id": null,
+        "publish_allowed": false,
+        "search_submit_allowed": false,
+        "schema_enabled": false,
+        "schema_enabled_reason": "disabled until visible FAQ preview and CMS draft postcheck verify FAQ/schema alignment",
+        "requires_operator_review": true
+      },
+      "package_shape": {
+        "package_version": "editorial_package.v1",
+        "body_markdown_present": true,
+        "body_markdown_chars": 15759,
+        "faq_count": 6,
+        "internal_link_count": 5,
+        "conditional_internal_links": [
+          "/en/career/jobs"
+        ],
+        "title_chars": 59,
+        "h1_chars": 64,
+        "seo_title_chars": 40,
+        "seo_description_chars": 139,
+        "excerpt_chars": 158
+      },
+      "cta_route_gate": {
+        "status": "pass",
+        "primary_cta_href": "/en/tests/holland-career-interest-test-riasec",
+        "public_canonical_route_only": true,
+        "forbidden_private_route_seen": false
+      },
+      "faq_schema_gate": {
+        "status": "conditional_pass_for_preflight",
+        "faq_visible_ready_count": 6,
+        "schema_enabled_before_preview": false,
+        "requirement": "Enable FAQ/schema only after visible FAQ preview matches schema entries."
+      },
+      "public_exposure_absence": {
+        "article_api_status": 404,
+        "article_seo_api_status": 404,
+        "web_route_status": 404,
+        "sitemap_xml": "absent",
+        "llms_txt": "absent",
+        "llms_full_txt": "absent"
+      },
+      "draft_create_preflight": {
+        "status": "blocked",
+        "hidden_cms_slug_collision": "Unknown",
+        "hidden_translation_group_collision": "Unknown",
+        "operator_write_permission": "Unknown",
+        "importer_dry_run_status": "fail",
+        "importer_dry_run_error": "Array to string conversion",
+        "importer_dry_run_would_write": false
+      }
+    }
+  ],
+  "checks": {
+    "package_integrity": "pass",
+    "draft_defaults_noindex": "pass",
+    "public_absence": "pass",
+    "sitemap_llms_absence": "pass",
+    "cta_public_canonical_only": "pass",
+    "forbidden_private_routes": "pass",
+    "faq_visible_schema_alignment": "conditional_pass_for_preflight",
+    "reference_source_review": "publish_blocking_operator_acceptance_required",
+    "cover_image_media": "blocked_placeholder_required",
+    "importer_dry_run": "fail",
+    "hidden_cms_collision_check": "Unknown",
+    "operator_permission_check": "Unknown"
+  },
+  "dry_run_commands": [
+    {
+      "locale": "zh",
+      "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan articles:import-editorial-package --file=docs/seo/cms-import-packages/riasec-explanation-v2/zh.article-target.json --locale=zh --dry-run --allow-claim-warnings --json",
+      "ok": false,
+      "action": "will_skip",
+      "error_code": "unexpected_error",
+      "error_message": "Array to string conversion"
+    },
+    {
+      "locale": "en",
+      "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan articles:import-editorial-package --file=docs/seo/cms-import-packages/riasec-explanation-v2/en.article-target.json --locale=en --dry-run --allow-claim-warnings --json",
+      "ok": false,
+      "action": "will_skip",
+      "error_code": "unexpected_error",
+      "error_message": "Array to string conversion"
+    }
+  ],
+  "public_http_checks": {
+    "article_api": [
+      {
+        "url": "https://api.fermatmind.com/api/v0.5/articles/riasec-holland-career-interest-test-explained?locale=zh",
+        "status": 404
+      },
+      {
+        "url": "https://api.fermatmind.com/api/v0.5/articles/riasec-holland-career-interest-test-explained/seo?locale=zh",
+        "status": 404
+      },
+      {
+        "url": "https://api.fermatmind.com/api/v0.5/articles/what-is-riasec-holland-code-career-interest-test?locale=en",
+        "status": 404
+      },
+      {
+        "url": "https://api.fermatmind.com/api/v0.5/articles/what-is-riasec-holland-code-career-interest-test/seo?locale=en",
+        "status": 404
+      }
+    ],
+    "web_routes": [
+      {
+        "url": "https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained",
+        "status": 404
+      },
+      {
+        "url": "https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test",
+        "status": 404
+      }
+    ],
+    "discovery_surfaces": [
+      {
+        "url": "https://fermatmind.com/sitemap.xml",
+        "target_slugs": "absent"
+      },
+      {
+        "url": "https://fermatmind.com/llms.txt",
+        "target_slugs": "absent"
+      },
+      {
+        "url": "https://fermatmind.com/llms-full.txt",
+        "target_slugs": "absent"
+      }
+    ]
+  },
+  "hard_gates": {
+    "draft_create_requires_exact_user_authorization": true,
+    "exact_draft_authorization_present": false,
+    "exact_publish_authorization_present": false,
+    "exact_search_submission_authorization_present": false,
+    "draft_authorization_alone_is_sufficient_now": false,
+    "additional_blockers_before_draft_create": [
+      "Resolve importer dry-run Array to string conversion for zh/en target packages.",
+      "Verify hidden CMS slug collisions via authorized read-only CMS/DB path or operator UI evidence.",
+      "Verify hidden translation_group_id collision via authorized read-only CMS/DB path or operator UI evidence.",
+      "Confirm operator has draft/import write permission without invoking publish/release."
+    ]
+  },
+  "next_step_request": {
+    "status": "blocked_before_draft_create",
+    "recommended_next_task": "Fix or adapt importer schema mapping, then rerun CMS draft preflight; do not create draft yet.",
+    "draft_create_task": "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01 remains blocked."
+  }
+}

--- a/backend/docs/seo/riasec-explanation-cms-draft-preflight.md
+++ b/backend/docs/seo/riasec-explanation-cms-draft-preflight.md
@@ -1,0 +1,47 @@
+# RIASEC Explanation CMS Draft Preflight
+
+Task: `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-PREFLIGHT-01`
+
+Decision: **NO-GO for CMS draft creation; GO for documenting draft preflight blockers.**
+
+## Scope
+
+This preflight uses the archived GPT-5.5 Pro V2 content package and the generated CMS import package as inputs. It does not create CMS draft records, publish, submit search URLs, deploy, access private URLs, or rewrite article content.
+
+## Target Public Routes
+
+- zh: `/zh/articles/riasec-holland-career-interest-test-explained`
+- en: `/en/articles/what-is-riasec-holland-code-career-interest-test`
+
+## Checks Completed
+
+- Draft defaults remain `status=draft`, `is_public=false`, `is_indexable=false`, `robots=noindex,nofollow`, and `published_revision_id=null`.
+- CTA routes remain public canonical RIASEC test routes.
+- No result/order/share/pay/payment/history/private/tokenized URL was introduced.
+- Public API and web route checks returned 404 for both target slugs.
+- `sitemap.xml`, `llms.txt`, and `llms-full.txt` do not include either target slug.
+- FAQ entries are present in the package, while schema remains disabled until visible FAQ preview can be verified.
+
+## Blockers
+
+- Controlled importer dry-run fails for both locales with `Array to string conversion`.
+- Hidden CMS slug collision is `Unknown`.
+- Hidden translation group collision is `Unknown`.
+- Current operator draft/import permission is `Unknown`.
+- Source review and psychometrics review remain publish blockers.
+- Cover image is still a CMS Media Library placeholder.
+
+## Result
+
+`SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01` remains blocked.
+
+Exact draft-only authorization is still required for any future draft creation, but authorization alone is not sufficient right now. The importer dry-run blocker and hidden collision checks must be resolved before creating zh/en CMS drafts.
+
+## Forbidden Actions Not Performed
+
+- No CMS draft was created.
+- No publish action was performed.
+- No production deploy was performed.
+- No search submission was performed.
+- No private result/order/share/pay/payment/history/tokenized URL was accessed.
+- No article copy, title, H1, meta, FAQ, CTA label, or internal-link anchor text was written or rewritten by Codex.

--- a/backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationDraftPreflightTest extends TestCase
+{
+    public function test_draft_preflight_blocks_draft_create_publish_and_search_submission(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-PREFLIGHT-01', $preflight['task_id']);
+        $this->assertFalse($preflight['cms_draft_created']);
+        $this->assertFalse($preflight['cms_draft_create_allowed']);
+        $this->assertFalse($preflight['publish_allowed']);
+        $this->assertFalse($preflight['search_submit_allowed']);
+        $this->assertFalse($preflight['deploy_allowed']);
+        $this->assertFalse($preflight['content_rewrite_performed']);
+        $this->assertFalse($preflight['private_url_accessed']);
+        $this->assertFalse($preflight['production_write_performed']);
+        $this->assertStringStartsWith('NO-GO for CMS draft creation', $preflight['preflight_decision']);
+    }
+
+    public function test_preflight_preserves_unknown_collision_state_and_importer_blocker(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json');
+
+        $this->assertSame('fail', $preflight['checks']['importer_dry_run']);
+        $this->assertSame('Unknown', $preflight['checks']['hidden_cms_collision_check']);
+        $this->assertSame('Unknown', $preflight['checks']['operator_permission_check']);
+        $this->assertFalse($preflight['hard_gates']['draft_authorization_alone_is_sufficient_now']);
+        $this->assertContains(
+            'Resolve importer dry-run Array to string conversion for zh/en target packages.',
+            $preflight['hard_gates']['additional_blockers_before_draft_create']
+        );
+
+        foreach ($preflight['dry_run_commands'] as $command) {
+            $this->assertFalse($command['ok']);
+            $this->assertSame('will_skip', $command['action']);
+            $this->assertSame('unexpected_error', $command['error_code']);
+            $this->assertSame('Array to string conversion', $command['error_message']);
+        }
+
+        foreach ($preflight['targets'] as $target) {
+            $this->assertSame('Unknown', $target['draft_create_preflight']['hidden_cms_slug_collision']);
+            $this->assertSame('Unknown', $target['draft_create_preflight']['hidden_translation_group_collision']);
+            $this->assertSame('Unknown', $target['draft_create_preflight']['operator_write_permission']);
+            $this->assertSame('fail', $target['draft_create_preflight']['importer_dry_run_status']);
+        }
+    }
+
+    public function test_public_absence_and_draft_defaults_are_locked(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json');
+        $targets = collect($preflight['targets'])->keyBy('locale');
+
+        $this->assertSame('/zh/articles/riasec-holland-career-interest-test-explained', $targets['zh']['canonical_path']);
+        $this->assertSame('/en/articles/what-is-riasec-holland-code-career-interest-test', $targets['en']['canonical_path']);
+        $this->assertSame('riasec-explanation-article-2026-06-v2', $targets['zh']['translation_group_id']);
+        $this->assertSame($targets['zh']['translation_group_id'], $targets['en']['translation_group_id']);
+
+        foreach (['zh', 'en'] as $locale) {
+            $target = $targets[$locale];
+
+            $this->assertSame('draft', $target['draft_defaults']['status']);
+            $this->assertFalse($target['draft_defaults']['is_public']);
+            $this->assertFalse($target['draft_defaults']['is_indexable']);
+            $this->assertSame('noindex,nofollow', $target['draft_defaults']['robots']);
+            $this->assertNull($target['draft_defaults']['published_revision_id']);
+            $this->assertFalse($target['draft_defaults']['publish_allowed']);
+            $this->assertFalse($target['draft_defaults']['search_submit_allowed']);
+            $this->assertFalse($target['draft_defaults']['schema_enabled']);
+
+            $this->assertSame(404, $target['public_exposure_absence']['article_api_status']);
+            $this->assertSame(404, $target['public_exposure_absence']['article_seo_api_status']);
+            $this->assertSame(404, $target['public_exposure_absence']['web_route_status']);
+            $this->assertSame('absent', $target['public_exposure_absence']['sitemap_xml']);
+            $this->assertSame('absent', $target['public_exposure_absence']['llms_txt']);
+            $this->assertSame('absent', $target['public_exposure_absence']['llms_full_txt']);
+        }
+    }
+
+    public function test_preflight_contains_no_forbidden_routes_or_private_identifiers(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46189,7 +46189,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-cms-draft-preflight-01",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "title": "docs(cms): preflight RIASEC explanation draft creation",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01"
@@ -46221,7 +46221,9 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "PR opened; waiting for GitHub checks.",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1918",
+        "commit_sha": "f9be6642a997ef74e2c2542abf10ee0e0ee55d5b"
       }
     },
     "result": {
@@ -46240,8 +46242,8 @@
       ]
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "f9be6642a997ef74e2c2542abf10ee0e0ee55d5b",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1918",
     "transitions": [
       {
         "at": "2026-06-05T10:52:00+08:00",
@@ -46260,6 +46262,11 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Draft preflight artifact/report/test passed local checks; draft creation remains blocked by importer dry-run failure and Unknown hidden CMS/operator checks."
+      },
+      {
+        "status": "pr_open",
+        "evidence": "https://github.com/fermatmind/fap-api/pull/1918",
+        "commit_sha": "f9be6642a997ef74e2c2542abf10ee0e0ee55d5b"
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46189,7 +46189,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-cms-draft-preflight-01",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "title": "docs(cms): preflight RIASEC explanation draft creation",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01"
@@ -46220,10 +46220,10 @@
         "notes": "Draft preflight docs/generated artifact/test passed. Public absence checks passed. Controlled importer dry-run failed for zh/en with Array to string conversion, so draft creation remains blocked."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR opened; waiting for GitHub checks.",
+        "status": "pass",
+        "evidence": "GitHub checks passed on PR #1918 before ready-to-merge ledger update.",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1918",
-        "commit_sha": "f9be6642a997ef74e2c2542abf10ee0e0ee55d5b"
+        "commit_sha": "6cbdc628007ad271a6ece7b4524f0d3f8d6e3bf4"
       }
     },
     "result": {
@@ -46242,7 +46242,7 @@
       ]
     },
     "failure_reason": null,
-    "commit_sha": "f9be6642a997ef74e2c2542abf10ee0e0ee55d5b",
+    "commit_sha": "6cbdc628007ad271a6ece7b4524f0d3f8d6e3bf4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1918",
     "transitions": [
       {
@@ -46267,6 +46267,11 @@
         "status": "pr_open",
         "evidence": "https://github.com/fermatmind/fap-api/pull/1918",
         "commit_sha": "f9be6642a997ef74e2c2542abf10ee0e0ee55d5b"
+      },
+      {
+        "status": "ready_to_merge",
+        "evidence": "GitHub checks passed; PR is ready for merge after ledger update checks pass.",
+        "commit_sha": "6cbdc628007ad271a6ece7b4524f0d3f8d6e3bf4"
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46093,11 +46093,11 @@
     "repo": "fap-api",
     "base": "main",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T04:10:39Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "branch": "codex/seo-article-riasec-v2-cms-import-package-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "docs(cms): prepare RIASEC explanation CMS import package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-REFERENCE-SOURCE-REVIEW-01"
@@ -46128,10 +46128,8 @@
         "notes": "CMS import package test, JSON/YAML parse, and scoped diff check passed. No CMS write performed."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR rebased onto latest origin/main; waiting for GitHub checks on rebased head.",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
-        "commit_sha": "fdb6b1e1b840fdc4ddeeefde7813d120c4b38a95"
+        "status": "pass",
+        "evidence": "PR #1915 merged at 2026-06-05T04:10:39Z with merge commit ae12a9d4e1be5dc4f033112a9957038a6146eb57; remote branch deleted; local branch absent."
       }
     },
     "result": {
@@ -46146,7 +46144,7 @@
       "search_submit_allowed": false
     },
     "failure_reason": null,
-    "commit_sha": "fdb6b1e1b840fdc4ddeeefde7813d120c4b38a95",
+    "commit_sha": "ae12a9d4e1be5dc4f033112a9957038a6146eb57",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1915",
     "transitions": [
       {
@@ -46175,6 +46173,11 @@
         "status": "rebased_ready_to_merge",
         "evidence": "PR rebased onto latest origin/main after main moved during checks.",
         "commit_sha": "fdb6b1e1b840fdc4ddeeefde7813d120c4b38a95"
+      },
+      {
+        "status": "merged",
+        "evidence": "PR #1915 merged at 2026-06-05T04:10:39Z; origin/main and local main point to merge commit ae12a9d4e1be5dc4f033112a9957038a6146eb57.",
+        "commit_sha": "ae12a9d4e1be5dc4f033112a9957038a6146eb57"
       }
     ]
   },
@@ -46186,7 +46189,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "branch": "codex/seo-article-riasec-v2-cms-draft-preflight-01",
-    "status": "planned",
+    "status": "local_checks_passed",
     "title": "docs(cms): preflight RIASEC explanation draft creation",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01"
@@ -46197,23 +46200,45 @@
         "evidence": "User provided an explicit /goal for the RIASEC explanation V2 SEO article PR train, including PR ids, branches, titles, scopes, allowed paths, and hard gates. Default execution is allowed only through CMS draft preflight."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01 to merge."
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-CMS-IMPORT-PACKAGE-01 merged as PR #1915 at 2026-06-05T04:10:39Z; origin/main contains merge commit ae12a9d4e1be5dc4f033112a9957038a6146eb57."
       },
       "scope_validation": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/docs/seo/riasec-explanation-cms-draft-preflight.md, backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json, backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php, and docs/codex PR-train metadata."
       },
       "local": {
-        "status": "pending",
-        "commands": []
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationDraftPreflightTest --no-ansi",
+          "git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "notes": "Draft preflight docs/generated artifact/test passed. Public absence checks passed. Controlled importer dry-run failed for zh/en with Array to string conversion, so draft creation remains blocked."
       },
       "github": {
         "status": "pending",
         "evidence": null
       }
     },
-    "result": {},
+    "result": {
+      "preflight_artifact": "backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json",
+      "report": "backend/docs/seo/riasec-explanation-cms-draft-preflight.md",
+      "decision": "NO-GO for CMS draft creation; GO for documenting draft preflight blockers.",
+      "cms_draft_created": false,
+      "cms_draft_create_allowed": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false,
+      "blockers": [
+        "Controlled importer dry-run fails for zh/en with Array to string conversion.",
+        "Hidden CMS slug collision is Unknown.",
+        "Hidden translation_group_id collision is Unknown.",
+        "Operator draft/import permission is Unknown."
+      ]
+    },
     "failure_reason": null,
     "commit_sha": null,
     "pr_url": null,
@@ -46223,6 +46248,18 @@
         "from": "missing_from_manifest",
         "to": "planned",
         "notes": "Initialized from explicit SEO-ARTICLE-CONTENT-PACKAGE-RIASEC-EXPLANATION-01 /goal. No CMS mutation, publish, search submission, deploy, private URL access, or content rewrite authorized."
+      },
+      {
+        "at": "2026-06-05T12:10:00+08:00",
+        "from": "planned",
+        "to": "in_progress",
+        "notes": "Started CMS draft preflight after PR #1915 merged. No CMS draft creation, publish, search submission, deploy, private URL access, or content rewrite authorized."
+      },
+      {
+        "at": "2026-06-05T12:20:00+08:00",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Draft preflight artifact/report/test passed local checks; draft creation remains blocked by importer dry-run failure and Unknown hidden CMS/operator checks."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22150,25 +22150,25 @@ prs:
     branch: codex/seo-article-riasec-v2-cms-import-package-01
     title: "docs(cms): prepare RIASEC explanation CMS import package"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: in_progress
+    status: merged
     scope:
       - Convert the validated content package into backend/CMS import package format without writing CMS records.
       - Preserve draft defaults, noindex/nofollow, operator review requirement, CTA safety, FAQ/schema alignment, and baseline placeholders.
     allowed_paths:
       - backend/docs/seo/cms-import-packages/riasec-explanation-v2/**
       - backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json
-      - backend/tests/Feature/Seo/RiasecExplanationCmsImportPackageTest.php
+      - backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Rewrite article content, create CMS drafts, publish, submit search URLs, deploy, or access private URLs.
     validation:
-      - php -l backend/tests/Feature/Seo/RiasecExplanationCmsImportPackageTest.php
+      - php -l backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php
       - python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json >/dev/null
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsImportPackageTest --no-ansi
-      - git diff --check -- backend/docs/seo/cms-import-packages/riasec-explanation-v2 backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json backend/tests/Feature/Seo/RiasecExplanationCmsImportPackageTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check -- backend/docs/seo/cms-import-packages/riasec-explanation-v2 backend/docs/seo/generated/riasec-explanation-cms-import-package.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsImportPackageTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false
@@ -22189,7 +22189,7 @@ prs:
     branch: codex/seo-article-riasec-v2-cms-draft-preflight-01
     title: "docs(cms): preflight RIASEC explanation draft creation"
     train_scope: seo_article_content_package_riasec_explanation_v2
-    status: planned
+    status: in_progress
     scope:
       - Run dry-run/preflight checks for creating zh/en CMS draft records without creating drafts.
       - Confirm slugs, translation group, importer readiness, draft defaults, noindex, sitemap/llms absence, CTA safety, and unresolved publish blockers.
@@ -22197,18 +22197,18 @@ prs:
     allowed_paths:
       - backend/docs/seo/riasec-explanation-cms-draft-preflight.md
       - backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json
-      - backend/tests/Feature/Seo/RiasecExplanationDraftPreflightTest.php
+      - backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
       - Create CMS draft records, publish, submit search URLs, deploy, rewrite content, or access private URLs.
     validation:
-      - php -l backend/tests/Feature/Seo/RiasecExplanationDraftPreflightTest.php
+      - php -l backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php
       - python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json >/dev/null
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationDraftPreflightTest --no-ansi
-      - git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json backend/tests/Feature/Seo/RiasecExplanationDraftPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false


### PR DESCRIPTION
## What changed
- Added the RIASEC explanation CMS draft preflight report and generated preflight artifact.
- Added a focused test that locks draft-create, publish, search submission, deploy, private URL, and content rewrite gates.
- Reconciled the merged CMS import package PR and marked this preflight step in progress/local-validated in the train metadata.

## Why
- Confirms the package remains safe and absent from public discovery surfaces while identifying blockers before any CMS draft write.

## Validation commands
- php -l backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php
- python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml-ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationDraftPreflightTest --no-ansi
- git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-preflight.v1.json backend/tests/Feature/SEO/RiasecExplanationDraftPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS draft creation.
- No publish.
- No production deploy.
- No search submission.
- No private URL access.
- No article copy rewrite by Codex.
- Draft create remains blocked by importer dry-run failure and Unknown hidden CMS/operator checks.
