### PR TITLE
docs(codex): add Help revision request train entry

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44817,7 +44817,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-revision-request-01",
     "base": "origin/main",
-    "status": "pending_revision_request",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): revise v01 Help content package and rerun review request",
     "depends_on": [
@@ -44835,6 +44835,21 @@
       "scope_preflight": {
         "status": "pass",
         "evidence": "Task may revise only the local v01 package draft fields needed to clear #1919 guard findings and may write review/revision artifacts. CMS mutation, publish, deploy, private URL access, payment/refund actions, and secret/env/cookie/token reads are forbidden."
+      },
+      "github": {
+        "status": "pass",
+        "commands": [
+          "gh pr checks 1921 --watch --interval 15"
+        ],
+        "jobs": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep blocking secrets"
+        ]
       }
     },
     "failure_reason": null,
@@ -44899,6 +44914,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1921 with manifest/state commit 44963cc25081001c33eac973cc67333975475fc9; GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "PR #1921 GitHub checks passed and changed files remained limited to manifest/state."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44838,8 +44838,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "44963cc25081001c33eac973cc67333975475fc9",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1921",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44894,6 +44894,11 @@
         "at": "2026-06-05",
         "status": "pending_revision_request",
         "note": "Manifest/state entry added; implementation must run as a separate scoped PR and preserve no CMS mutation, no publish, no deploy, no private URL access, and no secret/env/cookie/token reads."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1921 with manifest/state commit 44963cc25081001c33eac973cc67333975475fc9; GitHub checks are pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44658,7 +44658,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-editorial-review-01",
     "base": "origin/main",
-    "status": "ready_to_merge_blocked_review_artifact",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): prepare Help CMS draft editorial review request",
     "depends_on": [
@@ -44722,9 +44722,9 @@
     "failure_reason": "Visible draft content fields in the v01 package hit private-identifier/result-link guard categories; Operator editorial review request was not made.",
     "commit_sha": "702f64ec56f6da3e56d4f320108cbf44d63f7e32",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1919",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T04:31:34Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "planned_outputs": {
       "generated_artifact": "backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json",
       "operations_report": "backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md",
@@ -44803,6 +44803,97 @@
         "at": "2026-06-05",
         "status": "ready_to_merge_blocked_review_artifact",
         "note": "PR #1919 GitHub checks passed and changed files remained within the four allowed paths. Editorial review status remains blocked."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged",
+        "note": "Reconciled after PR #1919 squash merge; origin/main contains merge commit 78a8432b690827a2741f39efedb734d3140fc91c, remote task branch is absent, and local cleanup was executed."
+      }
+    ],
+    "merge_commit": "78a8432b690827a2741f39efedb734d3140fc91c",
+    "merge_commit_sha": "78a8432b690827a2741f39efedb734d3140fc91c"
+  },
+  "HELP-CONTENT-DRAFT-REVISION-REQUEST-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-revision-request-01",
+    "base": "origin/main",
+    "status": "pending_revision_request",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): revise v01 Help content package and rerun review request",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding HELP-CONTENT-DRAFT-REVISION-REQUEST-01 manifest/state entries and scoped the task to revising the local v01 Help package, then rerunning review request."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01 is merged as PR #1919; origin/main contains merge commit 78a8432b690827a2741f39efedb734d3140fc91c."
+      },
+      "scope_preflight": {
+        "status": "pass",
+        "evidence": "Task may revise only the local v01 package draft fields needed to clear #1919 guard findings and may write review/revision artifacts. CMS mutation, publish, deploy, private URL access, payment/refund actions, and secret/env/cookie/token reads are forbidden."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "external_asset_paths": [
+      "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+      "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01"
+    ],
+    "planned_outputs": {
+      "revision_artifact": "backend/docs/help/generated/help-content-draft-revision-request-01.v1.json",
+      "revision_report": "backend/docs/operations/help-content-draft-revision-request-2026-06-05.md",
+      "review_rerun_artifact": "backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json",
+      "review_rerun_report": "backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md",
+      "operator_approval_allowed_for_codex": false,
+      "publish_allowed": false,
+      "cms_mutation_allowed": false
+    },
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "editorial_approval_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-REVISION-REQUEST-OPERATOR-APPROVAL",
+        "status": "hard_gate",
+        "note": "Codex may rerun review request after revision, but Operator editorial approval must remain explicit and separate."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-REVISION-REQUEST-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish, indexability, sitemap/llms inclusion, search submission, CMS mutation, and deploy remain forbidden."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-REVISION-REQUEST-LOCAL-PACKAGE",
+        "status": "external_asset",
+        "note": "The v01 zip/folder are local external assets outside the git repository; the PR records hashes and review artifacts, not a CMS write."
+      }
+    ],
+    "next_task": null,
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "manifest_state_authorized",
+        "note": "User authorized supplementing manifest/state entries for HELP-CONTENT-DRAFT-REVISION-REQUEST-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pending_revision_request",
+        "note": "Manifest/state entry added; implementation must run as a separate scoped PR and preserve no CMS mutation, no publish, no deploy, no private URL access, and no secret/env/cookie/token reads."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21602,7 +21602,7 @@ prs:
     branch: codex/help-content-draft-editorial-review-01
     title: "docs(help): prepare Help CMS draft editorial review request"
     train_scope: window_9_help_service_content
-    status: blocked_private_identifier_guard
+    status: merged
     depends_on:
       - HELP-CONTENT-DRAFT-REVIEW-PREFLIGHT-01
     scope:
@@ -21622,6 +21622,55 @@ prs:
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
       - git diff --check -- backend/docs/help/generated/help-content-draft-editorial-review-01.v1.json backend/docs/operations/help-content-draft-editorial-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-REVISION-REQUEST-01
+
+  - id: HELP-CONTENT-DRAFT-REVISION-REQUEST-01
+    repo: fap-api
+    branch: codex/help-content-draft-revision-request-01
+    title: "docs(help): revise v01 Help content package and rerun review request"
+    train_scope: window_9_help_service_content
+    status: pending_revision_request
+    depends_on:
+      - HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01
+    scope:
+      - Use the existing v01 Help service content package at `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`.
+      - Revise only the local v01 package draft fields needed to clear the #1919 private-identifier/result-link guard findings.
+      - Recompute package hash and rerun the editorial review request scan against the revised local v01 package.
+      - Archive revision evidence, guard-scan result, review request status, package hash delta, and sidecar issues.
+      - Do not claim Operator editorial approval; approval remains a separate hard gate.
+    external_asset_paths:
+      - /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+      - /Users/rainie/Desktop/fermatmind-help-service-content-drafts-01
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-revision-request-01.v1.json
+      - backend/docs/operations/help-content-draft-revision-request-2026-06-05.md
+      - backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json
+      - backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or approve editorial review on Operator's behalf.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-revision-request-01.v1.json >/dev/null
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi
+      - git diff --check -- backend/docs/help/generated/help-content-draft-revision-request-01.v1.json backend/docs/operations/help-content-draft-revision-request-2026-06-05.md backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false


### PR DESCRIPTION
## What changed
- Added the authorized `HELP-CONTENT-DRAFT-REVISION-REQUEST-01` manifest/state entry.
- Reconciled `HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-01` as merged after PR #1919.

## Why
- #1919 blocked the Help editorial review request on private-identifier/result-link guard findings. The next task needs an explicit train entry before Codex can revise the local v01 package and rerun review request.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No local v01 package revision was performed in this PR.
- No review request rerun was performed in this PR.
- No CMS mutation, publish, deploy, search submission, private URL access, payment/refund action, payment-provider change, or secret/env/cookie/token read was performed.

## Repository rule impact
- Help content remains CMS/backend-authoritative. This PR only updates PR train metadata and records local package revision as an external asset workflow for the next scoped PR.