### PR TITLE
docs(help): record Help policy owner answers

### DIFF
--- a/backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json
@@ -1,0 +1,160 @@
+{
+  "schema_version": "help_content_draft_policy_owner_answers.v1",
+  "task": "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01",
+  "generated_at": "2026-06-05",
+  "decision": "POLICY_OWNER_ANSWERS_RECORDED_WITH_PUBLISH_STILL_BLOCKED",
+  "source_context": {
+    "depends_on": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01",
+    "operator_review_artifact": "backend/docs/help/generated/help-content-draft-operator-review-01.v1.json",
+    "operator_review_decision": "REVIEW_BLOCKED_POLICY_OWNER_INPUTS_REQUIRED",
+    "source_package_path": "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+    "source_package_sha256": "f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9"
+  },
+  "policy_owner_answers": {
+    "refund_exclusions": {
+      "answer": "非“费马测试”原因",
+      "normalized_meaning_for_followup": "Refund exclusion: reasons not caused by FermatMind/Fermat test service.",
+      "source": "user_policy_owner_answer_2026-06-05"
+    },
+    "refund_handling_time": {
+      "answer": "三个工作日",
+      "normalized_meaning_for_followup": "Refund handling time: three business days.",
+      "source": "user_policy_owner_answer_2026-06-05"
+    },
+    "data_deletion_handling_time": {
+      "answer": "两年",
+      "normalized_meaning_for_followup": "Data deletion handling time: two years, as provided by the policy owner.",
+      "source": "user_policy_owner_answer_2026-06-05"
+    },
+    "retained_data_exceptions_after_deletion": {
+      "answer": "无",
+      "normalized_meaning_for_followup": "No retained-data exceptions after completed deletion.",
+      "source": "user_policy_owner_answer_2026-06-05"
+    },
+    "privacy_analytics_wording_confirmation": {
+      "answer": "正确",
+      "normalized_meaning_for_followup": "GA4, Baidu analytics, and first-party analytics privacy wording is confirmed as correct by the policy owner.",
+      "source": "user_policy_owner_answer_2026-06-05"
+    }
+  },
+  "blocker_resolution_mapping": [
+    {
+      "blocker_id": "refund_policy_owner_fields",
+      "prior_status": "blocked",
+      "answer_status": "answered",
+      "remaining_gate": "Apply the answers to the draft content package/CMS draft fields in a separate authorized PR."
+    },
+    {
+      "blocker_id": "data_deletion_policy_owner_fields",
+      "prior_status": "blocked",
+      "answer_status": "answered",
+      "remaining_gate": "Apply the answers to the draft content package/CMS draft fields in a separate authorized PR."
+    },
+    {
+      "blocker_id": "privacy_analytics_owner_confirmation",
+      "prior_status": "blocked",
+      "answer_status": "answered",
+      "remaining_gate": "Apply the confirmation to the relevant draft metadata/content in a separate authorized PR."
+    },
+    {
+      "blocker_id": "contact_support_route_and_support_contact",
+      "prior_status": "blocked",
+      "answer_status": "not_addressed_in_this_task",
+      "remaining_gate": "Decide whether draft links should use the existing public canonical /support route or a new CMS-backed contact-support route."
+    },
+    {
+      "blocker_id": "faq_schema_publish_gate",
+      "prior_status": "blocked",
+      "answer_status": "not_addressed_in_this_task",
+      "remaining_gate": "Verify visible FAQ to JSON-LD equality only after policy fields are applied and public visibility is authorized."
+    }
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false,
+    "content_rewrite_performed": false,
+    "policy_answers_recorded_only": true
+  },
+  "recommended_pr_train": [
+    {
+      "id": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01",
+      "repo": "fap-api/fap-web decision split",
+      "purpose": "Decide public canonical handling for contact support references before content revision.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    },
+    {
+      "id": "HELP-CMS-SERVICE-FIELDS-01",
+      "repo": "fap-api",
+      "purpose": "Add or verify first-class CMS fields needed for support contact, policy version, reviewer, FAQ items, and schema gate authority.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01",
+      "repo": "fap-api",
+      "purpose": "Apply policy owner answers to the local revised v01 Help content package or generated import package without CMS writes.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+      "repo": "fap-api",
+      "purpose": "Sync the policy-updated package to the existing 12 Help CMS drafts while preserving draft/non-public/non-indexable/unpublished state.",
+      "mutation_allowed": true,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01",
+      "repo": "fap-api",
+      "purpose": "Run second read-only operator review request after policy answers and contact-support handling are applied.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_operator_review": true
+    },
+    {
+      "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+      "repo": "fap-web",
+      "purpose": "Enable or harden Help FAQ schema only from visible CMS/backend FAQ authority.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+      "repo": "fap-api/fap-web",
+      "purpose": "Run publish preflight over CMS draft state, support routes, schema, canonical paths, sitemap/llms, and private URL guards.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01",
+      "repo": "fap-api",
+      "purpose": "Publish the 12 Help ContentPage drafts only after exact publish authorization.",
+      "mutation_allowed": true,
+      "publish_allowed": true,
+      "requires_exact_publish_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01",
+      "repo": "fap-api/fap-web",
+      "purpose": "Verify public 200s, canonical paths, schema, sitemap/llms exposure, and private URL guardrails after publish.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "requires_user_authorization": true
+    }
+  ],
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01"
+}

--- a/backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md
@@ -1,0 +1,65 @@
+# HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01
+
+Decision: `POLICY_OWNER_ANSWERS_RECORDED_WITH_PUBLISH_STILL_BLOCKED`
+
+This task records policy-owner answers for the Help service content train. It did not publish, deploy, mutate CMS data, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, rewrite content, or claim Operator approval.
+
+## Inputs
+
+- Prior review artifact: `backend/docs/help/generated/help-content-draft-operator-review-01.v1.json`
+- Prior review decision: `REVIEW_BLOCKED_POLICY_OWNER_INPUTS_REQUIRED`
+- Revised v01 zip: `/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`
+- Revised v01 SHA-256: `f971f5cd279018c2db469ccd87c43484c4983de5484e8c1e47343aa5813e6bb9`
+- Policy owner answers provided by the user on 2026-06-05.
+
+## Recorded Policy Owner Answers
+
+| Field | Answer | Follow-up interpretation |
+| --- | --- | --- |
+| Refund exclusions | 非“费马测试”原因 | Exclude refund requests for reasons not caused by FermatMind/Fermat test service. |
+| Refund handling time | 三个工作日 | Handle refund requests within three business days. |
+| Data deletion handling time | 两年 | Record as provided by policy owner; apply only in a later authorized content/CMS task. |
+| Retained-data exceptions after deletion | 无 | No retained-data exceptions after completed deletion. |
+| Privacy analytics wording confirmation | 正确 | GA4, Baidu analytics, and first-party analytics privacy wording is confirmed as correct by the policy owner. |
+
+## Blocker Mapping
+
+- `refund_policy_owner_fields`: answered, but not yet applied to the local package or CMS drafts.
+- `data_deletion_policy_owner_fields`: answered, but not yet applied to the local package or CMS drafts.
+- `privacy_analytics_owner_confirmation`: answered, but not yet applied to the relevant draft metadata/content.
+- `contact_support_route_and_support_contact`: still open; this PR does not decide `/help/contact-support` versus the existing public canonical `/support`.
+- `faq_schema_publish_gate`: still open; visible FAQ to JSON-LD equality must be verified only after policy fields are applied and public visibility is authorized.
+
+## Recommended PR Train
+
+1. `HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01`
+2. `HELP-CMS-SERVICE-FIELDS-01`
+3. `HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01`
+4. `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01`
+5. `HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01`
+6. `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01`
+7. `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01`
+8. `HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01`
+9. `HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01`
+
+Only `HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01` is added to the manifest/state in this PR. The follow-up PR ids above still require separate manifest/state authorization before execution.
+
+## Remaining Hard Gates
+
+- No publish without separate exact publish authorization.
+- No Operator approval claimed by Codex.
+- No CMS mutation in this task.
+- Contact-support route handling remains unresolved.
+- First-class ContentPage `support_contact` remains unverified.
+- FAQPage schema remains conditional until visible FAQ/JSON-LD equality is verified after content is finalized.
+
+## Validation Commands
+
+```bash
+shasum -a 256 /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45187,6 +45187,126 @@
       }
     ]
   },
+  "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-policy-owner-answers-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): record Help policy owner answers",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized supplementing manifest/state entries for HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01 with read-only/docs-only scope."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01 is merged as PR #1933 and closed through PR #1935."
+      },
+      "policy_owner_answers": {
+        "status": "recorded",
+        "answers": {
+          "refund_exclusions": "非“费马测试”原因",
+          "refund_handling_time": "三个工作日",
+          "data_deletion_handling_time": "两年",
+          "retained_data_exceptions_after_deletion": "无",
+          "privacy_analytics_wording_confirmation": "正确"
+        }
+      },
+      "scope_preflight": {
+        "status": "pass",
+        "evidence": "Current scope records policy owner answers and follow-up PR train only; no CMS mutation, publish, deploy, search submission, private URL access, payment/refund action, payment-provider change, content rewrite, or secret/env/cookie/token read is allowed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "shasum -a 256 /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "pass"
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "pass"
+          }
+        ]
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "ee5142d32dc640d38854e15382de99acc5cb6060",
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "POLICY_OWNER_ANSWERS_RECORDED_WITH_PUBLISH_STILL_BLOCKED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md",
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "content_rewrite_performed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION",
+        "status": "open_followup",
+        "note": "Decide whether Help content should use the existing public canonical /support route or a new CMS-backed contact-support Help route."
+      },
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS",
+        "status": "open_followup",
+        "note": "First-class support_contact, policy_version, reviewer, faq_items, and schema_enabled authority remains a later CMS/backend task."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish remains blocked and requires separate exact authorization after policy answers are applied, Operator review passes, and publish preflight passes."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User provided policy owner answers and authorized supplementing manifest/state entries for HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Created policy-owner answer artifact and operations report; local validation pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Policy-owner answer artifact, state JSON, manifest YAML, package hash, and scoped diff whitespace checks passed."
+      }
+    ]
+  },
   "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01": {
     "repo": "fap-api",
     "branch": "codex/public-benefit-asset-packages-archive-01",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45191,7 +45191,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-policy-owner-answers-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help policy owner answers",
     "depends_on": [
@@ -45248,7 +45248,7 @@
     },
     "failure_reason": null,
     "commit_sha": "704e0ba4353dbac90e647420d937f951659661a6",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1936",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45304,6 +45304,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Policy-owner answer artifact, state JSON, manifest YAML, package hash, and scoped diff whitespace checks passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_opened",
+        "note": "Opened PR #1936 for HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45247,7 +45247,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "ee5142d32dc640d38854e15382de99acc5cb6060",
+    "commit_sha": "704e0ba4353dbac90e647420d937f951659661a6",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32072,7 +32072,7 @@
   "FERMAT-MARKETING-SKILLS-ADAPTATION-02": {
     "repo": "fap-api",
     "branch": "codex/fermat-marketing-skills-adaptation-02",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "depends_on": [
       "FERMAT-MARKETING-SKILLS-ADAPTATION-01"
     ],
@@ -45244,6 +45244,21 @@
             "status": "pass"
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "checks": [
+          "hygiene",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN"
       }
     },
     "failure_reason": null,
@@ -45309,6 +45324,11 @@
         "at": "2026-06-05",
         "status": "pr_opened",
         "note": "Opened PR #1936 for HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN. Publish remains blocked; Operator approval was not claimed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -18474,7 +18474,7 @@ prs:
     base: main
     title: "IQ-NORM-03 unlock IQ score claims through norm authority"
     train_scope: iq_production_launch
-    status: in_progress
+    status: ready_to_merge
     scope:
       - Wire IQ scoring/report claim fields to backend norm authority only.
     allowed_paths:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21775,6 +21775,49 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01
 
+  - id: HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01
+    repo: fap-api
+    branch: codex/help-content-draft-policy-owner-answers-01
+    title: "docs(help): record Help policy owner answers"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    depends_on:
+      - HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01
+    scope:
+      - Record the policy-owner answers needed to unblock the Help service draft review train after HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01.
+      - Map the answers to prior blockers and list the follow-up PR train without applying content revisions, mutating CMS, publishing, deploying, submitting search URLs, accessing private URLs, reading secrets, or claiming Operator approval.
+      - Preserve publish and Operator review gates for later explicitly authorized tasks.
+    external_asset_paths:
+      - /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json
+      - backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, deploy, submit search URLs, mutate CMS, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, rewrite content, or claim Operator approval.
+    validation:
+      - shasum -a 256 /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added `HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01` to the Help service content PR train manifest/state.
- Recorded the policy-owner answers for refund exclusions, refund handling time, data deletion handling time, retained-data exceptions, and analytics privacy wording confirmation.
- Added a generated artifact and operations note mapping the answers to the prior operator-review blockers and listing follow-up PR train recommendations.

## Why
`HELP-CONTENT-DRAFT-OPERATOR-REVIEW-01` was blocked on missing policy-owner inputs. This PR records those answers without applying content revisions or changing CMS/public state.

## Validation
- `shasum -a 256 /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip`
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json backend/docs/operations/help-content-draft-policy-owner-answers-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No publish, deploy, search submission, or payment/refund action.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token read.
- No content rewrite.
- No Operator approval claimed.
- Contact-support route decision remains a follow-up.
- CMS service fields and FAQ schema authority remain follow-ups.

## Repository rule impact
Help/service content remains CMS/backend-authoritative through `content_pages`. This PR records policy-owner metadata only and does not introduce frontend fallback content or runtime authority changes.
