### PR TITLE
docs(codex): close Help contact support decision ledger

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45330,7 +45330,7 @@
     "repo": "fap-api",
     "branch": "codex/help-contact-support-decision-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help direct email support decision",
     "depends_on": [
@@ -45378,16 +45378,27 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "checks": []
+        "status": "pass",
+        "checks": [
+          "hygiene",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN"
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "0ba72097997e920dd1c1c2e38a1158a6bf993c68",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1942",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T14:40:52Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "DIRECT_EMAIL_SUPPORT_CONTACT_SELECTED_WITH_PUBLISH_STILL_BLOCKED",
       "generated_artifact": "backend/docs/help/generated/help-content-draft-contact-support-decision-01.v1.json",
@@ -45446,6 +45457,16 @@
         "at": "2026-06-05",
         "status": "pr_opened",
         "note": "Opened PR #1942 for HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN. Scope remained docs/ledger only; no CMS mutation or publish was performed."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "merged_closeout_reconciled",
+        "note": "PR #1942 merged on GitHub at 2026-06-05T14:40:52Z with merge commit 0ba72097997e920dd1c1c2e38a1158a6bf993c68; origin/main contains the merge commit; remote branch was deleted and local cleanup was complete."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21823,7 +21823,7 @@ prs:
     branch: codex/help-contact-support-decision-01
     title: "docs(help): record Help direct email support decision"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     depends_on:
       - HELP-CONTENT-DRAFT-POLICY-OWNER-ANSWERS-01
     scope:


### PR DESCRIPTION
## What changed
- Reconciled HELP-CONTENT-DRAFT-CONTACT-SUPPORT-DECISION-01 after PR #1942 merged.
- Marked the manifest/state entry merged and recorded GitHub checks, merge commit, remote branch deletion, and local cleanup.

## Why
- The next Help service PR depends on this train item being closed in the ledger.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or Operator approval claim.

## Repository rule impact
- Ledger-only closeout. Content authority remains CMS/backend.