### PR TITLE
docs(codex): close Help operator review ledger

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45029,7 +45029,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-review-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help draft operator review blockers",
     "depends_on": [
@@ -45110,11 +45110,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "73512455e27d35a380a02526c02acb0c5818c05a",
+    "commit_sha": "8ffc8f36c7f6b52987d586e8b06cf88636cafe8c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1933",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T12:58:40Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "REVIEW_BLOCKED_POLICY_OWNER_INPUTS_REQUIRED",
       "review_passed": false,
@@ -45179,6 +45179,11 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "GitHub checks passed and merge state was CLEAN. PR result remains review blocked because policy-owner fields and contact-support readiness are unresolved."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged_closeout_reconciled",
+        "note": "PR #1933 merged on GitHub at 2026-06-05T12:58:40Z with merge commit 8ffc8f36c7f6b52987d586e8b06cf88636cafe8c; origin/main contains the merge commit; remote branch was deleted and local task branch cleanup was completed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21738,7 +21738,7 @@ prs:
     branch: codex/help-content-draft-operator-review-01
     title: "docs(help): record Help draft operator review blockers"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     depends_on:
       - HELP-CONTENT-DRAFT-CMS-SYNC-01
     scope:


### PR DESCRIPTION
## What changed
- Closed the HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01 ledger after PR #1933 merged.
- Marked manifest/state as merged and recorded merge commit, merged_at, remote branch deletion, and local cleanup.

## Why
- PR #1933 merged successfully, but the latest main branch still had the state ledger at `pr_opened` / manifest at `in_progress`.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Review remains blocked for policy-owner inputs. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, content rewrite, payment/refund action, or Operator approval claim.

## Repository rule impact
- No content authority change. This is ledger-only closeout.