### PR TITLE
HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01 docs(help): record Help direct email support decision

### DIFF
--- a/backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json
@@ -1,0 +1,120 @@
+{
+  "schema_version": "help_content_draft_contact_support_decision.v1",
+  "task": "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01",
+  "generated_at": "2026-06-05",
+  "decision": "DIRECT_EMAIL_SUPPORT_CONTACT_SELECTED_WITH_PUBLISH_STILL_BLOCKED",
+  "source_context": {
+    "depends_on": "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01",
+    "policy_owner_answers_artifact": "backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json",
+    "prior_blocker_id": "contact_support_route_and_support_contact",
+    "user_decision": "direct email support contact",
+    "support_email": "support@fermatmind.com"
+  },
+  "contact_support_decision": {
+    "selected_contact_mode": "email",
+    "selected_contact_target": "support@fermatmind.com",
+    "selected_public_canonical": "mailto:support@fermatmind.com",
+    "new_help_contact_support_route_required": false,
+    "existing_support_route_required_for_this_decision": false,
+    "notes": [
+      "Help service content should direct users to email support@fermatmind.com for support contact.",
+      "This decision removes the /help/contact-support route as a publish-blocking requirement for the current Help service content train.",
+      "Any public route such as /support may remain a separate product navigation surface, but this task does not require or modify it."
+    ]
+  },
+  "blocker_resolution_mapping": [
+    {
+      "blocker_id": "contact_support_route_and_support_contact",
+      "prior_status": "blocked",
+      "decision_status": "resolved_by_email_contact_decision",
+      "remaining_gate": "Apply the email-contact decision to the revised local package/import package in HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01, then sync CMS drafts only after explicit CMS mutation authorization."
+    },
+    {
+      "blocker_id": "support_contact_first_class_field",
+      "prior_status": "unverified",
+      "decision_status": "still_open",
+      "remaining_gate": "HELP-CMS-SERVICE-FIELDS-01 should add or verify first-class support_contact authority before publish preflight."
+    },
+    {
+      "blocker_id": "faq_schema_publish_gate",
+      "prior_status": "blocked",
+      "decision_status": "still_open",
+      "remaining_gate": "Verify visible FAQ to JSON-LD equality only after policy/contact revisions are applied and schema authority is available."
+    }
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false,
+    "content_rewrite_performed": false,
+    "contact_support_decision_recorded_only": true
+  },
+  "recommended_pr_train": [
+    {
+      "id": "HELP-CMS-SERVICE-FIELDS-01",
+      "repo": "fap-api",
+      "purpose": "Add or verify first-class CMS fields needed for support_contact, policy_version, reviewer, faq_items, and schema_enabled authority.",
+      "mutation_allowed": false,
+      "publish_allowed": false
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01",
+      "repo": "fap-api",
+      "purpose": "Apply policy-owner answers and the direct-email support decision to the local revised v01 Help package/import artifact without CMS writes.",
+      "mutation_allowed": false,
+      "publish_allowed": false
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+      "repo": "fap-api",
+      "purpose": "Sync the policy/contact-updated package to the existing 12 Help CMS drafts while preserving draft/non-public/non-indexable/unpublished state.",
+      "mutation_allowed": true,
+      "publish_allowed": false,
+      "requires_explicit_cms_mutation_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01",
+      "repo": "fap-api",
+      "purpose": "Run second read-only operator review request after policy answers and contact-support handling are applied.",
+      "mutation_allowed": false,
+      "publish_allowed": false,
+      "operator_approval_claimed_by_codex": false
+    },
+    {
+      "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+      "repo": "fap-web",
+      "purpose": "Enable or harden Help FAQ schema only from visible CMS/backend FAQ authority.",
+      "mutation_allowed": false,
+      "publish_allowed": false
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+      "repo": "fap-api/fap-web",
+      "purpose": "Run publish preflight over CMS draft state, support contact, schema, canonical paths, sitemap/llms, and private URL guards.",
+      "mutation_allowed": false,
+      "publish_allowed": false
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01",
+      "repo": "fap-api",
+      "purpose": "Publish the 12 Help ContentPage drafts only after exact publish authorization.",
+      "mutation_allowed": true,
+      "publish_allowed": true,
+      "requires_exact_publish_authorization": true
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01",
+      "repo": "fap-api/fap-web",
+      "purpose": "Verify public 200s, canonical paths, schema, sitemap/llms exposure, and private URL guardrails after publish.",
+      "mutation_allowed": false,
+      "publish_allowed": false
+    }
+  ],
+  "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-01"
+}

--- a/backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md
+++ b/backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md
@@ -1,0 +1,60 @@
+# HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01
+
+Decision: `DIRECT_EMAIL_SUPPORT_CONTACT_SELECTED_WITH_PUBLISH_STILL_BLOCKED`
+
+This task records the support-contact decision for the Help service content train. It did not publish, deploy, mutate CMS data, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, rewrite content, or claim Operator approval.
+
+## Inputs
+
+- Prior policy-owner artifact: `backend/docs/help/generated/help-content-draft-policy-owner-answers-01.v1.json`
+- Prior blocker: `contact_support_route_and_support_contact`
+- User decision on 2026-06-05: direct email contact support.
+- Support email: `support@fermatmind.com`
+
+## Contact Support Decision
+
+| Field | Decision |
+| --- | --- |
+| Selected support mode | Email |
+| Selected support target | `support@fermatmind.com` |
+| Selected public canonical | `mailto:support@fermatmind.com` |
+| Require new `/help/contact-support` route | No |
+| Require `/support` route change in this PR | No |
+
+The Help service draft train should treat direct email to `support@fermatmind.com` as the contact-support path. The missing `/help/contact-support` page is no longer a publish blocker for this train, provided later package/CMS revisions remove or replace any dependency on that route.
+
+## Blocker Mapping
+
+- `contact_support_route_and_support_contact`: resolved by selecting direct email support as the contact path, pending application to package/import/CMS drafts.
+- `support_contact_first_class_field`: still open; first-class ContentPage support-contact authority should be added or verified before publish preflight.
+- `faq_schema_publish_gate`: still open; visible FAQ and JSON-LD equality must be verified only after content/schema authority is finalized.
+
+## Recommended Next PR Train
+
+1. `HELP-CMS-SERVICE-FIELDS-01`
+2. `HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01`
+3. `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01`
+4. `HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01`
+5. `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01`
+6. `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01`
+7. `HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01`
+8. `HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01`
+
+## Remaining Hard Gates
+
+- No publish without separate exact publish authorization.
+- No Operator approval claimed by Codex.
+- No CMS mutation in this task.
+- First-class ContentPage `support_contact` remains unverified.
+- Contact-support decision still needs to be applied to the local revised package/import artifact before CMS sync.
+- FAQPage schema remains conditional until visible FAQ/JSON-LD equality is verified after content is finalized.
+
+## Validation Commands
+
+```bash
+python3 -m json.tool backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45326,6 +45326,124 @@
       }
     ]
   },
+  "HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-contact-support-decision-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): record Help direct email support decision",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User requested the next Help service PR train and decided that support contact should be direct email contact."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01 is merged as PR #1936 and final status reconciliation is merged as PR #1940."
+      },
+      "contact_support_decision": {
+        "status": "recorded",
+        "selected_contact_mode": "email",
+        "support_email": "support@fermatmind.com",
+        "selected_public_canonical": "mailto:support@fermatmind.com",
+        "new_help_contact_support_route_required": false
+      },
+      "scope_preflight": {
+        "status": "pass",
+        "evidence": "Current scope records the direct-email support-contact decision only; no CMS mutation, publish, deploy, search submission, private URL access, payment/refund action, payment-provider change, content rewrite, frontend fallback content, Operator approval claim, or secret/env/cookie/token read is allowed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "pass"
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "pass"
+          }
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "checks": []
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "DIRECT_EMAIL_SUPPORT_CONTACT_SELECTED_WITH_PUBLISH_STILL_BLOCKED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md",
+      "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "content_rewrite_performed": false,
+      "frontend_fallback_content_added": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS",
+        "status": "open_followup",
+        "note": "First-class support_contact, policy_version, reviewer, faq_items, and schema_enabled authority remains a later CMS/backend task."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY",
+        "status": "open_followup",
+        "note": "Apply policy-owner answers and direct-email support contact to the local revised package/import artifact before CMS sync."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish remains blocked and requires separate exact authorization after policy/contact revisions are applied, Operator review passes, and publish preflight passes."
+      }
+    ],
+    "next_task": "HELP-CMS-SERVICE-FIELDS-01",
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User requested the Help service content PR train and decided to use direct email contact support."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Created direct-email support-contact decision artifact and operations report; local validation pending."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Contact-support decision artifact, state JSON, manifest YAML, and scoped diff whitespace checks passed."
+      }
+    ]
+  },
   "PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01": {
     "repo": "fap-api",
     "branch": "codex/public-benefit-asset-packages-archive-01",

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45330,7 +45330,7 @@
     "repo": "fap-api",
     "branch": "codex/help-contact-support-decision-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help direct email support decision",
     "depends_on": [
@@ -45384,7 +45384,7 @@
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1942",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45441,6 +45441,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Contact-support decision artifact, state JSON, manifest YAML, and scoped diff whitespace checks passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_opened",
+        "note": "Opened PR #1942 for HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21818,6 +21818,46 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01
 
+  - id: HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01
+    repo: fap-api
+    branch: codex/help-contact-support-decision-01
+    title: "docs(help): record Help direct email support decision"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    depends_on:
+      - HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01
+    scope:
+      - Record the policy-owner support-contact decision for the Help service draft train.
+      - Select direct email to support@fermatmind.com as the support contact path and remove the missing /help/contact-support route as a publish-blocking requirement for this train.
+      - Preserve publish, CMS mutation, deployment, search submission, private URL, secret, payment/refund, and Operator approval gates for later explicitly authorized tasks.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json
+      - backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, deploy, submit search URLs, mutate CMS, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, rewrite content, add frontend fallback content, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CMS-SERVICE-FIELDS-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01 to the Help service PR train.
- Recorded the decision to use direct email contact via support@fermatmind.com.
- Removed /help/contact-support as a publish-blocking route requirement for this train, pending later package/CMS application.

## Why
- Prior operator review blocked on contact-support route handling and support_contact authority.
- The policy decision is now direct email contact support, so the next content revision can apply that without creating a new public route.

## Validation
- python3 -m json.tool backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json backend/docs/operations/help-content-draft-contact-support-decision-2026-06-05.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation.
- No publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or Operator approval claim.
- HELP-CMS-SERVICE-FIELDS-01 remains the next backend/CMS authority task.

## Repository rule impact
- Content authority remains CMS/backend. This PR records a decision artifact only and does not add frontend fallback content or runtime editorial authority.