### PR TITLE
docs(benefit): gate DailyGiving redacted public proof

### DIFF
--- a/backend/docs/operations/daily-giving-redacted-public-proof.md
+++ b/backend/docs/operations/daily-giving-redacted-public-proof.md
@@ -1,0 +1,63 @@
+# DailyGiving Redacted Public Proof Gate
+
+Date: 2026-06-05
+
+PR train item: `DAILY-GIVING-REDACTED-PUBLIC-PROOF-01`
+
+Mode: public-proof readiness gate, generated artifact, and focused contract test only. This PR does not create, edit, upload, or publish a proof file. It does not mutate production records, CMS, media library, search channels, social channels, deploy state, or indexability.
+
+## Decision
+
+The first DailyGiving record may not become public until a separate redacted public proof artifact exists, has been reviewed, and is bound through `proof_public_url` with `proof_status=redacted_available`. The raw transaction proof and raw receipt proof remain private-only operator assets.
+
+## Source Selection
+
+Use the receipt or donor confirmation proof as the preferred source for the public proof artifact. Do not use a bank or wallet transaction detail screenshot as public proof unless a reviewer confirms all account, balance, transaction, and device metadata fields are fully removed.
+
+## Required Redactions
+
+The redacted public proof must remove or mask every sensitive field if present:
+
+- donor personal identifiers beyond the public brand name approved for display;
+- donor email, phone, address, account, card, wallet, or payment account details;
+- full receipt id, full transaction serial, full order id, and payment-provider user id;
+- balance, account/card tail data, billing metadata, QR token, session id, auth token, and private receipt URLs;
+- local device UI metadata, inbox UI, browser UI, private local paths, or admin comments.
+
+The reviewer may leave only public-safe fields needed to support the record:
+
+- recipient name;
+- recipient public website;
+- donation date;
+- amount and currency;
+- non-sensitive issuer context;
+- short masked public reference if needed.
+
+## URL Gate
+
+`proof_public_url` may be set only after review. It must:
+
+- use `https://`;
+- point to the redacted artifact, not a raw receipt or transaction proof;
+- avoid private, raw, auth, session, token, account, order, or receipt-private indicators;
+- follow the existing storage gate shape such as a reviewed `/media/`, `/public/`, or `redacted` URL;
+- be different from `proof_private_path`.
+
+## Release Blockers
+
+Before any later public activation:
+
+- raw proof is confirmed private-only;
+- redacted public proof exists as a separate reviewed artifact;
+- reviewer confirms no sensitive field remains visible;
+- `proof_status=redacted_available`;
+- `proof_public_url` points only to the reviewed public artifact;
+- `receipt_reference_redacted`, if used, is short and masked;
+- `proof_redaction_notes` and private receipt references remain admin-only;
+- claim lint rejects official partnership, endorsement, certification, guaranteed impact, or UNICEF/UN backing implications;
+- `is_indexable=false` remains set;
+- no trust badge, paid-page trust claim, search submission, social distribution, or public amplification is enabled.
+
+## Deferred Sidecar
+
+This PR intentionally leaves the actual image redaction and public media URL creation outside the repository. The next production activation remains blocked until an operator supplies a reviewed public media URL and explicitly authorizes production record mutation.

--- a/backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json
+++ b/backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json
@@ -1,0 +1,109 @@
+{
+  "id": "DAILY-GIVING-REDACTED-PUBLIC-PROOF-01",
+  "date": "2026-06-05",
+  "mode": "public_proof_readiness_gate_only",
+  "record_code": "FM-GIVING-2026-06-001",
+  "source_selection": {
+    "preferred_public_source": "receipt_or_donor_confirmation_proof",
+    "bank_transaction_screenshot_public_use": "blocked_unless_all_account_balance_transaction_and_device_metadata_are_removed",
+    "raw_proof_storage": "private_only"
+  },
+  "required_redactions": [
+    "donor_personal_identifiers_beyond_approved_public_brand_name",
+    "donor_email_phone_address",
+    "account_card_wallet_or_payment_account_details",
+    "full_receipt_id",
+    "full_transaction_serial",
+    "full_order_id",
+    "payment_provider_user_id",
+    "balance",
+    "billing_metadata",
+    "qr_token",
+    "session_id",
+    "auth_token",
+    "private_receipt_url",
+    "local_device_ui_metadata",
+    "private_local_paths",
+    "admin_comments"
+  ],
+  "allowed_public_fields_after_review": [
+    "recipient_name",
+    "recipient_public_website",
+    "donation_date",
+    "amount_and_currency",
+    "non_sensitive_issuer_context",
+    "short_masked_public_reference"
+  ],
+  "proof_public_url_gate": {
+    "requires_https": true,
+    "requires_reviewed_redacted_artifact": true,
+    "requires_proof_status": "redacted_available",
+    "must_not_equal_proof_private_path": true,
+    "accepted_shape_markers": [
+      "redacted",
+      "/public/",
+      "/media/"
+    ],
+    "forbidden_markers": [
+      "/private/",
+      "raw-receipt",
+      "raw_receipt",
+      "auth_token",
+      "session_id",
+      "receipt_reference_private",
+      "proof_private_path",
+      "internal_notes"
+    ]
+  },
+  "public_api_forbidden_fields": [
+    "proof_private_path",
+    "proof_redaction_notes",
+    "receipt_reference_private",
+    "internal_notes",
+    "created_by_admin_user_id",
+    "updated_by_admin_user_id"
+  ],
+  "claim_boundaries": {
+    "unicef_or_un_endorsement": false,
+    "official_partnership": false,
+    "certification": false,
+    "guaranteed_impact": false,
+    "trust_badge_allowed_now": false,
+    "public_amplification_allowed_now": false
+  },
+  "runtime_actions": {
+    "redacted_public_proof_created": false,
+    "proof_uploaded": false,
+    "production_record_mutated": false,
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "indexability_enabled": false,
+    "search_submission_performed": false,
+    "social_distribution_performed": false,
+    "deploy_performed": false
+  },
+  "required_before_public_activation": [
+    "reviewed_redacted_public_proof_artifact",
+    "public_media_url_supplied_by_operator",
+    "proof_status_redacted_available",
+    "proof_public_url_bound_to_reviewed_public_artifact",
+    "private_fields_absent_from_public_api",
+    "claim_lint_passed",
+    "is_indexable_false_retained",
+    "no_trust_badge"
+  ],
+  "sidecar_issues": [
+    {
+      "id": "REDACTED_PUBLIC_MEDIA_URL",
+      "status": "blocked_external_operator_input",
+      "note": "A reviewed redacted public media URL is required before production record activation."
+    },
+    {
+      "id": "FAP_WEB_PROOF_PUBLIC_URL_ADAPTER",
+      "status": "follow_up_pr_required",
+      "note": "The frontend should map proof_public_url to the DailyGiving Evidence link."
+    }
+  ],
+  "next_pr": "DAILY-GIVING-PROOF-PUBLIC-URL-FRONTEND-ADAPTER-01",
+  "blocked_until": "reviewed_redacted_public_media_url_exists"
+}

--- a/backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php
@@ -1,0 +1,131 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Foundation;
+
+use App\Models\DailyGivingRecord;
+use Tests\TestCase;
+
+final class DailyGivingRedactedPublicProofTest extends TestCase
+{
+    public function test_artifact_keeps_runtime_and_public_amplification_actions_blocked(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'redacted_public_proof_created',
+            'proof_uploaded',
+            'production_record_mutated',
+            'cms_mutation_performed',
+            'publish_performed',
+            'indexability_enabled',
+            'search_submission_performed',
+            'social_distribution_performed',
+            'deploy_performed',
+        ] as $field) {
+            $this->assertFalse($artifact['runtime_actions'][$field], $field);
+        }
+
+        $this->assertFalse($artifact['claim_boundaries']['trust_badge_allowed_now']);
+        $this->assertFalse($artifact['claim_boundaries']['public_amplification_allowed_now']);
+        $this->assertSame('reviewed_redacted_public_media_url_exists', $artifact['blocked_until']);
+    }
+
+    public function test_artifact_requires_redaction_of_sensitive_proof_fields(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'full_receipt_id',
+            'full_transaction_serial',
+            'account_card_wallet_or_payment_account_details',
+            'balance',
+            'auth_token',
+            'session_id',
+            'private_receipt_url',
+            'local_device_ui_metadata',
+            'private_local_paths',
+            'admin_comments',
+        ] as $field) {
+            $this->assertContains($field, $artifact['required_redactions']);
+        }
+    }
+
+    public function test_artifact_matches_storage_gate_for_public_proof_url_shape(): void
+    {
+        $artifact = $this->artifact();
+        $gate = $artifact['proof_public_url_gate'];
+
+        $this->assertTrue($gate['requires_https']);
+        $this->assertTrue($gate['requires_reviewed_redacted_artifact']);
+        $this->assertSame(DailyGivingRecord::PROOF_REDACTED_AVAILABLE, $gate['requires_proof_status']);
+        $this->assertTrue($gate['must_not_equal_proof_private_path']);
+        $this->assertContains('redacted', $gate['accepted_shape_markers']);
+        $this->assertContains('/media/', $gate['accepted_shape_markers']);
+        $this->assertContains('/private/', $gate['forbidden_markers']);
+        $this->assertContains('raw-receipt', $gate['forbidden_markers']);
+    }
+
+    public function test_model_gate_accepts_reviewed_redacted_public_media_url_only(): void
+    {
+        $safeRecord = new DailyGivingRecord([
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+        ]);
+
+        $this->assertSame([], $safeRecord->proofStorageGateViolations());
+
+        $unsafeRecord = new DailyGivingRecord([
+            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/private/raw-receipt-2026-06-05.pdf',
+        ]);
+
+        $this->assertContains('proof_public_url must point to reviewed redacted public proof only', $unsafeRecord->proofStorageGateViolations());
+    }
+
+    public function test_public_api_forbidden_fields_remain_private_only(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'proof_private_path',
+            'proof_redaction_notes',
+            'receipt_reference_private',
+            'internal_notes',
+            'created_by_admin_user_id',
+            'updated_by_admin_user_id',
+        ] as $field) {
+            $this->assertContains($field, $artifact['public_api_forbidden_fields']);
+        }
+    }
+
+    public function test_no_endorsement_or_official_partnership_claims_are_allowed(): void
+    {
+        $artifact = $this->artifact();
+
+        foreach ([
+            'unicef_or_un_endorsement',
+            'official_partnership',
+            'certification',
+            'guaranteed_impact',
+        ] as $claim) {
+            $this->assertFalse($artifact['claim_boundaries'][$claim], $claim);
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function artifact(): array
+    {
+        $path = base_path('docs/operations/generated/daily-giving-redacted-public-proof.v1.json');
+        $payload = json_decode((string) file_get_contents($path), true);
+
+        $this->assertIsArray($payload);
+
+        return $payload;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47137,6 +47137,108 @@
       }
     ]
   },
+  "DAILY-GIVING-REDACTED-PUBLIC-PROOF-01": {
+    "repo": "fap-api",
+    "branch": "codex/daily-giving-redacted-public-proof-01",
+    "base": "main",
+    "status": "pr_open_github_checks_pending",
+    "train_scope": "window_7_public_benefit_trust_gate",
+    "title": "docs(benefit): gate DailyGiving redacted public proof",
+    "depends_on": [
+      "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized DAILY-GIVING-REDACTED-PUBLIC-PROOF-01 as a fap-api gate PR defining redacted public proof requirements, checklist, generated artifact, and tests while forbidding real proof handling, publish, index, trust badge, social/search, CMS mutation, and endorsement implications."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01 merged as PR #1926 at 7d21cdf9f28c234a2c3c5ff107db9627ba4adcc3."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are limited to the redacted public proof gate doc, generated artifact, focused contract test, and docs/codex ledger paths. No proof file, public media URL, production record, CMS mutation, publish, index, trust badge, search, social, or deploy action was performed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php",
+          "python3 -m json.tool backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRedactedPublicProofTest --no-ansi",
+          "git diff --check -- backend/docs/operations/daily-giving-redacted-public-proof.md backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "Passed syntax, JSON/YAML parsing, focused DailyGivingRedactedPublicProofTest, scoped diff check, and focused committed-surface leakage scan. PHPUnit exited 0 with warnings from the temporary checkout missing backend/.env."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": null
+      }
+    },
+    "result": {
+      "redacted_public_proof_gate_defined": true,
+      "redacted_public_proof_created": false,
+      "proof_uploaded": false,
+      "production_database_record_mutated": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "indexability_enabled": false,
+      "search_submission_performed": false,
+      "social_distribution_performed": false,
+      "deploy_performed": false,
+      "trust_badge_allowed_now": false,
+      "public_amplification_allowed_now": false,
+      "next_pr_supported": "DAILY-GIVING-PROOF-PUBLIC-URL-FRONTEND-ADAPTER-01"
+    },
+    "failure_reason": null,
+    "commit_sha": "5421dbab5c1d466d613b682e6d6d22c51a5378e2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1932",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "scope_validation": {
+      "allowed_paths_only": true,
+      "cms_write_performed": false,
+      "publish_performed": false,
+      "redacted_public_proof_created": false,
+      "proof_uploaded": false,
+      "production_database_record_mutated": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "notes": "Scope stayed within the PR14 docs/generated/test/ledger paths. This PR defines the redacted public proof gate only and leaves actual public media URL creation as a sidecar."
+    },
+    "sidecars": [
+      {
+        "id": "REDACTED_PUBLIC_MEDIA_URL",
+        "status": "blocked_external_operator_input",
+        "note": "A reviewed redacted public media URL is required before production record activation. This is not introduced by the gate PR and must not stop the next adapter PR when local scope validation and required checks are green."
+      }
+    ],
+    "next_task": "DAILY-GIVING-PROOF-PUBLIC-URL-FRONTEND-ADAPTER-01",
+    "transitions": [
+      {
+        "at": "2026-06-05T12:40:00Z",
+        "from": "missing_from_manifest",
+        "to": "in_progress",
+        "notes": "Initialized from explicit user authorization. This PR is gate-only and does not create or upload proof, set proof_public_url, mutate production records, publish, index, create trust badges, submit search URLs, run social distribution, mutate CMS, deploy, or imply UNICEF/UN endorsement."
+      },
+      {
+        "at": "2026-06-05T12:48:00Z",
+        "from": "in_progress",
+        "to": "local_checks_passed",
+        "notes": "Local manifest checks passed. The remaining reviewed redacted public media URL is recorded as an external sidecar and does not block the next frontend adapter PR."
+      },
+      {
+        "at": "2026-06-05T12:53:00Z",
+        "from": "local_checks_passed",
+        "to": "pr_open_github_checks_pending",
+        "notes": "Opened https://github.com/fermatmind/fap-api/pull/1932 from codex/daily-giving-redacted-public-proof-01. GitHub required checks are pending."
+      }
+    ]
+  },
   "HELP-CONTENT-DRAFT-CMS-SYNC-01": {
     "repo": "fap-api",
     "branch": "codex/help-content-draft-cms-sync-01",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -24800,7 +24800,7 @@
     "merge_commit": "29ec08275027a517993a7cea0fdc6c117bc85c87"
   },
   "OPS-RELEASE-WORKFLOW-01": {
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "repo": "fap-api",
     "repo_path": "/Users/rainie/Desktop/GitHub/fap-api",
     "branch": "codex/ops-release-workflow-01",
@@ -47174,8 +47174,8 @@
         "notes": "Passed syntax, JSON/YAML parsing, focused DailyGivingRedactedPublicProofTest, scoped diff check, and focused committed-surface leakage scan. PHPUnit exited 0 with warnings from the temporary checkout missing backend/.env."
       },
       "github": {
-        "status": "pending",
-        "evidence": null
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #1932: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -47236,6 +47236,12 @@
         "from": "local_checks_passed",
         "to": "pr_open_github_checks_pending",
         "notes": "Opened https://github.com/fermatmind/fap-api/pull/1932 from codex/daily-giving-redacted-public-proof-01. GitHub required checks are pending."
+      },
+      {
+        "at": "2026-06-05T13:02:00Z",
+        "from": "pr_open_github_checks_pending",
+        "to": "ready_to_merge",
+        "notes": "GitHub checks passed for PR #1932 and merge state can be rechecked before squash merge."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47194,7 +47194,7 @@
       "next_pr_supported": "DAILY-GIVING-PROOF-PUBLIC-URL-FRONTEND-ADAPTER-01"
     },
     "failure_reason": null,
-    "commit_sha": "5421dbab5c1d466d613b682e6d6d22c51a5378e2",
+    "commit_sha": "0ff71b5c39ea5445251d90842bbc4ca87387763c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1932",
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22254,6 +22254,54 @@ prs:
     content_authority: private operator ledger outside repository
     next_task: DAILY-GIVING-REDACTED-PUBLIC-PROOF-01
 
+  - id: DAILY-GIVING-REDACTED-PUBLIC-PROOF-01
+    repo: fap-api
+    depends_on:
+      - DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01
+    branch: codex/daily-giving-redacted-public-proof-01
+    title: "docs(benefit): gate DailyGiving redacted public proof"
+    train_scope: window_7_public_benefit_trust_gate
+    status: in_progress
+    scope:
+      - Define the reviewed redacted public proof gate for the first DailyGiving record.
+      - Add required redaction checklist, URL-shape requirements, claim boundaries, and generated artifact.
+      - Add focused contract coverage for runtime-action blocks, sensitive-field redaction, public URL gate shape, public API private-field exclusions, and endorsement claim boundaries.
+      - Keep the actual proof artifact, public media URL, production record activation, publish, index, trust badge, social/search, CMS mutation, and deploy actions blocked.
+    allowed_paths:
+      - backend/docs/operations/daily-giving-redacted-public-proof.md
+      - backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json
+      - backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Create, edit, upload, or commit proof files, raw receipts, redacted images, public media URLs, private local paths, receipt IDs, transaction serials, account details, balances, production database records, CMS mutations, publish/index changes, trust badges, search submissions, social distribution, deploys, or endorsement/official-partnership claims.
+    validation:
+      - php -l backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php
+      - python3 -m json.tool backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRedactedPublicProofTest --no-ansi
+      - git diff --check -- backend/docs/operations/daily-giving-redacted-public-proof.md backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    sidecar_issues:
+      - id: REDACTED_PUBLIC_MEDIA_URL
+        status: blocked_external_operator_input
+        note: Reviewed redacted public media URL is required before production record activation.
+    next_task: DAILY-GIVING-PROOF-PUBLIC-URL-FRONTEND-ADAPTER-01
+
   - id: SEO-ARTICLE-RIASEC-V2-PACKAGE-ARCHIVE-01
     repo: fap-api
     branch: codex/seo-article-riasec-v2-package-archive-01


### PR DESCRIPTION
## What changed
- Added the DailyGiving redacted public proof gate for the first record.
- Added a generated gate artifact and focused PHPUnit contract coverage.
- Registered DAILY-GIVING-REDACTED-PUBLIC-PROOF-01 in the PR train manifest/state.

## Why
- The first DailyGiving record needs a reviewed redacted public proof gate before any public activation.
- The actual public media URL remains an external sidecar blocker and must not stop the next frontend adapter PR after this PR is green.

## Validation
- `php -l backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php`
- `python3 -m json.tool backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRedactedPublicProofTest --no-ansi`
- `git diff --check -- backend/docs/operations/daily-giving-redacted-public-proof.md backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No real proof artifact was created, edited, uploaded, or committed.
- No `proof_public_url`, production record activation, CMS mutation, publish, indexability, trust badge, search submission, social distribution, deploy, or UNICEF/UN endorsement implication.
- Public record activation remains blocked until a reviewed redacted public media URL exists.