### PR TITLE
docs(help): block Help editorial review request

### DIFF
--- a/backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json
@@ -1,0 +1,247 @@
+{
+  "schema": "help-content-draft-editorial-review-01.v1",
+  "task": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01",
+  "generated_at": "2026-06-05",
+  "review_status": "blocked",
+  "decision": "BLOCKED_PRIVATE_IDENTIFIER_AND_RESULT_URL_GUARD",
+  "source_package": {
+    "zip_path": "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+    "expected_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+    "actual_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+    "sha256_match": true,
+    "file_count": 14,
+    "required_file_check": "pass",
+    "content_mode": "draft_only",
+    "publish_allowed": false,
+    "requires_operator_review": true,
+    "cms_draft_created_by_package": false
+  },
+  "required_files": {
+    "missing": [],
+    "unexpected": [],
+    "files": [
+      "README.md",
+      "index.json",
+      "01_UNLOCK-FAILURE-HELP-CARD-01.md",
+      "01_UNLOCK-FAILURE-HELP-CARD-01.yaml",
+      "02_PAYMENT-REFUND-FAQ-PACKAGE-01.md",
+      "02_PAYMENT-REFUND-FAQ-PACKAGE-01.yaml",
+      "03_RESULT-RECOVERY-FAQ-01.md",
+      "03_RESULT-RECOVERY-FAQ-01.yaml",
+      "04_PRIVACY-FAQ-PACKAGE-01.md",
+      "04_PRIVACY-FAQ-PACKAGE-01.yaml",
+      "05_NONDIAGNOSTIC-HELP-COPY-01.md",
+      "05_NONDIAGNOSTIC-HELP-COPY-01.yaml",
+      "06_DATA-DELETION-REQUEST-FAQ-01.md",
+      "06_DATA-DELETION-REQUEST-FAQ-01.yaml"
+    ]
+  },
+  "asset_matrix": [
+    {
+      "asset_id": "UNLOCK-FAILURE-HELP-CARD-01",
+      "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01",
+      "source_yaml": "01_UNLOCK-FAILURE-HELP-CARD-01.yaml",
+      "slugs": {
+        "zh-CN": "help-unlock-failure",
+        "en": "help-unlock-failure"
+      },
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "PAYMENT-REFUND-FAQ-PACKAGE-01",
+      "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01",
+      "source_yaml": "02_PAYMENT-REFUND-FAQ-PACKAGE-01.yaml",
+      "slugs": {
+        "zh-CN": "help-payment-refund",
+        "en": "help-payment-refund"
+      },
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "RESULT-RECOVERY-FAQ-01",
+      "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01",
+      "source_yaml": "03_RESULT-RECOVERY-FAQ-01.yaml",
+      "slugs": {
+        "zh-CN": "help-result-recovery",
+        "en": "help-result-recovery"
+      },
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "PRIVACY-FAQ-PACKAGE-01",
+      "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01",
+      "source_yaml": "04_PRIVACY-FAQ-PACKAGE-01.yaml",
+      "slugs": {
+        "zh-CN": "help-privacy-data",
+        "en": "help-privacy-data"
+      },
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "NONDIAGNOSTIC-HELP-COPY-01",
+      "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01",
+      "source_yaml": "05_NONDIAGNOSTIC-HELP-COPY-01.yaml",
+      "slugs": {
+        "zh-CN": "help-use-boundaries",
+        "en": "help-use-boundaries"
+      },
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "DATA-DELETION-REQUEST-FAQ-01",
+      "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01",
+      "source_yaml": "06_DATA-DELETION-REQUEST-FAQ-01.yaml",
+      "slugs": {
+        "zh-CN": "help-data-deletion",
+        "en": "help-data-deletion"
+      },
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    }
+  ],
+  "import_and_cms_draft_evidence": {
+    "import_package": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "content_page_source": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "create_artifact": "backend/docs/help/generated/help-content-draft-create-01.v1.json",
+    "postcheck_artifact": "backend/docs/help/generated/help-content-draft-postcheck-01.v1.json",
+    "preflight_artifact": "backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json",
+    "expected_target_count": 12,
+    "created_record_count": 12,
+    "postcheck_record_count": 12,
+    "locales": [
+      "zh-CN",
+      "en"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true,
+    "all_review_state_owner_review": true,
+    "live_cms_write_performed_in_this_pr": false
+  },
+  "visible_content_guard_scan": {
+    "scope": "draft_title, draft_summary, visible_body_draft, faq_draft_items from package YAML files",
+    "guard_metadata_fields_excluded_from_block_trigger": [
+      "forbidden_claims_checklist",
+      "global_forbidden_route_families",
+      "support_fields_required",
+      "cms_fields_to_fill"
+    ],
+    "status": "blocked",
+    "blocked_assets": [
+      {
+        "asset_id": "UNLOCK-FAILURE-HELP-CARD-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "PAYMENT-REFUND-FAQ-PACKAGE-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "RESULT-RECOVERY-FAQ-01",
+        "fields": [
+          "draft_summary",
+          "visible_body_draft",
+          "faq_draft_items"
+        ],
+        "hit_categories": [
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "PRIVACY-FAQ-PACKAGE-01",
+        "fields": [
+          "visible_body_draft",
+          "faq_draft_items"
+        ],
+        "hit_categories": [
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "DATA-DELETION-REQUEST-FAQ-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      }
+    ],
+    "passing_assets": [
+      "NONDIAGNOSTIC-HELP-COPY-01"
+    ]
+  },
+  "operator_review": {
+    "review_requested": false,
+    "review_passed": false,
+    "operator_editorial_approval_present": false,
+    "block_reason": "Visible draft content fields contain private-identifier/result-link guard categories, so this PR cannot request or claim Operator editorial review."
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-PRIVATE-ID-GUARD",
+      "status": "blocked",
+      "note": "Visible draft fields contain payment_id and/or result_url guard categories. Content must be revised before Operator review can be requested."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-SUPPORT-CONTACT-FIELD",
+      "status": "open_publish_preflight",
+      "note": "support@fermatmind.com exists in the import package layer, but prior postcheck did not verify it inside production ContentPage rows or a first-class support_contact field."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish, CMS mutation, deploy, search submission, and private URL access remain forbidden."
+    }
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false
+  },
+  "validation": {
+    "zip_sha_verification": "pass",
+    "json_parse": "pass",
+    "yaml_parse": "pass",
+    "focused_contract": {
+      "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+      "status": "pass",
+      "result": "1 test passed, 454 assertions"
+    },
+    "diff_check": "pass"
+  },
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-REVISION-REQUEST-01"
+}

--- a/backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md
@@ -1,0 +1,72 @@
+# HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01
+
+Decision: `blocked`
+
+## Source Package
+
+- Zip path: `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`
+- Expected SHA-256: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6`
+- Actual SHA-256: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6`
+- Required file check: pass, 14 files present.
+- Package mode: draft only.
+
+## Draft Evidence
+
+- Import package: `backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json`
+- ContentPage source: `backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json`
+- Create artifact: `backend/docs/help/generated/help-content-draft-create-01.v1.json`
+- Postcheck artifact: `backend/docs/help/generated/help-content-draft-postcheck-01.v1.json`
+- Review preflight artifact: `backend/docs/help/generated/help-content-draft-review-preflight-01.v1.json`
+- Draft rows checked from merged artifacts: 12.
+- Locales: `zh-CN`, `en`.
+- Slugs: `help-unlock-failure`, `help-payment-refund`, `help-result-recovery`, `help-privacy-data`, `help-use-boundaries`, `help-data-deletion`.
+- Draft state from postcheck/preflight: draft, non-public, non-indexable, unpublished.
+
+## Review Status
+
+`blocked`
+
+Codex did not request, perform, or claim Operator editorial approval. The package cannot proceed to review request because visible draft fields contain private-identifier or result-link guard categories.
+
+## Blocking Findings
+
+The scan covered package YAML visible draft fields only: `draft_title`, `draft_summary`, `visible_body_draft`, and `faq_draft_items`. Guard metadata fields such as `global_forbidden_route_families` were treated as safety metadata, not as user-visible copy.
+
+- `UNLOCK-FAILURE-HELP-CARD-01`: `visible_body_draft` hit `payment_id` and `result_url` categories.
+- `PAYMENT-REFUND-FAQ-PACKAGE-01`: `visible_body_draft` hit `payment_id` and `result_url` categories.
+- `RESULT-RECOVERY-FAQ-01`: `draft_summary`, `visible_body_draft`, and `faq_draft_items` hit `result_url`.
+- `PRIVACY-FAQ-PACKAGE-01`: `visible_body_draft` and `faq_draft_items` hit `result_url`.
+- `DATA-DELETION-REQUEST-FAQ-01`: `visible_body_draft` hit `payment_id` and `result_url` categories.
+- `NONDIAGNOSTIC-HELP-COPY-01`: no visible-content guard hit found.
+
+No publishable replacement copy was written in this PR.
+
+## Sidecars
+
+- `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-PRIVATE-ID-GUARD`: blocked until the package is revised so visible Help draft fields avoid private identifier and result-link guard categories.
+- `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-SUPPORT-CONTACT-FIELD`: `support@fermatmind.com` exists in the import package layer, but prior postcheck did not verify it inside production ContentPage rows or a first-class `support_contact` field.
+- `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-PUBLISH-BLOCK`: publish, CMS mutation, deploy, search submission, and private URL access remain forbidden.
+
+## Scope Boundary
+
+- CMS mutation performed: no.
+- Publish performed: no.
+- Deploy performed: no.
+- Search submission performed: no.
+- Payment/refund action performed: no.
+- Payment provider changed: no.
+- Private result/order/share/pay/payment/history URL accessed: no.
+- Secret/env/cookie/token read: no.
+- Operator approval claimed: no.
+
+## Validation
+
+- Zip SHA verification: pass.
+- JSON parse: pass.
+- YAML parse: pass.
+- Focused contract: `HelpContentImportPackageTest` passed, 1 test and 454 assertions.
+- Scoped diff check: pass.
+
+## Next Task Recommendation
+
+`HELP-CONTENT-DRAFT-REVISION-REQUEST-01`

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44705,8 +44705,8 @@
       }
     },
     "failure_reason": "Visible draft content fields in the v01 package hit private-identifier/result-link guard categories; Operator editorial review request was not made.",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "702f64ec56f6da3e56d4f320108cbf44d63f7e32",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1919",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44778,6 +44778,11 @@
         "at": "2026-06-05",
         "status": "blocked_private_identifier_guard",
         "note": "Zip SHA and file list passed, 12 draft rows matched merged import/postcheck/preflight evidence, but visible package draft fields hit private identifier/result-link guard categories. Review request was not made."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1919 with blocked review artifact commit 702f64ec56f6da3e56d4f320108cbf44d63f7e32; GitHub checks are pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44658,7 +44658,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-editorial-review-01",
     "base": "origin/main",
-    "status": "blocked_private_identifier_guard",
+    "status": "ready_to_merge_blocked_review_artifact",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review request",
     "depends_on": [
@@ -44701,6 +44701,21 @@
             "command": "git diff --check -- backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
             "status": "passed"
           }
+        ]
+      },
+      "github": {
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1919 --watch --interval 15"
+        ],
+        "jobs": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep blocking secrets"
         ]
       }
     },
@@ -44783,6 +44798,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1919 with blocked review artifact commit 702f64ec56f6da3e56d4f320108cbf44d63f7e32; GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge_blocked_review_artifact",
+        "note": "PR #1919 GitHub checks passed and changed files remained within the four allowed paths. Editorial review status remains blocked."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44658,7 +44658,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-editorial-review-01",
     "base": "origin/main",
-    "status": "pending_operator_review_request",
+    "status": "blocked_private_identifier_guard",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review request",
     "depends_on": [
@@ -44676,9 +44676,35 @@
       "scope_preflight": {
         "status": "pass",
         "evidence": "Editorial-review PR scope is review request and decision-capture only; Codex must not claim Operator editorial approval, mutate CMS, publish, deploy, access private URLs, run payment/refund flows, or read secrets/env/cookies/tokens."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+            "status": "passed",
+            "evidence": "1 test passed, 454 assertions."
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
       }
     },
-    "failure_reason": null,
+    "failure_reason": "Visible draft content fields in the v01 package hit private-identifier/result-link guard categories; Operator editorial review request was not made.",
     "commit_sha": null,
     "pr_url": null,
     "merged_at": null,
@@ -44702,6 +44728,18 @@
       "private_url_access_performed": false,
       "secret_env_cookie_token_read": false
     },
+    "result": {
+      "review_status": "blocked",
+      "decision": "BLOCKED_PRIVATE_IDENTIFIER_AND_RESULT_URL_GUARD",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md",
+      "zip_sha256_checked": true,
+      "draft_count_checked": 12,
+      "operator_review_requested": false,
+      "operator_editorial_approval_present": false,
+      "publish_allowed_now": false,
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-REVISION-REQUEST-01"
+    },
     "sidecars": [
       {
         "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-OPERATOR-APPROVAL",
@@ -44717,9 +44755,14 @@
         "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-SUPPORT-CONTACT-FIELD",
         "status": "open",
         "note": "support@fermatmind.com exists in the import package, but prior postcheck did not verify a first-class support_contact field on production ContentPage rows."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-PRIVATE-ID-GUARD",
+        "status": "blocked",
+        "note": "Visible draft fields contain payment_id and/or result_url guard categories; no Operator review request was made."
       }
     ],
-    "next_task": null,
+    "next_task": "HELP-CONTENT-DRAFT-REVISION-REQUEST-01",
     "transitions": [
       {
         "at": "2026-06-05",
@@ -44730,6 +44773,11 @@
         "at": "2026-06-05",
         "status": "pending_operator_review_request",
         "note": "Manifest/state entry added; implementation must run as a separate scoped PR and stop before claiming Operator editorial approval."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "blocked_private_identifier_guard",
+        "note": "Zip SHA and file list passed, 12 draft rows matched merged import/postcheck/preflight evidence, but visible package draft fields hit private identifier/result-link guard categories. Review request was not made."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21602,7 +21602,7 @@ prs:
     branch: codex/help-content-draft-editorial-review-01
     title: "docs(help): prepare Help CMS draft editorial review request"
     train_scope: window_9_help_service_content
-    status: pending_operator_review_request
+    status: blocked_private_identifier_guard
     depends_on:
       - HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01
     scope:


### PR DESCRIPTION
## What changed
- Added the `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01` generated artifact and operations report.
- Verified the v01 uploaded package SHA and required file list.
- Compared package/import/postcheck/preflight evidence for the 12 Help CMS draft targets.
- Marked the editorial review status as `blocked` because visible draft fields hit private-identifier/result-link guard categories.
- Updated PR train metadata/state for the blocked review outcome.

## Why
- The task explicitly requires blocking review if private route, raw private ID, payment identifier, result URL, history URL, or tokenized URL guard categories appear in visible content fields.

## Validation
- Zip SHA verification: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6` matched.
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi`
- `git diff --check -- backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No Operator editorial approval was requested or claimed.
- No CMS mutation, publish, deploy, search submission, private URL access, payment/refund action, payment-provider change, or secret/env/cookie/token read was performed.
- Content revision is deferred to `HELP-CONTENT-DRAFT-REVISION-REQUEST-01`.

## Repository rule impact
- Help content remains CMS/backend-authoritative. This PR adds blocked review evidence only and does not add frontend fallback content.