### PR TITLE
docs(codex): mark Help CMS sync status merged

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47135,7 +47135,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-cms-sync-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync revised Help content package to CMS drafts",
     "depends_on": [

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21692,7 +21692,7 @@ prs:
     branch: codex/help-content-draft-cms-sync-01
     title: "ops(help): sync revised Help content package to CMS drafts"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     depends_on:
       - HELP-CONTENT-DRAFT-REVISION-REQUEST-01
     scope:


### PR DESCRIPTION
## What changed
- Corrected the HELP-CONTENT-DRAFT-CMS-SYNC-01 manifest status from `in_progress` to `merged`.
- Corrected the state ledger top-level status from `pr_opened` to `merged`.

## Why
- PR #1928 recorded the merge commit, merged_at, remote branch deletion, and local cleanup, but the two top-level status fields remained stale.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or Operator approval claim.

## Repository rule impact
- No content authority change. This is status-only PR-train ledger closeout.