### PR TITLE
feat(benefit): allow operator approved DailyGiving proof

### DIFF
--- a/backend/app/Filament/Ops/Resources/DailyGivingRecordResource.php
+++ b/backend/app/Filament/Ops/Resources/DailyGivingRecordResource.php
@@ -108,8 +108,10 @@ class DailyGivingRecordResource extends Resource
                                     ->native(false)
                                     ->options([
                                         DailyGivingRecord::PROOF_NONE => 'None',
-                                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'Redacted Pending',
-                                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'Redacted Available',
+                                        DailyGivingRecord::PROOF_OPERATOR_APPROVED_PENDING => 'Operator Approval Pending',
+                                        DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE => 'Operator Approved Public Proof',
+                                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'Legacy Redacted Pending',
+                                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'Legacy Redacted Available',
                                         DailyGivingRecord::PROOF_WITHHELD => 'Withheld',
                                     ])
                                     ->default(DailyGivingRecord::PROOF_NONE),
@@ -221,6 +223,8 @@ class DailyGivingRecordResource extends Resource
                 Tables\Columns\TextColumn::make('proof_status')
                     ->badge()
                     ->color(fn (string $state): string => match ($state) {
+                        DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE => 'success',
+                        DailyGivingRecord::PROOF_OPERATOR_APPROVED_PENDING => 'warning',
                         DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'success',
                         DailyGivingRecord::PROOF_REDACTED_PENDING => 'warning',
                         DailyGivingRecord::PROOF_WITHHELD => 'gray',
@@ -258,8 +262,10 @@ class DailyGivingRecordResource extends Resource
                 Tables\Filters\SelectFilter::make('proof_status')
                     ->options([
                         DailyGivingRecord::PROOF_NONE => 'None',
-                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'Redacted Pending',
-                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'Redacted Available',
+                        DailyGivingRecord::PROOF_OPERATOR_APPROVED_PENDING => 'Operator Approval Pending',
+                        DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE => 'Operator Approved Public Proof',
+                        DailyGivingRecord::PROOF_REDACTED_PENDING => 'Legacy Redacted Pending',
+                        DailyGivingRecord::PROOF_REDACTED_AVAILABLE => 'Legacy Redacted Available',
                         DailyGivingRecord::PROOF_WITHHELD => 'Withheld',
                     ]),
                 Tables\Filters\TernaryFilter::make('is_public'),

--- a/backend/app/Models/DailyGivingRecord.php
+++ b/backend/app/Models/DailyGivingRecord.php
@@ -4,10 +4,10 @@ declare(strict_types=1);
 
 namespace App\Models;
 
-use InvalidArgumentException;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
+use InvalidArgumentException;
 
 class DailyGivingRecord extends Model
 {
@@ -27,6 +27,10 @@ class DailyGivingRecord extends Model
 
     public const PROOF_NONE = 'none';
 
+    public const PROOF_OPERATOR_APPROVED_PENDING = 'operator_approved_pending';
+
+    public const PROOF_OPERATOR_APPROVED_AVAILABLE = 'operator_approved_available';
+
     public const PROOF_REDACTED_PENDING = 'redacted_pending';
 
     public const PROOF_REDACTED_AVAILABLE = 'redacted_available';
@@ -42,6 +46,8 @@ class DailyGivingRecord extends Model
 
     public const PROOF_STATUSES = [
         self::PROOF_NONE,
+        self::PROOF_OPERATOR_APPROVED_PENDING,
+        self::PROOF_OPERATOR_APPROVED_AVAILABLE,
         self::PROOF_REDACTED_PENDING,
         self::PROOF_REDACTED_AVAILABLE,
         self::PROOF_WITHHELD,
@@ -53,9 +59,15 @@ class DailyGivingRecord extends Model
     ];
 
     public const PUBLISHABLE_PROOF_STATUSES = [
+        self::PROOF_OPERATOR_APPROVED_AVAILABLE,
         self::PROOF_REDACTED_AVAILABLE,
         self::PROOF_WITHHELD,
         self::PROOF_NONE,
+    ];
+
+    public const PUBLIC_PROOF_AVAILABLE_STATUSES = [
+        self::PROOF_OPERATOR_APPROVED_AVAILABLE,
+        self::PROOF_REDACTED_AVAILABLE,
     ];
 
     public const MANUAL_SOCIAL_SYNC_FIELDS = [
@@ -225,16 +237,16 @@ class DailyGivingRecord extends Model
             $violations[] = 'proof_private_path must point to a private disk/bucket path, not a public URL/path';
         }
 
-        if ($publicUrl !== '' && ! $this->looksLikeReviewedPublicProofUrl($publicUrl)) {
-            $violations[] = 'proof_public_url must point to reviewed redacted public proof only';
+        if ($publicUrl !== '' && ! $this->looksLikeOperatorApprovedPublicProofUrl($publicUrl)) {
+            $violations[] = 'proof_public_url must point to operator-approved public proof media only';
         }
 
         if ($privatePath !== '' && $publicUrl !== '' && hash_equals($privatePath, $publicUrl)) {
             $violations[] = 'proof_public_url must not equal proof_private_path';
         }
 
-        if ($publicUrl !== '' && $proofStatus !== self::PROOF_REDACTED_AVAILABLE) {
-            $violations[] = 'proof_public_url requires proof_status=redacted_available';
+        if ($publicUrl !== '' && ! in_array($proofStatus, self::PUBLIC_PROOF_AVAILABLE_STATUSES, true)) {
+            $violations[] = 'proof_public_url requires proof_status=operator_approved_available';
         }
 
         if ($proofStatus === self::PROOF_WITHHELD && trim((string) ($this->proof_redaction_notes ?? '')) === '') {
@@ -267,7 +279,7 @@ class DailyGivingRecord extends Model
         return str_contains($normalized, '/private/');
     }
 
-    private function looksLikeReviewedPublicProofUrl(string $url): bool
+    private function looksLikeOperatorApprovedPublicProofUrl(string $url): bool
     {
         $normalized = strtolower(trim($url));
 
@@ -275,14 +287,13 @@ class DailyGivingRecord extends Model
             return false;
         }
 
-        foreach (['/private/', 'proof_private_path', 'receipt_reference_private', 'internal_notes', 'auth_token', 'session_id', 'raw-receipt', 'raw_receipt'] as $forbidden) {
+        foreach (['/private/', 'proof_private_path', 'receipt_reference_private', 'internal_notes', 'auth_token', 'session_id', 'token=', 'secret', 'private_url'] as $forbidden) {
             if (str_contains($normalized, $forbidden)) {
                 return false;
             }
         }
 
-        return str_contains($normalized, 'redacted')
-            || str_contains($normalized, '/public/')
+        return str_contains($normalized, '/public/')
             || str_contains($normalized, '/media/');
     }
 }

--- a/backend/database/factories/DailyGivingRecordFactory.php
+++ b/backend/database/factories/DailyGivingRecordFactory.php
@@ -26,7 +26,7 @@ class DailyGivingRecordFactory extends Factory
             'amount_minor' => fake()->numberBetween(10000, 500000),
             'currency' => 'USD',
             'donation_status' => DailyGivingRecord::DONATION_COMPLETED,
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
             'proof_public_url' => null,
             'proof_private_path' => null,
             'proof_redaction_notes' => null,

--- a/backend/docs/operations/daily-giving-first-record-private-ledger.md
+++ b/backend/docs/operations/daily-giving-first-record-private-ledger.md
@@ -22,7 +22,7 @@ The first DailyGiving private draft record is ready for backend private storage 
 | `amount_minor` | `7500` |
 | `currency` | `CNY` |
 | `donation_status` | `completed` |
-| `proof_status` | `redacted_pending` |
+| `proof_status` | `operator_approved_pending` |
 | `is_public` | `false` |
 | `is_indexable` | `false` |
 | `published_at` | `null` |
@@ -37,7 +37,7 @@ The first DailyGiving private draft record is ready for backend private storage 
 - Transaction serial, masked account details, balance, and local device UI metadata are not committed.
 - The receipt donor-facing ID is not committed.
 - `proof_public_url` remains empty.
-- Redacted public proof has not been created.
+- Operator-approved public proof URL has not been bound.
 
 ## Claim Boundary
 
@@ -51,8 +51,8 @@ The first DailyGiving private draft record is ready for backend private storage 
 Before any public visibility:
 
 - Mirror or upload raw proof to a backend-confirmed private disk or bucket.
-- Create a separate redacted public proof artifact, likely from the receipt proof rather than the transaction screenshot.
-- Review the redacted artifact for receipt ID, transaction serial, account, balance, private URL, token, and local device metadata leakage.
+- Upload or select the original charity donation proof image as operator-approved public media.
+- Review the public media URL shape for private URL, token, secret, credential, and backend-only path leakage.
 - Create or update the production DailyGiving record only through an authorized private backend path.
 - Keep `is_public=false` until proof and claim review pass.
 - Keep `is_indexable=false`.

--- a/backend/docs/operations/daily-giving-first-record-review-template.md
+++ b/backend/docs/operations/daily-giving-first-record-review-template.md
@@ -15,7 +15,7 @@ The first real DailyGiving record must be created only after a separate private-
 - Proof storage gate is deployed and active for every save path.
 - Raw receipt storage location is confirmed private at the disk or bucket level.
 - Operator has the real receipt/proof in hand.
-- Redaction reviewer is assigned.
+- Operator proof reviewer is assigned.
 - DailyGiving remains `noindex`.
 - DailyGiving remains absent from sitemap, `llms.txt`, and `llms-full.txt`.
 - Foundation page is complete enough to explain plan boundaries without relying on DailyGiving as a trust badge.
@@ -34,9 +34,9 @@ The first record must start as private draft state:
 | `amount_minor` | receipt amount in minor units | for planned first donation, CNY 10 means `1000` only after receipt supports it |
 | `currency` | receipt currency | ISO code, expected `CNY` only after receipt supports it |
 | `donation_status` | `planned` or private draft equivalent before review | may become `completed` only after receipt review |
-| `proof_status` | `none` or `redacted_pending` before redaction | `redacted_available` only after public proof review |
+| `proof_status` | `none` or `operator_approved_pending` before public proof approval | `operator_approved_available` only after public proof review |
 | `proof_private_path` | private disk/bucket path only | never a public URL |
-| `proof_public_url` | blank until redacted proof is approved | must be reviewed redacted public media if present |
+| `proof_public_url` | blank until public proof is approved | must be operator-approved public media if present |
 | `proof_redaction_notes` | admin-only reviewer notes | required when proof is withheld |
 | `receipt_reference_private` | private reference if needed | never public |
 | `receipt_reference_redacted` | masked public reference if safe | reviewer-approved only |
@@ -49,7 +49,7 @@ The first record must start as private draft state:
 ## Review Gates Before Public Visibility
 
 - Raw proof is stored privately and not exposed as URL, public media, or tokenized path.
-- Public proof is either a reviewed redacted public media URL or withheld with admin-only reviewer reason.
+- Public proof is either an operator-approved original charity donation proof media URL or withheld with admin-only reviewer reason.
 - Public projection does not expose private proof path, redaction notes, private receipt reference, internal notes, or admin user ids.
 - Recipient, amount, currency, and date match the receipt.
 - `donation_status` is `completed` or `verified`.
@@ -75,4 +75,4 @@ After the separately authorized first record is reviewed and activated:
 
 ## Hard Stop
 
-The next step is `DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01`. It must be separately authorized before any production record, raw proof, private proof path, redacted proof, public record activation, CMS mutation, publish, search submission, social distribution, trust badge, or deploy action.
+The next step is `DAILY-GIVING-FIRST-RECORD-PRIVATE-LEDGER-01`. It must be separately authorized before any production record, raw proof, private proof path, public proof URL binding, public record activation, CMS mutation, publish, search submission, social distribution, trust badge, or deploy action.

--- a/backend/docs/operations/daily-giving-ops-readiness-scan-2026-06-03.md
+++ b/backend/docs/operations/daily-giving-ops-readiness-scan-2026-06-03.md
@@ -69,7 +69,9 @@ Remaining risk:
 - `proof_status=withheld` is publishable by current `isPublishable()` logic. That may be acceptable for privacy, but public amplification needs a clear policy for when withheld proof is allowed.
 - The public API scope does not include `proof_status` filtering. It relies on operator workflow and tests around `isPublishable()`, not on the API query itself.
 
-Conclusion: proof storage is field-separated, but the disk/privacy enforcement path is Unknown. Public amplification should remain blocked until a readiness gate proves proof originals are private and redacted public evidence is intentional.
+Conclusion: proof storage is field-separated, but the disk/privacy enforcement path is Unknown. Public amplification should remain blocked until a readiness gate proves proof originals are private and public evidence is intentional.
+
+2026-06-05 update: this scan's earlier redacted-public-evidence wording is superseded by the repository rule that operator-approved original charity donation proof images may be used as public proof media. The private-path, API-field, noindex, claim, and trust-badge blockers remain unchanged.
 
 ## 5. Public Page Indexability
 
@@ -144,7 +146,7 @@ Permitted later direction:
 Before Daily Giving can be publicly amplified, all of the following should pass:
 
 1. At least one production DailyGiving record is intentionally operator-created, completed or verified, review-approved, and safe for public display.
-2. The record is either backed by a redacted public proof URL or has an approved withheld-proof reason.
+2. The record is either backed by an operator-approved public proof URL or has an approved withheld-proof reason.
 3. Raw proof originals are proven private at the storage/path level.
 4. `proof_private_path`, redaction notes, private receipt references, internal notes, admin IDs, and private sync diagnostics remain absent from public API output.
 5. Public API records and months return the intended records.

--- a/backend/docs/operations/daily-giving-proof-redaction-sop.md
+++ b/backend/docs/operations/daily-giving-proof-redaction-sop.md
@@ -1,4 +1,4 @@
-# DailyGiving Proof Redaction SOP
+# DailyGiving Proof Public Approval SOP
 
 Date: 2026-06-05
 
@@ -8,31 +8,28 @@ Mode: SOP, generated artifact, and contract test only. This PR does not create r
 
 ## Decision
 
-Raw proof must stay private. Public proof may exist only as a separate redacted public artifact after review. Withheld proof is allowed only as a reviewer-approved privacy or safety exception, and cannot power a trust badge or public amplification claim.
+Raw private storage paths, admin-only notes, backend-only ledger fields, tokens, private URLs, secrets, and credentials must stay private. Public proof may be the original charity donation proof image when the operator approves that image for public media use. A separate redacted derivative is not required. Withheld proof is allowed only as a reviewer-approved privacy or safety exception, and cannot power a trust badge or public amplification claim.
 
 ## Storage Classes
 
 | Proof class | Storage rule | Public access |
 | --- | --- | --- |
-| raw receipt / raw proof | private disk or private bucket only | forbidden |
+| private raw proof path / private ledger proof | private disk or private bucket only | forbidden |
 | admin proof access | private storage driver or short-TTL signed admin URL | admin-only |
-| redacted public proof | public-safe media path or public signed URL after review | allowed after review |
+| operator-approved public proof | public media URL after operator review | allowed after review |
 | withheld proof | private raw proof retained with reviewer reason | public proof unavailable |
 
-## Redaction Standard
+## Public Approval Standard
 
-No redaction is allowed only when reviewer inspection confirms no sensitive fields exist.
+The original charity donation proof image may be public when the operator approves it for public use. Review focuses on URL and system-boundary safety, not on creating a mandatory derivative.
 
-Fields that must be redacted if present:
+Fields that must never be exposed through public API, frontend rendering, sitemap, llms, social distribution, or search submission:
 
-- donor legal name unless explicitly approved;
-- donor email, phone, address;
-- bank account, card number, payment account id;
-- full transaction number or full order number;
-- payment provider user id;
-- billing or invoice address;
-- QR payment token;
+- private storage path;
+- backend-only ledger field;
+- proof redaction notes;
 - session id, auth token, private receipt URL, browser URL with private token;
+- secret, credential, or signed private URL;
 - internal admin comments.
 
 Fields that may remain visible after review:
@@ -42,7 +39,7 @@ Fields that may remain visible after review:
 - amount and currency;
 - non-sensitive receipt issuer name;
 - proof status;
-- short masked public reference.
+- operator-approved public receipt context.
 
 ## Withheld Proof Rule
 
@@ -61,15 +58,15 @@ Public API must not expose:
 - payment account details
 - private sync diagnostics
 
-Public API may expose only reviewed public fields such as recipient, date, amount, currency, proof status, redacted proof URL, redacted receipt reference, social links after review, and public notes after claim lint.
+Public API may expose only reviewed public fields such as recipient, date, amount, currency, proof status, `proof_public_url`, public receipt reference if approved, social links after review, and public notes after claim lint.
 
 ## Review Checklist
 
 Before `is_public=true`:
 
 - raw proof is private;
-- public proof URL, if present, points only to redacted proof;
-- sensitive fields are redacted or reviewer confirms none exist;
+- public proof URL, if present, points only to operator-approved public media;
+- private storage path, token, private URL, secret, credential, and backend-only fields are absent from the public API;
 - withheld proof has reviewer reason;
 - recipient/date/amount are verified;
 - public notes pass claim lint;

--- a/backend/docs/operations/daily-giving-proof-storage-gate.md
+++ b/backend/docs/operations/daily-giving-proof-storage-gate.md
@@ -14,10 +14,11 @@ DailyGiving records now have a model-level proof storage gate. Any save path mus
 
 - `proof_private_path` must look like a private disk or private bucket path.
 - `proof_private_path` must not be a public URL or public media path.
-- `proof_public_url` must be an HTTPS reviewed public proof URL.
-- `proof_public_url` must not contain private/admin/raw receipt indicators.
+- `proof_public_url` must be an HTTPS operator-approved public media URL.
+- `proof_public_url` may point to the original charity donation proof image; a separate redacted derivative is not required.
+- `proof_public_url` must not contain private/admin/token/secret indicators.
 - `proof_public_url` must not equal `proof_private_path`.
-- `proof_public_url` requires `proof_status=redacted_available`.
+- `proof_public_url` requires `proof_status=operator_approved_available`.
 - `proof_status=withheld` requires admin-only `proof_redaction_notes`.
 
 ## Public Projection Boundary

--- a/backend/docs/operations/daily-giving-public-release-prereq.md
+++ b/backend/docs/operations/daily-giving-public-release-prereq.md
@@ -17,7 +17,7 @@ DailyGiving is not ready for public trust amplification until the public release
 - At least one public record is completed or verified.
 - At least one public record is verified before any trust badge or high-amplification claim is considered.
 - Public records remain `is_indexable=false` during first-record review.
-- Each public record has a reviewed proof state: redacted public proof URL, or withheld proof with admin-only reviewer reason.
+- Each public record has a reviewed proof state: operator-approved public proof media URL, or withheld proof with admin-only reviewer reason.
 - Public API never returns raw proof paths, private receipt references, redaction notes, internal notes, or admin user ids.
 - DailyGiving pages remain `noindex`.
 - DailyGiving routes remain absent from sitemap, `llms.txt`, and `llms-full.txt`.
@@ -29,4 +29,4 @@ The release gate allows only controlled public record visibility after review. I
 
 ## Deferred Until First Record Authorization
 
-The first real record requires a separate private-ledger authorization. Raw receipt storage, redacted proof creation, record review, and public record activation are intentionally outside this PR.
+The first real record requires a separate private-ledger authorization. Raw receipt storage, operator-approved public media upload, record review, and public record activation are intentionally outside this PR.

--- a/backend/docs/operations/daily-giving-redacted-public-proof.md
+++ b/backend/docs/operations/daily-giving-redacted-public-proof.md
@@ -1,58 +1,47 @@
-# DailyGiving Redacted Public Proof Gate
+# DailyGiving Operator-Approved Public Proof Gate
 
 Date: 2026-06-05
 
 PR train item: `DAILY-GIVING-REDACTED-PUBLIC-PROOF-01`
 
-Mode: public-proof readiness gate, generated artifact, and focused contract test only. This PR does not create, edit, upload, or publish a proof file. It does not mutate production records, CMS, media library, search channels, social channels, deploy state, or indexability.
+Mode: public-proof readiness gate, generated artifact, and focused contract test only. This inherited file name still references the earlier redaction gate, but the current repository rule allows operator-approved original charity donation proof images as public proof media. This PR does not create, edit, upload, or publish a proof file. It does not mutate production records, CMS, media library, search channels, social channels, deploy state, or indexability.
 
 ## Decision
 
-The first DailyGiving record may not become public until a separate redacted public proof artifact exists, has been reviewed, and is bound through `proof_public_url` with `proof_status=redacted_available`. The raw transaction proof and raw receipt proof remain private-only operator assets.
+The first DailyGiving record may not become public until an operator-approved public media URL exists and is bound through `proof_public_url` with `proof_status=operator_approved_available`. A separate redacted derivative is not required when the operator approves the original charity donation receipt/proof image for public use.
 
 ## Source Selection
 
-Use the receipt or donor confirmation proof as the preferred source for the public proof artifact. Do not use a bank or wallet transaction detail screenshot as public proof unless a reviewer confirms all account, balance, transaction, and device metadata fields are fully removed.
+Use the charity donation receipt or donor confirmation proof as the preferred public proof source. Do not use a bank or wallet transaction detail screenshot as public proof. Raw private storage paths, admin-only ledger fields, tokens, private URLs, secrets, and credentials must remain private.
 
-## Required Redactions
+## Public Proof Boundary
 
-The redacted public proof must remove or mask every sensitive field if present:
+The operator-approved public proof media may show donation-facing receipt content needed to support the public record, including:
 
-- donor personal identifiers beyond the public brand name approved for display;
-- donor email, phone, address, account, card, wallet, or payment account details;
-- full receipt id, full transaction serial, full order id, and payment-provider user id;
-- balance, account/card tail data, billing metadata, QR token, session id, auth token, and private receipt URLs;
-- local device UI metadata, inbox UI, browser UI, private local paths, or admin comments.
-
-The reviewer may leave only public-safe fields needed to support the record:
-
-- recipient name;
-- recipient public website;
+- recipient name and public website;
 - donation date;
 - amount and currency;
-- non-sensitive issuer context;
-- short masked public reference if needed.
+- public receipt or donor-confirmation context approved by the operator.
+
+The public API and frontend must still never expose private storage paths, admin-only notes, backend-only ledger fields, tokens, private URLs, secrets, credentials, or system metadata.
 
 ## URL Gate
 
 `proof_public_url` may be set only after review. It must:
 
 - use `https://`;
-- point to the redacted artifact, not a raw receipt or transaction proof;
-- avoid private, raw, auth, session, token, account, order, or receipt-private indicators;
-- follow the existing storage gate shape such as a reviewed `/media/`, `/public/`, or `redacted` URL;
+- point to operator-approved public media for the original charity donation proof image;
+- avoid private, auth, session, token, secret, credential, or backend-only indicators;
+- follow the existing storage gate shape such as a reviewed `/media/` or `/public/` URL;
 - be different from `proof_private_path`.
 
 ## Release Blockers
 
 Before any later public activation:
 
-- raw proof is confirmed private-only;
-- redacted public proof exists as a separate reviewed artifact;
-- reviewer confirms no sensitive field remains visible;
-- `proof_status=redacted_available`;
-- `proof_public_url` points only to the reviewed public artifact;
-- `receipt_reference_redacted`, if used, is short and masked;
+- operator-approved public proof media URL exists;
+- `proof_status=operator_approved_available`;
+- `proof_public_url` points only to the operator-approved public media asset;
 - `proof_redaction_notes` and private receipt references remain admin-only;
 - claim lint rejects official partnership, endorsement, certification, guaranteed impact, or UNICEF/UN backing implications;
 - `is_indexable=false` remains set;
@@ -60,4 +49,4 @@ Before any later public activation:
 
 ## Deferred Sidecar
 
-This PR intentionally leaves the actual image redaction and public media URL creation outside the repository. The next production activation remains blocked until an operator supplies a reviewed public media URL and explicitly authorizes production record mutation.
+This PR intentionally leaves public media upload outside the repository. The next production activation remains blocked until an operator supplies the real public media URL and explicitly authorizes production record mutation.

--- a/backend/docs/operations/generated/daily-giving-first-record-private-ledger.v1.json
+++ b/backend/docs/operations/generated/daily-giving-first-record-private-ledger.v1.json
@@ -21,7 +21,7 @@
     "currency": "CNY",
     "donation_status": "completed",
     "verified": false,
-    "proof_status": "redacted_pending",
+    "proof_status": "operator_approved_pending",
     "proof_public_url": null,
     "is_public": false,
     "is_indexable": false,
@@ -45,7 +45,7 @@
     "deploy_performed": false
   },
   "public_release": {
-    "redacted_public_proof_created": false,
+    "operator_approved_public_proof_url_bound": false,
     "publish_performed": false,
     "search_submission_performed": false,
     "social_distribution_performed": false,
@@ -62,5 +62,5 @@
     "guaranteed_impact_claim_allowed": false,
     "unsupported_stable_daily_operation_claim_allowed": false
   },
-  "next_authorization_required": "DAILY-GIVING-REDACTED-PUBLIC-PROOF-01"
+  "next_authorization_required": "DAILY-GIVING-ORIGINAL-PUBLIC-PROOF-01"
 }

--- a/backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json
+++ b/backend/docs/operations/generated/daily-giving-first-record-review-template.v1.json
@@ -8,7 +8,7 @@
   "proof_uploaded": false,
   "proof_processed": false,
   "private_proof_path_created": false,
-  "redacted_public_proof_created": false,
+  "operator_approved_public_proof_url_bound": false,
   "cms_mutation_performed": false,
   "publish_performed": false,
   "search_submission_performed": false,
@@ -34,7 +34,7 @@
     ],
     "proof_status_allowed": [
       "none",
-      "redacted_pending"
+      "operator_approved_pending"
     ],
     "is_public": false,
     "is_indexable": false,
@@ -42,7 +42,7 @@
   },
   "public_activation_required_gates": [
     "raw_proof_private_storage_confirmed",
-    "redacted_public_proof_reviewed_or_withheld_reason_recorded",
+    "operator_approved_public_proof_media_or_withheld_reason_recorded",
     "recipient_amount_currency_date_verified_against_receipt",
     "public_projection_private_fields_absent",
     "claim_lint_clean",

--- a/backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json
+++ b/backend/docs/operations/generated/daily-giving-proof-redaction-sop.v1.json
@@ -1,5 +1,5 @@
 {
-  "version": "daily_giving_proof_redaction_sop.v1",
+  "version": "daily_giving_proof_public_approval_sop.v1",
   "generated_at": "2026-06-05T00:00:00+08:00",
   "mode": "sop_only",
   "record_created": false,
@@ -18,10 +18,10 @@
       "mode": "private_storage_driver_or_short_ttl_signed_admin_url",
       "public_access": false
     },
-    "redacted_public_proof": {
-      "storage": "public_safe_media_or_public_signed_url",
+    "operator_approved_public_proof": {
+      "storage": "public_media_url_after_operator_review",
       "public_access": "allowed_after_review",
-      "must_be_separate_from_raw_proof": true
+      "separate_redacted_derivative_required": false
     },
     "withheld_proof": {
       "reviewer_reason_required": true,
@@ -29,23 +29,16 @@
       "can_support_high_amplification": false
     }
   },
-  "redaction_required_fields": [
-    "donor_legal_name_unless_approved",
-    "donor_email",
-    "donor_phone",
-    "donor_address",
-    "bank_account",
-    "card_number",
-    "payment_account_id",
-    "full_transaction_number",
-    "full_order_number",
-    "payment_provider_user_id",
-    "billing_or_invoice_address",
-    "qr_payment_token",
+  "public_forbidden_system_fields": [
+    "private_storage_path",
+    "backend_only_ledger_field",
+    "proof_redaction_notes",
     "session_id",
     "auth_token",
     "private_receipt_url",
     "browser_url_with_private_token",
+    "secret_or_credential",
+    "signed_private_url",
     "internal_admin_comments"
   ],
   "public_visible_after_review": [
@@ -55,7 +48,7 @@
     "currency",
     "non_sensitive_receipt_issuer_name",
     "proof_status",
-    "short_masked_public_reference"
+    "operator_approved_public_receipt_context"
   ],
   "public_api_forbidden_fields": [
     "proof_private_path",
@@ -84,7 +77,7 @@
   ],
   "release_review_required": [
     "raw_proof_private",
-    "public_proof_redacted_or_withheld_reason_present",
+    "operator_approved_public_proof_or_withheld_reason_present",
     "recipient_date_amount_verified",
     "public_notes_claim_linted",
     "is_indexable_false_retained",

--- a/backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json
+++ b/backend/docs/operations/generated/daily-giving-proof-storage-gate.v1.json
@@ -10,10 +10,11 @@
   "enforced_rules": [
     "proof_private_path_requires_private_disk_or_bucket_shape",
     "proof_private_path_rejects_public_url_or_public_media_path",
-    "proof_public_url_requires_https_reviewed_public_proof_shape",
-    "proof_public_url_rejects_private_or_raw_receipt_indicators",
+    "proof_public_url_requires_https_operator_approved_public_media_shape",
+    "proof_public_url_allows_original_charity_donation_proof_image",
+    "proof_public_url_rejects_private_admin_token_or_secret_indicators",
     "proof_public_url_must_not_equal_proof_private_path",
-    "proof_public_url_requires_redacted_available_status",
+    "proof_public_url_requires_operator_approved_available_status",
     "withheld_proof_requires_admin_redaction_notes_reason"
   ],
   "public_projection_forbidden_fields": [

--- a/backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json
+++ b/backend/docs/operations/generated/daily-giving-public-api-smoke.v1.json
@@ -20,7 +20,7 @@
     "show_api_status": 200,
     "fixture_is_indexable": false,
     "fixture_donation_status": "verified",
-    "fixture_proof_status": "redacted_available"
+    "fixture_proof_status": "operator_approved_available"
   },
   "forbidden_public_fields": [
     "proof_private_path",

--- a/backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json
+++ b/backend/docs/operations/generated/daily-giving-public-release-prereq.v1.json
@@ -31,11 +31,11 @@
       "verified"
     ],
     "proof_status_allowed": [
-      "redacted_available",
+      "operator_approved_available",
       "withheld"
     ],
     "withheld_requires_admin_redaction_notes": true,
-    "redacted_public_proof_requires_proof_public_url": true
+    "operator_approved_public_proof_requires_proof_public_url": true
   },
   "required_indexability_gates": {
     "daily_giving_page_noindex": true,

--- a/backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json
+++ b/backend/docs/operations/generated/daily-giving-redacted-public-proof.v1.json
@@ -1,55 +1,48 @@
 {
   "id": "DAILY-GIVING-REDACTED-PUBLIC-PROOF-01",
   "date": "2026-06-05",
-  "mode": "public_proof_readiness_gate_only",
+  "mode": "operator_approved_public_proof_readiness_gate_only",
   "record_code": "FM-GIVING-2026-06-001",
   "source_selection": {
-    "preferred_public_source": "receipt_or_donor_confirmation_proof",
-    "bank_transaction_screenshot_public_use": "blocked_unless_all_account_balance_transaction_and_device_metadata_are_removed",
-    "raw_proof_storage": "private_only"
+    "preferred_public_source": "original_charity_donation_receipt_or_donor_confirmation_proof",
+    "bank_transaction_screenshot_public_use": "blocked",
+    "separate_redacted_derivative_required": false
   },
-  "required_redactions": [
-    "donor_personal_identifiers_beyond_approved_public_brand_name",
-    "donor_email_phone_address",
-    "account_card_wallet_or_payment_account_details",
-    "full_receipt_id",
-    "full_transaction_serial",
-    "full_order_id",
-    "payment_provider_user_id",
-    "balance",
-    "billing_metadata",
-    "qr_token",
+  "forbidden_public_proof_fields": [
+    "private_storage_path",
     "session_id",
     "auth_token",
+    "tokenized_url",
     "private_receipt_url",
-    "local_device_ui_metadata",
     "private_local_paths",
-    "admin_comments"
+    "admin_comments",
+    "backend_only_ledger_fields",
+    "secrets",
+    "system_credentials"
   ],
-  "allowed_public_fields_after_review": [
+  "allowed_public_fields_after_operator_approval": [
     "recipient_name",
     "recipient_public_website",
     "donation_date",
     "amount_and_currency",
-    "non_sensitive_issuer_context",
-    "short_masked_public_reference"
+    "public_receipt_or_donor_confirmation_context"
   ],
   "proof_public_url_gate": {
     "requires_https": true,
-    "requires_reviewed_redacted_artifact": true,
-    "requires_proof_status": "redacted_available",
+    "requires_operator_approved_public_media": true,
+    "requires_proof_status": "operator_approved_available",
     "must_not_equal_proof_private_path": true,
     "accepted_shape_markers": [
-      "redacted",
       "/public/",
       "/media/"
     ],
     "forbidden_markers": [
       "/private/",
-      "raw-receipt",
-      "raw_receipt",
       "auth_token",
       "session_id",
+      "token=",
+      "secret",
+      "private_url",
       "receipt_reference_private",
       "proof_private_path",
       "internal_notes"
@@ -72,7 +65,7 @@
     "public_amplification_allowed_now": false
   },
   "runtime_actions": {
-    "redacted_public_proof_created": false,
+    "operator_approved_public_proof_url_bound": false,
     "proof_uploaded": false,
     "production_record_mutated": false,
     "cms_mutation_performed": false,
@@ -83,10 +76,10 @@
     "deploy_performed": false
   },
   "required_before_public_activation": [
-    "reviewed_redacted_public_proof_artifact",
+    "operator_approved_public_media_url",
     "public_media_url_supplied_by_operator",
-    "proof_status_redacted_available",
-    "proof_public_url_bound_to_reviewed_public_artifact",
+    "proof_status_operator_approved_available",
+    "proof_public_url_bound_to_operator_approved_public_media",
     "private_fields_absent_from_public_api",
     "claim_lint_passed",
     "is_indexable_false_retained",
@@ -94,9 +87,9 @@
   ],
   "sidecar_issues": [
     {
-      "id": "REDACTED_PUBLIC_MEDIA_URL",
+      "id": "OPERATOR_APPROVED_PUBLIC_MEDIA_URL",
       "status": "blocked_external_operator_input",
-      "note": "A reviewed redacted public media URL is required before production record activation."
+      "note": "An operator-approved public media URL for the original charity donation proof image is required before production record activation."
     },
     {
       "id": "FAP_WEB_PROOF_PUBLIC_URL_ADAPTER",
@@ -105,5 +98,5 @@
     }
   ],
   "next_pr": "DAILY-GIVING-PROOF-PUBLIC-URL-FRONTEND-ADAPTER-01",
-  "blocked_until": "reviewed_redacted_public_media_url_exists"
+  "blocked_until": "operator_approved_public_media_url_exists"
 }

--- a/backend/tests/Feature/Foundation/DailyGivingFirstRecordPrivateLedgerTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingFirstRecordPrivateLedgerTest.php
@@ -22,7 +22,7 @@ final class DailyGivingFirstRecordPrivateLedgerTest extends TestCase
         $this->assertSame('CNY', $record['currency']);
         $this->assertSame('completed', $record['donation_status']);
         $this->assertFalse($record['verified']);
-        $this->assertSame('redacted_pending', $record['proof_status']);
+        $this->assertSame('operator_approved_pending', $record['proof_status']);
         $this->assertNull($record['proof_public_url']);
         $this->assertFalse($record['is_public']);
         $this->assertFalse($record['is_indexable']);
@@ -68,7 +68,7 @@ final class DailyGivingFirstRecordPrivateLedgerTest extends TestCase
             $this->assertFalse($value, $field);
         }
 
-        $this->assertSame('DAILY-GIVING-REDACTED-PUBLIC-PROOF-01', $artifact['next_authorization_required']);
+        $this->assertSame('DAILY-GIVING-ORIGINAL-PUBLIC-PROOF-01', $artifact['next_authorization_required']);
     }
 
     public function test_committed_documents_do_not_leak_private_transaction_details(): void

--- a/backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingFirstRecordReviewTemplateTest.php
@@ -17,7 +17,7 @@ final class DailyGivingFirstRecordReviewTemplateTest extends TestCase
             'proof_uploaded',
             'proof_processed',
             'private_proof_path_created',
-            'redacted_public_proof_created',
+            'operator_approved_public_proof_url_bound',
             'cms_mutation_performed',
             'publish_performed',
             'search_submission_performed',
@@ -39,7 +39,7 @@ final class DailyGivingFirstRecordReviewTemplateTest extends TestCase
         $artifact = $this->artifact();
 
         $this->assertSame(['planned'], $artifact['initial_private_record_state']['donation_status_allowed']);
-        $this->assertSame(['none', 'redacted_pending'], $artifact['initial_private_record_state']['proof_status_allowed']);
+        $this->assertSame(['none', 'operator_approved_pending'], $artifact['initial_private_record_state']['proof_status_allowed']);
         $this->assertFalse($artifact['initial_private_record_state']['is_public']);
         $this->assertFalse($artifact['initial_private_record_state']['is_indexable']);
         $this->assertNull($artifact['initial_private_record_state']['published_at']);

--- a/backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingProofRedactionSopTest.php
@@ -17,11 +17,11 @@ final class DailyGivingProofRedactionSopTest extends TestCase
         return json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
     }
 
-    public function test_raw_proof_is_private_and_public_proof_is_separate_redacted_media(): void
+    public function test_private_proof_paths_stay_private_and_original_public_proof_is_allowed(): void
     {
         $artifact = $this->artifact();
 
-        $this->assertSame('daily_giving_proof_redaction_sop.v1', $artifact['version']);
+        $this->assertSame('daily_giving_proof_public_approval_sop.v1', $artifact['version']);
         $this->assertFalse($artifact['record_created']);
         $this->assertFalse($artifact['proof_uploaded']);
         $this->assertFalse($artifact['proof_processed']);
@@ -29,15 +29,15 @@ final class DailyGivingProofRedactionSopTest extends TestCase
 
         $this->assertSame('private_disk_or_private_bucket', $artifact['storage_classes']['raw_proof']['storage']);
         $this->assertFalse($artifact['storage_classes']['raw_proof']['public_access']);
-        $this->assertTrue($artifact['storage_classes']['redacted_public_proof']['must_be_separate_from_raw_proof']);
+        $this->assertFalse($artifact['storage_classes']['operator_approved_public_proof']['separate_redacted_derivative_required']);
     }
 
     public function test_sensitive_fields_and_private_api_fields_are_forbidden_publicly(): void
     {
         $artifact = $this->artifact();
 
-        foreach (['donor_email', 'payment_account_id', 'full_transaction_number', 'auth_token', 'private_receipt_url'] as $field) {
-            $this->assertContains($field, $artifact['redaction_required_fields']);
+        foreach (['private_storage_path', 'backend_only_ledger_field', 'auth_token', 'private_receipt_url', 'signed_private_url'] as $field) {
+            $this->assertContains($field, $artifact['public_forbidden_system_fields']);
         }
 
         foreach (['proof_private_path', 'proof_redaction_notes', 'receipt_reference_private', 'internal_notes', 'created_by_admin_user_id', 'updated_by_admin_user_id'] as $field) {

--- a/backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingProofStorageGateTest.php
@@ -9,12 +9,12 @@ use Tests\TestCase;
 
 final class DailyGivingProofStorageGateTest extends TestCase
 {
-    public function test_storage_gate_accepts_private_raw_proof_and_reviewed_redacted_public_proof(): void
+    public function test_storage_gate_accepts_private_raw_proof_and_operator_approved_original_public_proof(): void
     {
         $record = new DailyGivingRecord([
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
             'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
-            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/original-2026-06-05.png',
         ]);
 
         $this->assertSame([], $record->proofStorageGateViolations());
@@ -23,7 +23,7 @@ final class DailyGivingProofStorageGateTest extends TestCase
     public function test_storage_gate_rejects_public_raw_proof_paths_and_private_public_urls(): void
     {
         $record = new DailyGivingRecord([
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
             'proof_private_path' => 'https://media.fermatmind.com/raw-receipt.pdf',
             'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/private/raw-receipt.pdf',
         ]);
@@ -31,17 +31,17 @@ final class DailyGivingProofStorageGateTest extends TestCase
         $violations = $record->proofStorageGateViolations();
 
         $this->assertContains('proof_private_path must point to a private disk/bucket path, not a public URL/path', $violations);
-        $this->assertContains('proof_public_url must point to reviewed redacted public proof only', $violations);
+        $this->assertContains('proof_public_url must point to operator-approved public proof media only', $violations);
     }
 
-    public function test_public_url_requires_redacted_available_and_withheld_requires_reason(): void
+    public function test_public_url_requires_operator_approved_available_and_withheld_requires_reason(): void
     {
         $recordWithPublicUrl = new DailyGivingRecord([
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_PENDING,
-            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_PENDING,
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/original-2026-06-05.png',
         ]);
 
-        $this->assertContains('proof_public_url requires proof_status=redacted_available', $recordWithPublicUrl->proofStorageGateViolations());
+        $this->assertContains('proof_public_url requires proof_status=operator_approved_available', $recordWithPublicUrl->proofStorageGateViolations());
 
         $withheld = new DailyGivingRecord([
             'proof_status' => DailyGivingRecord::PROOF_WITHHELD,
@@ -54,8 +54,8 @@ final class DailyGivingProofStorageGateTest extends TestCase
     {
         $record = new DailyGivingRecord([
             'record_code' => 'FM-GIVING-2026-06-001',
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
-            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/original-2026-06-05.png',
             'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
             'proof_redaction_notes' => 'Private reviewer note.',
             'receipt_reference_private' => 'private-receipt-id',

--- a/backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingPublicApiSmokeTest.php
@@ -17,8 +17,8 @@ final class DailyGivingPublicApiSmokeTest extends TestCase
         $record = DailyGivingRecord::factory()->verified()->create([
             'record_code' => 'FM-GIVING-2026-06-SMOKE',
             'donation_date' => '2026-06-05',
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
-            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-smoke-2026-06-05.pdf',
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/original-smoke-2026-06-05.png',
             'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt-smoke.pdf',
             'proof_redaction_notes' => 'Test fixture reviewer note.',
             'receipt_reference_private' => 'PRIVATE-SMOKE-REF',
@@ -46,7 +46,7 @@ final class DailyGivingPublicApiSmokeTest extends TestCase
             ->assertJsonPath('ok', true)
             ->assertJsonPath('record.record_code', $record->record_code)
             ->assertJsonPath('record.donation_status', DailyGivingRecord::DONATION_VERIFIED)
-            ->assertJsonPath('record.proof_status', DailyGivingRecord::PROOF_REDACTED_AVAILABLE);
+            ->assertJsonPath('record.proof_status', DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE);
 
         $publicRecord = $show->json('record');
 

--- a/backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRecordPublicApiTest.php
@@ -125,7 +125,7 @@ class DailyGivingRecordPublicApiTest extends TestCase
     public function test_show_exposes_allowed_public_fields(): void
     {
         $record = DailyGivingRecord::factory()->completed()->create([
-            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/original-2026-06-05.png',
             'receipt_reference_redacted' => 'REF-REDACTED',
             'social_x_url' => 'https://x.com/fermatmind/status/123',
             'social_linkedin_url' => 'https://linkedin.com/feed/update/456',

--- a/backend/tests/Feature/Foundation/DailyGivingRecordPublicationGateTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRecordPublicationGateTest.php
@@ -202,10 +202,10 @@ class DailyGivingRecordPublicationGateTest extends TestCase
         $this->assertArrayHasKey('published_at', $public);
     }
 
-    public function test_redacted_pending_proof_status_is_not_publishable(): void
+    public function test_operator_approved_pending_proof_status_is_not_publishable(): void
     {
         $record = DailyGivingRecord::factory()->completed()->make([
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_PENDING,
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_PENDING,
             'is_public' => true,
             'published_at' => now(),
         ]);

--- a/backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php
+++ b/backend/tests/Feature/Foundation/DailyGivingRedactedPublicProofTest.php
@@ -14,7 +14,7 @@ final class DailyGivingRedactedPublicProofTest extends TestCase
         $artifact = $this->artifact();
 
         foreach ([
-            'redacted_public_proof_created',
+            'operator_approved_public_proof_url_bound',
             'proof_uploaded',
             'production_record_mutated',
             'cms_mutation_performed',
@@ -29,26 +29,22 @@ final class DailyGivingRedactedPublicProofTest extends TestCase
 
         $this->assertFalse($artifact['claim_boundaries']['trust_badge_allowed_now']);
         $this->assertFalse($artifact['claim_boundaries']['public_amplification_allowed_now']);
-        $this->assertSame('reviewed_redacted_public_media_url_exists', $artifact['blocked_until']);
+        $this->assertSame('operator_approved_public_media_url_exists', $artifact['blocked_until']);
     }
 
-    public function test_artifact_requires_redaction_of_sensitive_proof_fields(): void
+    public function test_artifact_forbids_private_and_system_proof_fields_publicly(): void
     {
         $artifact = $this->artifact();
 
         foreach ([
-            'full_receipt_id',
-            'full_transaction_serial',
-            'account_card_wallet_or_payment_account_details',
-            'balance',
             'auth_token',
             'session_id',
+            'private_storage_path',
             'private_receipt_url',
-            'local_device_ui_metadata',
             'private_local_paths',
             'admin_comments',
         ] as $field) {
-            $this->assertContains($field, $artifact['required_redactions']);
+            $this->assertContains($field, $artifact['forbidden_public_proof_fields']);
         }
     }
 
@@ -58,32 +54,31 @@ final class DailyGivingRedactedPublicProofTest extends TestCase
         $gate = $artifact['proof_public_url_gate'];
 
         $this->assertTrue($gate['requires_https']);
-        $this->assertTrue($gate['requires_reviewed_redacted_artifact']);
-        $this->assertSame(DailyGivingRecord::PROOF_REDACTED_AVAILABLE, $gate['requires_proof_status']);
+        $this->assertTrue($gate['requires_operator_approved_public_media']);
+        $this->assertSame(DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE, $gate['requires_proof_status']);
         $this->assertTrue($gate['must_not_equal_proof_private_path']);
-        $this->assertContains('redacted', $gate['accepted_shape_markers']);
         $this->assertContains('/media/', $gate['accepted_shape_markers']);
         $this->assertContains('/private/', $gate['forbidden_markers']);
-        $this->assertContains('raw-receipt', $gate['forbidden_markers']);
+        $this->assertContains('auth_token', $gate['forbidden_markers']);
     }
 
-    public function test_model_gate_accepts_reviewed_redacted_public_media_url_only(): void
+    public function test_model_gate_accepts_operator_approved_original_public_media_url_only(): void
     {
         $safeRecord = new DailyGivingRecord([
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
             'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
-            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/redacted-2026-06-05.pdf',
+            'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/public/original-2026-06-05.png',
         ]);
 
         $this->assertSame([], $safeRecord->proofStorageGateViolations());
 
         $unsafeRecord = new DailyGivingRecord([
-            'proof_status' => DailyGivingRecord::PROOF_REDACTED_AVAILABLE,
+            'proof_status' => DailyGivingRecord::PROOF_OPERATOR_APPROVED_AVAILABLE,
             'proof_private_path' => 'daily-giving/private/2026-06-05/raw-receipt.pdf',
             'proof_public_url' => 'https://media.fermatmind.com/foundation/daily-giving/private/raw-receipt-2026-06-05.pdf',
         ]);
 
-        $this->assertContains('proof_public_url must point to reviewed redacted public proof only', $unsafeRecord->proofStorageGateViolations());
+        $this->assertContains('proof_public_url must point to operator-approved public proof media only', $unsafeRecord->proofStorageGateViolations());
     }
 
     public function test_public_api_forbidden_fields_remain_private_only(): void


### PR DESCRIPTION
## What changed
- Adds `operator_approved_pending` and `operator_approved_available` DailyGiving proof statuses while retaining legacy `redacted_*` statuses for compatibility.
- Updates the model proof storage gate so `proof_public_url` can point to operator-approved public media for the original charity donation proof image instead of requiring a separate redacted derivative.
- Keeps public API/private-field boundaries intact: private paths, redaction notes, private receipt references, internal notes, admin ids, tokens, private URLs, secrets, and credentials remain blocked from public surfaces.
- Updates Filament labels, factories, generated artifacts, operations docs, and focused Foundation tests to the operator-approved public proof contract.

## Why
The repository rules now allow charity donation original receipt/proof images to be uploaded as the public proof media asset. The backend contract needed to match that operating model so later activation can use a real `proof_public_url` without the old mandatory-redaction semantic conflict.

## Validation
- `php -l` on changed PHP model/resource/factory/test files
- `python3 -m json.tool` on changed generated DailyGiving artifacts
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='DailyGivingProofStorageGateTest|DailyGivingRedactedPublicProofTest|DailyGivingPublicApiSmokeTest|DailyGivingRecordPublicationGateTest|DailyGivingRecordPublicApiTest|DailyGivingFirstRecordReviewTemplateTest|DailyGivingFirstRecordPrivateLedgerTest|DailyGivingProofRedactionSopTest|DailyGivingPublicReleasePrereqTest' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=DailyGivingRecord --no-ansi`
- `backend/vendor/bin/pint --test ...changed PHP files...`
- `git diff --check`
- residual semantic scan for the old mandatory reviewed-redacted public proof gate

## Deferred / sidecar
- No proof upload in this PR.
- No CMS or production DB mutation in this PR.
- No public record activation in this PR.
- No deploy, publish, sitemap, llms, search submission, social distribution, or trust badge change.
- Next external step: upload/select the operator-approved original charity donation proof image in public media and provide a real public `proof_public_url`.
- Next activation step after that URL exists: authorize the first production DailyGiving record activation with `is_public=true` and `is_indexable=false`.

## Repository rule impact
This PR implements the rules added in PR #1941: DailyGiving public proof media may be the operator-approved original charity donation proof image, while backend remains the authority for proof status, public URL acceptance, public API field exclusion, noindex, and claim boundaries.
