### PR TITLE
docs(benefit): define DailyGiving first record review template

### DIFF
--- a/backend/docs/operations/daily-giving-first-record-review-template.md
+++ b/backend/docs/operations/daily-giving-first-record-review-template.md
@@ -1,0 +1,78 @@
+# DailyGiving First Record Review Template
+
+Date: 2026-06-05
+
+PR train item: `DAILY-GIVING-FIRST-RECORD-REVIEW-TEMPLATE-01`
+
+Mode: review template, generated artifact, and contract test only. This PR does not create production records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, run social distribution, call payment providers, deploy, or read secrets.
+
+## Decision
+
+The first real DailyGiving record must be created only after a separate private-ledger authorization. Until that authorization exists, the correct asset state is a reviewed template and a hard stop before any raw receipt, private proof path, or public record mutation.
+
+## Preconditions Before First Private Ledger Action
+
+- Proof storage gate is deployed and active for every save path.
+- Raw receipt storage location is confirmed private at the disk or bucket level.
+- Operator has the real receipt/proof in hand.
+- Redaction reviewer is assigned.
+- DailyGiving remains `noindex`.
+- DailyGiving remains absent from sitemap, `llms.txt`, and `llms-full.txt`.
+- Foundation page is complete enough to explain plan boundaries without relying on DailyGiving as a trust badge.
+- Claim lint is clean for official relationship, endorsement, certification, guaranteed-impact, and unsupported stable-operation implications.
+
+## First Draft Record Inputs
+
+The first record must start as private draft state:
+
+| Field | Required initial value or source | Review rule |
+| --- | --- | --- |
+| `record_code` | generated format `FM-GIVING-YYYY-MM-NNN` | no private token or order id |
+| `donation_date` | receipt date | must match receipt |
+| `recipient_name` | receipt recipient | recipient-only; no official relationship implication |
+| `recipient_official_url` | public recipient website if verified | public canonical only |
+| `amount_minor` | receipt amount in minor units | for planned first donation, CNY 10 means `1000` only after receipt supports it |
+| `currency` | receipt currency | ISO code, expected `CNY` only after receipt supports it |
+| `donation_status` | `planned` or private draft equivalent before review | may become `completed` only after receipt review |
+| `proof_status` | `none` or `redacted_pending` before redaction | `redacted_available` only after public proof review |
+| `proof_private_path` | private disk/bucket path only | never a public URL |
+| `proof_public_url` | blank until redacted proof is approved | must be reviewed redacted public media if present |
+| `proof_redaction_notes` | admin-only reviewer notes | required when proof is withheld |
+| `receipt_reference_private` | private reference if needed | never public |
+| `receipt_reference_redacted` | masked public reference if safe | reviewer-approved only |
+| `public_notes` | blank or claim-linted note | no endorsement or guaranteed-impact implication |
+| `internal_notes` | admin-only context | never public |
+| `is_public` | `false` before final review | may become true only after review gates pass |
+| `is_indexable` | `false` | must remain false for first record |
+| `published_at` | blank before final review | set only after completed/verified public review |
+
+## Review Gates Before Public Visibility
+
+- Raw proof is stored privately and not exposed as URL, public media, or tokenized path.
+- Public proof is either a reviewed redacted public media URL or withheld with admin-only reviewer reason.
+- Public projection does not expose private proof path, redaction notes, private receipt reference, internal notes, or admin user ids.
+- Recipient, amount, currency, and date match the receipt.
+- `donation_status` is `completed` or `verified`.
+- `is_public=true` is approved only after proof and claim review.
+- `is_indexable=false` remains set.
+- Records API returns at least one public record after activation.
+- Months API returns at least one month after activation.
+- DailyGiving page remains `noindex`.
+- sitemap, `llms.txt`, and `llms-full.txt` remain free of DailyGiving entries.
+- Trust badge remains blocked.
+
+## Required Post-Activation Smoke
+
+After the separately authorized first record is reviewed and activated:
+
+- records API total is greater than zero;
+- months API count is greater than zero;
+- public API returns no private fields;
+- DailyGiving page metadata remains `noindex`;
+- sitemap and llms surfaces exclude DailyGiving;
+- claim lint remains clean;
+- public amplification remains blocked unless a later explicit gate allows it.
+
+## Hard Stop
+
+The next step is `DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01`. It must be separately authorized before any production record, raw proof, private proof path, redacted proof, public record activation, CMS mutation, publish, search submission, social distribution, trust badge, or deploy action.

--- a/backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json
+++ b/backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json
@@ -1,0 +1,73 @@
+{
+  "schema_version": 1,
+  "id": "DAILY-GIVING-FIRST-RECORD-REVIEW-TEMPLATE-01",
+  "date": "2026-06-05",
+  "mode": "review_template_only",
+  "decision": "Prepare the first-record review template and stop before any production record or proof mutation.",
+  "production_record_created": false,
+  "proof_uploaded": false,
+  "proof_processed": false,
+  "private_proof_path_created": false,
+  "redacted_public_proof_created": false,
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "social_distribution_performed": false,
+  "payment_provider_call_performed": false,
+  "deploy_performed": false,
+  "trust_badge_allowed_now": false,
+  "public_amplification_allowed_now": false,
+  "daily_giving_indexable_allowed_now": false,
+  "daily_giving_sitemap_inclusion_allowed_now": false,
+  "daily_giving_llms_inclusion_allowed_now": false,
+  "operator_intent": {
+    "planned_amount_minor": 1000,
+    "planned_currency": "CNY",
+    "recipient_name": "United Nations Foundation",
+    "recipient_role": "recipient_only",
+    "requires_receipt_confirmation": true,
+    "official_relationship_claim_allowed": false
+  },
+  "initial_private_record_state": {
+    "donation_status_allowed": [
+      "planned"
+    ],
+    "proof_status_allowed": [
+      "none",
+      "redacted_pending"
+    ],
+    "is_public": false,
+    "is_indexable": false,
+    "published_at": null
+  },
+  "public_activation_required_gates": [
+    "raw_proof_private_storage_confirmed",
+    "redacted_public_proof_reviewed_or_withheld_reason_recorded",
+    "recipient_amount_currency_date_verified_against_receipt",
+    "public_projection_private_fields_absent",
+    "claim_lint_clean",
+    "donation_status_completed_or_verified",
+    "is_public_true_after_review",
+    "is_indexable_false",
+    "daily_giving_page_noindex",
+    "sitemap_llms_daily_giving_absent",
+    "trust_badge_blocked"
+  ],
+  "forbidden_public_fields": [
+    "proof_private_path",
+    "proof_redaction_notes",
+    "receipt_reference_private",
+    "internal_notes",
+    "created_by_admin_user_id",
+    "updated_by_admin_user_id"
+  ],
+  "claim_boundary": {
+    "official_relationship_claim_allowed": false,
+    "endorsement_claim_allowed": false,
+    "certification_claim_allowed": false,
+    "guaranteed_impact_claim_allowed": false,
+    "unsupported_stable_daily_operation_claim_allowed": false
+  },
+  "next_authorization_required": "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01",
+  "authorization_prompt_required": true
+}

--- a/backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php
@@ -1,0 +1,112 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use Tests\TestCase;
+
+final class DailyGivingFirstRecordReviewTemplateTest extends TestCase
+{
+    public function test_first_record_review_template_blocks_all_runtime_mutations(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'production_record_created',
+            'proof_uploaded',
+            'proof_processed',
+            'private_proof_path_created',
+            'redacted_public_proof_created',
+            'cms_mutation_performed',
+            'publish_performed',
+            'search_submission_performed',
+            'social_distribution_performed',
+            'payment_provider_call_performed',
+            'deploy_performed',
+            'trust_badge_allowed_now',
+            'public_amplification_allowed_now',
+            'daily_giving_indexable_allowed_now',
+            'daily_giving_sitemap_inclusion_allowed_now',
+            'daily_giving_llms_inclusion_allowed_now',
+        ] as $field) {
+            $this->assertFalse($artifact[$field], $field);
+        }
+    }
+
+    public function test_first_record_review_template_keeps_initial_record_private_and_noindex(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(['planned'], $artifact['initial_private_record_state']['donation_status_allowed']);
+        $this->assertSame(['none', 'redacted_pending'], $artifact['initial_private_record_state']['proof_status_allowed']);
+        $this->assertFalse($artifact['initial_private_record_state']['is_public']);
+        $this->assertFalse($artifact['initial_private_record_state']['is_indexable']);
+        $this->assertNull($artifact['initial_private_record_state']['published_at']);
+        $this->assertSame('DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01', $artifact['next_authorization_required']);
+        $this->assertTrue($artifact['authorization_prompt_required']);
+    }
+
+    public function test_first_record_review_template_preserves_claim_and_public_field_boundaries(): void
+    {
+        $artifact = $this->artifact();
+        $doc = (string) file_get_contents(base_path('docs/operations/daily-giving-first-record-review-template.md'));
+
+        foreach ([
+            'official_relationship_claim_allowed',
+            'endorsement_claim_allowed',
+            'certification_claim_allowed',
+            'guaranteed_impact_claim_allowed',
+            'unsupported_stable_daily_operation_claim_allowed',
+        ] as $field) {
+            $this->assertFalse($artifact['claim_boundary'][$field], $field);
+        }
+
+        foreach ([
+            'proof_private_path',
+            'proof_redaction_notes',
+            'receipt_reference_private',
+            'internal_notes',
+            'created_by_admin_user_id',
+            'updated_by_admin_user_id',
+        ] as $field) {
+            $this->assertContains($field, $artifact['forbidden_public_fields']);
+        }
+
+        foreach ([
+            'UN official partner',
+            'United Nations official partner',
+            'official endorsement',
+            'guaranteed impact',
+            'officially certified',
+        ] as $forbiddenClaim) {
+            $this->assertStringNotContainsString($forbiddenClaim, $doc);
+        }
+    }
+
+    public function test_first_record_review_template_tracks_operator_intent_without_creating_record(): void
+    {
+        $artifact = $this->artifact();
+
+        $this->assertSame(1000, $artifact['operator_intent']['planned_amount_minor']);
+        $this->assertSame('CNY', $artifact['operator_intent']['planned_currency']);
+        $this->assertSame('United Nations Foundation', $artifact['operator_intent']['recipient_name']);
+        $this->assertSame('recipient_only', $artifact['operator_intent']['recipient_role']);
+        $this->assertTrue($artifact['operator_intent']['requires_receipt_confirmation']);
+        $this->assertFalse($artifact['operator_intent']['official_relationship_claim_allowed']);
+        $this->assertFalse($artifact['production_record_created']);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/operations/generated/daily-giving-first-record-review-template.v1.json');
+        $payload = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -35526,7 +35526,7 @@
   "CONTENT-PACKS-INDEX-ARTIFACT-01": {
     "repo": "fap-api",
     "branch": "fix/content-packs-index-artifact-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "commit_sha": "7e0cc715e03b105e51c9556596212c48bb962868",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1763",
     "checks": {
@@ -37086,7 +37086,7 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
+      "allowed_paths_only": true,
       "git_diff_check": null,
       "git_diff_cached_check": null
     },
@@ -46505,9 +46505,9 @@
     "failure_reason": null,
     "commit_sha": "cac138c18d4573e9ae9f7d15e884f6fdb0f19aa0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1917",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T04:12:52Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "scope_validation": {
       "allowed_paths_only": true,
       "cms_write_performed": false,
@@ -46543,6 +46543,112 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed for PR #1917; ready for squash merge. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T04:31:28Z",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "notes": "Reconciled stale PR10 ledger while starting PR12: GitHub PR #1917 is MERGED at 3c15a7f8f43ac46f4f04b0b1b46a5266da093151, origin/main contains the merge commit, the remote branch is deleted, and the local task branch is absent."
+      }
+    ]
+  },
+  "DAILY-GIVING-FIRST-RECORD-REVIEW-TEMPLATE-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-first-record-review-template-01",
+    "base": "main",
+    "status": "local_checks_passed",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): define DailyGiving first record review template",
+    "depends_on": [
+      "DAILY-GIVING-PUBLIC-API-SMOKE-01"
+    ],
+    "external_prerequisites": [
+      {
+        "repo": "fap-web",
+        "id": "DAILY-GIVING-INDEXABILITY-GATE-01",
+        "pr_url": "https://github.com/fermatmind/fap-web/pull/1059",
+        "merge_commit_sha": "e695916300581f2a9d1c4957b8cdbb20c51130fb",
+        "merged_at": "2026-06-05T04:27:29Z"
+      }
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized Window 7 Public Benefit / Foundation / DailyGiving Trust Gate PR train through PR12 and required stopping before record/proof mutation steps."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "DAILY-GIVING-PUBLIC-API-SMOKE-01 merged as fap-api PR #1917 at 3c15a7f8f43ac46f4f04b0b1b46a5266da093151. DAILY-GIVING-INDEXABILITY-GATE-01 merged as fap-web PR #1059 at e695916300581f2a9d1c4957b8cdbb20c51130fb."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the DailyGiving first-record review template doc, generated artifact, focused contract test, and docs/codex manifest/state. No production record/proof/CMS/publish/deploy/search/social/index/trust badge/payment action was performed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php",
+          "python3 -m json.tool backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingFirstRecordReviewTemplateTest --no-ansi",
+          "git diff --check -- backend/docs/operations/daily-giving-first-record-review-template.md backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "All local checks exited 0 after installing dependencies in the temporary worktree. Focused PHPUnit passed 50 assertions with warnings from the temporary checkout missing backend/.env."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "result": {
+      "review_template_created": true,
+      "production_record_created": false,
+      "proof_uploaded": false,
+      "proof_processed": false,
+      "private_proof_path_created": false,
+      "redacted_public_proof_created": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "social_distribution_performed": false,
+      "payment_provider_call_performed": false,
+      "deploy_performed": false,
+      "trust_badge_allowed_now": false,
+      "public_amplification_allowed_now": false,
+      "daily_giving_indexable_allowed_now": false,
+      "next_authorization_required": "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01"
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": null,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "daily_giving_record_created": false,
+      "proof_file_processed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Scope stayed within PR12 docs/generated/test/ledger paths. PR12 is template-only and must hard stop before DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01."
+    },
+    "next_task": "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01",
+    "transitions": [
+      {
+        "at": "2026-06-05T04:31:28Z",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized PR12 after fap-api PR10 and fap-web PR11 merge verification. No production record/proof/CMS/publish/deploy/search/social/index/trust badge action authorized."
+      },
+      {
+        "at": "2026-06-05T04:34:20Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Local syntax, JSON/YAML, focused PHPUnit, and scoped diff checks passed. No production writes or record/proof mutations performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46556,7 +46556,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-first-record-review-template-01",
     "base": "main",
-    "status": "local_checks_passed",
+    "status": "pr_open_github_checks_pending",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving first record review template",
     "depends_on": [
@@ -46599,7 +46599,7 @@
       },
       "github": {
         "status": "pending",
-        "evidence": null
+        "evidence": "Opened GitHub PR #1920 at https://github.com/fermatmind/fap-api/pull/1920. Required GitHub checks are pending."
       }
     },
     "result": {
@@ -46621,13 +46621,13 @@
       "next_authorization_required": "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01"
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "2113c42cc14ef48a80c0e194ff56e9e4956a895a",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1920",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "scope_validation": {
-      "allowed_paths_only": null,
+      "allowed_paths_only": true,
       "cms_write_performed": false,
       "publish_performed": false,
       "daily_giving_record_created": false,
@@ -46649,6 +46649,12 @@
         "from": "in_progress",
         "to": "local_checks_passed",
         "notes": "Local syntax, JSON/YAML, focused PHPUnit, and scoped diff checks passed. No production writes or record/proof mutations performed."
+      },
+      {
+        "at": "2026-06-05T04:37:24Z",
+        "from": "local_checks_passed",
+        "to": "pr_open_github_checks_pending",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1920 from branch codex/daily-giving-first-record-review-template-01. GitHub required checks are pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24627,7 +24627,7 @@
     "updated_at": "2026-05-17T10:36:34.999719Z"
   },
   "OPS-CI-CODESCAN-API-01": {
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-ci-codescan-api-01",
@@ -46598,8 +46598,8 @@
         "notes": "All local checks exited 0 after installing dependencies in the temporary worktree. Focused PHPUnit passed 50 assertions with warnings from the temporary checkout missing backend/.env."
       },
       "github": {
-        "status": "pending",
-        "evidence": "Opened GitHub PR #1920 at https://github.com/fermatmind/fap-api/pull/1920. Required GitHub checks are pending."
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #1920 on head 48d9731a1116465f167d592f2f1b5455c99711aa: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -46655,6 +46655,12 @@
         "from": "local_checks_passed",
         "to": "pr_open_github_checks_pending",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1920 from branch codex/daily-giving-first-record-review-template-01. GitHub required checks are pending."
+      },
+      {
+        "at": "2026-06-05T08:26:15Z",
+        "from": "pr_open_github_checks_pending",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed and merge state was CLEAN. Pre-merge scope validation remained limited to PR12 docs/generated/test/ledger paths."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22066,6 +22066,55 @@ prs:
     content_authority: CMS/backend
     next_task: DAILY-GIVING-INDEXABILITY-GATE-01
 
+  - id: DAILY-GIVING-FIRST-RECORD-REVIEW-TEMPLATE-01
+    repo: fap-api
+    depends_on:
+      - DAILY-GIVING-PUBLIC-API-SMOKE-01
+    external_prerequisites:
+      - repo: fap-web
+        id: DAILY-GIVING-INDEXABILITY-GATE-01
+        pr_url: https://github.com/fermatmind/fap-web/pull/1059
+        merge_commit_sha: e695916300581f2a9d1c4957b8cdbb20c51130fb
+    branch: codex/daily-giving-first-record-review-template-01
+    title: "docs(benefit): define DailyGiving first record review template"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Add DailyGiving first-record review template for the later private-ledger authorization.
+      - Add generated first-record review template artifact.
+      - Add focused contract coverage for runtime-mutation blocks, private/noindex initial state, public-field exclusions, and claim boundaries.
+      - Keep real records, proof, CMS, publish, index, trust badge, search, social, payment-provider calls, and deploy actions non-mutating.
+    allowed_paths:
+      - backend/docs/operations/daily-giving-first-record-review-template.md
+      - backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json
+      - backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create production records, upload proof, process proof files, mutate CMS, publish, index DailyGiving, create trust badges, submit search URLs, run social distribution, call payment providers, deploy, or read secrets.
+    validation:
+      - php -l backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php
+      - python3 -m json.tool backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingFirstRecordReviewTemplateTest --no-ansi
+      - git diff --check -- backend/docs/operations/daily-giving-first-record-review-template.md backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01
+
   - id: SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01
     repo: fap-api
     branch: codex/seo-article-riasec-v2-package-archive-01


### PR DESCRIPTION
## What changed
- Added the DailyGiving first-record review template for the later private-ledger authorization.
- Added a generated review-template artifact that keeps record/proof/CMS/publish/index/trust/search/social/payment/deploy actions blocked.
- Added focused PHPUnit coverage for mutation blocks, private/noindex initial state, public-field exclusions, claim boundaries, and operator intent without creating a record.
- Reconciled the stale PR10 ledger state now that fap-api PR #1917 is merged, and recorded the fap-web PR11 external prerequisite.

## Why
This is the final PR before the first real DailyGiving record/proof step. It gives the operator a concrete review contract while preserving the hard stop before any production record, raw proof, private proof path, redacted proof, or public activation mutation.

## Validation
- `php -l backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php`
- `python3 -m json.tool backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingFirstRecordReviewTemplateTest --no-ansi`
- `git diff --check -- backend/docs/operations/daily-giving-first-record-review-template.md backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

Focused PHPUnit passed 50 assertions with warnings from the temporary checkout missing `backend/.env`.

## Intentionally deferred
- No production record creation.
- No raw proof/private proof path creation.
- No redacted public proof creation.
- No CMS mutation or publish.
- No DailyGiving indexing, sitemap/llms inclusion, trust badge, search submission, social distribution, payment-provider call, deploy, secret access, or private URL access.
- Next step requires explicit authorization for `DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01`.
