### PR TITLE
docs(help): record Help draft operator review blockers

### DIFF
--- a/backend/docs/help/generated/help-content-draft-operator-review-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-operator-review-01.v1.json
@@ -1,0 +1,169 @@
+{
+  "schema": "help-content-draft-operator-review-01.v1",
+  "task": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01",
+  "generated_at": "2026-06-05",
+  "decision": "REVIEW_BLOCKED_POLICY_OWNER_INPUTS_REQUIRED",
+  "review_passed": false,
+  "operator_approval_claimed": false,
+  "publish_allowed": false,
+  "source_package": {
+    "zip_path": "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+    "sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+    "expected_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+    "sha256_match": true,
+    "schema_version": "help_service_content_drafts.v1",
+    "content_mode": "draft_only",
+    "requires_operator_review": true,
+    "publish_allowed": false,
+    "asset_count": 6,
+    "locale_count": 2,
+    "expected_cms_draft_count": 12
+  },
+  "inputs_reviewed": [
+    "fermatmind-help-service-content-drafts-01/index.json",
+    "fermatmind-help-service-content-drafts-01/01_UNLOCK-FAILURE-HELP-CARD-01.yaml",
+    "fermatmind-help-service-content-drafts-01/02_PAYMENT-REFUND-FAQ-PACKAGE-01.yaml",
+    "fermatmind-help-service-content-drafts-01/03_RESULT-RECOVERY-FAQ-01.yaml",
+    "fermatmind-help-service-content-drafts-01/04_PRIVACY-FAQ-PACKAGE-01.yaml",
+    "fermatmind-help-service-content-drafts-01/05_NONDIAGNOSTIC-HELP-COPY-01.yaml",
+    "fermatmind-help-service-content-drafts-01/06_DATA-DELETION-REQUEST-FAQ-01.yaml",
+    "backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json",
+    "read-only production ContentPage status/hash postcheck",
+    "public help route and sitemap/llms absence checks"
+  ],
+  "cms_draft_postcheck": {
+    "status": "pass",
+    "record_count": 12,
+    "all_status_draft": true,
+    "all_non_public": true,
+    "all_non_indexable": true,
+    "all_unpublished": true,
+    "all_owner_review": true,
+    "records_created": 0,
+    "records_updated_in_this_task": 0,
+    "local_sync_artifact": "backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json",
+    "production_read_only_checked": true
+  },
+  "visible_content_review": {
+    "status": "conditional_pass",
+    "asset_count": 6,
+    "localized_draft_count": 12,
+    "faq_items_per_asset": 4,
+    "visible_body_private_route_hits": 0,
+    "visible_body_raw_identifier_hits": 0,
+    "policy_checklist_contains_forbidden_route_families": true,
+    "policy_checklist_hit_interpretation": "expected guardrail inventory, not visible body exposure",
+    "theme_coverage": {
+      "unlock_failure": "present",
+      "payment_refund": "present",
+      "result_recovery": "present",
+      "privacy_data": "present",
+      "non_diagnostic_boundary": "present",
+      "data_deletion_request": "present"
+    },
+    "private_url_boundary": "pass",
+    "raw_payment_or_order_identifier_boundary": "pass",
+    "medical_or_diagnostic_boundary": "pass_for_editorial_review",
+    "overclaim_boundary": "pass_for_editorial_review"
+  },
+  "public_surface_checks": {
+    "status": "pass",
+    "localized_help_routes_checked": 12,
+    "localized_help_routes_all_404": true,
+    "contact_support_routes": [
+      {
+        "url": "https://fermatmind.com/zh/help/contact-support",
+        "status": 404
+      },
+      {
+        "url": "https://fermatmind.com/en/help/contact-support",
+        "status": 404
+      }
+    ],
+    "sitemap_llms_target_hits": 0,
+    "search_submission_performed": false
+  },
+  "blockers": [
+    {
+      "id": "refund_policy_owner_fields",
+      "status": "blocked",
+      "details": [
+        "refund_exclusions remains operator_review_required",
+        "refund_handling_time remains operator_review_required"
+      ]
+    },
+    {
+      "id": "data_deletion_policy_owner_fields",
+      "status": "blocked",
+      "details": [
+        "data deletion handling_time remains operator_review_required",
+        "retained_data_exceptions remains operator_review_required"
+      ]
+    },
+    {
+      "id": "privacy_analytics_owner_confirmation",
+      "status": "blocked",
+      "details": [
+        "analytics wording still requires operator confirmation before publish",
+        "backend/source-of-truth privacy wording still requires review before publish"
+      ]
+    },
+    {
+      "id": "contact_support_route_and_support_contact",
+      "status": "blocked",
+      "details": [
+        "content package references /help/contact-support internal links",
+        "zh/en /help/contact-support public routes currently return 404",
+        "support@fermatmind.com is user-confirmed, but first-class ContentPage support_contact remains unverified"
+      ]
+    },
+    {
+      "id": "faq_schema_publish_gate",
+      "status": "blocked",
+      "details": [
+        "FAQPage schema remains conditional",
+        "visible FAQ to JSON-LD equality must be verified in a publish preflight after policy fields are finalized"
+      ]
+    }
+  ],
+  "non_blocking_passes": [
+    "Revised v01 package hash matched expected hash.",
+    "All six Help service asset categories are present.",
+    "Visible bodies do not include private result/order/share/pay/payment/history route examples.",
+    "Visible bodies do not request full order number, full payment id, full transaction id, full result URL, or full history URL.",
+    "Production ContentPage rows remain draft, non-public, non-indexable, unpublished, and owner_review.",
+    "Public localized Help routes remain absent from public surface.",
+    "sitemap.xml, llms.txt, and llms-full.txt target hits remain zero."
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false,
+    "content_rewrite_performed": false,
+    "allowed_paths_only": true
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-POLICY-OWNER-FIELDS",
+      "status": "hard_gate",
+      "note": "Policy owner must provide refund exclusions, refund handling time, data deletion handling time, retained-data exceptions, and privacy analytics wording confirmation before review can pass."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-ROUTE",
+      "status": "hard_gate",
+      "note": "The package references contact-support internal links, but zh/en public contact-support routes currently return 404."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish remains blocked and requires separate explicit publish authorization after policy-owner review and publish preflight."
+    }
+  ],
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01"
+}

--- a/backend/docs/operations/help-content-draft-operator-review-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-operator-review-2026-06-05.md
@@ -1,0 +1,80 @@
+# HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01
+
+Decision: `REVIEW_BLOCKED_POLICY_OWNER_INPUTS_REQUIRED`
+
+This review did not publish, deploy, mutate CMS data, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+
+## Inputs
+
+- Revised v01 zip: `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`
+- SHA-256: `f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9`
+- Existing sync artifact: `backend/docs/help/generated/help-content-draft-cms-sync-01.v1.json`
+- Production read-only ContentPage status/hash postcheck.
+- Public Help route and sitemap/llms absence checks.
+
+## Draft State
+
+Result: `PASS`
+
+- CMS draft count checked: `12`
+- All status draft: `true`
+- All non-public: `true`
+- All non-indexable: `true`
+- All unpublished: `true`
+- All owner review: `true`
+- Records created in this task: `0`
+- Records updated in this task: `0`
+
+## Editorial Safety Review
+
+Result: `CONDITIONAL_PASS`
+
+- Six Help service asset categories are present.
+- zh/en localized drafts are present for each category.
+- Visible bodies do not include private result/order/share/pay/payment/history route examples.
+- Visible bodies do not request full order number, full payment id, full transaction id, full result URL, or full history URL.
+- Non-diagnostic and overclaim boundaries are present enough for editorial review.
+- Forbidden route family hits in the YAML package are from guardrail/checklist fields, not visible page body.
+
+No content rewrite was performed.
+
+## Public Surface
+
+Result: `PASS`
+
+- 12 localized public Help routes remain 404.
+- `sitemap.xml`, `llms.txt`, and `llms-full.txt` target hits remain `0`.
+- `/zh/help/contact-support` and `/en/help/contact-support` currently return 404.
+
+## Blockers
+
+Review is not passed because policy-owner inputs are still unresolved:
+
+- Refund exclusions remain `operator_review_required`.
+- Refund handling time remains `operator_review_required`.
+- Data deletion handling time remains `operator_review_required`.
+- Retained-data exceptions remain `operator_review_required`.
+- Privacy analytics wording still requires operator confirmation.
+- The package references `/help/contact-support`, but the zh/en contact-support routes return 404.
+- `support@fermatmind.com` is user-confirmed, but first-class ContentPage `support_contact` remains unverified.
+- FAQPage schema remains conditional until visible FAQ and JSON-LD equality can be verified after policy fields are finalized.
+
+## Decision
+
+`BLOCKED`: do not publish and do not mark Operator review as passed.
+
+Recommended next task: `HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01`.
+
+## Validation Commands
+
+```bash
+shasum -a 256 /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+ssh -o BatchMode=yes fap-api-prod 'cd /var/www/fap-api/current/backend && php artisan tinker --execute="..."'
+python3 - <<'PY'
+# public Help route and sitemap/llms absence checks
+PY
+git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-01.v1.json backend/docs/operations/help-content-draft-operator-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45025,6 +45025,138 @@
       "review_rerun_report": "backend/docs/operations/help-content-draft-editorial-review-rerun-2026-06-05.md"
     }
   },
+  "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-operator-review-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): record Help draft operator review blockers",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-CMS-SYNC-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized execution of HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01. Codex did not treat execution authorization as publish approval or unblocked Operator approval."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-CMS-SYNC-01 is merged as PR #1927 and ledger closeout is merged through PR #1930."
+      },
+      "source_package": {
+        "status": "pass",
+        "sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9",
+        "content_mode": "draft_only",
+        "publish_allowed": false,
+        "requires_operator_review": true
+      },
+      "cms_draft_postcheck": {
+        "status": "pass",
+        "record_count": 12,
+        "all_status_draft": true,
+        "all_non_public": true,
+        "all_non_indexable": true,
+        "all_unpublished": true,
+        "all_owner_review": true
+      },
+      "review": {
+        "status": "blocked_policy_owner_inputs_required",
+        "review_passed": false,
+        "operator_approval_claimed": false,
+        "notes": "Visible-body private URL/raw identifier checks passed, but refund exclusions, refund handling time, data deletion handling time, retained-data exceptions, privacy analytics wording confirmation, contact-support routing, and FAQ schema equality remain unresolved."
+      },
+      "public_surface": {
+        "status": "pass_with_contact_support_blocker",
+        "localized_help_routes_all_404": true,
+        "contact_support_routes_404": true,
+        "sitemap_llms_target_hits": 0
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-01.v1.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "pass"
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-01.v1.json backend/docs/operations/help-content-draft-operator-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "pass"
+          }
+        ]
+      }
+    },
+    "failure_reason": "Operator review not passed because policy-owner inputs and contact-support route/support_contact readiness remain unresolved.",
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "REVIEW_BLOCKED_POLICY_OWNER_INPUTS_REQUIRED",
+      "review_passed": false,
+      "operator_approval_claimed": false,
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-operator-review-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-operator-review-2026-06-05.md",
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "content_rewrite_performed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-POLICY-OWNER-FIELDS",
+        "status": "hard_gate",
+        "note": "Need refund exclusions, refund handling time, data deletion handling time, retained-data exceptions, and privacy analytics wording confirmation before review can pass."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-ROUTE",
+        "status": "hard_gate",
+        "note": "The package references contact-support internal links, but zh/en contact-support routes currently return 404."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish remains blocked and requires separate exact approval after policy-owner fields, operator review, and publish preflight pass."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized execution of HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Created blocked operator-review artifact and operations report; local validation pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Operator-review artifact, state JSON, manifest YAML, and scoped diff whitespace checks passed. Review remains blocked and Operator approval was not claimed."
+      }
+    ]
+  },
   "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01": {
     "repo": "fap-api",
     "branch": "codex/public-benefit-asset-packages-archive-01",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45029,7 +45029,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-review-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help draft operator review blockers",
     "depends_on": [
@@ -45095,8 +45095,8 @@
       }
     },
     "failure_reason": "Operator review not passed because policy-owner inputs and contact-support route/support_contact readiness remain unresolved.",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "40931a5dd0c1efa81024fa8b0eaa7dc3e6df845c",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1933",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45154,6 +45154,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Operator-review artifact, state JSON, manifest YAML, and scoped diff whitespace checks passed. Review remains blocked and Operator approval was not claimed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_opened",
+        "note": "Opened PR #1933. Review remains blocked; publish and Operator approval remain unclaimed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31994,7 +31994,7 @@
   "FERMAT-MARKETING-SKILLS-ADAPTATION-01": {
     "repo": "fap-api",
     "branch": "codex/fermat-marketing-skills-adaptation-01",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "depends_on": [
       "MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00"
     ],
@@ -45092,10 +45092,25 @@
             "status": "pass"
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "checks": [
+          "hygiene",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN"
       }
     },
-    "failure_reason": "Operator review not passed because policy-owner inputs and contact-support route/support_contact readiness remain unresolved.",
-    "commit_sha": "40931a5dd0c1efa81024fa8b0eaa7dc3e6df845c",
+    "failure_reason": null,
+    "commit_sha": "73512455e27d35a380a02526c02acb0c5818c05a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1933",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -45159,6 +45174,11 @@
         "at": "2026-06-05",
         "status": "pr_opened",
         "note": "Opened PR #1933. Review remains blocked; publish and Operator approval remain unclaimed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN. PR result remains review blocked because policy-owner fields and contact-support readiness are unresolved."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21733,6 +21733,48 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01
 
+  - id: HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01
+    repo: fap-api
+    branch: codex/help-content-draft-operator-review-01
+    title: "docs(help): record Help draft operator review blockers"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    depends_on:
+      - HELP-CONTENT-DRAFT-CMS-SYNC-01
+    scope:
+      - Review the revised v01 Help service content package and synced 12 Help ContentPage CMS drafts for editorial safety, service-policy completeness, private URL safety, draft-only state, and publish readiness blockers.
+      - Record review output without rewriting content, mutating CMS, publishing, deploying, submitting search URLs, accessing private URLs, reading secrets, or claiming Operator approval if blockers remain.
+      - Preserve blocked/conditional status where policy-owner inputs are missing.
+    external_asset_paths:
+      - /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-operator-review-01.v1.json
+      - backend/docs/operations/help-content-draft-operator-review-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, deploy, submit search URLs, mutate CMS, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, rewrite content, or claim Operator approval when policy-owner inputs remain unresolved.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-01.v1.json backend/docs/operations/help-content-draft-operator-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01 to the PR train manifest and state ledger.
- Added a generated review artifact and operations report for the revised v01 Help service content package and synced 12 CMS drafts.
- Recorded the review result as blocked because policy-owner inputs and contact-support readiness are still unresolved.

## Why
- The previous CMS sync put the revised v01 Help content into 12 draft-only ContentPage rows. This PR records the next operator-review evidence without publishing or mutating CMS.

## Validation
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-01.v1.json backend/docs/operations/help-content-draft-operator-review-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Operator review is not marked passed.
- Publish, deploy, search submission, CMS mutation, payment/refund action, private URL access, secret/env/cookie/token read, content rewrite, and payment-provider changes were not performed.
- Policy-owner answers remain required for refund exclusions, refund handling time, data deletion handling time, retained-data exceptions, privacy analytics wording confirmation, and contact-support route/support_contact readiness.

## Repository rule impact
- Help content remains CMS/backend-authoritative via ContentPage drafts. No frontend fallback or runtime content authority was added.