### PR TITLE
docs(help): revise v01 Help content package and rerun review request

### DIFF
--- a/backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json
@@ -1,0 +1,332 @@
+{
+  "generated_at": "2026-06-05",
+  "task": "HELP-CONTENT-DRAFT-REVISION-REQUEST-01",
+  "source_package": {
+    "zip_path": "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+    "folder_path": "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01",
+    "original_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+    "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+    "sha256_changed": true,
+    "required_file_check": "pass",
+    "missing_files": [],
+    "unexpected_files": [],
+    "file_count": 14,
+    "content_mode": "draft_only",
+    "publish_allowed": false,
+    "requires_operator_review": true,
+    "cms_draft_created_by_this_pr": false
+  },
+  "package_assets": [
+    {
+      "asset_id": "UNLOCK-FAILURE-HELP-CARD-01",
+      "yaml": "01_UNLOCK-FAILURE-HELP-CARD-01.yaml",
+      "markdown": "01_UNLOCK-FAILURE-HELP-CARD-01.md",
+      "slug_zh": "/zh/help/unlock-failure",
+      "slug_en": "/en/help/unlock-failure",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "PAYMENT-REFUND-FAQ-PACKAGE-01",
+      "yaml": "02_PAYMENT-REFUND-FAQ-PACKAGE-01.yaml",
+      "markdown": "02_PAYMENT-REFUND-FAQ-PACKAGE-01.md",
+      "slug_zh": "/zh/help/payment-refund",
+      "slug_en": "/en/help/payment-refund",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "RESULT-RECOVERY-FAQ-01",
+      "yaml": "03_RESULT-RECOVERY-FAQ-01.yaml",
+      "markdown": "03_RESULT-RECOVERY-FAQ-01.md",
+      "slug_zh": "/zh/help/result-recovery",
+      "slug_en": "/en/help/result-recovery",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "PRIVACY-FAQ-PACKAGE-01",
+      "yaml": "04_PRIVACY-FAQ-PACKAGE-01.yaml",
+      "markdown": "04_PRIVACY-FAQ-PACKAGE-01.md",
+      "slug_zh": "/zh/help/privacy-data",
+      "slug_en": "/en/help/privacy-data",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "NONDIAGNOSTIC-HELP-COPY-01",
+      "yaml": "05_NONDIAGNOSTIC-HELP-COPY-01.yaml",
+      "markdown": "05_NONDIAGNOSTIC-HELP-COPY-01.md",
+      "slug_zh": "/zh/help/use-boundaries",
+      "slug_en": "/en/help/use-boundaries",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "DATA-DELETION-REQUEST-FAQ-01",
+      "yaml": "06_DATA-DELETION-REQUEST-FAQ-01.yaml",
+      "markdown": "06_DATA-DELETION-REQUEST-FAQ-01.md",
+      "slug_zh": "/zh/help/data-deletion",
+      "slug_en": "/en/help/data-deletion",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    }
+  ],
+  "changed_assets": [
+    "UNLOCK-FAILURE-HELP-CARD-01",
+    "PAYMENT-REFUND-FAQ-PACKAGE-01",
+    "RESULT-RECOVERY-FAQ-01",
+    "PRIVACY-FAQ-PACKAGE-01",
+    "DATA-DELETION-REQUEST-FAQ-01"
+  ],
+  "unchanged_assets": [
+    "NONDIAGNOSTIC-HELP-COPY-01"
+  ],
+  "revision_summary": {
+    "UNLOCK-FAILURE-HELP-CARD-01": [
+      "visible_body_draft.zh",
+      "visible_body_draft.en"
+    ],
+    "PAYMENT-REFUND-FAQ-PACKAGE-01": [
+      "visible_body_draft.zh",
+      "visible_body_draft.en"
+    ],
+    "RESULT-RECOVERY-FAQ-01": [
+      "page_purpose",
+      "draft_summary.zh",
+      "draft_summary.en",
+      "visible_body_draft.zh",
+      "visible_body_draft.en",
+      "faq_draft_items[3]"
+    ],
+    "PRIVACY-FAQ-PACKAGE-01": [
+      "page_purpose",
+      "visible_body_draft.zh",
+      "visible_body_draft.en",
+      "faq_draft_items[0]",
+      "faq_draft_items[3]"
+    ],
+    "DATA-DELETION-REQUEST-FAQ-01": [
+      "visible_body_draft.zh",
+      "visible_body_draft.en"
+    ]
+  },
+  "visible_content_guard_scan": {
+    "scope": "draft_title, draft_summary, visible_body_draft, faq_draft_items from revised package YAML files",
+    "guard_metadata_fields_excluded_from_block_trigger": [
+      "forbidden_claims_checklist",
+      "global_forbidden_route_families",
+      "support_fields_required",
+      "cms_fields_to_fill",
+      "operator_policy"
+    ],
+    "status": "pass",
+    "blocked_assets": [],
+    "previous_blocked_assets": [
+      {
+        "asset_id": "UNLOCK-FAILURE-HELP-CARD-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "PAYMENT-REFUND-FAQ-PACKAGE-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "RESULT-RECOVERY-FAQ-01",
+        "fields": [
+          "draft_summary",
+          "visible_body_draft",
+          "faq_draft_items"
+        ],
+        "hit_categories": [
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "PRIVACY-FAQ-PACKAGE-01",
+        "fields": [
+          "visible_body_draft",
+          "faq_draft_items"
+        ],
+        "hit_categories": [
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "DATA-DELETION-REQUEST-FAQ-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      }
+    ]
+  },
+  "cms_draft_evidence": {
+    "source": "merged postcheck artifact; no CMS read or mutation was performed in this PR",
+    "expected_target_count": 12,
+    "postcheck_record_count": 12,
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "rows_checked_from_artifact": [
+      {
+        "id": 42,
+        "locale": "en",
+        "slug": "help-data-deletion",
+        "path": "/help/data-deletion",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01"
+      },
+      {
+        "id": 41,
+        "locale": "zh-CN",
+        "slug": "help-data-deletion",
+        "path": "/help/data-deletion",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01"
+      },
+      {
+        "id": 34,
+        "locale": "en",
+        "slug": "help-payment-refund",
+        "path": "/help/payment-refund",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 33,
+        "locale": "zh-CN",
+        "slug": "help-payment-refund",
+        "path": "/help/payment-refund",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 38,
+        "locale": "en",
+        "slug": "help-privacy-data",
+        "path": "/help/privacy-data",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 37,
+        "locale": "zh-CN",
+        "slug": "help-privacy-data",
+        "path": "/help/privacy-data",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 36,
+        "locale": "en",
+        "slug": "help-result-recovery",
+        "path": "/help/result-recovery",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01"
+      },
+      {
+        "id": 35,
+        "locale": "zh-CN",
+        "slug": "help-result-recovery",
+        "path": "/help/result-recovery",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01"
+      },
+      {
+        "id": 32,
+        "locale": "en",
+        "slug": "help-unlock-failure",
+        "path": "/help/unlock-failure",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01"
+      },
+      {
+        "id": 31,
+        "locale": "zh-CN",
+        "slug": "help-unlock-failure",
+        "path": "/help/unlock-failure",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01"
+      },
+      {
+        "id": 40,
+        "locale": "en",
+        "slug": "help-use-boundaries",
+        "path": "/help/use-boundaries",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01"
+      },
+      {
+        "id": 39,
+        "locale": "zh-CN",
+        "slug": "help-use-boundaries",
+        "path": "/help/use-boundaries",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01"
+      }
+    ],
+    "cms_content_mutated_in_this_pr": false,
+    "revised_package_applied_to_cms_rows": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-CMS-DRAFT-SYNC",
+      "status": "open_followup_or_operator_action",
+      "note": "The local v01 package was revised and rescanned, but this PR did not mutate existing CMS draft rows."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-SUPPORT-CONTACT-FIELD",
+      "status": "open_publish_preflight",
+      "note": "support@fermatmind.com exists in the import package layer, but prior postcheck did not verify it inside production ContentPage rows or a first-class support_contact field."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish, CMS mutation, deploy, search submission, payment/refund action, and private URL access remain forbidden."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-OPERATOR-APPROVAL",
+      "status": "hard_gate",
+      "note": "Operator editorial approval was not performed or claimed by Codex."
+    }
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false
+  },
+  "schema": "help-content-draft-editorial-review-rerun-01.v1",
+  "review_status": "review_requested",
+  "decision": "REVIEW_REQUESTED_VISIBLE_GUARD_PASS_OPERATOR_APPROVAL_REQUIRED",
+  "operator_review": {
+    "review_requested": true,
+    "review_passed": false,
+    "operator_editorial_approval_present": false,
+    "approval_claimed_by_codex": false,
+    "block_reason": null
+  },
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-CMS-SYNC-OR-OPERATOR-REVIEW-01"
+}

--- a/backend/docs/help/generated/help-content-draft-revision-request-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-revision-request-01.v1.json
@@ -1,0 +1,323 @@
+{
+  "generated_at": "2026-06-05",
+  "task": "HELP-CONTENT-DRAFT-REVISION-REQUEST-01",
+  "source_package": {
+    "zip_path": "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+    "folder_path": "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01",
+    "original_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+    "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+    "sha256_changed": true,
+    "required_file_check": "pass",
+    "missing_files": [],
+    "unexpected_files": [],
+    "file_count": 14,
+    "content_mode": "draft_only",
+    "publish_allowed": false,
+    "requires_operator_review": true,
+    "cms_draft_created_by_this_pr": false
+  },
+  "package_assets": [
+    {
+      "asset_id": "UNLOCK-FAILURE-HELP-CARD-01",
+      "yaml": "01_UNLOCK-FAILURE-HELP-CARD-01.yaml",
+      "markdown": "01_UNLOCK-FAILURE-HELP-CARD-01.md",
+      "slug_zh": "/zh/help/unlock-failure",
+      "slug_en": "/en/help/unlock-failure",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "PAYMENT-REFUND-FAQ-PACKAGE-01",
+      "yaml": "02_PAYMENT-REFUND-FAQ-PACKAGE-01.yaml",
+      "markdown": "02_PAYMENT-REFUND-FAQ-PACKAGE-01.md",
+      "slug_zh": "/zh/help/payment-refund",
+      "slug_en": "/en/help/payment-refund",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "RESULT-RECOVERY-FAQ-01",
+      "yaml": "03_RESULT-RECOVERY-FAQ-01.yaml",
+      "markdown": "03_RESULT-RECOVERY-FAQ-01.md",
+      "slug_zh": "/zh/help/result-recovery",
+      "slug_en": "/en/help/result-recovery",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "PRIVACY-FAQ-PACKAGE-01",
+      "yaml": "04_PRIVACY-FAQ-PACKAGE-01.yaml",
+      "markdown": "04_PRIVACY-FAQ-PACKAGE-01.md",
+      "slug_zh": "/zh/help/privacy-data",
+      "slug_en": "/en/help/privacy-data",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "NONDIAGNOSTIC-HELP-COPY-01",
+      "yaml": "05_NONDIAGNOSTIC-HELP-COPY-01.yaml",
+      "markdown": "05_NONDIAGNOSTIC-HELP-COPY-01.md",
+      "slug_zh": "/zh/help/use-boundaries",
+      "slug_en": "/en/help/use-boundaries",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    },
+    {
+      "asset_id": "DATA-DELETION-REQUEST-FAQ-01",
+      "yaml": "06_DATA-DELETION-REQUEST-FAQ-01.yaml",
+      "markdown": "06_DATA-DELETION-REQUEST-FAQ-01.md",
+      "slug_zh": "/zh/help/data-deletion",
+      "slug_en": "/en/help/data-deletion",
+      "faq_items": 4,
+      "schema_eligible_after_review": true
+    }
+  ],
+  "changed_assets": [
+    "UNLOCK-FAILURE-HELP-CARD-01",
+    "PAYMENT-REFUND-FAQ-PACKAGE-01",
+    "RESULT-RECOVERY-FAQ-01",
+    "PRIVACY-FAQ-PACKAGE-01",
+    "DATA-DELETION-REQUEST-FAQ-01"
+  ],
+  "unchanged_assets": [
+    "NONDIAGNOSTIC-HELP-COPY-01"
+  ],
+  "revision_summary": {
+    "UNLOCK-FAILURE-HELP-CARD-01": [
+      "visible_body_draft.zh",
+      "visible_body_draft.en"
+    ],
+    "PAYMENT-REFUND-FAQ-PACKAGE-01": [
+      "visible_body_draft.zh",
+      "visible_body_draft.en"
+    ],
+    "RESULT-RECOVERY-FAQ-01": [
+      "page_purpose",
+      "draft_summary.zh",
+      "draft_summary.en",
+      "visible_body_draft.zh",
+      "visible_body_draft.en",
+      "faq_draft_items[3]"
+    ],
+    "PRIVACY-FAQ-PACKAGE-01": [
+      "page_purpose",
+      "visible_body_draft.zh",
+      "visible_body_draft.en",
+      "faq_draft_items[0]",
+      "faq_draft_items[3]"
+    ],
+    "DATA-DELETION-REQUEST-FAQ-01": [
+      "visible_body_draft.zh",
+      "visible_body_draft.en"
+    ]
+  },
+  "visible_content_guard_scan": {
+    "scope": "draft_title, draft_summary, visible_body_draft, faq_draft_items from revised package YAML files",
+    "guard_metadata_fields_excluded_from_block_trigger": [
+      "forbidden_claims_checklist",
+      "global_forbidden_route_families",
+      "support_fields_required",
+      "cms_fields_to_fill",
+      "operator_policy"
+    ],
+    "status": "pass",
+    "blocked_assets": [],
+    "previous_blocked_assets": [
+      {
+        "asset_id": "UNLOCK-FAILURE-HELP-CARD-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "PAYMENT-REFUND-FAQ-PACKAGE-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "RESULT-RECOVERY-FAQ-01",
+        "fields": [
+          "draft_summary",
+          "visible_body_draft",
+          "faq_draft_items"
+        ],
+        "hit_categories": [
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "PRIVACY-FAQ-PACKAGE-01",
+        "fields": [
+          "visible_body_draft",
+          "faq_draft_items"
+        ],
+        "hit_categories": [
+          "result_url"
+        ]
+      },
+      {
+        "asset_id": "DATA-DELETION-REQUEST-FAQ-01",
+        "fields": [
+          "visible_body_draft"
+        ],
+        "hit_categories": [
+          "payment_id",
+          "result_url"
+        ]
+      }
+    ]
+  },
+  "cms_draft_evidence": {
+    "source": "merged postcheck artifact; no CMS read or mutation was performed in this PR",
+    "expected_target_count": 12,
+    "postcheck_record_count": 12,
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "rows_checked_from_artifact": [
+      {
+        "id": 42,
+        "locale": "en",
+        "slug": "help-data-deletion",
+        "path": "/help/data-deletion",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01"
+      },
+      {
+        "id": 41,
+        "locale": "zh-CN",
+        "slug": "help-data-deletion",
+        "path": "/help/data-deletion",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01"
+      },
+      {
+        "id": 34,
+        "locale": "en",
+        "slug": "help-payment-refund",
+        "path": "/help/payment-refund",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 33,
+        "locale": "zh-CN",
+        "slug": "help-payment-refund",
+        "path": "/help/payment-refund",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 38,
+        "locale": "en",
+        "slug": "help-privacy-data",
+        "path": "/help/privacy-data",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 37,
+        "locale": "zh-CN",
+        "slug": "help-privacy-data",
+        "path": "/help/privacy-data",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01"
+      },
+      {
+        "id": 36,
+        "locale": "en",
+        "slug": "help-result-recovery",
+        "path": "/help/result-recovery",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01"
+      },
+      {
+        "id": 35,
+        "locale": "zh-CN",
+        "slug": "help-result-recovery",
+        "path": "/help/result-recovery",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01"
+      },
+      {
+        "id": 32,
+        "locale": "en",
+        "slug": "help-unlock-failure",
+        "path": "/help/unlock-failure",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01"
+      },
+      {
+        "id": 31,
+        "locale": "zh-CN",
+        "slug": "help-unlock-failure",
+        "path": "/help/unlock-failure",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01"
+      },
+      {
+        "id": 40,
+        "locale": "en",
+        "slug": "help-use-boundaries",
+        "path": "/help/use-boundaries",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01"
+      },
+      {
+        "id": 39,
+        "locale": "zh-CN",
+        "slug": "help-use-boundaries",
+        "path": "/help/use-boundaries",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01"
+      }
+    ],
+    "cms_content_mutated_in_this_pr": false,
+    "revised_package_applied_to_cms_rows": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-CMS-DRAFT-SYNC",
+      "status": "open_followup_or_operator_action",
+      "note": "The local v01 package was revised and rescanned, but this PR did not mutate existing CMS draft rows."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-SUPPORT-CONTACT-FIELD",
+      "status": "open_publish_preflight",
+      "note": "support@fermatmind.com exists in the import package layer, but prior postcheck did not verify it inside production ContentPage rows or a first-class support_contact field."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish, CMS mutation, deploy, search submission, payment/refund action, and private URL access remain forbidden."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-REVISION-OPERATOR-APPROVAL",
+      "status": "hard_gate",
+      "note": "Operator editorial approval was not performed or claimed by Codex."
+    }
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false
+  },
+  "schema": "help-content-draft-revision-request-01.v1",
+  "decision": "REVISION_PACKAGE_READY_FOR_REVIEW_RERUN"
+}

--- a/backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md
@@ -1,0 +1,31 @@
+# HELP-CONTENT-DRAFT-EDITORIAL-REVIEW-RERUN-01
+
+Decision: `review_requested`
+
+## Package Hash
+
+- Original SHA-256: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6`
+- Revised SHA-256: `f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9`
+- Hash changed: `true`
+
+## Review Rerun Result
+
+The revised local v01 Help service content package passed the visible draft-field guard scan that blocked #1919. The scan covered `draft_title`, `draft_summary`, `visible_body_draft`, and `faq_draft_items` in the YAML package files.
+
+## Operator Boundary
+
+- Review requested: `true`
+- Review passed: `false`
+- Operator editorial approval present: `false`
+- Publish allowed: `false`
+- CMS mutation performed: `false`
+
+## Draft Count Checked
+
+Existing CMS draft evidence remains based on the merged postcheck artifact: `12` records, draft-only, non-public, non-indexable, and unpublished. This PR did not update CMS content.
+
+## Sidecars
+
+- CMS draft sync remains outside this PR.
+- Support contact field verification remains a publish preflight sidecar.
+- Publish/search/deploy/private URL access remain hard blocked.

--- a/backend/docs/operations/help-content-draft-revision-request-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-revision-request-2026-06-05.md
@@ -1,0 +1,58 @@
+# HELP-CONTENT-DRAFT-REVISION-REQUEST-01
+
+Decision: `review_requested`
+
+## Scope
+
+This PR revises the local v01 Help service content package enough to clear the #1919 visible-content guard and reruns the editorial review request scan. It does not mutate CMS rows, publish pages, deploy code, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+
+## Source Package
+
+- Zip path: `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`
+- Folder path: `/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01`
+- Original SHA-256: `2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6`
+- Revised SHA-256: `f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9`
+- Required file check: `pass`
+- Required files: `14`
+- Package mode: `draft_only`
+
+## Revision Summary
+
+- Changed assets: `UNLOCK-FAILURE-HELP-CARD-01, PAYMENT-REFUND-FAQ-PACKAGE-01, RESULT-RECOVERY-FAQ-01, PRIVACY-FAQ-PACKAGE-01, DATA-DELETION-REQUEST-FAQ-01`
+- Unchanged asset: `NONDIAGNOSTIC-HELP-COPY-01`
+- Revision strategy: replace visible draft references to complete private order/payment/result access details with safer generic private-access wording.
+- No v02 package was created; the same local v01 zip path was refreshed with the revised package.
+
+## Guard Rerun
+
+- Scan scope: `draft_title`, `draft_summary`, `visible_body_draft`, and `faq_draft_items` from revised package YAML files.
+- Prior #1919 status: `blocked`.
+- Current status: `pass`.
+- Blocked assets after revision: `0`.
+
+## CMS Draft Evidence
+
+- Existing CMS draft count checked from merged postcheck artifact: `12`.
+- Draft state remains from prior postcheck evidence: draft, non-public, non-indexable, unpublished.
+- CMS content was not mutated in this PR.
+- The revised local package has not been applied to existing CMS draft rows in this PR.
+
+## Review Request Status
+
+`review_requested`
+
+Codex did not request, perform, or claim Operator editorial approval. Operator approval remains a separate hard gate.
+
+## Sidecars
+
+- `HELP-CONTENT-DRAFT-REVISION-CMS-DRAFT-SYNC`: revised local package is not applied to CMS draft rows in this PR.
+- `HELP-CONTENT-DRAFT-REVISION-SUPPORT-CONTACT-FIELD`: `support@fermatmind.com` exists in the import package layer, but prior postcheck did not verify it inside production ContentPage rows or a first-class `support_contact` field.
+- `HELP-CONTENT-DRAFT-REVISION-PUBLISH-BLOCK`: publish, CMS mutation, deploy, search submission, payment/refund action, and private URL access remain forbidden.
+- `HELP-CONTENT-DRAFT-REVISION-OPERATOR-APPROVAL`: Operator editorial approval was not performed or claimed by Codex.
+
+## Validation Planned
+
+- JSON parse for generated artifacts and train state.
+- YAML parse for train manifest.
+- Focused `HelpContentImportPackageTest`.
+- Scoped diff checks.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44817,7 +44817,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-revision-request-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_open",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): revise v01 Help content package and rerun review request",
     "depends_on": [
@@ -44837,18 +44837,9 @@
         "evidence": "Task may revise only the local v01 package draft fields needed to clear #1919 guard findings and may write review/revision artifacts. CMS mutation, publish, deploy, private URL access, payment/refund actions, and secret/env/cookie/token reads are forbidden."
       },
       "github": {
-        "status": "pass",
+        "status": "pending",
         "commands": [
-          "gh pr checks 1921 --watch --interval 15"
-        ],
-        "jobs": [
-          "hygiene",
-          "supply-chain",
-          "content-pack-build-validate",
-          "verify-bigfive",
-          "verify-mbti-legacy",
-          "verify-mbti-v2",
-          "Semgrep blocking secrets"
+          "gh pr checks 1925 --watch --interval 15"
         ]
       },
       "package_revision": {
@@ -44896,8 +44887,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "7d611361e12aea67fec4718c36976046e8bb2e5e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1925",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44977,6 +44968,11 @@
         "at": "2026-06-05",
         "status": "rebased_local_checks_still_passed",
         "note": "Rebased the task branch onto the latest origin/main after main advanced by one commit; JSON/YAML parse, scoped diff check, and HelpContentImportPackageTest still passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/1925 for HELP-CONTENT-DRAFT-REVISION-REQUEST-01 after local validation passed. GitHub checks are pending."
       }
     ],
     "result": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44817,7 +44817,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-revision-request-01",
     "base": "origin/main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): revise v01 Help content package and rerun review request",
     "depends_on": [
@@ -44837,9 +44837,19 @@
         "evidence": "Task may revise only the local v01 package draft fields needed to clear #1919 guard findings and may write review/revision artifacts. CMS mutation, publish, deploy, private URL access, payment/refund actions, and secret/env/cookie/token reads are forbidden."
       },
       "github": {
-        "status": "pending",
+        "status": "pass",
         "commands": [
           "gh pr checks 1925 --watch --interval 15"
+        ],
+        "jobs": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep blocking secrets",
+          "Semgrep OSS"
         ]
       },
       "package_revision": {
@@ -44887,7 +44897,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "7d611361e12aea67fec4718c36976046e8bb2e5e",
+    "commit_sha": "e13a893f864dbdb148e9fa95e72d9fe6a003a05e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1925",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -44973,6 +44983,11 @@
         "at": "2026-06-05",
         "status": "pr_open",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1925 for HELP-CONTENT-DRAFT-REVISION-REQUEST-01 after local validation passed. GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "PR #1925 GitHub checks passed and changed files remained within the allowed revision/review artifact and PR-train state paths. Review status remains review_requested; Operator approval remains unclaimed."
       }
     ],
     "result": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44817,7 +44817,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-revision-request-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "local_checks_passed",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): revise v01 Help content package and rerun review request",
     "depends_on": [
@@ -44850,11 +44850,54 @@
           "verify-mbti-v2",
           "Semgrep blocking secrets"
         ]
+      },
+      "package_revision": {
+        "status": "pass",
+        "original_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+        "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+        "changed_assets": [
+          "UNLOCK-FAILURE-HELP-CARD-01",
+          "PAYMENT-REFUND-FAQ-PACKAGE-01",
+          "RESULT-RECOVERY-FAQ-01",
+          "PRIVACY-FAQ-PACKAGE-01",
+          "DATA-DELETION-REQUEST-FAQ-01"
+        ],
+        "visible_guard_status": "pass"
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-revision-request-01.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "passed"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+            "status": "passed_with_warning",
+            "evidence": "Exit 0; 1 test warning, 454 assertions."
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-revision-request-01.v1.json backend/docs/operations/help-content-draft-revision-request-2026-06-05.md backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "passed"
+          }
+        ]
       }
     },
     "failure_reason": null,
-    "commit_sha": "44963cc25081001c33eac973cc67333975475fc9",
-    "pr_url": "https://github.com/fermatmind/fap-api/pull/1921",
+    "commit_sha": null,
+    "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -44919,8 +44962,37 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "PR #1921 GitHub checks passed and changed files remained limited to manifest/state."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Revised the local v01 package at the approved zip path, recomputed SHA-256, and generated revision/review-rerun artifacts. No CMS mutation, publish, deploy, private URL access, or secret/env/cookie/token read was performed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Generated artifacts parsed, manifest/state parsed, scoped diff check passed, and HelpContentImportPackageTest exited 0 with 454 assertions and one Laravel warning. Review rerun status is review_requested; Operator approval remains unclaimed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "rebased_local_checks_still_passed",
+        "note": "Rebased the task branch onto the latest origin/main after main advanced by one commit; JSON/YAML parse, scoped diff check, and HelpContentImportPackageTest still passed."
       }
-    ]
+    ],
+    "result": {
+      "review_status": "review_requested",
+      "package_hash_checked": true,
+      "original_sha256": "2e3a947b3b59663e6f359de0237a4efe4e7dc2ec518be93b3bda15ffeb0aaae6",
+      "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+      "draft_count_checked": 12,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "operator_approval_claimed": false,
+      "revision_artifact": "backend/docs/help/generated/help-content-draft-revision-request-01.v1.json",
+      "revision_report": "backend/docs/operations/help-content-draft-revision-request-2026-06-05.md",
+      "review_rerun_artifact": "backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json",
+      "review_rerun_report": "backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md"
+    }
   },
   "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01": {
     "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Revised the local v01 Help service content package to clear the #1919 visible draft-field guard for payment/result private-detail wording.
- Repacked the same local v01 zip path and recorded the hash delta in generated artifacts.
- Added revision and editorial-review-rerun artifacts plus operations reports.
- Updated the PR-train state for HELP-CONTENT-DRAFT-REVISION-REQUEST-01.

## Why
#1919 blocked the Operator review request because visible draft fields contained private identifier/result-link guard categories. This PR reruns the review request against the revised local package without mutating CMS drafts or publishing anything.

## Validation
- python3 -m json.tool backend/docs/help/generated/help-content-draft-revision-request-01.v1.json >/dev/null
- python3 -m json.tool backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi
- git diff --check -- backend/docs/help/generated/help-content-draft-revision-request-01.v1.json backend/docs/operations/help-content-draft-revision-request-2026-06-05.md backend/docs/help/generated/help-content-draft-editorial-review-rerun-01.v1.json backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation or CMS draft content sync.
- No Operator editorial approval claimed.
- No publish, deploy, search submission, payment/refund action, provider change, private URL access, or secret/env/cookie/token read.
- support_contact row-level verification remains a publish preflight sidecar.

## Repository rule impact
Help content remains CMS/backend-authoritative. This PR only records revision/review-request evidence and does not introduce frontend fallback content or runtime authority changes.