### PR TITLE
feat(cms): add science content page dry run

### DIFF
--- a/backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php
+++ b/backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php
@@ -1,0 +1,75 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ScienceContentPageDraftDryRunService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ScienceContentPageDraftDryRunCommand extends Command
+{
+    protected $signature = 'content-pages:science-draft-dry-run
+        {--package= : Path to the Science ContentPage CMS draft package directory}
+        {--json : Emit machine-readable JSON only}';
+
+    protected $description = 'Validate the Science ContentPage CMS draft package mapping without writing ContentPage rows.';
+
+    public function handle(ScienceContentPageDraftDryRunService $service): int
+    {
+        try {
+            $package = trim((string) $this->option('package'));
+            if ($package === '') {
+                throw new \RuntimeException('--package is required.');
+            }
+
+            $summary = $service->dryRun($package);
+
+            if ((bool) $this->option('json')) {
+                $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('task='.$summary['task']);
+            $this->line('mode='.$summary['mode']);
+            $this->line('dry_run='.(($summary['dry_run'] ?? false) ? 'true' : 'false'));
+            $this->line('would_write='.(($summary['would_write'] ?? false) ? 'true' : 'false'));
+            $this->line('pages_seen='.$summary['pages_seen']);
+            $this->line('pages_expected='.$summary['pages_expected']);
+            $this->line('pages_ready_for_non_public_draft_import='.$summary['pages_ready_for_non_public_draft_import']);
+            $this->line('pages_blocked='.$summary['pages_blocked']);
+            $this->line('issue_count='.$summary['issue_count']);
+            $this->line('status='.$summary['status']);
+
+            foreach ($summary['pages'] as $page) {
+                $this->line(sprintf(
+                    'page=%s action=%s decision=%s slug=%s kind=%s status=%s public=%s indexable=%s',
+                    (string) ($page['page_key'] ?? 'Unknown'),
+                    (string) ($page['planned_action'] ?? 'Unknown'),
+                    (string) ($page['draft_import_decision'] ?? 'Unknown'),
+                    (string) data_get($page, 'normalized_content_page.slug', 'Unknown'),
+                    (string) data_get($page, 'normalized_content_page.kind', 'Unknown'),
+                    (string) data_get($page, 'normalized_content_page.status', 'Unknown'),
+                    data_get($page, 'normalized_content_page.is_public') === false ? 'false' : 'true',
+                    data_get($page, 'normalized_content_page.is_indexable') === false ? 'false' : 'true',
+                ));
+            }
+
+            if (($summary['issue_count'] ?? 0) > 0) {
+                $this->warn('dry-run completed with blockers; no writes performed.');
+
+                return self::SUCCESS;
+            }
+
+            $this->info('dry-run validation complete; no writes performed.');
+
+            return self::SUCCESS;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php
+++ b/backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php
@@ -1,0 +1,320 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\ContentPage;
+use Symfony\Component\Yaml\Yaml;
+
+final class ScienceContentPageDraftDryRunService
+{
+    private const EXPECTED_PAGE_KEYS = [
+        'SCIENCE-HUB-CONTENT-01',
+        'METHOD-BOUNDARY-CONTENT-01',
+        'ITEM-DESIGN-CONTENT-01',
+        'RELIABILITY-VALIDITY-CONTENT-01',
+        'DATA-NOTES-CONTENT-01',
+        'MISCONCEPTIONS-CONTENT-01',
+    ];
+
+    private const DRAFT_FALSE_FIELDS = [
+        'is_public',
+        'is_indexable',
+        'sitemap_eligible',
+        'llms_eligible',
+        'footer_eligible',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function dryRun(string $packagePath): array
+    {
+        $root = rtrim($packagePath, DIRECTORY_SEPARATOR);
+        if ($root === '' || ! is_dir($root)) {
+            throw new \RuntimeException('Science ContentPage draft package directory does not exist: '.$packagePath);
+        }
+
+        $manifestPath = $root.DIRECTORY_SEPARATOR.'manifest.json';
+        if (! is_file($manifestPath)) {
+            throw new \RuntimeException('manifest.json is required in the package root.');
+        }
+
+        $manifest = $this->readJson($manifestPath);
+        $issues = [];
+        $pages = [];
+
+        $defaults = $manifest['eligibility_defaults'] ?? null;
+        if (! is_array($defaults)) {
+            $issues[] = $this->issue('manifest', 'missing_eligibility_defaults', 'eligibility_defaults is required.');
+        } else {
+            foreach (self::DRAFT_FALSE_FIELDS as $field) {
+                if (($defaults[$field] ?? null) !== false) {
+                    $issues[] = $this->issue('manifest', 'unsafe_default_'.$field, $field.' must default to false.');
+                }
+            }
+        }
+
+        $manifestPages = $manifest['pages'] ?? null;
+        if (! is_array($manifestPages)) {
+            $issues[] = $this->issue('manifest', 'missing_pages', 'manifest pages must be an array.');
+            $manifestPages = [];
+        }
+
+        $seenKeys = [];
+        foreach ($manifestPages as $index => $page) {
+            if (! is_array($page)) {
+                $issues[] = $this->issue('manifest.pages['.$index.']', 'invalid_page_entry', 'page entry must be an object.');
+
+                continue;
+            }
+
+            $pageResult = $this->validatePage($root, $page, $index);
+            $pages[] = $pageResult;
+            $seenKeys[] = (string) ($pageResult['page_key'] ?? '');
+            foreach ($pageResult['issues'] as $issue) {
+                $issues[] = $issue;
+            }
+        }
+
+        $missingKeys = array_values(array_diff(self::EXPECTED_PAGE_KEYS, $seenKeys));
+        foreach ($missingKeys as $missingKey) {
+            $issues[] = $this->issue('manifest', 'missing_expected_page', 'Missing expected page '.$missingKey.'.');
+        }
+
+        $duplicateKeys = $this->duplicates($seenKeys);
+        foreach ($duplicateKeys as $duplicateKey) {
+            $issues[] = $this->issue('manifest', 'duplicate_page_key', 'Duplicate page_key '.$duplicateKey.'.');
+        }
+
+        $blockingPages = array_values(array_filter(
+            $pages,
+            static fn (array $page): bool => ($page['draft_import_decision'] ?? '') !== 'draft_import_ready'
+        ));
+
+        return [
+            'task' => 'SCIENCE-CONTENTPAGE-IMPORTER-DRYRUN-01',
+            'mode' => 'dry_run',
+            'dry_run' => true,
+            'would_write' => false,
+            'database_writes_allowed' => false,
+            'package_path' => $root,
+            'package_status' => (string) ($manifest['status'] ?? 'Unknown'),
+            'pages_seen' => count($pages),
+            'pages_expected' => count(self::EXPECTED_PAGE_KEYS),
+            'pages_ready_for_non_public_draft_import' => count($pages) - count($blockingPages),
+            'pages_blocked' => count($blockingPages),
+            'issue_count' => count($issues),
+            'status' => $issues === [] ? 'pass_no_write_dry_run' : 'blocked_no_write_dry_run',
+            'pages' => $pages,
+            'issues' => $issues,
+            'non_runtime_guarantees' => [
+                'cms_mutation_performed' => false,
+                'content_import_performed' => false,
+                'publish_performed' => false,
+                'sitemap_changed' => false,
+                'llms_changed' => false,
+                'footer_changed' => false,
+                'private_url_accessed' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifestPage
+     * @return array<string, mixed>
+     */
+    private function validatePage(string $root, array $manifestPage, int $index): array
+    {
+        $issues = [];
+        $pageKey = (string) ($manifestPage['page_key'] ?? 'Unknown');
+        $file = (string) ($manifestPage['file'] ?? '');
+        $filePath = $file !== '' ? $root.DIRECTORY_SEPARATOR.str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $file) : '';
+        $frontmatter = [];
+        $body = '';
+
+        if ($file === '') {
+            $issues[] = $this->issue($pageKey, 'missing_file', 'manifest page file is required.');
+        } elseif (! is_file($filePath)) {
+            $issues[] = $this->issue($pageKey, 'page_file_not_found', 'page file does not exist: '.$file);
+        } else {
+            [$frontmatter, $body] = $this->readFrontmatter($filePath);
+        }
+
+        foreach (['page_key', 'proposed_slug', 'page_type', 'kind', 'review_state'] as $requiredField) {
+            if (! array_key_exists($requiredField, $manifestPage)) {
+                $issues[] = $this->issue($pageKey, 'missing_manifest_'.$requiredField, $requiredField.' is required in manifest.');
+            }
+            if ($frontmatter !== [] && ! array_key_exists($requiredField, $frontmatter)) {
+                $issues[] = $this->issue($pageKey, 'missing_frontmatter_'.$requiredField, $requiredField.' is required in page frontmatter.');
+            }
+        }
+
+        foreach (['page_key', 'proposed_slug', 'page_type', 'review_state', 'science_review_required', 'legal_review_required'] as $field) {
+            if (array_key_exists($field, $manifestPage) && array_key_exists($field, $frontmatter)
+                && $manifestPage[$field] !== $frontmatter[$field]) {
+                $issues[] = $this->issue($pageKey, 'manifest_frontmatter_mismatch_'.$field, $field.' differs between manifest and page frontmatter.');
+            }
+        }
+
+        foreach (self::DRAFT_FALSE_FIELDS as $field) {
+            if (($manifestPage[$field] ?? false) !== false && ($frontmatter[$field] ?? false) !== false) {
+                $issues[] = $this->issue($pageKey, 'unsafe_'.$field, $field.' must remain false for dry-run import.');
+            }
+        }
+
+        $pageType = (string) ($manifestPage['page_type'] ?? '');
+        if (! in_array($pageType, ContentPage::PAGE_TYPES, true)) {
+            $issues[] = $this->issue($pageKey, 'unsupported_page_type', 'Unsupported ContentPage page_type '.$pageType.'.');
+        }
+
+        $reviewState = (string) ($manifestPage['review_state'] ?? '');
+        if (! in_array($reviewState, ContentPage::REVIEW_STATES, true)) {
+            $issues[] = $this->issue($pageKey, 'unsupported_review_state', 'Unsupported ContentPage review_state '.$reviewState.'.');
+        }
+
+        $proposedPath = $this->normalizePath((string) ($manifestPage['proposed_slug'] ?? ''));
+        $fallbackPath = $this->normalizePath((string) ($manifestPage['fallback_slug'] ?? ($frontmatter['fallback_slug_if_nested_route_not_supported'] ?? '')));
+        $canonicalPath = $this->chooseCanonicalPath($pageKey, $proposedPath, $fallbackPath);
+        if ($canonicalPath === '') {
+            $issues[] = $this->issue($pageKey, 'missing_canonical_path', 'A public canonical candidate path is required.');
+        }
+
+        if ($this->hasPrivateRouteReference($body) || $this->hasPrivateRouteReference(json_encode($manifestPage, JSON_UNESCAPED_SLASHES) ?: '')) {
+            $issues[] = $this->issue($pageKey, 'private_route_pattern_present', 'Private route patterns may only appear as blocked metadata, not body/internal links.');
+        }
+
+        $metadataOnlyFields = [];
+        foreach (['sitemap_eligible', 'llms_eligible', 'footer_eligible', 'visible_faq_items', 'claim_boundary_notes', 'reviewer_checklist', 'publish_blockers', 'unknown_fields'] as $field) {
+            if (str_contains($body, $field.':') || array_key_exists($field, $manifestPage) || array_key_exists($field, $frontmatter)) {
+                $metadataOnlyFields[] = $field;
+            }
+        }
+
+        $normalized = [
+            'org_id' => 0,
+            'slug' => ltrim($canonicalPath, '/'),
+            'path' => $canonicalPath,
+            'canonical_path' => $canonicalPath,
+            'kind' => ContentPage::KIND_POLICY,
+            'source_kind' => (string) ($manifestPage['kind'] ?? 'Unknown'),
+            'page_type' => $pageType,
+            'locale' => 'zh-CN',
+            'title_source_field' => 'zh_title',
+            'template' => 'policy',
+            'animation_profile' => 'editorial',
+            'status' => ContentPage::STATUS_DRAFT,
+            'review_state' => $reviewState,
+            'science_review_required' => (bool) ($manifestPage['science_review_required'] ?? false),
+            'legal_review_required' => (bool) ($manifestPage['legal_review_required'] ?? false),
+            'is_public' => false,
+            'is_indexable' => false,
+            'seo_title_source_field' => 'meta_title_draft',
+            'meta_description_source_field' => 'meta_description_draft',
+            'content_md_source' => 'page_markdown_body',
+            'metadata_only_not_content_page_fields' => array_values(array_unique($metadataOnlyFields)),
+        ];
+
+        $action = 'create_non_public_draft';
+        $decision = 'draft_import_ready';
+        if ($canonicalPath === '/method-boundaries') {
+            $action = 'reconcile_existing_authority_only';
+            $decision = 'blocked_existing_authority_reconciliation_required';
+        }
+        if ($issues !== [] && $decision === 'draft_import_ready') {
+            $decision = 'blocked_schema_or_package_validation';
+        }
+
+        return [
+            'index' => $index,
+            'page_key' => $pageKey,
+            'file' => $file,
+            'draft_import_decision' => $decision,
+            'planned_action' => $action,
+            'normalized_content_page' => $normalized,
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Invalid JSON file: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function readFrontmatter(string $path): array
+    {
+        $content = (string) file_get_contents($path);
+        if (! preg_match('/\A---\R(?P<yaml>.*?)\R---\R(?P<body>.*)\z/s', $content, $matches)) {
+            throw new \RuntimeException('Page file is missing YAML frontmatter: '.$path);
+        }
+
+        $frontmatter = Yaml::parse((string) $matches['yaml']);
+        if (! is_array($frontmatter)) {
+            throw new \RuntimeException('Page frontmatter must parse to an object: '.$path);
+        }
+
+        return [$frontmatter, (string) $matches['body']];
+    }
+
+    private function normalizePath(string $path): string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '';
+        }
+
+        return '/'.trim($path, '/');
+    }
+
+    private function chooseCanonicalPath(string $pageKey, string $proposedPath, string $fallbackPath): string
+    {
+        if ($pageKey === 'DATA-NOTES-CONTENT-01' && $fallbackPath === '/data-privacy') {
+            return $fallbackPath;
+        }
+
+        return $proposedPath !== '' ? $proposedPath : $fallbackPath;
+    }
+
+    private function hasPrivateRouteReference(string $value): bool
+    {
+        $bodyWithoutForbiddenList = preg_replace('/forbidden_routes:\s*(?:(?:\r?\n)\s*-\s*[^\r\n]+)+/m', '', $value) ?? $value;
+
+        return preg_match('#/(?:results?/|orders?\b|pay\b|payment\b|checkout\b|share/|history\b)#i', $bodyWithoutForbiddenList) === 1
+            || preg_match('/(?:token=|orderNo=|payment_intent=)/i', $bodyWithoutForbiddenList) === 1;
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function duplicates(array $values): array
+    {
+        $counts = array_count_values(array_filter($values, static fn (string $value): bool => $value !== ''));
+
+        return array_values(array_keys(array_filter($counts, static fn (int $count): bool => $count > 1)));
+    }
+
+    /**
+     * @return array{scope: string, code: string, message: string}
+     */
+    private function issue(string $scope, string $code, string $message): array
+    {
+        return [
+            'scope' => $scope,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php
@@ -1,0 +1,225 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\ContentPage;
+use App\Services\Cms\ScienceContentPageDraftDryRunService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ScienceContentPageDraftDryRunCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function dry_run_maps_six_science_pages_without_database_writes(): void
+    {
+        $package = $this->writeSciencePackage();
+
+        $this->artisan('content-pages:science-draft-dry-run', [
+            '--package' => $package,
+        ])
+            ->expectsOutputToContain('task=SCIENCE-CONTENTPAGE-IMPORTER-DRYRUN-01')
+            ->expectsOutputToContain('dry_run=true')
+            ->expectsOutputToContain('would_write=false')
+            ->expectsOutputToContain('pages_seen=6')
+            ->expectsOutputToContain('pages_ready_for_non_public_draft_import=5')
+            ->expectsOutputToContain('pages_blocked=1')
+            ->expectsOutputToContain('page=METHOD-BOUNDARY-CONTENT-01 action=reconcile_existing_authority_only decision=blocked_existing_authority_reconciliation_required')
+            ->expectsOutputToContain('kind=policy status=draft public=false indexable=false')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    #[Test]
+    public function json_output_preserves_no_write_flags_and_metadata_only_fields(): void
+    {
+        $package = $this->writeSciencePackage();
+
+        $this->artisan('content-pages:science-draft-dry-run', [
+            '--package' => $package,
+            '--json' => true,
+        ])->assertExitCode(0);
+
+        $payload = app(ScienceContentPageDraftDryRunService::class)->dryRun($package);
+
+        $this->assertIsArray($payload);
+        $this->assertSame('pass_no_write_dry_run', $payload['status']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertFalse($payload['database_writes_allowed']);
+        $this->assertSame(6, $payload['pages_seen']);
+        $this->assertSame(5, $payload['pages_ready_for_non_public_draft_import']);
+        $this->assertSame(1, $payload['pages_blocked']);
+        $this->assertFalse($payload['non_runtime_guarantees']['cms_mutation_performed']);
+
+        $scienceHub = collect($payload['pages'])->firstWhere('page_key', 'SCIENCE-HUB-CONTENT-01');
+        $this->assertSame('policy', $scienceHub['normalized_content_page']['kind']);
+        $this->assertSame('trust_methodology_hub', $scienceHub['normalized_content_page']['source_kind']);
+        $this->assertSame('draft', $scienceHub['normalized_content_page']['status']);
+        $this->assertFalse($scienceHub['normalized_content_page']['is_public']);
+        $this->assertFalse($scienceHub['normalized_content_page']['is_indexable']);
+        $this->assertContains('visible_faq_items', $scienceHub['normalized_content_page']['metadata_only_not_content_page_fields']);
+        $this->assertContains('sitemap_eligible', $scienceHub['normalized_content_page']['metadata_only_not_content_page_fields']);
+
+        $dataNotes = collect($payload['pages'])->firstWhere('page_key', 'DATA-NOTES-CONTENT-01');
+        $this->assertSame('data-privacy', $dataNotes['normalized_content_page']['slug']);
+
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    #[Test]
+    public function dry_run_blocks_unsafe_defaults_without_writing(): void
+    {
+        $package = $this->writeSciencePackage([
+            'eligibility_defaults' => [
+                'is_public' => true,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'footer_eligible' => false,
+            ],
+        ]);
+
+        $this->artisan('content-pages:science-draft-dry-run', [
+            '--package' => $package,
+        ])
+            ->expectsOutputToContain('issue_count=1')
+            ->expectsOutputToContain('status=blocked_no_write_dry_run')
+            ->expectsOutputToContain('dry-run completed with blockers; no writes performed.')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifestOverrides
+     */
+    private function writeSciencePackage(array $manifestOverrides = []): string
+    {
+        $root = storage_path('framework/testing/science-contentpage-dry-run-'.str()->uuid());
+        $pagesDir = $root.DIRECTORY_SEPARATOR.'pages';
+        mkdir($pagesDir, 0777, true);
+
+        $pages = [
+            ['SCIENCE-HUB-CONTENT-01', '/science', 'science', 'trust_methodology_hub', 'science_review', true, true, '01-science-hub-content-01.md'],
+            ['METHOD-BOUNDARY-CONTENT-01', '/method-boundaries', 'boundary', 'trust_methodology_boundary', 'science_review', true, true, '02-method-boundary-content-01.md'],
+            ['ITEM-DESIGN-CONTENT-01', '/item-design-notes', 'methodology', 'item_design_notes', 'science_review', true, false, '03-item-design-content-01.md'],
+            ['RELIABILITY-VALIDITY-CONTENT-01', '/reliability-validity', 'methodology', 'evidence_measurement_error', 'science_review', true, false, '04-reliability-validity-content-01.md'],
+            ['DATA-NOTES-CONTENT-01', '/data-results-notes', 'privacy', 'data_results_notes', 'owner_review', false, true, '05-data-notes-content-01.md', '/data-privacy'],
+            ['MISCONCEPTIONS-CONTENT-01', '/common-misconceptions', 'boundary', 'misconceptions', 'science_review', true, false, '06-misconceptions-content-01.md'],
+        ];
+
+        $manifestPages = [];
+        foreach ($pages as $page) {
+            [$key, $slug, $pageType, $kind, $reviewState, $scienceReview, $legalReview, $file] = $page;
+            $fallback = $page[8] ?? $slug;
+            $manifestPages[] = [
+                'page_key' => $key,
+                'zh_title' => 'Draft '.$key,
+                'en_title' => 'Draft '.$key,
+                'proposed_slug' => $slug,
+                'fallback_slug' => $fallback,
+                'page_type' => $pageType,
+                'kind' => $kind,
+                'review_state' => $reviewState,
+                'science_review_required' => $scienceReview,
+                'legal_review_required' => $legalReview,
+                'file' => 'pages/'.$file,
+            ];
+
+            file_put_contents($pagesDir.DIRECTORY_SEPARATOR.$file, $this->pageMarkdown(
+                $key,
+                $slug,
+                $fallback,
+                $pageType,
+                $kind,
+                $reviewState,
+                $scienceReview,
+                $legalReview,
+            ));
+        }
+
+        $manifest = array_replace_recursive([
+            'package' => 'FermatMind Science / Methodology CMS Draft Package',
+            'status' => 'draft_only_not_for_publication',
+            'eligibility_defaults' => [
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'footer_eligible' => false,
+            ],
+            'pages' => $manifestPages,
+        ], $manifestOverrides);
+
+        file_put_contents($root.DIRECTORY_SEPARATOR.'manifest.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    private function pageMarkdown(
+        string $key,
+        string $slug,
+        string $fallback,
+        string $pageType,
+        string $kind,
+        string $reviewState,
+        bool $scienceReview,
+        bool $legalReview,
+    ): string {
+        $science = $scienceReview ? 'true' : 'false';
+        $legal = $legalReview ? 'true' : 'false';
+
+        return <<<MD
+---
+page_key: {$key}
+zh_title: Draft {$key}
+en_title: Draft {$key}
+proposed_slug: {$slug}
+fallback_slug_if_nested_route_not_supported: {$fallback}
+page_type: {$pageType}
+kind: {$kind}
+review_state: {$reviewState}
+science_review_required: {$science}
+legal_review_required: {$legal}
+is_public: false
+is_indexable: false
+sitemap_eligible: false
+llms_eligible: false
+footer_eligible: false
+meta_title_draft: Draft meta
+meta_description_draft: Draft description.
+h1: Draft heading
+internal_links_allowed:
+  - /tests
+  - /privacy
+forbidden_routes:
+  - /result/*
+  - /orders/*
+unknown_fields:
+  - public_validation_report_url
+---
+
+# content_md
+
+## Draft body
+
+This is draft-only explanatory content for importer validation.
+
+visible_faq_items:
+  - question: Is this publishable?
+    answer: No. This fixture is draft-only.
+
+claim_boundary_notes:
+  - Keep claims conservative.
+
+reviewer_checklist:
+  - Confirm review gates.
+MD;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -938,6 +938,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_science_content_page_draft_dry_run_importer_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
+            'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_content_pages_controlled_publish_runtime_files(): void
     {
         $changed = [
@@ -2818,6 +2828,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isScienceContentPageDraftDryRunImporterFile($file)) {
+                continue;
+            }
+
             if ($this->isContentPagesControlledPublishRuntimeFile($file)) {
                 continue;
             }
@@ -3769,6 +3783,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isContentPagesLocalBaselineImportPackageFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/ContentPagesImportLocalBaseline.php';
+    }
+
+    private function isScienceContentPageDraftDryRunImporterFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
+            'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
+        ], true);
     }
 
     private function isContentPagesControlledPublishRuntimeFile(string $file): bool


### PR DESCRIPTION
## What changed
- Added a no-write `content-pages:science-draft-dry-run` Artisan command for the six Science ContentPage CMS draft files.
- Added a dry-run service that maps package frontmatter/manifest fields to existing `ContentPage` fields without database writes.
- Added feature tests proving the command preserves draft-only state, blocks unsafe defaults, and leaves `content_pages` empty.

## Why
This is the backend importer dry-run gate before any Science ContentPage CMS import. It verifies slug/locale/body/FAQ/CTA/review state/claim metadata/SEO field mapping while keeping CMS mutation, DB writes, import, publish, sitemap, llms, and footer exposure disabled.

## Real package dry-run result
Command:

```bash
php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2' --json
```

Result summary:
- `pages_seen=6`
- `pages_ready_for_non_public_draft_import=5`
- `pages_blocked=1`
- `would_write=false`
- `database_writes_allowed=false`
- `/method-boundaries` is blocked as `reconcile_existing_authority_only`
- `DATA-NOTES-CONTENT-01` maps to fallback slug `/data-privacy`
- unsupported draft `kind` values normalize to backend `policy` while preserving `source_kind`

## Validation
- `php artisan test --filter ScienceContentPageDraftDryRunCommandTest --compact --display-warnings`
- `./vendor/bin/pint --test app/Services/Cms/ScienceContentPageDraftDryRunService.php app/Console/Commands/ScienceContentPageDraftDryRunCommand.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php`
- `php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2' --json`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --cached --check`

## Intentionally deferred
- CMS operator review readiness gate.
- Pre-real-import QA gate for claims, private URLs, visible FAQ/schema eligibility, CTA route safety, and discoverability exclusion.
- No CMS mutation, real import, publish, deployment, sitemap/llms/footer changes, or production data access in this PR.
