### PR TITLE
ops(help): sync revised Help content package to CMS drafts

### DIFF
--- a/backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json
@@ -1,0 +1,364 @@
+{
+  "schema": "help-content-draft-cms-sync-01.v1",
+  "task": "HELP-CONTENT-DRAFT-CMS-SYNC-01",
+  "generated_at": "2026-06-05",
+  "decision": "CMS_DRAFT_SYNC_COMPLETED_WITH_PUBLISH_BLOCKED",
+  "source_package": {
+    "zip_path": "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+    "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+    "expected_revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+    "sha256_match": true,
+    "local_source_file": "/private/tmp/help-content-draft-cms-sync-01-source/content_pages.help_service_drafts_01.revised.json",
+    "local_source_sha256": "911ee53b6e4f8d4bb8ca368fa9e0ffccd6c6ef10a11e06385dc9e8faa17e5128",
+    "local_source_rows": 12,
+    "remote_temp_source_dir": "/tmp/fm-help-cms-sync.Ln1ubI",
+    "remote_temp_source_removed": true
+  },
+  "dry_run": {
+    "command": "php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fm-help-cms-sync.Ln1ubI --no-ansi",
+    "passed": true,
+    "files_found": 1,
+    "pages_found": 12,
+    "will_create": 0,
+    "will_update": 12,
+    "will_skip": 0
+  },
+  "sync": {
+    "command": "php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fm-help-cms-sync.Ln1ubI --no-ansi",
+    "performed": true,
+    "files_found": 1,
+    "pages_found": 12,
+    "will_create": 0,
+    "will_update": 12,
+    "will_skip": 0,
+    "status_mode": "draft",
+    "upsert": true
+  },
+  "cms_postcheck": {
+    "count": 12,
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true,
+    "all_owner_review": true,
+    "rows": [
+      {
+        "id": 42,
+        "locale": "en",
+        "slug": "help-data-deletion",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/data-deletion",
+        "canonical_path": "/help/data-deletion",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "0db5493cc1f2621040e76c8f1af09d4473849af182fb9870f18ce0e43ad33cea",
+        "content_md_sha256": "edf811aca0acacb468c5ab1a090c0a21f5c15377588e6a96443809de5c73c292"
+      },
+      {
+        "id": 41,
+        "locale": "zh-CN",
+        "slug": "help-data-deletion",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/data-deletion",
+        "canonical_path": "/help/data-deletion",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:DATA-DELETION-REQUEST-FAQ-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "079e387425c0100e5011c5fdc16c3849fdad7b4b60203f73d6a3140c9c45f463",
+        "content_md_sha256": "f39bc87b2ae05e3b7e756521b0ccbbff97086ae8c8110a9c262e2f39cb4552b8"
+      },
+      {
+        "id": 34,
+        "locale": "en",
+        "slug": "help-payment-refund",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/payment-refund",
+        "canonical_path": "/help/payment-refund",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "2dfe2110c45b2c01bb3ceab94aad4259d088d9959f606254366d990c40e58ce6",
+        "content_md_sha256": "1565371ab1a3aab602673993d38a16d9c338f6c227322c908e96cbb845a460d9"
+      },
+      {
+        "id": 33,
+        "locale": "zh-CN",
+        "slug": "help-payment-refund",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/payment-refund",
+        "canonical_path": "/help/payment-refund",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PAYMENT-REFUND-FAQ-PACKAGE-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "3fe66c055be88eb35b3b433f6a19275fe9a8e2ed60127368b1b1581c9bb7052a",
+        "content_md_sha256": "d1eb540b5e981e196571f035427a43933a8348ea9f279547d00ae8b4b60ecbd2"
+      },
+      {
+        "id": 38,
+        "locale": "en",
+        "slug": "help-privacy-data",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/privacy-data",
+        "canonical_path": "/help/privacy-data",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "4f7b27a41da6793ad0157cbb39823b9998f69ea6326d83080e915961666f2c7a",
+        "content_md_sha256": "b166b946f388099214b7dfbbad5a957da539336de1786822ebd0def033234be8"
+      },
+      {
+        "id": 37,
+        "locale": "zh-CN",
+        "slug": "help-privacy-data",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/privacy-data",
+        "canonical_path": "/help/privacy-data",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:PRIVACY-FAQ-PACKAGE-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "476a53ad52b682bb92c03c4a34cc7d19343d6f4ee2f2557b4580334e596f4713",
+        "content_md_sha256": "b7657b8ecf9d795f88eba1b43541d19cbc93680b5ed866dcc862ee1f903897ee"
+      },
+      {
+        "id": 36,
+        "locale": "en",
+        "slug": "help-result-recovery",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/result-recovery",
+        "canonical_path": "/help/result-recovery",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "215161a1da66ad71307b1d267562df59ecd46e7d142f79e44c40a7660f9514e6",
+        "content_md_sha256": "fd01919ef2252a950cd5d64a12ecb27864d1f771024c4a0892a5f40d7d77c2af"
+      },
+      {
+        "id": 35,
+        "locale": "zh-CN",
+        "slug": "help-result-recovery",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/result-recovery",
+        "canonical_path": "/help/result-recovery",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:RESULT-RECOVERY-FAQ-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "c75ddf9a55f35259eac08f9ff9fc7497ce0c4839e849fac61fbc7038a54b38fd",
+        "content_md_sha256": "022b325d11acaf5a30ee6f47b0e2bf7a39091e10481299474e6a9835d2d61aec"
+      },
+      {
+        "id": 32,
+        "locale": "en",
+        "slug": "help-unlock-failure",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/unlock-failure",
+        "canonical_path": "/help/unlock-failure",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "51e99ccfe5e3dd558401cd7741bfd0667b94eec8732744021b2cd509c7a570ca",
+        "content_md_sha256": "5ef02631889fd9d4e81a0d53c0428150e6ca1361bf9c2d6b5eddd576b6222410"
+      },
+      {
+        "id": 31,
+        "locale": "zh-CN",
+        "slug": "help-unlock-failure",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/unlock-failure",
+        "canonical_path": "/help/unlock-failure",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:UNLOCK-FAILURE-HELP-CARD-01",
+        "source_updated_at": "2026-06-05T00:00:00.000000Z",
+        "summary_sha256": "8432ddf4a18aa3c5a023ca7f82840940040511f59e638f71ccc0a58fc4f0fc94",
+        "content_md_sha256": "e277080867fca7c0c32a4271a89c0b9eb6a0cf91d868bf460fdf290e512dbbd6"
+      },
+      {
+        "id": 40,
+        "locale": "en",
+        "slug": "help-use-boundaries",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/use-boundaries",
+        "canonical_path": "/help/use-boundaries",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01",
+        "source_updated_at": "2026-06-04T00:00:00.000000Z",
+        "summary_sha256": "80e2320d18f233f4f8ba4b50b8a2485aa947e772104383e649caad5e2f477a41",
+        "content_md_sha256": "cd2c1c2fb428c65d633ec84915d926128c725851655df5f414ea36a13d47796a"
+      },
+      {
+        "id": 39,
+        "locale": "zh-CN",
+        "slug": "help-use-boundaries",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "path": "/help/use-boundaries",
+        "canonical_path": "/help/use-boundaries",
+        "review_state": "owner_review",
+        "source_doc": "HELP-SERVICE-CONTENT-DRAFTS-01:NONDIAGNOSTIC-HELP-COPY-01",
+        "source_updated_at": "2026-06-04T00:00:00.000000Z",
+        "summary_sha256": "6681f38e73e4ca9023f781cfb6a8bc5a71c329f56d2569a18cacad67bc7a123b",
+        "content_md_sha256": "6fe8a97d4b7691a5265a8b4cb12a0a823f6ebd09624eedae2265c022f42815b2"
+      }
+    ]
+  },
+  "public_surface_checks": {
+    "localized_routes": {
+      "checked_count": 12,
+      "all_404": true,
+      "routes": [
+        {
+          "url": "https://fermatmind.com/zh/help/unlock-failure",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/zh/help/payment-refund",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/zh/help/result-recovery",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/zh/help/privacy-data",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/zh/help/use-boundaries",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/zh/help/data-deletion",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/en/help/unlock-failure",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/en/help/payment-refund",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/en/help/result-recovery",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/en/help/privacy-data",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/en/help/use-boundaries",
+          "status": 404
+        },
+        {
+          "url": "https://fermatmind.com/en/help/data-deletion",
+          "status": 404
+        }
+      ]
+    },
+    "enumeration": [
+      {
+        "url": "https://fermatmind.com/sitemap.xml",
+        "status": 200,
+        "target_hits": 0,
+        "hits": []
+      },
+      {
+        "url": "https://fermatmind.com/llms.txt",
+        "status": 200,
+        "target_hits": 0,
+        "hits": []
+      },
+      {
+        "url": "https://fermatmind.com/llms-full.txt",
+        "status": 200,
+        "target_hits": 0,
+        "hits": []
+      }
+    ],
+    "all_target_hits_zero": true
+  },
+  "operator_review": {
+    "review_passed": false,
+    "operator_editorial_approval_present": false,
+    "approval_claimed_by_codex": false,
+    "next_gate": "Operator editorial review remains required before publish."
+  },
+  "scope_validation": {
+    "cms_mutation_performed": true,
+    "cms_mutation_scope": "existing 12 Help ContentPage draft rows only",
+    "records_created": 0,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-CMS-SYNC-OPERATOR-APPROVAL",
+      "status": "hard_gate",
+      "note": "Operator editorial approval remains separate and was not claimed."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-CMS-SYNC-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish, indexability, sitemap/llms inclusion, deploy, and search submission remain forbidden."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-CMS-SYNC-SUPPORT-CONTACT-FIELD",
+      "status": "open_publish_preflight",
+      "note": "support@fermatmind.com exists in the import package layer; a first-class ContentPage support_contact field is still not verified."
+    }
+  ]
+}

--- a/backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md
@@ -1,0 +1,78 @@
+# HELP-CONTENT-DRAFT-CMS-SYNC-01
+
+Decision: `CMS_DRAFT_SYNC_COMPLETED_WITH_PUBLISH_BLOCKED`
+
+## Scope
+
+Synced the revised v01 Help service content package to the existing 12 Help `ContentPage` CMS drafts through the controlled importer. This task did not publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator editorial approval.
+
+## Source
+
+- Revised zip: `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`
+- Revised SHA-256: `f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9`
+- Local generated source rows: `12`
+- Remote temp source dir: `/tmp/fm-help-cms-sync.Ln1ubI`
+- Remote temp source removed: `true`
+
+## Dry Run
+
+Command:
+
+```text
+php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fm-help-cms-sync.Ln1ubI --no-ansi
+```
+
+Result:
+
+```text
+files_found=1
+pages_found=12
+will_create=0
+will_update=12
+will_skip=0
+dry-run complete
+```
+
+## CMS Sync
+
+Command:
+
+```text
+php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fm-help-cms-sync.Ln1ubI --no-ansi
+```
+
+Result:
+
+```text
+files_found=1
+pages_found=12
+will_create=0
+will_update=12
+will_skip=0
+import complete
+```
+
+## Postcheck
+
+- Record count: `12`
+- All status draft: `true`
+- All non-public: `true`
+- All non-indexable: `true`
+- All unpublished: `true`
+- All owner review: `true`
+
+## Public Surface
+
+- Localized public routes checked: `12`
+- All target routes 404: `true`
+- sitemap/llms target hits: `0`
+
+## Sidecars
+
+- `HELP-CONTENT-DRAFT-CMS-SYNC-OPERATOR-APPROVAL`: Operator editorial approval remains required and was not claimed.
+- `HELP-CONTENT-DRAFT-CMS-SYNC-PUBLISH-BLOCK`: publish, deploy, indexability, sitemap/llms inclusion, and search submission remain forbidden.
+- `HELP-CONTENT-DRAFT-CMS-SYNC-SUPPORT-CONTACT-FIELD`: first-class ContentPage support contact remains unverified for publish preflight.
+
+## Next Task
+
+`HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01` should be a separate authorization. Codex cannot approve editorial review on the Operator's behalf.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31850,7 +31850,7 @@
   "RESULT-EN-PARITY-06": {
     "repo": "fap-api",
     "branch": "codex/result-en-parity-06-bigfive-v2-en-assets",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "depends_on": [
       "RESULT-EN-PARITY-05"
     ],
@@ -44894,6 +44894,21 @@
             "status": "passed"
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "merge_state": "CLEAN",
+        "checks": [
+          "hygiene",
+          "Semgrep blocking secrets",
+          "supply-chain",
+          "semgrep sarif non-blocking upload",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep OSS"
+        ]
       }
     },
     "failure_reason": null,
@@ -47068,7 +47083,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "305bb45e02c74c2a3dbeab704ff78a6a3c072ed5",
+    "commit_sha": "fef2189cccb002b0fc57931ea600b03c018bdceb",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1927",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -47142,6 +47157,11 @@
         "at": "2026-06-05",
         "status": "pr_opened",
         "note": "Opened PR #1927 with scoped CMS sync artifacts and PR-train metadata."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN. Changed files remained limited to the CMS sync generated artifact, operations report, manifest, and state ledger."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -44817,7 +44817,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-revision-request-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): revise v01 Help content package and rerun review request",
     "depends_on": [
@@ -44897,11 +44897,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "e13a893f864dbdb148e9fa95e72d9fe6a003a05e",
+    "commit_sha": "df144673921fcdd3470653ee974ea5f13af6dc41",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1925",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T09:23:17Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "external_asset_paths": [
       "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
       "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01"
@@ -44988,6 +44988,11 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "PR #1925 GitHub checks passed and changed files remained within the allowed revision/review artifact and PR-train state paths. Review status remains review_requested; Operator approval remains unclaimed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged_reconciled",
+        "note": "Reconciled while starting HELP-CONTENT-DRAFT-CMS-SYNC-01: PR #1925 is merged, origin/main contains df144673921fcdd3470653ee974ea5f13af6dc41, and local/remote task branch cleanup was completed."
       }
     ],
     "result": {
@@ -46981,6 +46986,157 @@
         "from": "pr_open_github_checks_pending",
         "to": "ready_to_merge",
         "notes": "GitHub checks passed and merge state was CLEAN. Pre-merge scope validation remained limited to PR12 docs/generated/test/ledger paths."
+      }
+    ]
+  },
+  "HELP-CONTENT-DRAFT-CMS-SYNC-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-cms-sync-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "ops(help): sync revised Help content package to CMS drafts",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-REVISION-REQUEST-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized Codex to execute HELP-CONTENT-DRAFT-CMS-SYNC-01, limited to syncing revised v01 Help content to existing 12 Help CMS drafts while preserving draft/non-public/non-indexable/unpublished state."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-REVISION-REQUEST-01 is merged as PR #1925 and origin/main contains df144673921fcdd3470653ee974ea5f13af6dc41."
+      },
+      "package_hash": {
+        "status": "pass",
+        "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9"
+      },
+      "production_dry_run": {
+        "status": "pass",
+        "files_found": 1,
+        "pages_found": 12,
+        "will_create": 0,
+        "will_update": 12,
+        "will_skip": 0
+      },
+      "production_sync": {
+        "status": "pass",
+        "performed": true,
+        "will_create": 0,
+        "will_update": 12,
+        "will_skip": 0
+      },
+      "postcheck": {
+        "status": "pass",
+        "record_count": 12,
+        "all_status_draft": true,
+        "all_non_public": true,
+        "all_non_indexable": true,
+        "all_unpublished": true
+      },
+      "public_surface": {
+        "status": "pass",
+        "routes_all_404": true,
+        "sitemap_llms_hits": 0
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "pass"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+            "status": "passed_with_warning",
+            "notes": "Exited 0 with 454 assertions and one Laravel warning in the temporary worktree."
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "pass"
+          }
+        ]
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "CMS_DRAFT_SYNC_COMPLETED_WITH_PUBLISH_BLOCKED",
+      "cms_mutation_performed": true,
+      "records_created": 0,
+      "records_updated": 12,
+      "record_count_checked": 12,
+      "publish_performed": false,
+      "operator_approval_claimed": false,
+      "revised_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": true,
+      "cms_mutation_scope": "existing 12 Help ContentPage draft rows only",
+      "records_created": 0,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-CMS-SYNC-OPERATOR-APPROVAL",
+        "status": "hard_gate",
+        "note": "Operator editorial approval remains separate and was not claimed."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-CMS-SYNC-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish, indexability, sitemap/llms inclusion, deploy, and search submission remain forbidden."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-CMS-SYNC-SUPPORT-CONTACT-FIELD",
+        "status": "open_publish_preflight",
+        "note": "support@fermatmind.com exists in the import package layer; a first-class ContentPage support_contact field is still not verified."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01 after separate authorization",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized syncing revised v01 Help content to existing 12 CMS draft rows only."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "production_sync_completed",
+        "note": "Dry-run passed with will_create=0 and will_update=12; executed importer with --upsert --status=draft; postcheck confirmed 12 rows remain draft, non-public, non-indexable, unpublished, and owner_review."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Archived CMS sync artifact and operations report; local repo checks are pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "JSON/YAML parses passed, scoped diff whitespace check passed, and HelpContentImportPackageTest exited 0 with 454 assertions and one Laravel warning."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46993,7 +46993,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-cms-sync-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync revised Help content package to CMS drafts",
     "depends_on": [
@@ -47068,8 +47068,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "305bb45e02c74c2a3dbeab704ff78a6a3c072ed5",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1927",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -47137,6 +47137,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "JSON/YAML parses passed, scoped diff whitespace check passed, and HelpContentImportPackageTest exited 0 with 454 assertions and one Laravel warning."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_opened",
+        "note": "Opened PR #1927 with scoped CMS sync artifacts and PR-train metadata."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21687,6 +21687,52 @@ prs:
     content_authority: CMS/backend
     next_task: null
 
+  - id: HELP-CONTENT-DRAFT-CMS-SYNC-01
+    repo: fap-api
+    branch: codex/help-content-draft-cms-sync-01
+    title: "ops(help): sync revised Help content package to CMS drafts"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    depends_on:
+      - HELP-CONTENT-DRAFT-REVISION-REQUEST-01
+    scope:
+      - Use the revised v01 Help service content package at `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`.
+      - Sync revised v01 package content to the existing 12 Help `ContentPage` CMS drafts through the controlled `content-pages:import-local-baseline --upsert --status=draft` path.
+      - Keep every synced row draft, non-public, non-indexable, unpublished, and in owner review.
+      - Archive dry-run output, import output, post-sync CMS draft state, public absence checks, package hash, and sidecar issues.
+      - Do not claim Operator editorial approval; approval remains a separate hard gate.
+    external_asset_paths:
+      - /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+      - /Users/rainie/Desktop/fermatmind-help-service-content-drafts-01
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json
+      - backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or approve editorial review on Operator's behalf.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi
+      - git diff --check -- backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    database_mutation: true
+    payment_provider_call: false
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added the HELP-CONTENT-DRAFT-CMS-SYNC-01 train entry and state record.
- Archived the revised v01 Help content CMS sync evidence, including package hash, production dry-run, production sync, CMS postcheck, public absence checks, and sidecar gates.
- Reconciled HELP-CONTENT-DRAFT-REVISION-REQUEST-01 as merged to unblock this train item.

## Why
- The revised v01 Help package needed to be synced into the existing 12 Help ContentPage CMS drafts while keeping every row draft-only, non-public, non-indexable, unpublished, and pending owner/operator review.

## Validation
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi`
- `git diff --check -- backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json backend/docs/operations/help-content-draft-cms-sync-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Operator editorial approval remains a hard gate and is not claimed here.
- Publish, deploy, search submission, indexability, sitemap/llms inclusion, payment/refund actions, and private URL access were not performed.
- `support_contact` as a first-class ContentPage field remains a publish-preflight sidecar; `support@fermatmind.com` is present in the import package layer.

## Repository rule impact
- Help service content remains CMS/backend-authoritative via ContentPage drafts. No frontend editorial fallback or runtime authority was added.