### PR TITLE
SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01｜record reference media revision approval blockers

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json
@@ -1,0 +1,223 @@
+{
+  "schema": "riasec-explanation-reference-media-revision-approval.v1",
+  "task_id": "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01",
+  "generated_at": "2026-06-05",
+  "decision": "NO-GO_OPERATOR_INPUTS_REQUIRED",
+  "approval_passed": false,
+  "operator_approval_claimed": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "cms_mutation_performed": false,
+  "deploy_performed": false,
+  "content_rewrite_performed": false,
+  "private_url_accessed": false,
+  "inputs_reviewed": [
+    "backend/docs/seo/generated/riasec-explanation-editorial-review.v1.json",
+    "backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json",
+    "backend/docs/seo/generated/riasec-explanation-cms-draft-create.v1.json"
+  ],
+  "draft_records": [
+    {
+      "locale": "zh",
+      "article_id": 40,
+      "working_revision_id": 45,
+      "slug": "riasec-holland-career-interest-test-explained",
+      "status": "draft",
+      "public": false,
+      "indexable": false,
+      "working_revision_status": "machine_draft",
+      "approved_at": null
+    },
+    {
+      "locale": "en",
+      "article_id": 41,
+      "working_revision_id": 46,
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "status": "draft",
+      "public": false,
+      "indexable": false,
+      "working_revision_status": "machine_draft",
+      "approved_at": null
+    }
+  ],
+  "approval_gates": [
+    {
+      "id": "reference_acceptance",
+      "status": "blocked",
+      "owner": "editor_or_psychometrics_reviewer",
+      "required_input": "Accepted final public source list, citation style, and source-to-claim acceptance for both locales.",
+      "evidence": "Reference source review remains partial; accepted references count is 0.",
+      "acceptance_criteria": [
+        "accepted_source_urls is non-empty and public",
+        "accepted_source_titles is non-empty",
+        "citation_style is selected",
+        "Holland/RIASEC model source acceptance is explicit",
+        "MBTI and Big Five comparison language is accepted or sent back for GPT revision",
+        "No official affiliation or certification implication is accepted"
+      ]
+    },
+    {
+      "id": "media_resolution",
+      "status": "blocked",
+      "owner": "cms_operator_or_design_owner",
+      "required_input": "CMS Media Library cover image, alt review, and social image readiness decision.",
+      "evidence": "CMS draft/import evidence still records cover image placeholder or missing CMS media.",
+      "acceptance_criteria": [
+        "cms_media_id is supplied",
+        "cover_image_url is a public CMS/media-library URL",
+        "cover_image_alt_reviewed is true",
+        "og_image_ready is true or explicitly deferred",
+        "twitter_image_ready is true or explicitly deferred"
+      ]
+    },
+    {
+      "id": "revision_approval",
+      "status": "blocked",
+      "owner": "operator_editor",
+      "required_input": "Explicit approval for zh revision 45 and en revision 46 after source/media/claim checks are resolved.",
+      "evidence": "Both working revisions remain machine_draft with approved_at=null.",
+      "acceptance_criteria": [
+        "zh_revision_id equals 45 or a newer reviewed revision id is supplied",
+        "en_revision_id equals 46 or a newer reviewed revision id is supplied",
+        "approved_by is non-empty",
+        "approved_at is non-empty and operator supplied",
+        "approval_notes confirm no content rewrite by Codex"
+      ]
+    },
+    {
+      "id": "claim_warning_acknowledgement",
+      "status": "blocked",
+      "owner": "operator_editor_or_psychometrics_reviewer",
+      "required_input": "Acknowledge the 2 zh boundary-context claim warnings or return the package to GPT for revision.",
+      "evidence": "Editorial review records zh_boundary_context_claim_warning_count=2 and en_boundary_context_claim_warning_count=0.",
+      "acceptance_criteria": [
+        "claim_warning_acknowledgement is true with owner and timestamp",
+        "or gpt_revision_required is true and publish remains blocked"
+      ]
+    },
+    {
+      "id": "conditional_internal_link_decision",
+      "status": "blocked",
+      "owner": "seo_operator",
+      "required_input": "Decide whether conditional career jobs internal links are eligible before publish.",
+      "evidence": "Conditional links to /zh/career/jobs and /en/career/jobs remain held for operator review.",
+      "acceptance_criteria": [
+        "conditional_links_activation_decision is activate or hold",
+        "activated links remain public canonical routes only",
+        "held links remain excluded or marked deferred before publish"
+      ]
+    },
+    {
+      "id": "product_availability_confirmation",
+      "status": "blocked",
+      "owner": "product_operator",
+      "required_input": "Confirm report-preview and product-availability statements against the live FermatMind RIASEC product module.",
+      "evidence": "Reference review records report-preview product availability as Unknown before publish.",
+      "acceptance_criteria": [
+        "product_availability_confirmed is true with owner and timestamp",
+        "or product availability language is sent back for GPT/package revision",
+        "no career-result promise, diagnosis, official certification, or deterministic job-decision claim is introduced"
+      ]
+    },
+    {
+      "id": "controlled_publish_preflight",
+      "status": "blocked",
+      "owner": "codex_after_separate_authorization",
+      "required_input": "Run publish preflight only after all prior gates pass and separate publish-preflight authorization is granted.",
+      "evidence": "This task has no publish authorization and does not perform CMS mutation.",
+      "acceptance_criteria": [
+        "all approval gates are pass",
+        "FAQ/schema visible equality is verified",
+        "canonical/noindex/indexable transition is verified before publish",
+        "sitemap and llms eligibility are verified before exposure",
+        "exact controlled publish authorization is still required for publish"
+      ]
+    }
+  ],
+  "operator_input_card": {
+    "reference_acceptance": {
+      "accepted_source_urls": "Unknown",
+      "accepted_source_titles": "Unknown",
+      "citation_style": "Unknown",
+      "holland_hexagon_terms_acceptance": "Unknown",
+      "mbti_big_five_comparison_acceptance": "Unknown",
+      "no_official_affiliation_acknowledgement": "Unknown"
+    },
+    "media_resolution": {
+      "cms_media_id": "Unknown",
+      "cover_image_url": "Unknown",
+      "cover_image_alt_reviewed": "Unknown",
+      "og_image_ready": "Unknown",
+      "twitter_image_ready": "Unknown"
+    },
+    "revision_approval": {
+      "zh_revision_id": 45,
+      "en_revision_id": 46,
+      "approved_by": "Unknown",
+      "approved_at": "Unknown",
+      "approval_notes": "Unknown"
+    },
+    "claim_and_link_decisions": {
+      "zh_claim_warning_count": 2,
+      "claim_warning_acknowledgement": "Unknown",
+      "gpt_revision_required": "Unknown",
+      "conditional_links_activation_decision": "Unknown",
+      "career_jobs_links": [
+        "/zh/career/jobs",
+        "/en/career/jobs"
+      ]
+    },
+    "product_availability": {
+      "product_availability_confirmed": "Unknown",
+      "report_preview_language_confirmed": "Unknown",
+      "confirmed_by": "Unknown",
+      "confirmed_at": "Unknown"
+    }
+  },
+  "safe_public_routes": [
+    "/zh/tests/holland-career-interest-test-riasec",
+    "/en/tests/holland-career-interest-test-riasec",
+    "/zh/career/jobs",
+    "/en/career/jobs"
+  ],
+  "sidecar_issues": [
+    {
+      "id": "RIASEC_V2_REFERENCE_ACCEPTANCE_REQUIRED",
+      "status": "blocked_external_operator_input",
+      "note": "Accepted references and claim-to-source mapping are required before CMS draft approval preflight can pass."
+    },
+    {
+      "id": "RIASEC_V2_CMS_MEDIA_REQUIRED",
+      "status": "blocked_external_operator_input",
+      "note": "A reviewed CMS Media Library cover image and alt decision are required before publish preflight can pass."
+    },
+    {
+      "id": "RIASEC_V2_REVISION_APPROVAL_REQUIRED",
+      "status": "blocked_external_operator_input",
+      "note": "The zh/en working revisions remain machine_draft and require explicit operator approval or GPT revision loop."
+    },
+    {
+      "id": "RIASEC_V2_PRODUCT_AVAILABILITY_CONFIRMATION_REQUIRED",
+      "status": "blocked_external_operator_input",
+      "note": "Report-preview and product-availability statements remain Unknown until a product operator confirms them."
+    }
+  ],
+  "next_task_recommendation": {
+    "id": "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01",
+    "status": "blocked_until_operator_inputs_supplied",
+    "cms_mutation_allowed": false,
+    "publish_allowed": false,
+    "search_submission_allowed": false
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "search_submission_performed": false,
+    "deploy_performed": false,
+    "content_rewrite_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false,
+    "allowed_paths_only": true
+  }
+}

--- a/backend/docs/seo/riasec-explanation-reference-media-revision-approval.md
+++ b/backend/docs/seo/riasec-explanation-reference-media-revision-approval.md
@@ -1,0 +1,67 @@
+# RIASEC Explanation V2 Reference, Media, and Revision Approval Gate
+
+Task: `SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01`
+
+Decision: **NO-GO: operator inputs required before CMS draft approval preflight.**
+
+This task did not rewrite article content, mutate CMS records, publish, submit search URLs, deploy, access private result/order/share/pay/payment/history URLs, read secrets, or claim operator approval.
+
+## Current Draft State
+
+| Locale | Article ID | Working revision | Status | Public | Indexable | Approval |
+| --- | ---: | ---: | --- | --- | --- | --- |
+| zh | 40 | 45 | draft | false | false | machine_draft / not approved |
+| en | 41 | 46 | draft | false | false | machine_draft / not approved |
+
+The drafts remain safe to keep unpublished. Public pages, sitemap exposure, llms exposure, search submission, and controlled publish remain blocked.
+
+## Blocking Gates
+
+| Gate | Status | Owner | Required input |
+| --- | --- | --- | --- |
+| Reference acceptance | blocked | editor or psychometrics reviewer | Accepted public source list, citation style, and source-to-claim acceptance. |
+| CMS media | blocked | CMS operator or design owner | CMS Media Library cover image, alt review, and social image decision. |
+| Revision approval | blocked | operator editor | Explicit approval for zh revision 45 and en revision 46 after source/media/claim checks. |
+| Claim warning acknowledgement | blocked | editor or psychometrics reviewer | Acknowledge the 2 zh boundary-context warnings or request GPT revision. |
+| Conditional internal links | blocked | SEO operator | Decide whether `/zh/career/jobs` and `/en/career/jobs` are eligible before publish. |
+| Product availability | blocked | product operator | Confirm report-preview and product-availability statements against the live RIASEC module. |
+| Controlled publish preflight | blocked | Codex after separate authorization | Run only after all prior gates pass. |
+
+## Operator Input Checklist
+
+Required before `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01` can pass:
+
+- `accepted_source_urls`: Unknown
+- `accepted_source_titles`: Unknown
+- `citation_style`: Unknown
+- `holland_hexagon_terms_acceptance`: Unknown
+- `mbti_big_five_comparison_acceptance`: Unknown
+- `no_official_affiliation_acknowledgement`: Unknown
+- `cms_media_id`: Unknown
+- `cover_image_url`: Unknown
+- `cover_image_alt_reviewed`: Unknown
+- `og_image_ready`: Unknown
+- `twitter_image_ready`: Unknown
+- `approved_by`: Unknown
+- `approved_at`: Unknown
+- `approval_notes`: Unknown
+- `claim_warning_acknowledgement`: Unknown
+- `gpt_revision_required`: Unknown
+- `conditional_links_activation_decision`: Unknown
+- `product_availability_confirmed`: Unknown
+- `report_preview_language_confirmed`: Unknown
+
+## Sidecar Issues
+
+- `RIASEC_V2_REFERENCE_ACCEPTANCE_REQUIRED`: accepted references and claim-to-source mapping are required before CMS draft approval preflight can pass.
+- `RIASEC_V2_CMS_MEDIA_REQUIRED`: reviewed CMS Media Library cover image and alt decision are required before publish preflight can pass.
+- `RIASEC_V2_REVISION_APPROVAL_REQUIRED`: zh/en working revisions remain machine_draft and require explicit operator approval or a GPT revision loop.
+- `RIASEC_V2_PRODUCT_AVAILABILITY_CONFIRMATION_REQUIRED`: report-preview and product-availability statements remain Unknown until product confirmation.
+
+## Next Gate
+
+Recommended next task: `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01`.
+
+Expected state unless operator inputs are supplied: **NO-GO / blocked external operator input**.
+
+No CMS mutation, publish, search submission, or deploy is authorized by this approval gate.

--- a/backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php
@@ -1,0 +1,116 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationReferenceMediaRevisionApprovalTest extends TestCase
+{
+    public function test_approval_gate_remains_blocked_without_operator_inputs(): void
+    {
+        $approval = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01', $approval['task_id']);
+        $this->assertSame('NO-GO_OPERATOR_INPUTS_REQUIRED', $approval['decision']);
+        $this->assertFalse($approval['approval_passed']);
+        $this->assertFalse($approval['operator_approval_claimed']);
+        $this->assertFalse($approval['publish_allowed']);
+        $this->assertFalse($approval['search_submit_allowed']);
+        $this->assertFalse($approval['cms_mutation_performed']);
+        $this->assertFalse($approval['deploy_performed']);
+        $this->assertFalse($approval['content_rewrite_performed']);
+        $this->assertFalse($approval['private_url_accessed']);
+    }
+
+    public function test_all_publish_blocking_approval_gates_are_recorded(): void
+    {
+        $approval = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json');
+        $gates = collect($approval['approval_gates'])->keyBy('id');
+
+        foreach ([
+            'reference_acceptance',
+            'media_resolution',
+            'revision_approval',
+            'claim_warning_acknowledgement',
+            'conditional_internal_link_decision',
+            'product_availability_confirmation',
+            'controlled_publish_preflight',
+        ] as $gateId) {
+            $this->assertArrayHasKey($gateId, $gates);
+            $this->assertSame('blocked', $gates[$gateId]['status']);
+            $this->assertNotEmpty($gates[$gateId]['owner']);
+            $this->assertNotEmpty($gates[$gateId]['required_input']);
+            $this->assertNotEmpty($gates[$gateId]['acceptance_criteria']);
+        }
+    }
+
+    public function test_unknown_operator_fields_are_not_coerced_to_false_or_zero(): void
+    {
+        $approval = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json');
+
+        $this->assertSame('Unknown', $approval['operator_input_card']['reference_acceptance']['accepted_source_urls']);
+        $this->assertSame('Unknown', $approval['operator_input_card']['media_resolution']['cms_media_id']);
+        $this->assertSame('Unknown', $approval['operator_input_card']['revision_approval']['approved_by']);
+        $this->assertSame('Unknown', $approval['operator_input_card']['claim_and_link_decisions']['claim_warning_acknowledgement']);
+        $this->assertSame('Unknown', $approval['operator_input_card']['product_availability']['product_availability_confirmed']);
+        $this->assertSame(2, $approval['operator_input_card']['claim_and_link_decisions']['zh_claim_warning_count']);
+    }
+
+    public function test_draft_records_remain_unpublished_non_public_and_non_indexable(): void
+    {
+        $approval = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json');
+        $records = collect($approval['draft_records'])->keyBy('locale');
+
+        foreach (['zh', 'en'] as $locale) {
+            $this->assertSame('draft', $records[$locale]['status']);
+            $this->assertFalse($records[$locale]['public']);
+            $this->assertFalse($records[$locale]['indexable']);
+            $this->assertSame('machine_draft', $records[$locale]['working_revision_status']);
+            $this->assertNull($records[$locale]['approved_at']);
+        }
+
+        $this->assertSame(45, $records['zh']['working_revision_id']);
+        $this->assertSame(46, $records['en']['working_revision_id']);
+    }
+
+    public function test_next_task_is_preflight_only_and_not_mutation_or_publish(): void
+    {
+        $approval = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01', $approval['next_task_recommendation']['id']);
+        $this->assertSame('blocked_until_operator_inputs_supplied', $approval['next_task_recommendation']['status']);
+        $this->assertFalse($approval['next_task_recommendation']['cms_mutation_allowed']);
+        $this->assertFalse($approval['next_task_recommendation']['publish_allowed']);
+        $this->assertFalse($approval['next_task_recommendation']['search_submission_allowed']);
+    }
+
+    public function test_artifact_contains_only_allowed_public_routes_and_no_private_identifiers(): void
+    {
+        $approval = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json');
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json') ?: '';
+
+        $this->assertSame([
+            '/zh/tests/holland-career-interest-test-riasec',
+            '/en/tests/holland-career-interest-test-riasec',
+            '/zh/career/jobs',
+            '/en/career/jobs',
+        ], $approval['safe_public_routes']);
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48080,7 +48080,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-reference-media-revision-approval-01",
-    "status": "local_checks_passed",
+    "status": "pr_open_github_checks_pending",
     "title": "docs(seo): record RIASEC reference media revision approval blockers",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -48111,6 +48111,10 @@
           "git diff --cached --check"
         ],
         "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed. Composer install and local .env setup were worktree-only and not staged."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1943"
       }
     },
     "result": {
@@ -48157,8 +48161,8 @@
         "note": "Report-preview and product-availability statements remain Unknown until product confirmation."
       }
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "ae47b780cf38eab5601d0d9e8feec8a11d5fecc3",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1943",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -48178,6 +48182,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Local validation passed with 6 focused PHPUnit assertions groups / 77 assertions, JSON/YAML parse, PHP lint, and scoped diff checks."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open_github_checks_pending",
+        "note": "Opened PR #1943 after local checks and scoped staging passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48080,7 +48080,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-reference-media-revision-approval-01",
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "title": "docs(seo): record RIASEC reference media revision approval blockers",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -48113,8 +48113,9 @@
         "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed. Composer install and local .env setup were worktree-only and not staged."
       },
       "github": {
-        "status": "pending",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/1943"
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1943",
+        "evidence": "GitHub checks passed on PR #1943: Semgrep, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -48161,7 +48162,7 @@
         "note": "Report-preview and product-availability statements remain Unknown until product confirmation."
       }
     ],
-    "commit_sha": "ae47b780cf38eab5601d0d9e8feec8a11d5fecc3",
+    "commit_sha": "4a31ac4852973b8d12386d4e447f4705775d2f6d",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1943",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -48187,6 +48188,11 @@
         "at": "2026-06-05",
         "status": "pr_open_github_checks_pending",
         "note": "Opened PR #1943 after local checks and scoped staging passed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "All required GitHub checks passed and changed files remain confined to the approval gate artifact/report/test and docs/codex metadata."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -46598,11 +46598,11 @@
     "repo": "fap-api",
     "base": "main",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T03:45:17Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "branch": "codex/seo-article-riasec-v2-reference-source-review-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "title": "docs(seo): verify reference needs for RIASEC explanation package",
     "depends_on": [
       "SEO-ARTICLE-RIASEC-V2-PACKAGE-VALIDATION-01"
@@ -46633,6 +46633,10 @@
       "github": {
         "status": "pass",
         "evidence": "GitHub checks passed on PR #1913: Semgrep, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #1913 is MERGED with merge commit c9b4052705c902f3e718520d19b588a589a183e8; this PR reconciles stale ledger state needed for dependency resolution."
       }
     },
     "result": {
@@ -46679,6 +46683,11 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "notes": "All required GitHub checks passed on PR #1913."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged_reconciled",
+        "note": "Reconciled stale ready_to_merge ledger state after GitHub showed PR #1913 merged at 2026-06-05T03:45:17Z."
       }
     ]
   },
@@ -47913,7 +47922,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-editorial-review-01",
-    "status": "pr_open_github_checks_pending",
+    "status": "merged",
     "title": "docs(seo): record RIASEC draft editorial blockers",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -47983,6 +47992,10 @@
         "status": "pass",
         "evidence": "PR #1937 checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking secrets, Semgrep OSS, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2.",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/1937"
+      },
+      "reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #1937 is MERGED with merge commit cc1184a94d28f7a313c8296371f5989a92929fdf; closeout PR #1938 merged with bbf9b5de0529ac3514bc481e4fc5a49d706a7953."
       }
     },
     "result": {
@@ -48055,6 +48068,116 @@
         "at": "2026-06-05",
         "status": "merged",
         "note": "PR #1937 was squash-merged at 2026-06-05T13:33:02Z with merge commit cc1184a94d28f7a313c8296371f5989a92929fdf; origin/main contains the merge commit; remote task branch is absent; local task branch cleanup is complete."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged_reconciled",
+        "note": "Reconciled stale pr_open_github_checks_pending ledger state after GitHub showed PR #1937 merged and closeout #1938 merged."
+      }
+    ]
+  },
+  "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/seo-article-riasec-v2-reference-media-revision-approval-01",
+    "status": "local_checks_passed",
+    "title": "docs(seo): record RIASEC reference media revision approval blockers",
+    "train_scope": "seo_article_content_package_riasec_explanation_v2",
+    "depends_on": [
+      "SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01 with necessary manifest/state entries, limited to reference/media/revision approval artifacts, publish blockers, operator input checklist, generated artifact/test/ledger. Content rewrite, CMS mutation, publish, search submission, deploy, and private URL access remain forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01 is merged as PR #1937 and closeout #1938 is merged on origin/main."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to the RIASEC approval artifact/report/test and docs/codex PR-train metadata, including stale dependency ledger reconciliation."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationReferenceMediaRevisionApprovalTest --no-ansi",
+          "git diff --check -- backend/docs/seo/riasec-explanation-reference-media-revision-approval.md backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed. Composer install and local .env setup were worktree-only and not staged."
+      }
+    },
+    "result": {
+      "decision": "NO-GO_OPERATOR_INPUTS_REQUIRED",
+      "approval_passed": false,
+      "operator_approval_claimed": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false,
+      "cms_mutation_performed": false,
+      "content_rewrite_performed": false,
+      "generated_artifact": "backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json",
+      "review_report": "backend/docs/seo/riasec-explanation-reference-media-revision-approval.md"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "content_rewrite_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "RIASEC_V2_REFERENCE_ACCEPTANCE_REQUIRED",
+        "status": "blocked_external_operator_input",
+        "note": "Accepted references and claim-to-source mapping are required before CMS draft approval preflight can pass."
+      },
+      {
+        "id": "RIASEC_V2_CMS_MEDIA_REQUIRED",
+        "status": "blocked_external_operator_input",
+        "note": "Reviewed CMS Media Library cover image and alt decision are required before publish preflight can pass."
+      },
+      {
+        "id": "RIASEC_V2_REVISION_APPROVAL_REQUIRED",
+        "status": "blocked_external_operator_input",
+        "note": "zh/en working revisions remain machine_draft and require explicit operator approval or GPT revision loop."
+      },
+      {
+        "id": "RIASEC_V2_PRODUCT_AVAILABILITY_CONFIRMATION_REQUIRED",
+        "status": "blocked_external_operator_input",
+        "note": "Report-preview and product-availability statements remain Unknown until product confirmation."
+      }
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "failure_reason": null,
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized the approval-gate PR with no content rewrite, CMS mutation, publish, search submission, deploy, or private URL access."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Added manifest entry, generated approval artifact, operator checklist report, focused artifact contract test, and dependency ledger reconciliation."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Local validation passed with 6 focused PHPUnit assertions groups / 77 assertions, JSON/YAML parse, PHP lint, and scoped diff checks."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22712,3 +22712,45 @@ prs:
     content_rewrite_allowed: false
     content_authority: CMS/backend
     next_task: SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01 after separate authorization
+
+  - id: SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01
+    repo: fap-api
+    depends_on:
+      - SEO-ARTICLE-RIASEC-V2-EDITORIAL-REVIEW-01
+    branch: codex/seo-article-riasec-v2-reference-media-revision-approval-01
+    title: "docs(seo): record RIASEC reference media revision approval blockers"
+    train_scope: seo_article_content_package_riasec_explanation_v2
+    status: in_progress
+    scope:
+      - Record the reference acceptance, CMS media, revision approval, claim-warning acknowledgement, conditional internal-link, and product-availability gates for the RIASEC V2 zh/en CMS drafts.
+      - Preserve a blocked/no-go publish status until operator/editor inputs are supplied and verified.
+      - Add a generated artifact, human-readable checklist, focused artifact contract test, and necessary PR-train ledger updates.
+    allowed_paths:
+      - backend/docs/seo/riasec-explanation-reference-media-revision-approval.md
+      - backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json
+      - backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite article body/title/H1/meta/FAQ/CTA, mutate CMS, publish, submit search URLs, deploy, or access private result/orders/share/pay/payment/history/tokenized URLs.
+      - Claim operator/editor approval, source acceptance, media readiness, revision approval, or product-availability confirmation without supplied operator evidence.
+    validation:
+      - php -l backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php
+      - python3 -m json.tool backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationReferenceMediaRevisionApprovalTest --no-ansi
+      - git diff --check -- backend/docs/seo/riasec-explanation-reference-media-revision-approval.md backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_rewrite_allowed: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01 after operator inputs and separate authorization


### PR DESCRIPTION
## What changed
- Added the RIASEC V2 reference/media/revision approval gate artifact and operator checklist.
- Added focused PHPUnit coverage for blocked approval gates, Unknown preservation, draft non-public state, public-route-only constraints, and no private identifiers.
- Added the PR-train manifest/state entry and reconciled stale merged dependency ledger facts for #1913/#1937.

## Why
The RIASEC zh/en CMS drafts are created but still blocked before any CMS draft approval preflight or publish preflight. This PR records the missing operator inputs without mutating CMS or rewriting article content.

## Validation
- php -l backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php
- python3 -m json.tool backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationReferenceMediaRevisionApprovalTest --no-ansi
- git diff --check -- backend/docs/seo/riasec-explanation-reference-media-revision-approval.md backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json backend/tests/Feature/SEO/RiasecExplanationReferenceMediaRevisionApprovalTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No CMS mutation, draft update, publish, search submission, deploy, or private URL access.
- CMS draft approval preflight remains blocked until operator inputs are supplied.

## Repository rule impact
Docs/generated/test-only approval gate. CMS/backend remains the authority for article content, media, revisions, publication state, sitemap/llms exposure, and controlled publish.