### PR TITLE
SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01: ops(cms): create RIASEC explanation article drafts

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json
@@ -1,0 +1,258 @@
+{
+  "task_id": "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01",
+  "generated_at": "2026-06-05T12:55:00Z",
+  "decision": "GO: RIASEC explanation zh/en CMS drafts created; publish, search submission, and public exposure remain blocked.",
+  "repo": "fap-api",
+  "content_authority": "CMS/backend",
+  "train_scope": "seo_article_content_package_riasec_explanation_v2",
+  "source_package": {
+    "package_dir": "backend/docs/seo/cms-import-packages/riasec-explanation-v2",
+    "zh_target": "backend/docs/seo/cms-import-packages/riasec-explanation-v2/zh.article-target.json",
+    "en_target": "backend/docs/seo/cms-import-packages/riasec-explanation-v2/en.article-target.json",
+    "content_rewrite_performed": false
+  },
+  "authorization": {
+    "cms_draft_create_authorized": true,
+    "cms_draft_create_authorization_scope": "draft-only CMS mutation for SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01",
+    "deployed_release_accepted_for_execution": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
+    "publish_authorized": false,
+    "search_submission_authorized": false,
+    "frontend_deploy_authorized": false,
+    "private_url_access_authorized": false
+  },
+  "backend_deploy_precondition": {
+    "performed": true,
+    "reason": "Production release lacked the merged RIASEC importer mapping and target package files before draft creation.",
+    "initial_approved_sha": "7d21cdf9f28c234a2c3c5ff107db9627ba4adcc3",
+    "initial_release_name": "backend-main-20260605-7d21cdf9",
+    "actual_deployed_revision": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
+    "actual_release_accepted_by_user": true,
+    "post_deploy_schema_verify": "pass",
+    "post_deploy_ops_healthz_snapshot": "pass",
+    "frontend_deploy_performed": false
+  },
+  "hard_boundaries": {
+    "cms_draft_created": true,
+    "production_write_performed": true,
+    "database_mutation_performed": true,
+    "cms_mutation_performed": true,
+    "publish_performed": false,
+    "publish_allowed": false,
+    "search_submission_performed": false,
+    "search_submit_allowed": false,
+    "content_rewrite_performed": false,
+    "private_url_accessed": false,
+    "result_order_share_pay_payment_history_private_tokenized_url_accessed": false,
+    "frontend_deploy_performed": false
+  },
+  "importer_dry_run": {
+    "zh": {
+      "ok": true,
+      "action": "will_create",
+      "would_write": true,
+      "errors_count": 0,
+      "warnings_count": 6,
+      "claim_matches_count": 2,
+      "references_count": 0,
+      "existing_article_id": null,
+      "body_hash": "e4c763a895ce2aed43fcbad09e975c5c84f59936126dbe461bf0411084b68ba7",
+      "answer_surface_hash": "7e27a8ee91455934534eb89350e0de62c7512647bea4df93899b2df00a3f3dbf"
+    },
+    "en": {
+      "ok": true,
+      "action": "will_create",
+      "would_write": true,
+      "errors_count": 0,
+      "warnings_count": 4,
+      "claim_matches_count": 0,
+      "references_count": 0,
+      "existing_article_id": null,
+      "body_hash": "1233d8180fe1a6618331e032cad71fa7dabacdb15f8601f84ac6267149447b8c",
+      "answer_surface_hash": "721e0a42b70c73cbe5f26cab4b69f67502dd7be55330f20a75471005b875e3d0"
+    }
+  },
+  "draft_create": {
+    "zh": {
+      "ok": true,
+      "action": "will_create",
+      "would_write": true,
+      "article_id": 40,
+      "working_revision_id": 45,
+      "working_revision_status": "machine_draft",
+      "published_revision_id": null,
+      "errors_count": 0,
+      "warnings_count": 6,
+      "claim_matches_count": 2,
+      "references_count": 0,
+      "body_hash": "e4c763a895ce2aed43fcbad09e975c5c84f59936126dbe461bf0411084b68ba7",
+      "answer_surface_hash": "7e27a8ee91455934534eb89350e0de62c7512647bea4df93899b2df00a3f3dbf"
+    },
+    "en": {
+      "ok": true,
+      "action": "will_create",
+      "would_write": true,
+      "article_id": 41,
+      "working_revision_id": 46,
+      "working_revision_status": "machine_draft",
+      "published_revision_id": null,
+      "errors_count": 0,
+      "warnings_count": 4,
+      "claim_matches_count": 0,
+      "references_count": 0,
+      "body_hash": "1233d8180fe1a6618331e032cad71fa7dabacdb15f8601f84ac6267149447b8c",
+      "answer_surface_hash": "721e0a42b70c73cbe5f26cab4b69f67502dd7be55330f20a75471005b875e3d0"
+    }
+  },
+  "production_postcheck": {
+    "articles": [
+      {
+        "id": 40,
+        "locale": "zh",
+        "slug": "riasec-holland-career-interest-test-explained",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "deleted_at": null,
+        "translation_group_id": "riasec-explanation-article-2026-06-v2"
+      },
+      {
+        "id": 41,
+        "locale": "en",
+        "slug": "what-is-riasec-holland-code-career-interest-test",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "published_revision_id": null,
+        "published_at": null,
+        "deleted_at": null,
+        "translation_group_id": "riasec-explanation-article-2026-06-v2"
+      }
+    ],
+    "seo_meta": [
+      {
+        "article_id": 40,
+        "locale": "zh",
+        "robots": "noindex,nofollow",
+        "is_indexable": false,
+        "canonical_url": "https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained"
+      },
+      {
+        "article_id": 41,
+        "locale": "en",
+        "robots": "noindex,nofollow",
+        "is_indexable": false,
+        "canonical_url": "https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test"
+      }
+    ],
+    "revisions": [
+      {
+        "id": 45,
+        "article_id": 40,
+        "locale": "zh",
+        "revision_number": 1,
+        "revision_status": "machine_draft",
+        "published_at": null,
+        "approved_at": null
+      },
+      {
+        "id": 46,
+        "article_id": 41,
+        "locale": "en",
+        "revision_number": 1,
+        "revision_status": "machine_draft",
+        "published_at": null,
+        "approved_at": null
+      }
+    ],
+    "translation_group_count": 2,
+    "duplicate_counts": {
+      "riasec-holland-career-interest-test-explained": 1,
+      "what-is-riasec-holland-code-career-interest-test": 1
+    },
+    "public_indexable_published_count": 0
+  },
+  "publish_blockers": {
+    "references_count": 0,
+    "cms_media_cover_image_missing": true,
+    "conditional_internal_links_held_for_operator_review": true,
+    "zh_boundary_context_claim_warning_count": 2,
+    "en_boundary_context_claim_warning_count": 0,
+    "working_revisions_require_human_approval": true,
+    "publish_preflight_required": true,
+    "explicit_publish_authorization_required": true
+  },
+  "public_exposure_postcheck": {
+    "article_pages": [
+      {
+        "locale": "zh",
+        "url": "https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained",
+        "status": 404,
+        "article_schema_present": false,
+        "faq_schema_present": false,
+        "target_canonical_present": false
+      },
+      {
+        "locale": "en",
+        "url": "https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test",
+        "status": 404,
+        "article_schema_present": false,
+        "faq_schema_present": false,
+        "target_canonical_present": false
+      }
+    ],
+    "article_apis": [
+      {
+        "locale": "zh",
+        "url": "https://api.fermatmind.com/api/v0.5/articles/riasec-holland-career-interest-test-explained",
+        "status": 404,
+        "target_slug_present": false
+      },
+      {
+        "locale": "zh",
+        "url": "https://api.fermatmind.com/api/v0.5/articles/riasec-holland-career-interest-test-explained/seo",
+        "status": 404,
+        "target_slug_present": false
+      },
+      {
+        "locale": "en",
+        "url": "https://api.fermatmind.com/api/v0.5/articles/what-is-riasec-holland-code-career-interest-test",
+        "status": 404,
+        "target_slug_present": false
+      },
+      {
+        "locale": "en",
+        "url": "https://api.fermatmind.com/api/v0.5/articles/what-is-riasec-holland-code-career-interest-test/seo",
+        "status": 404,
+        "target_slug_present": false
+      }
+    ],
+    "enumeration": {
+      "sitemap_xml": {
+        "status": 200,
+        "contains_zh_slug": false,
+        "contains_en_slug": false
+      },
+      "llms_txt": {
+        "status": 200,
+        "contains_zh_slug": false,
+        "contains_en_slug": false
+      },
+      "llms_full_txt": {
+        "status": 200,
+        "contains_zh_slug": false,
+        "contains_en_slug": false
+      }
+    }
+  },
+  "next_required_gates": [
+    "Operator editorial review",
+    "Accepted reference/source review",
+    "CMS Media Library cover image resolution",
+    "Working revision approval",
+    "Controlled publish preflight",
+    "Exact publish authorization before any publish",
+    "Post-publish 7-day and 14-day baseline review after a future publish"
+  ]
+}

--- a/backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md
+++ b/backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md
@@ -1,0 +1,70 @@
+# RIASEC Explanation V2 CMS Draft Create Postcheck
+
+Date: 2026-06-05
+
+Task: `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01`
+
+Decision: **GO for draft-only CMS creation; publish remains blocked.**
+
+## Scope
+
+Performed:
+
+- Backend production deploy precondition after exact user approval, because the previous production release did not contain the merged RIASEC importer mapping or package files.
+- Production importer dry-run for zh/en target packages.
+- Draft-only CMS creation for zh/en article drafts.
+- Read-only production DB postcheck.
+- Public article/API/sitemap/llms absence checks.
+
+Not performed:
+
+- No publish.
+- No search submission.
+- No frontend deploy.
+- No article body, FAQ, CTA, title, H1, meta, or slug rewrite.
+- No private result/order/share/pay/payment/history/tokenized URL access.
+
+## Production Drafts
+
+| Locale | Article ID | Revision ID | Slug | Status | Public | Indexable | Published revision |
+| --- | ---: | ---: | --- | --- | --- | --- | --- |
+| zh | 40 | 45 | `riasec-holland-career-interest-test-explained` | draft | false | false | null |
+| en | 41 | 46 | `what-is-riasec-holland-code-career-interest-test` | draft | false | false | null |
+
+Both records share `translation_group_id=riasec-explanation-article-2026-06-v2`.
+
+## Importer Result
+
+| Locale | Dry-run action | Import action | Errors | Warnings | Claim warnings | References |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| zh | will_create | will_create | 0 | 6 | 2 | 0 |
+| en | will_create | will_create | 0 | 4 | 0 | 0 |
+
+Working revisions remain `machine_draft`.
+
+## Publish Blockers
+
+- Accepted references are still missing.
+- CMS Media Library cover image is still unresolved.
+- Conditional internal links remain held for operator review.
+- zh has boundary-context claim warnings that require later publish-preflight handling.
+- Working revisions are not approved.
+- Exact publish authorization has not been granted.
+
+## Public Absence
+
+| Surface | zh | en |
+| --- | --- | --- |
+| Public article page | 404 | 404 |
+| Public article API | 404 | 404 |
+| Public article SEO API | 404 | 404 |
+| Article schema | absent | absent |
+| FAQ schema | absent | absent |
+| Target canonical | absent | absent |
+| sitemap.xml | absent | absent |
+| llms.txt | absent | absent |
+| llms-full.txt | absent | absent |
+
+## Next Gate
+
+The next task is editorial/operator review plus reference and media resolution. Publish remains forbidden until a separate controlled publish preflight passes and the user gives exact publish authorization.

--- a/backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php
@@ -1,0 +1,122 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationCmsDraftCreateTest extends TestCase
+{
+    public function test_draft_create_artifact_records_draft_only_cms_creation(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-create.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01', $artifact['task_id']);
+        $this->assertTrue($artifact['hard_boundaries']['cms_draft_created']);
+        $this->assertTrue($artifact['hard_boundaries']['production_write_performed']);
+        $this->assertTrue($artifact['hard_boundaries']['database_mutation_performed']);
+        $this->assertTrue($artifact['hard_boundaries']['cms_mutation_performed']);
+        $this->assertFalse($artifact['hard_boundaries']['publish_performed']);
+        $this->assertFalse($artifact['hard_boundaries']['publish_allowed']);
+        $this->assertFalse($artifact['hard_boundaries']['search_submission_performed']);
+        $this->assertFalse($artifact['hard_boundaries']['search_submit_allowed']);
+        $this->assertFalse($artifact['hard_boundaries']['content_rewrite_performed']);
+        $this->assertFalse($artifact['hard_boundaries']['private_url_accessed']);
+        $this->assertFalse($artifact['hard_boundaries']['result_order_share_pay_payment_history_private_tokenized_url_accessed']);
+        $this->assertFalse($artifact['hard_boundaries']['frontend_deploy_performed']);
+    }
+
+    public function test_importer_dry_run_and_create_results_are_locked(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-create.v1.json');
+
+        foreach (['zh', 'en'] as $locale) {
+            $this->assertTrue($artifact['importer_dry_run'][$locale]['ok']);
+            $this->assertSame('will_create', $artifact['importer_dry_run'][$locale]['action']);
+            $this->assertTrue($artifact['importer_dry_run'][$locale]['would_write']);
+            $this->assertSame(0, $artifact['importer_dry_run'][$locale]['errors_count']);
+
+            $this->assertTrue($artifact['draft_create'][$locale]['ok']);
+            $this->assertSame('will_create', $artifact['draft_create'][$locale]['action']);
+            $this->assertTrue($artifact['draft_create'][$locale]['would_write']);
+            $this->assertSame(0, $artifact['draft_create'][$locale]['errors_count']);
+            $this->assertSame('machine_draft', $artifact['draft_create'][$locale]['working_revision_status']);
+            $this->assertNull($artifact['draft_create'][$locale]['published_revision_id']);
+            $this->assertSame(0, $artifact['draft_create'][$locale]['references_count']);
+        }
+
+        $this->assertSame(40, $artifact['draft_create']['zh']['article_id']);
+        $this->assertSame(45, $artifact['draft_create']['zh']['working_revision_id']);
+        $this->assertSame(41, $artifact['draft_create']['en']['article_id']);
+        $this->assertSame(46, $artifact['draft_create']['en']['working_revision_id']);
+    }
+
+    public function test_postcheck_confirms_non_public_noindex_unpublished_state(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-create.v1.json');
+        $articles = collect($artifact['production_postcheck']['articles'])->keyBy('locale');
+        $seo = collect($artifact['production_postcheck']['seo_meta'])->keyBy('locale');
+
+        $this->assertSame(2, $artifact['production_postcheck']['translation_group_count']);
+        $this->assertSame(1, $artifact['production_postcheck']['duplicate_counts']['riasec-holland-career-interest-test-explained']);
+        $this->assertSame(1, $artifact['production_postcheck']['duplicate_counts']['what-is-riasec-holland-code-career-interest-test']);
+        $this->assertSame(0, $artifact['production_postcheck']['public_indexable_published_count']);
+
+        foreach (['zh', 'en'] as $locale) {
+            $this->assertSame('draft', $articles[$locale]['status']);
+            $this->assertFalse($articles[$locale]['is_public']);
+            $this->assertFalse($articles[$locale]['is_indexable']);
+            $this->assertNull($articles[$locale]['published_revision_id']);
+            $this->assertNull($articles[$locale]['published_at']);
+            $this->assertNull($articles[$locale]['deleted_at']);
+            $this->assertSame('riasec-explanation-article-2026-06-v2', $articles[$locale]['translation_group_id']);
+
+            $this->assertSame('noindex,nofollow', $seo[$locale]['robots']);
+            $this->assertFalse($seo[$locale]['is_indexable']);
+        }
+    }
+
+    public function test_public_pages_apis_sitemap_and_llms_do_not_expose_drafts(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-create.v1.json');
+
+        foreach ($artifact['public_exposure_postcheck']['article_pages'] as $page) {
+            $this->assertSame(404, $page['status']);
+            $this->assertFalse($page['article_schema_present']);
+            $this->assertFalse($page['faq_schema_present']);
+            $this->assertFalse($page['target_canonical_present']);
+        }
+
+        foreach ($artifact['public_exposure_postcheck']['article_apis'] as $api) {
+            $this->assertSame(404, $api['status']);
+            $this->assertFalse($api['target_slug_present']);
+        }
+
+        foreach ($artifact['public_exposure_postcheck']['enumeration'] as $surface) {
+            $this->assertSame(200, $surface['status']);
+            $this->assertFalse($surface['contains_zh_slug']);
+            $this->assertFalse($surface['contains_en_slug']);
+        }
+    }
+
+    public function test_artifact_contains_no_forbidden_private_routes_or_identifiers(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-create.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47451,7 +47451,7 @@
         "note": "Publish, public indexability, sitemap/llms inclusion, search submission, and post-publish baseline review remain forbidden until separate controlled publish authorization."
       }
     ],
-    "commit_sha": "7f0eb94944a8dc71e192774c06447cbdb6783f25",
+    "commit_sha": "83aaca47f9e04150aa8dbc0dbd26fed8716f6b58",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47302,5 +47302,182 @@
         "note": "PR #1927 merged on GitHub at 2026-06-05T12:13:59Z with merge commit fcce4e3a6b76d47a746dcd321c6acdd0cdab0713; origin/main contains the merge commit; remote branch was deleted and local task worktree/branch cleanup was completed."
       }
     ]
+  },
+  "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/seo-article-riasec-v2-cms-draft-create-01",
+    "status": "draft_created_postcheck_passed_publish_blocked_local_validation_pending",
+    "title": "ops(cms): create RIASEC explanation article drafts",
+    "train_scope": "seo_article_content_package_riasec_explanation_v2",
+    "depends_on": [
+      "SEO-ARTICLE-RIASEC-V2-IMPORTER-MAPPING-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01 for draft-only CMS mutation, then separately authorized backend production deploy to unlock the missing importer mapping, and then accepted deployed release e812d6f87f8b84b45d2e900d9d3844a0402635bc for continuing importer dry-run, draft-only create, and draft postcheck. Publish, search submission, frontend deploy, content rewrite, and private URL access remain forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-IMPORTER-MAPPING-01 merged as PR #1923 and origin/main contains merge commit 095a91ccd8d27c4ea9e9e1f490e992efd228c142."
+      },
+      "backend_deploy_precondition": {
+        "status": "pass",
+        "performed": true,
+        "initial_approved_sha": "7d21cdf9f28c234a2c3c5ff107db9627ba4adcc3",
+        "initial_release_name": "backend-main-20260605-7d21cdf9",
+        "actual_deployed_revision": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
+        "actual_release_accepted_by_user": true,
+        "schema_verify": "pass",
+        "ops_healthz_snapshot": "pass",
+        "frontend_deploy_performed": false,
+        "notes": "Backend deploy was performed only as a precondition because production lacked the merged importer mapping and package files. No frontend deploy was performed."
+      },
+      "production_importer_dry_run": {
+        "status": "pass",
+        "zh": {
+          "ok": true,
+          "action": "will_create",
+          "would_write": true,
+          "errors_count": 0,
+          "warnings_count": 6,
+          "claim_matches_count": 2,
+          "references_count": 0,
+          "existing_article_id": null
+        },
+        "en": {
+          "ok": true,
+          "action": "will_create",
+          "would_write": true,
+          "errors_count": 0,
+          "warnings_count": 4,
+          "claim_matches_count": 0,
+          "references_count": 0,
+          "existing_article_id": null
+        }
+      },
+      "production_draft_create": {
+        "status": "pass",
+        "zh": {
+          "article_id": 40,
+          "working_revision_id": 45,
+          "working_revision_status": "machine_draft",
+          "published_revision_id": null,
+          "errors_count": 0,
+          "warnings_count": 6
+        },
+        "en": {
+          "article_id": 41,
+          "working_revision_id": 46,
+          "working_revision_status": "machine_draft",
+          "published_revision_id": null,
+          "errors_count": 0,
+          "warnings_count": 4
+        }
+      },
+      "production_postcheck": {
+        "status": "pass",
+        "articles_status_draft": true,
+        "articles_non_public": true,
+        "articles_non_indexable": true,
+        "articles_unpublished": true,
+        "robots_noindex_nofollow": true,
+        "translation_group_count": 2,
+        "slug_duplicate_counts_all_one": true,
+        "public_indexable_published_count": 0
+      },
+      "public_surface": {
+        "status": "pass",
+        "article_pages_404": true,
+        "article_apis_404": true,
+        "article_schema_absent": true,
+        "faq_schema_absent": true,
+        "target_canonical_absent": true,
+        "sitemap_contains_target_slugs": false,
+        "llms_contains_target_slugs": false,
+        "llms_full_contains_target_slugs": false
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to RIASEC draft-create generated artifact, postcheck report, focused artifact contract test, and docs/codex PR-train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsDraftCreateTest --no-ansi",
+          "git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed."
+      }
+    },
+    "result": {
+      "cms_draft_created": true,
+      "records_created": 2,
+      "zh_article_id": 40,
+      "en_article_id": 41,
+      "publish_allowed": false,
+      "search_submit_allowed": false,
+      "content_rewrite_performed": false,
+      "private_url_accessed": false,
+      "frontend_deploy_performed": false,
+      "generated_artifact": "backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json",
+      "postcheck_report": "backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": true,
+      "cms_mutation_scope": "two RIASEC explanation Article draft rows only",
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "frontend_deploy_performed": false,
+      "content_rewrite_performed": false,
+      "private_url_access_performed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01",
+        "status": "next_gate",
+        "note": "Operator editorial review, accepted references, CMS media resolution, and revision approval remain required before any publish preflight."
+      },
+      {
+        "id": "SEO-ARTICLE-RIASEC-V2-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish, public indexability, sitemap/llms inclusion, search submission, and post-publish baseline review remain forbidden until separate controlled publish authorization."
+      }
+    ],
+    "commit_sha": "7f0eb94944a8dc71e192774c06447cbdb6783f25",
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "failure_reason": null,
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized draft-only CMS mutation and PR-train manifest/state entry updates for SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "backend_deploy_precondition_completed",
+        "note": "Backend deploy completed after separate exact authorization; deployed release e812d6f87f8b84b45d2e900d9d3844a0402635bc was accepted by the user for continuing draft create."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "draft_created_postcheck_passed_publish_blocked",
+        "note": "Production importer dry-run passed for zh/en and created article drafts 40 and 41 with working revisions 45 and 46. Postcheck confirmed draft/non-public/non-indexable/unpublished state and public absence."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Local JSON/YAML parsing, PHP lint, focused RiasecExplanationCmsDraftCreateTest, and scope diff checks passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47307,7 +47307,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-cms-draft-create-01",
-    "status": "draft_created_postcheck_passed_publish_blocked_local_validation_pending",
+    "status": "pr_open_github_checks_pending",
     "title": "ops(cms): create RIASEC explanation article drafts",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -47451,8 +47451,8 @@
         "note": "Publish, public indexability, sitemap/llms inclusion, search submission, and post-publish baseline review remain forbidden until separate controlled publish authorization."
       }
     ],
-    "commit_sha": "83aaca47f9e04150aa8dbc0dbd26fed8716f6b58",
-    "pr_url": null,
+    "commit_sha": "f9d2eb1c1c0c630a3e567d1d9e2eac25b87b2234",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1931",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -47477,6 +47477,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Local JSON/YAML parsing, PHP lint, focused RiasecExplanationCmsDraftCreateTest, and scope diff checks passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open_github_checks_pending",
+        "note": "Opened PR #1931 for scoped draft-create artifact, postcheck report, focused test, and PR-train metadata."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24800,7 +24800,7 @@
     "merge_commit": "29ec08275027a517993a7cea0fdc6c117bc85c87"
   },
   "OPS-RELEASE-WORKFLOW-01": {
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-release-workflow-01",
@@ -47414,6 +47414,11 @@
           "git diff --cached --check"
         ],
         "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #1931 checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2.",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1931"
       }
     },
     "result": {
@@ -47482,6 +47487,11 @@
         "at": "2026-06-05",
         "status": "pr_open_github_checks_pending",
         "note": "Opened PR #1931 for scoped draft-create artifact, postcheck report, focused test, and PR-train metadata."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1931 and changed files remain confined to draft-create artifact, postcheck report, focused test, and PR-train metadata."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22495,3 +22495,46 @@ prs:
     deploy_allowed: false
     content_authority: CMS/backend
     next_task: SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01
+
+  - id: SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01
+    repo: fap-api
+    depends_on:
+      - SEO-ARTICLE-RIASEC-V2-IMPORTER-MAPPING-01
+    branch: codex/seo-article-riasec-v2-cms-draft-create-01
+    title: "ops(cms): create RIASEC explanation article drafts"
+    train_scope: seo_article_content_package_riasec_explanation_v2
+    status: draft_created_postcheck_passed_publish_blocked
+    scope:
+      - Record the backend production deploy precondition performed under separate exact user authorization because the previous production release lacked merged RIASEC importer mapping and package files.
+      - Execute production importer dry-run for zh/en RIASEC explanation V2 article target packages.
+      - Create zh/en CMS Article drafts only, preserving non-public, non-indexable, unpublished state.
+      - Record draft postcheck, public article/API absence, sitemap/llms absence, publish blockers, and next editorial review gates.
+    allowed_paths:
+      - backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md
+      - backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json
+      - backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish articles, submit search URLs, deploy frontend, rewrite content, or access private result/orders/share/pay/payment/history/tokenized URLs.
+    validation:
+      - php -l backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php
+      - python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsDraftCreateTest --no-ansi
+      - git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    database_mutation: true
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    backend_deploy_precondition_performed: true
+    frontend_deploy_allowed: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01 after separate authorization


### PR DESCRIPTION
## What changed
- Recorded `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01` in the PR train manifest/state ledger.
- Archived the RIASEC V2 zh/en CMS draft-create generated artifact and postcheck report.
- Added a focused artifact contract test for draft-only state, public absence, sitemap/llms absence, and forbidden private-route guards.

## Why
- Production needed the merged importer mapping/package release before creating the RIASEC explanation drafts.
- The authorized draft-only importer run created zh article `40` / revision `45` and en article `41` / revision `46` as non-public, non-indexable, unpublished CMS drafts.
- Publish remains blocked by missing accepted references, unresolved CMS Media Library cover image, held conditional internal links, machine-draft revision state, and later publish-preflight authorization.

## Validation
- `php -l backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php`
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsDraftCreateTest --no-ansi`
- `git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsDraftCreateTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No publish.
- No search submission.
- No frontend deploy.
- No content rewrite.
- No private result/order/share/pay/payment/history/tokenized URL access.
- Editorial/operator review, accepted references, CMS media resolution, revision approval, and controlled publish preflight remain separate gates.

## Repository rule impact
- Article content and publication state remain CMS/backend-authoritative.
- This PR records a draft-only CMS operation; it does not create frontend content fallback or public runtime editorial content.