### PR TITLE
SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01: docs(seo): record RIASEC draft editorial blockers

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json
@@ -1,0 +1,217 @@
+{
+  "schema": "riasec-explanation-editorial-review.v1",
+  "task_id": "SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01",
+  "generated_at": "2026-06-05",
+  "decision": "REVIEW_BLOCKED_OPERATOR_INPUTS_REQUIRED",
+  "review_passed": false,
+  "operator_approval_claimed": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "cms_mutation_performed": false,
+  "deploy_performed": false,
+  "content_rewrite_performed": false,
+  "private_url_accessed": false,
+  "inputs_reviewed": [
+    "backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json",
+    "backend/docs/seo/riasec-explanation-cms-draft-create-postcheck.md",
+    "backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json",
+    "backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json",
+    "read-only production Article draft status postcheck",
+    "public article/API/sitemap/llms absence checks"
+  ],
+  "cms_draft_state": {
+    "status": "pass",
+    "records_created_in_this_task": 0,
+    "records_updated_in_this_task": 0,
+    "articles": [
+      {
+        "id": 40,
+        "locale": "zh",
+        "slug": "riasec-holland-career-interest-test-explained",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "robots": "noindex,nofollow",
+        "published_revision_id": null,
+        "working_revision_id": 45,
+        "working_revision_status": "machine_draft",
+        "approved_at": null
+      },
+      {
+        "id": 41,
+        "locale": "en",
+        "slug": "what-is-riasec-holland-code-career-interest-test",
+        "status": "draft",
+        "is_public": false,
+        "is_indexable": false,
+        "robots": "noindex,nofollow",
+        "published_revision_id": null,
+        "working_revision_id": 46,
+        "working_revision_status": "machine_draft",
+        "approved_at": null
+      }
+    ],
+    "translation_group_id": "riasec-explanation-article-2026-06-v2",
+    "public_indexable_published_count": 0
+  },
+  "editorial_system_review": {
+    "draft_state": "pass",
+    "public_surface_absence": "pass",
+    "cta_route_safety": "pass",
+    "cta_routes_allowed": [
+      "/zh/tests/holland-career-interest-test-riasec",
+      "/en/tests/holland-career-interest-test-riasec"
+    ],
+    "faq_schema_status": "conditional_until_publish_preflight",
+    "package_faq_schema_count_match": true,
+    "public_article_schema_present": false,
+    "public_faq_schema_present": false,
+    "internal_link_status": "conditional",
+    "conditional_internal_links_held_for_operator_review": [
+      "/zh/career/jobs",
+      "/en/career/jobs"
+    ],
+    "claim_boundary_status": "conditional",
+    "zh_boundary_context_claim_warning_count": 2,
+    "en_boundary_context_claim_warning_count": 0,
+    "references_status": "blocked",
+    "accepted_references_count": 0,
+    "source_review_status": "partially_verified_public_sources_with_publish_blockers",
+    "media_status": "blocked",
+    "cover_image_cms_media_missing": true,
+    "revision_approval_status": "blocked",
+    "all_working_revisions_machine_draft": true,
+    "product_availability_status": "operator_confirmation_required"
+  },
+  "publish_blockers": [
+    {
+      "id": "accepted_references_missing",
+      "status": "blocked",
+      "owner": "editor_or_psychometrics_reviewer",
+      "required_input": "Accept final source set and supply accepted references before controlled publish.",
+      "evidence": "references_count remains 0; reference source review is partial and publish-blocking."
+    },
+    {
+      "id": "cms_media_cover_image_missing",
+      "status": "blocked",
+      "owner": "cms_operator_or_design_owner",
+      "required_input": "Upload/choose CMS Media Library cover image and replace placeholder before controlled publish.",
+      "evidence": "Importer media status remains missing with cover image placeholder."
+    },
+    {
+      "id": "working_revisions_not_approved",
+      "status": "blocked",
+      "owner": "operator_editor",
+      "required_input": "Approve working revisions only after editorial/source/media checks pass.",
+      "evidence": "zh revision 45 and en revision 46 remain machine_draft with approved_at=null."
+    },
+    {
+      "id": "claim_boundary_acknowledgement_required",
+      "status": "blocked",
+      "owner": "operator_editor_or_psychometrics_reviewer",
+      "required_input": "Explicitly acknowledge zh boundary-context claim warnings or send package back for GPT content revision.",
+      "evidence": "zh import preserved 2 boundary-context claim warnings; en preserved 0."
+    },
+    {
+      "id": "conditional_internal_links_not_activated",
+      "status": "blocked",
+      "owner": "seo_operator",
+      "required_input": "Decide whether career jobs links are eligible for activation before publish.",
+      "evidence": "conditional career jobs links remain held for operator review."
+    },
+    {
+      "id": "product_availability_confirmation_required",
+      "status": "blocked",
+      "owner": "product_operator",
+      "required_input": "Confirm report-preview/product-availability statements against actual FermatMind RIASEC module behavior.",
+      "evidence": "Reference review records report-preview product availability as Unknown before publish."
+    },
+    {
+      "id": "controlled_publish_preflight_required",
+      "status": "blocked",
+      "owner": "codex_after_separate_publish_authorization",
+      "required_input": "Run controlled publish preflight after all editorial blockers are resolved and before any publish command.",
+      "evidence": "No publish authorization was granted in this task."
+    }
+  ],
+  "public_surface_checks": {
+    "status": "pass",
+    "article_pages": [
+      {
+        "locale": "zh",
+        "status": 404,
+        "article_schema_present": false,
+        "faq_schema_present": false,
+        "target_canonical_present": false
+      },
+      {
+        "locale": "en",
+        "status": 404,
+        "article_schema_present": false,
+        "faq_schema_present": false,
+        "target_canonical_present": false
+      }
+    ],
+    "article_apis_all_404": true,
+    "sitemap_contains_target_slugs": false,
+    "llms_contains_target_slugs": false,
+    "llms_full_contains_target_slugs": false,
+    "search_submission_performed": false
+  },
+  "operator_input_request_card": {
+    "reference_acceptance": {
+      "required": true,
+      "fields": [
+        "accepted_source_urls",
+        "accepted_source_titles",
+        "citation_style",
+        "holland_hexagon_terms_acceptance",
+        "mbti_big_five_comparison_acceptance",
+        "no_official_affiliation_acknowledgement"
+      ]
+    },
+    "media_resolution": {
+      "required": true,
+      "fields": [
+        "cms_media_id",
+        "cover_image_url",
+        "cover_image_alt_reviewed",
+        "og_image_ready",
+        "twitter_image_ready"
+      ]
+    },
+    "revision_approval": {
+      "required": true,
+      "fields": [
+        "zh_revision_id",
+        "en_revision_id",
+        "approved_by",
+        "approved_at",
+        "approval_notes"
+      ]
+    },
+    "publish_preflight_inputs": {
+      "required_later": true,
+      "fields": [
+        "claim_warning_acknowledgement",
+        "faq_visible_schema_equality",
+        "public_canonical_routes_only",
+        "sitemap_llms_publish_eligibility",
+        "7_day_baseline_fields",
+        "14_day_baseline_fields"
+      ]
+    }
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "search_submission_performed": false,
+    "deploy_performed": false,
+    "content_rewrite_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false,
+    "allowed_paths_only": true
+  },
+  "next_task_recommendation": "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01"
+}

--- a/backend/docs/seo/riasec-explanation-editorial-review.md
+++ b/backend/docs/seo/riasec-explanation-editorial-review.md
@@ -1,0 +1,63 @@
+# RIASEC Explanation V2 Editorial Review
+
+Task: `SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01`
+
+Decision: **BLOCKED: operator inputs required before publish preflight.**
+
+This task did not mutate CMS data, publish, submit search URLs, deploy, rewrite article content, access private result/order/share/pay/payment/history URLs, or claim operator approval.
+
+## Draft State
+
+Result: `PASS`
+
+| Locale | Article ID | Revision ID | Status | Public | Indexable | Published revision |
+| --- | ---: | ---: | --- | --- | --- | --- |
+| zh | 40 | 45 | draft | false | false | null |
+| en | 41 | 46 | draft | false | false | null |
+
+Both revisions remain `machine_draft` and unapproved.
+
+## Editorial System Review
+
+Result: `CONDITIONAL`
+
+- Public canonical CTA routes are safe.
+- Package FAQ counts matched schema expectations at package-validation time.
+- Public Article and FAQ schema remain absent while drafts are unpublished.
+- Conditional career-jobs internal links remain held for operator review.
+- zh has 2 boundary-context claim warnings that require explicit later acknowledgement or GPT package revision.
+- en has 0 claim warnings.
+
+## Publish Blockers
+
+- Accepted references are still missing.
+- CMS Media Library cover image is unresolved.
+- Working revisions are not approved.
+- zh claim-warning acknowledgement remains required.
+- Conditional career-jobs internal links need an activation decision.
+- Report-preview/product-availability wording remains operator-confirmation required.
+- Controlled publish preflight and exact publish authorization remain required.
+
+## Public Surface
+
+Result: `PASS`
+
+- zh/en article pages remain 404.
+- zh/en public article APIs remain 404.
+- `sitemap.xml`, `llms.txt`, and `llms-full.txt` do not contain target slugs.
+- No search submission was performed.
+
+## Next Input Card
+
+Recommended next task: `SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01`.
+
+Required inputs:
+
+- Accepted source URLs/titles and citation style.
+- Holland hexagon term acceptance.
+- MBTI/Big Five comparison acceptance.
+- CMS Media Library cover image and alt review.
+- zh/en revision approval owner and timestamp.
+- Claim-warning acknowledgement or GPT package revision request.
+
+Publish remains forbidden until those inputs are resolved and a separate controlled publish preflight is authorized.

--- a/backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php
@@ -1,0 +1,110 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationEditorialReviewTest extends TestCase
+{
+    public function test_editorial_review_blocks_publish_without_claiming_operator_approval(): void
+    {
+        $review = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-editorial-review.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01', $review['task_id']);
+        $this->assertSame('REVIEW_BLOCKED_OPERATOR_INPUTS_REQUIRED', $review['decision']);
+        $this->assertFalse($review['review_passed']);
+        $this->assertFalse($review['operator_approval_claimed']);
+        $this->assertFalse($review['publish_allowed']);
+        $this->assertFalse($review['search_submit_allowed']);
+        $this->assertFalse($review['cms_mutation_performed']);
+        $this->assertFalse($review['deploy_performed']);
+        $this->assertFalse($review['content_rewrite_performed']);
+        $this->assertFalse($review['private_url_accessed']);
+    }
+
+    public function test_draft_state_remains_noindex_unpublished_and_machine_draft(): void
+    {
+        $review = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-editorial-review.v1.json');
+        $articles = collect($review['cms_draft_state']['articles'])->keyBy('locale');
+
+        $this->assertSame('pass', $review['cms_draft_state']['status']);
+        $this->assertSame(0, $review['cms_draft_state']['records_created_in_this_task']);
+        $this->assertSame(0, $review['cms_draft_state']['records_updated_in_this_task']);
+        $this->assertSame(0, $review['cms_draft_state']['public_indexable_published_count']);
+
+        foreach (['zh', 'en'] as $locale) {
+            $this->assertSame('draft', $articles[$locale]['status']);
+            $this->assertFalse($articles[$locale]['is_public']);
+            $this->assertFalse($articles[$locale]['is_indexable']);
+            $this->assertSame('noindex,nofollow', $articles[$locale]['robots']);
+            $this->assertNull($articles[$locale]['published_revision_id']);
+            $this->assertSame('machine_draft', $articles[$locale]['working_revision_status']);
+            $this->assertNull($articles[$locale]['approved_at']);
+        }
+    }
+
+    public function test_review_records_required_publish_blockers_and_operator_inputs(): void
+    {
+        $review = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-editorial-review.v1.json');
+        $blockers = collect($review['publish_blockers'])->pluck('id')->all();
+
+        $this->assertContains('accepted_references_missing', $blockers);
+        $this->assertContains('cms_media_cover_image_missing', $blockers);
+        $this->assertContains('working_revisions_not_approved', $blockers);
+        $this->assertContains('claim_boundary_acknowledgement_required', $blockers);
+        $this->assertContains('conditional_internal_links_not_activated', $blockers);
+        $this->assertContains('product_availability_confirmation_required', $blockers);
+        $this->assertContains('controlled_publish_preflight_required', $blockers);
+
+        $this->assertTrue($review['operator_input_request_card']['reference_acceptance']['required']);
+        $this->assertTrue($review['operator_input_request_card']['media_resolution']['required']);
+        $this->assertTrue($review['operator_input_request_card']['revision_approval']['required']);
+        $this->assertTrue($review['operator_input_request_card']['publish_preflight_inputs']['required_later']);
+    }
+
+    public function test_public_surface_and_route_boundaries_remain_safe(): void
+    {
+        $review = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-editorial-review.v1.json');
+
+        $this->assertSame('pass', $review['public_surface_checks']['status']);
+        $this->assertTrue($review['public_surface_checks']['article_apis_all_404']);
+        $this->assertFalse($review['public_surface_checks']['sitemap_contains_target_slugs']);
+        $this->assertFalse($review['public_surface_checks']['llms_contains_target_slugs']);
+        $this->assertFalse($review['public_surface_checks']['llms_full_contains_target_slugs']);
+        $this->assertFalse($review['public_surface_checks']['search_submission_performed']);
+
+        foreach ($review['public_surface_checks']['article_pages'] as $page) {
+            $this->assertSame(404, $page['status']);
+            $this->assertFalse($page['article_schema_present']);
+            $this->assertFalse($page['faq_schema_present']);
+            $this->assertFalse($page['target_canonical_present']);
+        }
+
+        $this->assertSame([
+            '/zh/tests/holland-career-interest-test-riasec',
+            '/en/tests/holland-career-interest-test-riasec',
+        ], $review['editorial_system_review']['cta_routes_allowed']);
+    }
+
+    public function test_artifact_contains_no_forbidden_private_routes_or_identifiers(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-editorial-review.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47577,7 +47577,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-cms-draft-create-01",
-    "status": "pr_open_github_checks_pending",
+    "status": "merged",
     "title": "ops(cms): create RIASEC explanation article drafts",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -47767,6 +47767,135 @@
         "at": "2026-06-05",
         "status": "merged",
         "note": "PR #1931 was squash-merged at 2026-06-05T12:55:21Z with merge commit 81451ae547e8899a498f7743a221c65e993df9f5; origin/main contains the merge commit; remote task branch is absent; local task branch cleanup is complete."
+      }
+    ]
+  },
+  "SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/seo-article-riasec-v2-editorial-review-01",
+    "status": "local_validation_pending",
+    "title": "docs(seo): record RIASEC draft editorial blockers",
+    "train_scope": "seo_article_content_package_riasec_explanation_v2",
+    "depends_on": [
+      "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01, including necessary manifest/state entries, limited to editorial/operator review artifact, publish blockers, reference/media/revision approval checklist, generated artifact/test/ledger. Content rewrite, CMS mutation, publish, search submission, deploy, and private URL access remain forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01 is merged as PR #1931; origin/main contains merge commit 81451ae547e8899a498f7743a221c65e993df9f5. Closeout PR #1934 is also merged and origin/main contains 2bce0d086434754b268a28246541ec6271bffd4e."
+      },
+      "production_read_only_draft_state": {
+        "status": "pass",
+        "articles_status_draft": true,
+        "articles_non_public": true,
+        "articles_non_indexable": true,
+        "articles_unpublished": true,
+        "working_revisions_machine_draft": true,
+        "records_created_in_this_task": 0,
+        "records_updated_in_this_task": 0
+      },
+      "public_surface": {
+        "status": "pass",
+        "article_pages_404": true,
+        "article_apis_404": true,
+        "article_schema_absent": true,
+        "faq_schema_absent": true,
+        "target_canonical_absent": true,
+        "sitemap_contains_target_slugs": false,
+        "llms_contains_target_slugs": false,
+        "llms_full_contains_target_slugs": false,
+        "search_submission_performed": false
+      },
+      "editorial_review": {
+        "status": "blocked_operator_inputs_required",
+        "review_passed": false,
+        "operator_approval_claimed": false,
+        "publish_allowed": false,
+        "accepted_references_count": 0,
+        "cover_image_cms_media_missing": true,
+        "working_revisions_approved": false,
+        "zh_boundary_context_claim_warning_count": 2,
+        "conditional_internal_links_need_operator_decision": true,
+        "product_availability_confirmation_required": true
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to the RIASEC editorial review artifact/report/test plus docs/codex PR-train metadata, including stale draft-create ledger reconciliation needed for dependency resolution."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationEditorialReviewTest --no-ansi",
+          "git diff --check -- backend/docs/seo/riasec-explanation-editorial-review.md backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed."
+      }
+    },
+    "result": {
+      "decision": "REVIEW_BLOCKED_OPERATOR_INPUTS_REQUIRED",
+      "review_passed": false,
+      "operator_approval_claimed": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false,
+      "cms_mutation_performed": false,
+      "content_rewrite_performed": false,
+      "generated_artifact": "backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json",
+      "review_report": "backend/docs/seo/riasec-explanation-editorial-review.md"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "content_rewrite_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01",
+        "status": "next_gate",
+        "note": "Operator/editor must supply accepted references, CMS media cover image, revision approval, claim-warning acknowledgement, conditional internal-link decision, and product-availability confirmation before publish preflight."
+      },
+      {
+        "id": "SEO-ARTICLE-RIASEC-V2-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish, search submission, public indexability, sitemap/llms inclusion, and post-publish review remain forbidden until separate controlled publish preflight and exact publish authorization."
+      }
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "failure_reason": null,
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01 with manifest/state updates and no CMS mutation, publish, search submission, deploy, content rewrite, or private URL access."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "review_blocked_operator_inputs_required",
+        "note": "Editorial/system review recorded draft state pass and public absence pass, but review remains blocked on accepted references, CMS media, revision approval, claim-warning acknowledgement, conditional internal links, and product-availability confirmation."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Local JSON/YAML parsing, PHP lint, focused RiasecExplanationEditorialReviewTest, and scope diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47058,7 +47058,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-first-record-review-template-01",
     "base": "main",
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): define DailyGiving first record review template",
     "depends_on": [
@@ -47839,6 +47839,11 @@
           "git diff --cached --check"
         ],
         "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "PR #1937 checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2.",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1937"
       }
     },
     "result": {
@@ -47901,6 +47906,11 @@
         "at": "2026-06-05",
         "status": "pr_open_github_checks_pending",
         "note": "Opened PR #1937 for scoped RIASEC editorial review artifact, report, focused test, and PR-train metadata."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1937 and changed files remain confined to the RIASEC editorial review artifact/report/test and docs/codex metadata."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47774,7 +47774,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-editorial-review-01",
-    "status": "local_validation_pending",
+    "status": "pr_open_github_checks_pending",
     "title": "docs(seo): record RIASEC draft editorial blockers",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -47875,8 +47875,8 @@
         "note": "Publish, search submission, public indexability, sitemap/llms inclusion, and post-publish review remain forbidden until separate controlled publish preflight and exact publish authorization."
       }
     ],
-    "commit_sha": "23eb8e8f261e33ab7a62056e348ddd34bb07aa12",
-    "pr_url": null,
+    "commit_sha": "1fd67f12b602adbcf15ebd019e4e5e1d70fba2e3",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1937",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -47896,6 +47896,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Local JSON/YAML parsing, PHP lint, focused RiasecExplanationEditorialReviewTest, and scope diff checks passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open_github_checks_pending",
+        "note": "Opened PR #1937 for scoped RIASEC editorial review artifact, report, focused test, and PR-train metadata."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -47875,7 +47875,7 @@
         "note": "Publish, search submission, public indexability, sitemap/llms inclusion, and post-publish review remain forbidden until separate controlled publish preflight and exact publish authorization."
       }
     ],
-    "commit_sha": null,
+    "commit_sha": "23eb8e8f261e33ab7a62056e348ddd34bb07aa12",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -20105,7 +20105,7 @@ prs:
     branch: production-controlled-importer-execution
     title: "ops(cms): execute bilingual SEO canary draft-only import"
     train_scope: seo_cms_canary
-    status: draft_created_postcheck_passed_publish_blocked
+    status: merged
     scope:
       - Record the controlled production importer draft-only execution for the first bilingual SEO canary.
       - Record that zh-CN article 37 and en article 39 were created as non-public, non-indexable CMS drafts.
@@ -22628,3 +22628,44 @@ prs:
     frontend_deploy_allowed: false
     content_authority: CMS/backend
     next_task: SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01 after separate authorization
+
+  - id: SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01
+    repo: fap-api
+    depends_on:
+      - SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-CREATE-01
+    branch: codex/seo-article-riasec-v2-editorial-review-01
+    title: "docs(seo): record RIASEC draft editorial blockers"
+    train_scope: seo_article_content_package_riasec_explanation_v2
+    status: in_progress
+    scope:
+      - Review the RIASEC V2 zh/en CMS Article drafts for editorial/operator readiness using draft-create, reference-source, package-validation, production draft-state, and public-absence evidence.
+      - Record publish blockers, accepted-reference needs, CMS media needs, revision approval checklist, claim-warning acknowledgement needs, conditional internal-link decision, and product-availability confirmation needs.
+      - Preserve blocked status without rewriting article content, mutating CMS, publishing, deploying, submitting search URLs, accessing private URLs, or claiming operator approval.
+    allowed_paths:
+      - backend/docs/seo/riasec-explanation-editorial-review.md
+      - backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json
+      - backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite article body/title/H1/meta/FAQ/CTA, mutate CMS, publish, submit search URLs, deploy, or access private result/orders/share/pay/payment/history/tokenized URLs.
+    validation:
+      - php -l backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php
+      - python3 -m json.tool backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationEditorialReviewTest --no-ansi
+      - git diff --check -- backend/docs/seo/riasec-explanation-editorial-review.md backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_rewrite_allowed: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01 after separate authorization


### PR DESCRIPTION
## What changed
- Added `SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01` manifest/state entries.
- Added RIASEC V2 editorial/operator review artifact and report.
- Added a focused artifact contract test for draft-only state, blocker checklist, public absence, and forbidden private-route guards.
- Reconciled stale draft-create ledger status to merged based on PR #1931/#1934 merge evidence.

## Why
- The RIASEC V2 zh/en CMS drafts exist, but publish remains blocked until operator/editor inputs are supplied.
- This review records the exact blockers: accepted references, CMS Media Library cover image, working revision approval, zh claim-warning acknowledgement, conditional internal-link decision, product availability confirmation, and later controlled publish preflight.

## Validation
- `php -l backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php`
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationEditorialReviewTest --no-ansi`
- `git diff --check -- backend/docs/seo/riasec-explanation-editorial-review.md backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json backend/tests/Feature/SEO/RiasecExplanationEditorialReviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No publish.
- No search submission.
- No deploy.
- No content rewrite.
- No private result/order/share/pay/payment/history/tokenized URL access.
- Operator source/media/revision approval remains a separate gate.

## Repository rule impact
- Article content and publication state remain CMS/backend-authoritative.
- This PR records a review blocker artifact only; it does not add frontend fallback content or public runtime editorial content.