### PR TITLE
SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01｜preflight RIASEC draft approval readiness

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json
@@ -1,0 +1,184 @@
+{
+  "schema": "riasec-explanation-cms-draft-approval-preflight.v1",
+  "task_id": "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01",
+  "generated_at": "2026-06-05",
+  "source_gate": "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01",
+  "decision": "NO-GO_OPERATOR_INPUTS_REQUIRED",
+  "preflight_passed": false,
+  "operator_approval_claimed": false,
+  "cms_draft_approval_allowed": false,
+  "cms_mutation_performed": false,
+  "publish_allowed": false,
+  "search_submit_allowed": false,
+  "deploy_performed": false,
+  "content_rewrite_performed": false,
+  "private_url_accessed": false,
+  "inputs_reviewed": [
+    "backend/docs/seo/generated/riasec-explanation-reference-media-revision-approval.v1.json",
+    "backend/docs/seo/riasec-explanation-reference-media-revision-approval.md",
+    "docs/codex/pr-train-state.json"
+  ],
+  "draft_records": [
+    {
+      "locale": "zh",
+      "article_id": 40,
+      "working_revision_id": 45,
+      "slug": "riasec-holland-career-interest-test-explained",
+      "status": "draft",
+      "public": false,
+      "indexable": false,
+      "working_revision_status": "machine_draft",
+      "approved_at": null,
+      "approval_preflight_status": "blocked"
+    },
+    {
+      "locale": "en",
+      "article_id": 41,
+      "working_revision_id": 46,
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "status": "draft",
+      "public": false,
+      "indexable": false,
+      "working_revision_status": "machine_draft",
+      "approved_at": null,
+      "approval_preflight_status": "blocked"
+    }
+  ],
+  "operator_input_readiness": {
+    "status": "blocked",
+    "unknown_fields_preserved": true,
+    "ready_field_count": "Unknown",
+    "missing_or_unknown_inputs": [
+      "accepted_source_urls",
+      "accepted_source_titles",
+      "citation_style",
+      "holland_hexagon_terms_acceptance",
+      "mbti_big_five_comparison_acceptance",
+      "no_official_affiliation_acknowledgement",
+      "cms_media_id",
+      "cover_image_url",
+      "cover_image_alt_reviewed",
+      "og_image_ready",
+      "twitter_image_ready",
+      "approved_by",
+      "approved_at",
+      "approval_notes",
+      "claim_warning_acknowledgement",
+      "gpt_revision_required",
+      "conditional_links_activation_decision",
+      "product_availability_confirmed",
+      "report_preview_language_confirmed",
+      "confirmed_by",
+      "confirmed_at"
+    ],
+    "blocked_gates": [
+      "reference_acceptance",
+      "media_resolution",
+      "revision_approval",
+      "claim_warning_acknowledgement",
+      "conditional_internal_link_decision",
+      "product_availability_confirmation",
+      "controlled_publish_preflight"
+    ]
+  },
+  "approval_preflight_checks": [
+    {
+      "id": "source_acceptance_ready",
+      "status": "blocked",
+      "evidence": "accepted_source_urls, accepted_source_titles, citation_style, Holland/RIASEC acceptance, MBTI/Big Five comparison acceptance, and no-official-affiliation acknowledgement remain Unknown."
+    },
+    {
+      "id": "media_ready",
+      "status": "blocked",
+      "evidence": "cms_media_id, cover_image_url, cover_image_alt_reviewed, og_image_ready, and twitter_image_ready remain Unknown."
+    },
+    {
+      "id": "revision_approval_ready",
+      "status": "blocked",
+      "evidence": "zh revision 45 and en revision 46 remain machine_draft; approved_by, approved_at, and approval_notes remain Unknown."
+    },
+    {
+      "id": "claim_warning_ready",
+      "status": "blocked",
+      "evidence": "zh claim warning count remains 2; claim_warning_acknowledgement and gpt_revision_required remain Unknown."
+    },
+    {
+      "id": "internal_links_ready",
+      "status": "blocked",
+      "evidence": "conditional_links_activation_decision remains Unknown for /zh/career/jobs and /en/career/jobs."
+    },
+    {
+      "id": "product_availability_ready",
+      "status": "blocked",
+      "evidence": "product_availability_confirmed and report_preview_language_confirmed remain Unknown."
+    },
+    {
+      "id": "draft_public_safety",
+      "status": "pass",
+      "evidence": "Draft records remain draft, non-public, non-indexable, and machine_draft in the approval artifact."
+    },
+    {
+      "id": "public_route_safety",
+      "status": "pass",
+      "evidence": "Safe public routes are limited to RIASEC test pages and conditional career jobs routes; no private route is introduced."
+    }
+  ],
+  "publish_blockers": [
+    {
+      "id": "draft_approval_preflight_failed",
+      "status": "blocked",
+      "owner": "operator_editor",
+      "required_input": "Resolve all blocked approval preflight checks before any CMS draft approval mutation."
+    },
+    {
+      "id": "operator_inputs_unknown",
+      "status": "blocked",
+      "owner": "editorial_operator",
+      "required_input": "Supply or explicitly defer required operator fields. Unknown must remain Unknown until supplied."
+    },
+    {
+      "id": "cms_mutation_not_authorized",
+      "status": "hard_gate",
+      "owner": "operator",
+      "required_input": "Separate CMS mutation authorization is required before any draft revision approval or draft update."
+    },
+    {
+      "id": "controlled_publish_not_authorized",
+      "status": "hard_gate",
+      "owner": "operator",
+      "required_input": "Exact controlled publish authorization is required before any publish command."
+    }
+  ],
+  "next_task_recommendation": {
+    "id": "SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01",
+    "status": "allowed_as_no_mutation_readiness_artifact_only_after_separate_authorization",
+    "expected_decision_without_operator_inputs": "NO-GO_OPERATOR_INPUTS_REQUIRED",
+    "cms_mutation_allowed": false,
+    "publish_allowed": false,
+    "search_submission_allowed": false,
+    "deploy_allowed": false
+  },
+  "sidecar_issues": [
+    {
+      "id": "RIASEC_V2_CMS_DRAFT_APPROVAL_PREFLIGHT_NO_GO",
+      "status": "blocked_external_operator_input",
+      "note": "CMS draft approval preflight cannot pass until reference, media, revision, claim, internal-link, and product-availability inputs are supplied."
+    },
+    {
+      "id": "RIASEC_V2_NO_CMS_MUTATION_AUTHORIZATION",
+      "status": "hard_gate",
+      "note": "This task was preflight-only. CMS draft approval mutation requires separate explicit authorization."
+    }
+  ],
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "search_submission_performed": false,
+    "deploy_performed": false,
+    "content_rewrite_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "operator_approval_claimed": false,
+    "allowed_paths_only": true
+  }
+}

--- a/backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md
+++ b/backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md
@@ -1,0 +1,56 @@
+# RIASEC Explanation V2 CMS Draft Approval Preflight
+
+Task: `SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01`
+
+Decision: **NO-GO: operator inputs required before CMS draft approval.**
+
+This task did not rewrite article content, mutate CMS records, approve revisions, publish, submit search URLs, deploy, access private result/order/share/pay/payment/history URLs, read secrets, or claim operator approval.
+
+## Draft Approval Result
+
+| Locale | Article ID | Working revision | Draft state | Approval state | Preflight |
+| --- | ---: | ---: | --- | --- | --- |
+| zh | 40 | 45 | draft / non-public / non-indexable | machine_draft | blocked |
+| en | 41 | 46 | draft / non-public / non-indexable | machine_draft | blocked |
+
+## Blocked Inputs
+
+The following fields remain `Unknown` and must not be treated as false, zero, or approved:
+
+- accepted source URLs, source titles, and citation style
+- Holland/RIASEC source acceptance
+- MBTI and Big Five comparison acceptance
+- no-official-affiliation acknowledgement
+- CMS media ID, cover URL, alt review, OG image readiness, and Twitter image readiness
+- revision approver, approval timestamp, and approval notes
+- zh claim-warning acknowledgement or GPT revision decision
+- conditional career jobs internal-link decision
+- product availability and report-preview language confirmation
+
+## Preflight Checks
+
+| Check | Status |
+| --- | --- |
+| Source acceptance ready | blocked |
+| Media ready | blocked |
+| Revision approval ready | blocked |
+| Claim warning ready | blocked |
+| Internal links ready | blocked |
+| Product availability ready | blocked |
+| Draft public safety | pass |
+| Public route safety | pass |
+
+## Hard Gates
+
+- CMS mutation is not authorized.
+- Revision approval is not authorized.
+- Publish is not authorized.
+- Search submission is not authorized.
+- Deploy is not authorized.
+- Private result/order/share/pay/payment/history/tokenized URLs remain forbidden.
+
+## Next Task
+
+Recommended next task: `SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01` only as a no-mutation readiness artifact after separate authorization.
+
+Expected result without operator inputs: **NO-GO / operator inputs required**.

--- a/backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationCmsDraftApprovalPreflightTest extends TestCase
+{
+    public function test_preflight_blocks_draft_approval_without_operator_inputs(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01', $preflight['task_id']);
+        $this->assertSame('NO-GO_OPERATOR_INPUTS_REQUIRED', $preflight['decision']);
+        $this->assertFalse($preflight['preflight_passed']);
+        $this->assertFalse($preflight['operator_approval_claimed']);
+        $this->assertFalse($preflight['cms_draft_approval_allowed']);
+        $this->assertFalse($preflight['cms_mutation_performed']);
+        $this->assertFalse($preflight['publish_allowed']);
+        $this->assertFalse($preflight['search_submit_allowed']);
+        $this->assertFalse($preflight['deploy_performed']);
+        $this->assertFalse($preflight['content_rewrite_performed']);
+        $this->assertFalse($preflight['private_url_accessed']);
+    }
+
+    public function test_operator_inputs_remain_unknown_and_blocking(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json');
+
+        $this->assertSame('blocked', $preflight['operator_input_readiness']['status']);
+        $this->assertTrue($preflight['operator_input_readiness']['unknown_fields_preserved']);
+        $this->assertSame('Unknown', $preflight['operator_input_readiness']['ready_field_count']);
+        $this->assertContains('accepted_source_urls', $preflight['operator_input_readiness']['missing_or_unknown_inputs']);
+        $this->assertContains('cms_media_id', $preflight['operator_input_readiness']['missing_or_unknown_inputs']);
+        $this->assertContains('approved_by', $preflight['operator_input_readiness']['missing_or_unknown_inputs']);
+        $this->assertContains('claim_warning_acknowledgement', $preflight['operator_input_readiness']['missing_or_unknown_inputs']);
+        $this->assertContains('product_availability_confirmed', $preflight['operator_input_readiness']['missing_or_unknown_inputs']);
+    }
+
+    public function test_preflight_checks_keep_external_blockers_and_safe_checks_separate(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json');
+        $checks = collect($preflight['approval_preflight_checks'])->keyBy('id');
+
+        foreach ([
+            'source_acceptance_ready',
+            'media_ready',
+            'revision_approval_ready',
+            'claim_warning_ready',
+            'internal_links_ready',
+            'product_availability_ready',
+        ] as $blockedCheck) {
+            $this->assertSame('blocked', $checks[$blockedCheck]['status']);
+        }
+
+        $this->assertSame('pass', $checks['draft_public_safety']['status']);
+        $this->assertSame('pass', $checks['public_route_safety']['status']);
+    }
+
+    public function test_draft_records_are_not_public_indexable_or_approved(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json');
+        $records = collect($preflight['draft_records'])->keyBy('locale');
+
+        foreach (['zh', 'en'] as $locale) {
+            $this->assertSame('draft', $records[$locale]['status']);
+            $this->assertFalse($records[$locale]['public']);
+            $this->assertFalse($records[$locale]['indexable']);
+            $this->assertSame('machine_draft', $records[$locale]['working_revision_status']);
+            $this->assertNull($records[$locale]['approved_at']);
+            $this->assertSame('blocked', $records[$locale]['approval_preflight_status']);
+        }
+    }
+
+    public function test_next_publish_preflight_is_no_mutation_and_expected_no_go_without_inputs(): void
+    {
+        $preflight = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01', $preflight['next_task_recommendation']['id']);
+        $this->assertSame('NO-GO_OPERATOR_INPUTS_REQUIRED', $preflight['next_task_recommendation']['expected_decision_without_operator_inputs']);
+        $this->assertFalse($preflight['next_task_recommendation']['cms_mutation_allowed']);
+        $this->assertFalse($preflight['next_task_recommendation']['publish_allowed']);
+        $this->assertFalse($preflight['next_task_recommendation']['search_submission_allowed']);
+        $this->assertFalse($preflight['next_task_recommendation']['deploy_allowed']);
+    }
+
+    public function test_artifact_contains_no_forbidden_private_routes_or_identifiers(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48348,5 +48348,105 @@
         "note": "PR #1943 was squash-merged at 2026-06-05T14:48:22Z with merge commit 6b94f5004df326f88d9617aa29b55f84f1b5bfd4; remote branch is deleted and local task branch is absent."
       }
     ]
+  },
+  "SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01": {
+    "repo": "fap-api",
+    "base": "main",
+    "branch": "codex/seo-article-riasec-v2-cms-draft-approval-preflight-01",
+    "status": "local_checks_passed",
+    "title": "docs(seo): preflight RIASEC draft approval readiness",
+    "train_scope": "seo_article_content_package_riasec_explanation_v2",
+    "depends_on": [
+      "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01 with necessary manifest/state entries, limited to CMS draft approval preflight artifact, operator input readiness check, publish blockers, generated artifact/test/ledger. Content rewrite, CMS mutation, publish, search submission, deploy, and private URL access remain forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01 is merged as PR #1943 and closeout #1946 is merged on origin/main."
+      },
+      "preflight": {
+        "status": "blocked_external_operator_input",
+        "evidence": "Reference/media/revision approval artifact records Unknown operator inputs and blocked gates for references, media, revision approval, claim warning acknowledgement, conditional internal links, and product availability."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to the RIASEC CMS draft approval preflight artifact/report/test and docs/codex PR-train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php",
+          "python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsDraftApprovalPreflightTest --no-ansi",
+          "git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed. Composer install and local .env setup were worktree-only and not staged."
+      }
+    },
+    "result": {
+      "decision": "NO-GO_OPERATOR_INPUTS_REQUIRED",
+      "preflight_passed": false,
+      "cms_draft_approval_allowed": false,
+      "operator_approval_claimed": false,
+      "publish_allowed": false,
+      "search_submit_allowed": false,
+      "cms_mutation_performed": false,
+      "content_rewrite_performed": false,
+      "generated_artifact": "backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json",
+      "review_report": "backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "deploy_performed": false,
+      "content_rewrite_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "RIASEC_V2_CMS_DRAFT_APPROVAL_PREFLIGHT_NO_GO",
+        "status": "blocked_external_operator_input",
+        "note": "CMS draft approval preflight cannot pass until reference, media, revision, claim, internal-link, and product-availability inputs are supplied."
+      },
+      {
+        "id": "RIASEC_V2_NO_CMS_MUTATION_AUTHORIZATION",
+        "status": "hard_gate",
+        "note": "This task is preflight-only. CMS draft approval mutation requires separate explicit authorization."
+      }
+    ],
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "failure_reason": null,
+    "transitions": [
+      {
+        "at": "2026-06-05",
+        "status": "authorized",
+        "note": "User authorized CMS draft approval preflight with no content rewrite, CMS mutation, publish, search submission, deploy, or private URL access."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "in_progress",
+        "note": "Added manifest entry, generated preflight artifact, operator input readiness report, and focused artifact contract test."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "local_checks_passed",
+        "note": "Local validation passed with focused PHPUnit 6 tests / 52 assertions, JSON/YAML parse, PHP lint, and scoped diff checks."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -48353,7 +48353,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-cms-draft-approval-preflight-01",
-    "status": "local_checks_passed",
+    "status": "pr_open_github_checks_pending",
     "title": "docs(seo): preflight RIASEC draft approval readiness",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -48388,6 +48388,10 @@
           "git diff --cached --check"
         ],
         "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed. Composer install and local .env setup were worktree-only and not staged."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1949"
       }
     },
     "result": {
@@ -48425,8 +48429,8 @@
         "note": "This task is preflight-only. CMS draft approval mutation requires separate explicit authorization."
       }
     ],
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "45c317b8bf5fd397a7c6a64363bb18c5929c1708",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1949",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -48446,6 +48450,11 @@
         "at": "2026-06-05",
         "status": "local_checks_passed",
         "note": "Local validation passed with focused PHPUnit 6 tests / 52 assertions, JSON/YAML parse, PHP lint, and scoped diff checks."
+      },
+      {
+        "at": "2026-06-05",
+        "status": "pr_open_github_checks_pending",
+        "note": "Opened PR #1949 after local checks and scoped staging passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-05T12:17:44Z",
+  "updated_at": "2026-06-05T15:14:06Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -48353,7 +48353,7 @@
     "repo": "fap-api",
     "base": "main",
     "branch": "codex/seo-article-riasec-v2-cms-draft-approval-preflight-01",
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "title": "docs(seo): preflight RIASEC draft approval readiness",
     "train_scope": "seo_article_content_package_riasec_explanation_v2",
     "depends_on": [
@@ -48390,8 +48390,9 @@
         "notes": "PHP lint, JSON/YAML parsing, focused PHPUnit artifact contract, and scoped diff whitespace checks passed. Composer install and local .env setup were worktree-only and not staged."
       },
       "github": {
-        "status": "pending",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/1949"
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/1949",
+        "evidence": "GitHub checks passed for PR #1949: Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, hygiene, supply-chain, content-pack-build-validate, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "result": {
@@ -48429,7 +48430,7 @@
         "note": "This task is preflight-only. CMS draft approval mutation requires separate explicit authorization."
       }
     ],
-    "commit_sha": "45c317b8bf5fd397a7c6a64363bb18c5929c1708",
+    "commit_sha": "1d65a9334c60a43778d8dcd6b2a86ce87730086c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1949",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -48455,6 +48456,11 @@
         "at": "2026-06-05",
         "status": "pr_open_github_checks_pending",
         "note": "Opened PR #1949 after local checks and scoped staging passed."
+      },
+      {
+        "at": "2026-06-05T15:14:06Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1949; ready to merge subject to repo policy."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22794,3 +22794,45 @@ prs:
     content_rewrite_allowed: false
     content_authority: CMS/backend
     next_task: SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01 after operator inputs and separate authorization
+
+  - id: SEO-ARTICLE-RIASEC-V2-CMS-DRAFT-APPROVAL-PREFLIGHT-01
+    repo: fap-api
+    depends_on:
+      - SEO-ARTICLE-RIASEC-V2-REFERENCE-MEDIA-REVISION-APPROVAL-01
+    branch: codex/seo-article-riasec-v2-cms-draft-approval-preflight-01
+    title: "docs(seo): preflight RIASEC draft approval readiness"
+    train_scope: seo_article_content_package_riasec_explanation_v2
+    status: in_progress
+    scope:
+      - Check whether the RIASEC V2 zh/en CMS drafts have enough operator inputs to proceed toward CMS draft approval.
+      - Record operator input readiness, publish blockers, draft/public/indexing safety, and next-gate conditions without mutating CMS.
+      - Add a generated artifact, human-readable preflight report, focused artifact contract test, and necessary PR-train ledger updates.
+    allowed_paths:
+      - backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md
+      - backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json
+      - backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Rewrite article body/title/H1/meta/FAQ/CTA, mutate CMS, approve revisions, publish, submit search URLs, deploy, or access private result/orders/share/pay/payment/history/tokenized URLs.
+      - Convert Unknown operator inputs to false, 0, or pass.
+    validation:
+      - php -l backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php
+      - python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsDraftApprovalPreflightTest --no-ansi
+      - git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_rewrite_allowed: false
+    content_authority: CMS/backend
+    next_task: SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01 after separate authorization; expected NO-GO until operator inputs pass


### PR DESCRIPTION
## What changed
- Added the RIASEC V2 CMS draft approval preflight artifact and report.
- Added focused PHPUnit coverage for operator-input readiness, Unknown preservation, draft non-public/non-indexable state, and no private URL identifiers.
- Added the PR-train manifest/state entry for the preflight-only gate.

## Why
The previous approval gate recorded missing operator inputs. This PR verifies that CMS draft approval remains NO-GO until those external inputs are supplied, while preserving draft/public/indexing safety.

## Validation
- php -l backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php
- python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsDraftApprovalPreflightTest --no-ansi
- git diff --check -- backend/docs/seo/riasec-explanation-cms-draft-approval-preflight.md backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json backend/tests/Feature/SEO/RiasecExplanationCmsDraftApprovalPreflightTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No CMS mutation, draft approval, publish, search submission, deploy, or private URL access.
- Publish preflight is expected to remain NO-GO until operator inputs are supplied.

## Repository rule impact
Docs/generated/test-only preflight gate. CMS/backend remains the authority for article content, revisions, media, publication state, sitemap/llms exposure, and controlled publish.