### PR TITLE
SCIENCE-CONTENTPAGE-OPERATOR-REVIEW-01: add operator review readiness gate

### DIFF
--- a/backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php
+++ b/backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php
@@ -1,0 +1,57 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ScienceContentPageOperatorReviewReadinessService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ScienceContentPageOperatorReviewReadinessCommand extends Command
+{
+    protected $signature = 'content-pages:science-operator-review-readiness
+        {--package= : Optional path to the Science ContentPage CMS draft package directory}
+        {--json : Emit machine-readable JSON only}';
+
+    protected $description = 'Read-only check for Science ContentPage CMS operator review field readiness.';
+
+    public function handle(ScienceContentPageOperatorReviewReadinessService $service): int
+    {
+        try {
+            $package = trim((string) $this->option('package'));
+            $summary = $service->review($package !== '' ? $package : null);
+
+            if ((bool) $this->option('json')) {
+                $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('task='.$summary['task']);
+            $this->line('mode='.$summary['mode']);
+            $this->line('decision='.$summary['decision']);
+            $this->line('cms_mutation_performed='.(($summary['cms_mutation_performed'] ?? true) ? 'true' : 'false'));
+            $this->line('database_writes_allowed='.(($summary['database_writes_allowed'] ?? true) ? 'true' : 'false'));
+            $this->line('content_import_performed='.(($summary['content_import_performed'] ?? true) ? 'true' : 'false'));
+            $this->line('publish_performed='.(($summary['publish_performed'] ?? true) ? 'true' : 'false'));
+            $this->line('operator_review_ready_for_non_public_draft='.(($summary['operator_review_ready_for_non_public_draft'] ?? false) ? 'true' : 'false'));
+            $this->line('operator_publish_decision_ready='.(($summary['operator_publish_decision_ready'] ?? true) ? 'true' : 'false'));
+            $this->line('publish_allowed_default='.(($summary['publish_allowed_default'] ?? true) ? 'true' : 'false'));
+            $this->line('draft_pages_reviewable='.data_get($summary, 'draft_package.pages_reviewable_as_non_public_draft', 'Unknown'));
+            $this->line('draft_pages_requiring_authority_reconciliation='.data_get($summary, 'draft_package.pages_requiring_authority_reconciliation', 'Unknown'));
+
+            foreach (($summary['missing_first_class_publish_safety_fields'] ?? []) as $field) {
+                $this->line('missing_first_class_publish_safety_field='.$field);
+            }
+
+            $this->warn((string) $summary['reason']);
+
+            return self::SUCCESS;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php
+++ b/backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php
@@ -1,0 +1,262 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Filament\Ops\Resources\ContentPageResource;
+use App\Models\ContentPage;
+use ReflectionClass;
+
+final class ScienceContentPageOperatorReviewReadinessService
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function review(?string $packagePath = null): array
+    {
+        $draftDryRun = null;
+        if ($packagePath !== null && trim($packagePath) !== '') {
+            $draftDryRun = app(ScienceContentPageDraftDryRunService::class)->dryRun($packagePath);
+        }
+
+        $model = new ContentPage;
+        $fillable = $model->getFillable();
+        $casts = $model->getCasts();
+        $resourceSource = $this->sourceFor(ContentPageResource::class);
+        $controllerSource = $this->sourceFor(\App\Http\Controllers\API\V0_5\Cms\ContentPageController::class);
+        $editPageSource = $this->sourceFor(\App\Filament\Ops\Resources\ContentPageResource\Pages\EditContentPage::class);
+
+        $coreFields = $this->fieldStatus([
+            'slug',
+            'path',
+            'locale',
+            'kind',
+            'page_type',
+            'title',
+            'content_md',
+            'content_html',
+            'seo_title',
+            'meta_description',
+            'seo_description',
+            'canonical_path',
+            'status',
+            'review_state',
+            'owner',
+            'legal_review_required',
+            'science_review_required',
+            'last_reviewed_at',
+            'published_at',
+            'is_public',
+            'is_indexable',
+            'source_doc',
+        ], $fillable);
+
+        $reviewStates = $this->fieldStatus([
+            ContentPage::STATUS_DRAFT,
+            ContentPage::STATUS_PUBLISHED,
+            'owner_review',
+            'legal_review',
+            'science_review',
+            'approved',
+            'changes_requested',
+        ], array_merge(
+            [ContentPage::STATUS_DRAFT, ContentPage::STATUS_SCHEDULED, ContentPage::STATUS_PUBLISHED, ContentPage::STATUS_ARCHIVED],
+            ContentPage::REVIEW_STATES,
+        ));
+
+        $booleanCasts = $this->fieldStatus([
+            'legal_review_required',
+            'science_review_required',
+            'is_public',
+            'is_indexable',
+        ], array_keys(array_filter(
+            $casts,
+            static fn (string $cast): bool => $cast === 'boolean',
+        )));
+
+        $resourceFields = $this->sourceTokenStatus([
+            'status',
+            'review_state',
+            'is_public',
+            'is_indexable',
+            'legal_review_required',
+            'science_review_required',
+            'last_reviewed_at',
+            'published_at',
+            'owner',
+            'source_doc',
+            'content_md',
+            'seo_title',
+            'meta_description',
+            'seo_description',
+            'canonical_path',
+            'ops_publish_readiness',
+        ], $resourceSource);
+
+        $editPersistence = $this->sourceTokenStatus([
+            'status',
+            'review_state',
+            'is_public',
+            'is_indexable',
+            'legal_review_required',
+            'science_review_required',
+            'last_reviewed_at',
+            'published_at',
+            'owner',
+            'source_doc',
+            'content_md',
+            'seo_title',
+            'meta_description',
+            'seo_description',
+            'canonical_path',
+        ], $editPageSource);
+
+        $internalApiFields = $this->sourceTokenStatus([
+            'status',
+            'review_state',
+            'is_public',
+            'is_indexable',
+            'legal_review_required',
+            'science_review_required',
+            'last_reviewed_at',
+            'published_at',
+            'owner',
+            'content_md',
+            'seo_title',
+            'meta_description',
+            'seo_description',
+            'canonical_path',
+        ], $controllerSource);
+
+        $missingFirstClass = [
+            'publish_allowed',
+            'operator_approval_required',
+            'operator_approved_at',
+            'claim_gate_status',
+            'forbidden_claims',
+            'faq_schema_eligible',
+            'schema_eligibility_reviewed_at',
+        ];
+
+        $draftPagesReviewable = $draftDryRun === null
+            ? 'Unknown'
+            : (int) ($draftDryRun['pages_ready_for_non_public_draft_import'] ?? 0);
+        $reconciliationPages = $draftDryRun === null
+            ? 'Unknown'
+            : (int) ($draftDryRun['pages_blocked'] ?? 0);
+
+        $coreReady = $this->allPresent($coreFields)
+            && $this->allPresent($reviewStates)
+            && $this->allPresent($booleanCasts)
+            && $this->allPresent($resourceFields)
+            && $this->allPresent($editPersistence)
+            && $this->allPresent($internalApiFields);
+
+        return [
+            'task' => 'SCIENCE-CONTENTPAGE-OPERATOR-REVIEW-01',
+            'mode' => 'read_only_operator_review_gate',
+            'cms_mutation_performed' => false,
+            'database_writes_allowed' => false,
+            'content_import_performed' => false,
+            'publish_performed' => false,
+            'package_path' => $packagePath !== null && trim($packagePath) !== '' ? rtrim($packagePath, DIRECTORY_SEPARATOR) : 'Unknown',
+            'draft_package' => [
+                'status' => $draftDryRun['status'] ?? 'Unknown',
+                'pages_seen' => $draftDryRun['pages_seen'] ?? 'Unknown',
+                'pages_reviewable_as_non_public_draft' => $draftPagesReviewable,
+                'pages_requiring_authority_reconciliation' => $reconciliationPages,
+                'would_write' => $draftDryRun['would_write'] ?? false,
+            ],
+            'operator_review_ready_for_non_public_draft' => $coreReady,
+            'operator_publish_decision_ready' => false,
+            'publish_allowed_default' => false,
+            'natural_distribution_allowed' => false,
+            'decision' => $coreReady ? 'CONDITIONAL' : 'NO-GO',
+            'reason' => $coreReady
+                ? 'Core ContentPage review fields and CMS/API editing surfaces exist, but publish/claim/schema approval remains metadata or external QA rather than first-class CMS fields.'
+                : 'Core ContentPage review fields or editing surfaces are missing.',
+            'capabilities' => [
+                'content_page_core_fields' => $coreFields,
+                'review_states' => $reviewStates,
+                'boolean_review_casts' => $booleanCasts,
+                'filament_operator_fields' => $resourceFields,
+                'filament_edit_persistence' => $editPersistence,
+                'internal_api_fields' => $internalApiFields,
+            ],
+            'missing_first_class_publish_safety_fields' => $missingFirstClass,
+            'operator_must_check_before_publish' => [
+                'review_state_is_approved',
+                'science_review_required_resolved',
+                'legal_review_required_resolved',
+                'claim_gate_passed',
+                'faq_schema_visible_only',
+                'private_url_absent',
+                'cta_public_canonical_only',
+                'sitemap_llms_footer_remain_false_until_final_gate',
+            ],
+            'hard_no_go' => [
+                'no_cms_mutation',
+                'no_real_import',
+                'no_publish',
+                'no_private_url',
+                'no_schema_eligibility_without_visible_faq',
+                'no_claim_gate_bypass',
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $fields
+     * @param  list<string>  $available
+     * @return array<string, array{present: bool}>
+     */
+    private function fieldStatus(array $fields, array $available): array
+    {
+        $status = [];
+        foreach ($fields as $field) {
+            $status[$field] = ['present' => in_array($field, $available, true)];
+        }
+
+        return $status;
+    }
+
+    /**
+     * @param  list<string>  $tokens
+     * @return array<string, array{present: bool}>
+     */
+    private function sourceTokenStatus(array $tokens, string $source): array
+    {
+        $status = [];
+        foreach ($tokens as $token) {
+            $status[$token] = ['present' => $source !== '' && str_contains($source, $token)];
+        }
+
+        return $status;
+    }
+
+    /**
+     * @param  array<string, array{present: bool}>  $status
+     */
+    private function allPresent(array $status): bool
+    {
+        foreach ($status as $field) {
+            if (($field['present'] ?? false) !== true) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    private function sourceFor(string $class): string
+    {
+        $reflection = new ReflectionClass($class);
+        $file = $reflection->getFileName();
+        if (! is_string($file) || ! is_file($file)) {
+            return '';
+        }
+
+        return file_get_contents($file) ?: '';
+    }
+}

--- a/backend/tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\ContentPage;
+use App\Services\Cms\ScienceContentPageOperatorReviewReadinessService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ScienceContentPageOperatorReviewReadinessCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function operator_review_readiness_is_conditional_and_does_not_write_content_pages(): void
+    {
+        $package = $this->writeSciencePackage();
+
+        $this->artisan('content-pages:science-operator-review-readiness', [
+            '--package' => $package,
+        ])
+            ->expectsOutputToContain('task=SCIENCE-CONTENTPAGE-OPERATOR-REVIEW-01')
+            ->expectsOutputToContain('mode=read_only_operator_review_gate')
+            ->expectsOutputToContain('decision=CONDITIONAL')
+            ->expectsOutputToContain('cms_mutation_performed=false')
+            ->expectsOutputToContain('database_writes_allowed=false')
+            ->expectsOutputToContain('content_import_performed=false')
+            ->expectsOutputToContain('publish_performed=false')
+            ->expectsOutputToContain('operator_review_ready_for_non_public_draft=true')
+            ->expectsOutputToContain('operator_publish_decision_ready=false')
+            ->expectsOutputToContain('publish_allowed_default=false')
+            ->expectsOutputToContain('draft_pages_reviewable=5')
+            ->expectsOutputToContain('draft_pages_requiring_authority_reconciliation=1')
+            ->expectsOutputToContain('missing_first_class_publish_safety_field=publish_allowed')
+            ->expectsOutputToContain('missing_first_class_publish_safety_field=claim_gate_status')
+            ->expectsOutputToContain('missing_first_class_publish_safety_field=faq_schema_eligible')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    #[Test]
+    public function json_payload_distinguishes_draft_review_readiness_from_publish_decision_readiness(): void
+    {
+        $package = $this->writeSciencePackage();
+
+        $payload = app(ScienceContentPageOperatorReviewReadinessService::class)->review($package);
+
+        $this->assertSame('SCIENCE-CONTENTPAGE-OPERATOR-REVIEW-01', $payload['task']);
+        $this->assertSame('CONDITIONAL', $payload['decision']);
+        $this->assertTrue($payload['operator_review_ready_for_non_public_draft']);
+        $this->assertFalse($payload['operator_publish_decision_ready']);
+        $this->assertFalse($payload['publish_allowed_default']);
+        $this->assertFalse($payload['natural_distribution_allowed']);
+        $this->assertSame(5, $payload['draft_package']['pages_reviewable_as_non_public_draft']);
+        $this->assertSame(1, $payload['draft_package']['pages_requiring_authority_reconciliation']);
+        $this->assertFalse($payload['draft_package']['would_write']);
+
+        foreach (['review_state', 'science_review_required', 'legal_review_required', 'is_public', 'is_indexable'] as $field) {
+            $this->assertTrue($payload['capabilities']['content_page_core_fields'][$field]['present']);
+            $this->assertTrue($payload['capabilities']['filament_operator_fields'][$field]['present']);
+            $this->assertTrue($payload['capabilities']['internal_api_fields'][$field]['present']);
+        }
+
+        $this->assertContains('operator_approval_required', $payload['missing_first_class_publish_safety_fields']);
+        $this->assertContains('claim_gate_status', $payload['missing_first_class_publish_safety_fields']);
+        $this->assertContains('faq_schema_eligible', $payload['missing_first_class_publish_safety_fields']);
+        $this->assertContains('sitemap_llms_footer_remain_false_until_final_gate', $payload['operator_must_check_before_publish']);
+        $this->assertContains('no_real_import', $payload['hard_no_go']);
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    private function writeSciencePackage(): string
+    {
+        $root = storage_path('framework/testing/science-contentpage-operator-review-'.str()->uuid());
+        $pagesDir = $root.DIRECTORY_SEPARATOR.'pages';
+        mkdir($pagesDir, 0777, true);
+
+        $pages = [
+            ['SCIENCE-HUB-CONTENT-01', '/science', 'science', 'trust_methodology_hub', 'science_review', true, true, '01-science-hub-content-01.md'],
+            ['METHOD-BOUNDARY-CONTENT-01', '/method-boundaries', 'boundary', 'trust_methodology_boundary', 'science_review', true, true, '02-method-boundary-content-01.md'],
+            ['ITEM-DESIGN-CONTENT-01', '/item-design-notes', 'methodology', 'item_design_notes', 'science_review', true, false, '03-item-design-content-01.md'],
+            ['RELIABILITY-VALIDITY-CONTENT-01', '/reliability-validity', 'methodology', 'evidence_measurement_error', 'science_review', true, false, '04-reliability-validity-content-01.md'],
+            ['DATA-NOTES-CONTENT-01', '/data-results-notes', 'privacy', 'data_results_notes', 'owner_review', false, true, '05-data-notes-content-01.md', '/data-privacy'],
+            ['MISCONCEPTIONS-CONTENT-01', '/common-misconceptions', 'boundary', 'misconceptions', 'science_review', true, false, '06-misconceptions-content-01.md'],
+        ];
+
+        $manifestPages = [];
+        foreach ($pages as $page) {
+            [$key, $slug, $pageType, $kind, $reviewState, $scienceReview, $legalReview, $file] = $page;
+            $fallback = $page[8] ?? $slug;
+            $manifestPages[] = [
+                'page_key' => $key,
+                'zh_title' => 'Draft '.$key,
+                'en_title' => 'Draft '.$key,
+                'proposed_slug' => $slug,
+                'fallback_slug' => $fallback,
+                'page_type' => $pageType,
+                'kind' => $kind,
+                'review_state' => $reviewState,
+                'science_review_required' => $scienceReview,
+                'legal_review_required' => $legalReview,
+                'file' => 'pages/'.$file,
+            ];
+
+            file_put_contents($pagesDir.DIRECTORY_SEPARATOR.$file, $this->pageMarkdown(
+                $key,
+                $slug,
+                $fallback,
+                $pageType,
+                $kind,
+                $reviewState,
+                $scienceReview,
+                $legalReview,
+            ));
+        }
+
+        file_put_contents($root.DIRECTORY_SEPARATOR.'manifest.json', json_encode([
+            'package' => 'FermatMind Science / Methodology CMS Draft Package',
+            'status' => 'draft_only_not_for_publication',
+            'eligibility_defaults' => [
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'footer_eligible' => false,
+            ],
+            'pages' => $manifestPages,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    private function pageMarkdown(
+        string $key,
+        string $slug,
+        string $fallback,
+        string $pageType,
+        string $kind,
+        string $reviewState,
+        bool $scienceReview,
+        bool $legalReview,
+    ): string {
+        $science = $scienceReview ? 'true' : 'false';
+        $legal = $legalReview ? 'true' : 'false';
+
+        return <<<MD
+---
+page_key: {$key}
+zh_title: Draft {$key}
+en_title: Draft {$key}
+proposed_slug: {$slug}
+fallback_slug_if_nested_route_not_supported: {$fallback}
+page_type: {$pageType}
+kind: {$kind}
+review_state: {$reviewState}
+science_review_required: {$science}
+legal_review_required: {$legal}
+is_public: false
+is_indexable: false
+sitemap_eligible: false
+llms_eligible: false
+footer_eligible: false
+meta_title_draft: Draft meta
+meta_description_draft: Draft description.
+internal_links_allowed:
+  - /tests
+  - /privacy
+forbidden_routes:
+  - /result/*
+  - /orders/*
+---
+
+# content_md
+
+Draft-only body for operator review readiness validation.
+
+visible_faq_items:
+  - question: Is this publishable?
+    answer: No. This fixture is draft-only.
+
+claim_boundary_notes:
+  - Keep claims conservative.
+
+reviewer_checklist:
+  - Confirm review gates.
+MD;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -938,11 +938,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
-    public function test_runtime_freeze_classifier_ignores_science_content_page_draft_dry_run_importer_files(): void
+    public function test_runtime_freeze_classifier_ignores_science_content_page_no_write_gate_files(): void
     {
         $changed = [
             'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
+            'backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php',
             'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
+            'backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -2828,7 +2830,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
-            if ($this->isScienceContentPageDraftDryRunImporterFile($file)) {
+            if ($this->isScienceContentPageNoWriteGateFile($file)) {
                 continue;
             }
 
@@ -3785,11 +3787,13 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return $file === 'backend/app/Console/Commands/ContentPagesImportLocalBaseline.php';
     }
 
-    private function isScienceContentPageDraftDryRunImporterFile(string $file): bool
+    private function isScienceContentPageNoWriteGateFile(string $file): bool
     {
         return in_array($file, [
             'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
+            'backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php',
             'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
+            'backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added a read-only `content-pages:science-operator-review-readiness` command for Science ContentPage operator readiness checks.
- Added a service that inspects existing ContentPage model/CMS/API review fields and reports whether non-public draft review is supportable.
- Added tests proving no ContentPage writes occur and that publish readiness remains conditional when first-class publish safety fields are missing.
- Extended the BigFive runtime freeze allowlist for this no-write Science ContentPage gate.

## Why
This is the second Science ContentPage safety PR after the importer dry-run gate. It confirms operators have enough existing CMS fields to review non-public Science drafts, while preserving `CONDITIONAL` for actual publish decisions until claim/schema/operator approval fields are first-class or separately QA-gated.

## Validation
- `php artisan test --filter ScienceContentPageOperatorReviewReadinessCommandTest --compact --display-warnings`
- `php artisan content-pages:science-operator-review-readiness --package="/Users/rainie/Desktop/science_contentpage_cms_draft_package 2" --json`
- `./vendor/bin/pint --test app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest --compact`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Package dry-run summary
- `pages_seen=6`
- `pages_reviewable_as_non_public_draft=5`
- `pages_requiring_authority_reconciliation=1`
- `cms_mutation_performed=false`
- `content_import_performed=false`
- `publish_performed=false`
- `decision=CONDITIONAL`

## Deferred
- The pre-real-import QA gate is intentionally deferred to the next PR.
- No CMS mutation, real import, publish, sitemap/llms/footer exposure, or deployment is included.
- First-class fields such as `publish_allowed`, `claim_gate_status`, and `faq_schema_eligible` are reported as missing rather than invented in this PR.