### PR TITLE
SCIENCE-CONTENTPAGE-PRE-IMPORT-QA-01: add pre-real-import QA gate

### DIFF
--- a/backend/app/Console/Commands/ScienceContentPagePreImportQaCommand.php
+++ b/backend/app/Console/Commands/ScienceContentPagePreImportQaCommand.php
@@ -1,0 +1,72 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ScienceContentPagePreImportQaService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ScienceContentPagePreImportQaCommand extends Command
+{
+    protected $signature = 'content-pages:science-pre-import-qa
+        {--package= : Path to the Science ContentPage CMS draft package directory}
+        {--json : Emit machine-readable JSON only}';
+
+    protected $description = 'Read-only pre-real-import QA gate for Science ContentPage drafts.';
+
+    public function handle(ScienceContentPagePreImportQaService $service): int
+    {
+        try {
+            $package = trim((string) $this->option('package'));
+            if ($package === '') {
+                throw new \RuntimeException('--package is required.');
+            }
+
+            $summary = $service->check($package);
+
+            if ((bool) $this->option('json')) {
+                $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+                return self::SUCCESS;
+            }
+
+            $this->line('task='.$summary['task']);
+            $this->line('mode='.$summary['mode']);
+            $this->line('decision='.$summary['decision']);
+            $this->line('cms_mutation_performed='.(($summary['cms_mutation_performed'] ?? true) ? 'true' : 'false'));
+            $this->line('database_writes_allowed='.(($summary['database_writes_allowed'] ?? true) ? 'true' : 'false'));
+            $this->line('content_import_performed='.(($summary['content_import_performed'] ?? true) ? 'true' : 'false'));
+            $this->line('publish_performed='.(($summary['publish_performed'] ?? true) ? 'true' : 'false'));
+            $this->line('non_public_draft_import_qa_passed='.(($summary['non_public_draft_import_qa_passed'] ?? false) ? 'true' : 'false'));
+            $this->line('real_import_allowed='.(($summary['real_import_allowed'] ?? true) ? 'true' : 'false'));
+            $this->line('publish_allowed='.(($summary['publish_allowed'] ?? true) ? 'true' : 'false'));
+            $this->line('natural_distribution_allowed='.(($summary['natural_distribution_allowed'] ?? true) ? 'true' : 'false'));
+            $this->line('package_pre_import_qa_issue_count='.$summary['package_pre_import_qa_issue_count']);
+            $this->line('dry_run_pages_blocked='.data_get($summary, 'dry_run.pages_blocked', 'Unknown'));
+            $this->line('operator_publish_decision_ready='.(data_get($summary, 'operator_review.operator_publish_decision_ready') === true ? 'true' : 'false'));
+
+            foreach (($summary['blocking_reasons'] ?? []) as $reason) {
+                $this->line('blocking_reason='.$reason);
+            }
+
+            foreach (($summary['issues'] ?? []) as $issue) {
+                $this->line(sprintf(
+                    'issue scope=%s code=%s message=%s',
+                    (string) ($issue['scope'] ?? 'Unknown'),
+                    (string) ($issue['code'] ?? 'Unknown'),
+                    (string) ($issue['message'] ?? 'Unknown'),
+                ));
+            }
+
+            $this->warn('pre-import QA is read-only; real import and publish remain blocked unless all external approval gates are satisfied.');
+
+            return self::SUCCESS;
+        } catch (Throwable $throwable) {
+            $this->error($throwable->getMessage());
+
+            return self::FAILURE;
+        }
+    }
+}

--- a/backend/app/Services/Cms/ScienceContentPagePreImportQaService.php
+++ b/backend/app/Services/Cms/ScienceContentPagePreImportQaService.php
@@ -1,0 +1,377 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use Symfony\Component\Yaml\Yaml;
+
+final class ScienceContentPagePreImportQaService
+{
+    private const EXPOSURE_FALSE_FIELDS = [
+        'is_public',
+        'is_indexable',
+        'sitemap_eligible',
+        'llms_eligible',
+        'footer_eligible',
+    ];
+
+    private const ALLOWED_PUBLIC_ROUTE_PREFIXES = [
+        '/about',
+        '/common-misconceptions',
+        '/data-privacy',
+        '/evidence-measurement-error',
+        '/item-design-notes',
+        '/method-boundaries',
+        '/privacy',
+        '/science',
+        '/support',
+        '/tests',
+    ];
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function check(string $packagePath): array
+    {
+        $root = rtrim($packagePath, DIRECTORY_SEPARATOR);
+        if ($root === '' || ! is_dir($root)) {
+            throw new \RuntimeException('Science ContentPage draft package directory does not exist: '.$packagePath);
+        }
+
+        $dryRun = app(ScienceContentPageDraftDryRunService::class)->dryRun($root);
+        $operator = app(ScienceContentPageOperatorReviewReadinessService::class)->review($root);
+        $manifest = $this->readJson($root.DIRECTORY_SEPARATOR.'manifest.json');
+
+        $issues = [];
+        $pages = [];
+
+        $defaults = is_array($manifest['eligibility_defaults'] ?? null) ? $manifest['eligibility_defaults'] : [];
+        foreach (self::EXPOSURE_FALSE_FIELDS as $field) {
+            if (($defaults[$field] ?? null) !== false) {
+                $issues[] = $this->issue('manifest', 'unsafe_default_'.$field, $field.' must remain false before real import.');
+            }
+        }
+
+        foreach (($manifest['pages'] ?? []) as $index => $page) {
+            if (! is_array($page)) {
+                $issues[] = $this->issue('manifest.pages['.$index.']', 'invalid_page_entry', 'page entry must be an object.');
+
+                continue;
+            }
+
+            $pageQa = $this->checkPage($root, $page, $index);
+            $pages[] = $pageQa;
+            foreach ($pageQa['issues'] as $issue) {
+                $issues[] = $issue;
+            }
+        }
+
+        $dryRunBlockers = (int) ($dryRun['pages_blocked'] ?? 0);
+        $operatorPublishReady = ($operator['operator_publish_decision_ready'] ?? false) === true;
+        $operatorDraftReady = ($operator['operator_review_ready_for_non_public_draft'] ?? false) === true;
+
+        $contentQaPassed = $issues === [];
+        $nonPublicDraftImportQaPassed = $contentQaPassed && $operatorDraftReady;
+        $realImportAllowed = false;
+        $publishAllowed = false;
+
+        $blockingReasons = [];
+        if (! $contentQaPassed) {
+            $blockingReasons[] = 'package_pre_import_qa_issues_present';
+        }
+        if ($dryRunBlockers > 0) {
+            $blockingReasons[] = 'authority_reconciliation_required';
+        }
+        if (! $operatorPublishReady) {
+            $blockingReasons[] = 'operator_publish_decision_not_ready';
+        }
+
+        return [
+            'task' => 'SCIENCE-CONTENTPAGE-PRE-IMPORT-QA-01',
+            'mode' => 'read_only_pre_real_import_qa_gate',
+            'cms_mutation_performed' => false,
+            'database_writes_allowed' => false,
+            'content_import_performed' => false,
+            'publish_performed' => false,
+            'package_path' => $root,
+            'decision' => $blockingReasons === [] ? 'CONDITIONAL' : 'NO-GO',
+            'non_public_draft_import_qa_passed' => $nonPublicDraftImportQaPassed,
+            'real_import_allowed' => $realImportAllowed,
+            'publish_allowed' => $publishAllowed,
+            'natural_distribution_allowed' => false,
+            'package_pre_import_qa_issue_count' => count($issues),
+            'blocking_reasons' => $blockingReasons,
+            'dry_run' => [
+                'status' => $dryRun['status'] ?? 'Unknown',
+                'pages_seen' => $dryRun['pages_seen'] ?? 'Unknown',
+                'pages_ready_for_non_public_draft_import' => $dryRun['pages_ready_for_non_public_draft_import'] ?? 'Unknown',
+                'pages_blocked' => $dryRunBlockers,
+                'would_write' => $dryRun['would_write'] ?? false,
+            ],
+            'operator_review' => [
+                'operator_review_ready_for_non_public_draft' => $operatorDraftReady,
+                'operator_publish_decision_ready' => $operatorPublishReady,
+                'missing_first_class_publish_safety_fields' => $operator['missing_first_class_publish_safety_fields'] ?? [],
+            ],
+            'guards' => [
+                'forbidden_claims_absent' => ! $this->hasIssueCode($issues, 'forbidden_claim_pattern_present'),
+                'private_url_absent' => ! $this->hasIssueCode($issues, 'private_url_pattern_present'),
+                'faq_visible_only' => ! $this->hasIssueCode($issues, 'hidden_faq_or_schema_pattern_present'),
+                'cta_public_canonical_only' => ! $this->hasIssueCode($issues, 'unsafe_cta_or_internal_link_route'),
+                'draft_exposure_disabled' => ! $this->hasIssueCodePrefix($issues, 'unsafe_'),
+                'sitemap_llms_footer_disabled' => ! $this->hasAnyIssueCode($issues, [
+                    'unsafe_default_sitemap_eligible',
+                    'unsafe_default_llms_eligible',
+                    'unsafe_default_footer_eligible',
+                    'unsafe_sitemap_eligible',
+                    'unsafe_llms_eligible',
+                    'unsafe_footer_eligible',
+                ]),
+            ],
+            'pages' => $pages,
+            'issues' => $issues,
+            'hard_no_go' => [
+                'no_cms_mutation',
+                'no_real_import',
+                'no_publish',
+                'no_private_url',
+                'no_hidden_faq_schema',
+                'no_unsupported_claims',
+                'no_sitemap_llms_footer_exposure',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifestPage
+     * @return array<string, mixed>
+     */
+    private function checkPage(string $root, array $manifestPage, int $index): array
+    {
+        $issues = [];
+        $pageKey = (string) ($manifestPage['page_key'] ?? 'Unknown');
+        $file = (string) ($manifestPage['file'] ?? '');
+        $path = $file !== '' ? $root.DIRECTORY_SEPARATOR.str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $file) : '';
+
+        $frontmatter = [];
+        $body = '';
+        $raw = '';
+        if ($file === '' || ! is_file($path)) {
+            $issues[] = $this->issue($pageKey, 'page_file_not_found', 'page file does not exist: '.$file);
+        } else {
+            $raw = (string) file_get_contents($path);
+            [$frontmatter, $body] = $this->readFrontmatter($path);
+        }
+
+        foreach (self::EXPOSURE_FALSE_FIELDS as $field) {
+            if (($manifestPage[$field] ?? false) !== false || ($frontmatter[$field] ?? false) !== false) {
+                $issues[] = $this->issue($pageKey, 'unsafe_'.$field, $field.' must remain false before real import.');
+            }
+        }
+
+        if ($this->hasForbiddenClaimPattern($this->claimScanText($body))) {
+            $issues[] = $this->issue($pageKey, 'forbidden_claim_pattern_present', 'Diagnostic, guarantee, official endorsement, competitor attack, or proof-overclaim language is blocked.');
+        }
+
+        if ($this->hasPrivateUrlPattern($raw)) {
+            $issues[] = $this->issue($pageKey, 'private_url_pattern_present', 'Private route or tokenized URL patterns may only appear in forbidden_routes metadata.');
+        }
+
+        if ($this->hasHiddenFaqOrSchemaPattern($raw)) {
+            $issues[] = $this->issue($pageKey, 'hidden_faq_or_schema_pattern_present', 'FAQ/schema fields must come only from visible_faq_items before import.');
+        }
+
+        $routes = $this->routesFrom($manifestPage, $frontmatter);
+        foreach ($routes as $route) {
+            if (! $this->isAllowedPublicRoute($route)) {
+                $issues[] = $this->issue($pageKey, 'unsafe_cta_or_internal_link_route', 'Route is not an allowed public canonical route: '.$route);
+            }
+        }
+
+        return [
+            'index' => $index,
+            'page_key' => $pageKey,
+            'file' => $file,
+            'forbidden_claims_absent' => ! $this->hasIssueCode($issues, 'forbidden_claim_pattern_present'),
+            'private_url_absent' => ! $this->hasIssueCode($issues, 'private_url_pattern_present'),
+            'faq_visible_only' => ! $this->hasIssueCode($issues, 'hidden_faq_or_schema_pattern_present'),
+            'routes_public_canonical_only' => ! $this->hasIssueCode($issues, 'unsafe_cta_or_internal_link_route'),
+            'draft_exposure_disabled' => ! $this->hasIssueCodePrefix($issues, 'unsafe_'),
+            'issues' => $issues,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new \RuntimeException('Invalid JSON file: '.$path);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function readFrontmatter(string $path): array
+    {
+        $content = (string) file_get_contents($path);
+        if (! preg_match('/\A---\R(?P<yaml>.*?)\R---\R(?P<body>.*)\z/s', $content, $matches)) {
+            throw new \RuntimeException('Page file is missing YAML frontmatter: '.$path);
+        }
+
+        $frontmatter = Yaml::parse((string) $matches['yaml']);
+        if (! is_array($frontmatter)) {
+            throw new \RuntimeException('Page frontmatter must parse to an object: '.$path);
+        }
+
+        return [$frontmatter, (string) $matches['body']];
+    }
+
+    private function hasForbiddenClaimPattern(string $body): bool
+    {
+        $patterns = [
+            '/(?<!不)(?:诊断|确诊|治疗)(?!场景|工具|相关|判断)/u',
+            '/(?:保证|承诺|确保).{0,12}(?:职业|录用|晋升|收入|成功|匹配|关系|结果)/u',
+            '/(?:官方认证|官方背书|权威认证|临床认证|医学认证)/u',
+            '/(?:最科学|最准确|唯一正确|完全准确|百分之百|100%)/iu',
+            '/(?:竞品|123test|Truity).{0,24}(?:不准|错误|虚假|抄袭|垃圾|骗局)/iu',
+            '/(?:证明|证实).{0,12}(?:命运|天赋|能力全貌|职业成功|心理疾病)/u',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $body) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function claimScanText(string $body): string
+    {
+        return preg_replace('/\Rclaim_boundary_notes:\s*.*\z/s', '', $body) ?? $body;
+    }
+
+    private function hasPrivateUrlPattern(string $raw): bool
+    {
+        $withoutForbiddenRoutes = preg_replace('/forbidden_routes:\s*(?:(?:\r?\n)\s*-\s*[^\r\n]+)+/m', '', $raw) ?? $raw;
+
+        return preg_match('#/(?:results?/|orders?(?:/|\b)|pay(?:/|\b)|payment(?:/|\b)|checkout(?:/|\b)|share/|history(?:/|\b))#i', $withoutForbiddenRoutes) === 1
+            || preg_match('/(?:token=|orderNo=|payment_intent=|client_secret=|recovery_token=)/i', $withoutForbiddenRoutes) === 1;
+    }
+
+    private function hasHiddenFaqOrSchemaPattern(string $raw): bool
+    {
+        $withoutVisibleFaq = preg_replace('/visible_faq_items:\s*(?:(?:\r?\n)\s{2,}-\s[^\r\n]+|(?:\r?\n)\s{4,}[^\r\n]+)*/m', '', $raw) ?? $raw;
+
+        return preg_match('/(?<!visible_)faq_items\s*:/i', $withoutVisibleFaq) === 1
+            || preg_match('/(?:faq_schema|schema_enabled|schema_eligible)\s*:\s*true/i', $withoutVisibleFaq) === 1;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifestPage
+     * @param  array<string, mixed>  $frontmatter
+     * @return list<string>
+     */
+    private function routesFrom(array $manifestPage, array $frontmatter): array
+    {
+        $routes = [];
+        foreach (['primary_cta_route', 'secondary_cta_route', 'cta_route'] as $field) {
+            foreach ([$manifestPage, $frontmatter] as $source) {
+                if (is_string($source[$field] ?? null)) {
+                    $routes[] = $source[$field];
+                }
+            }
+        }
+
+        foreach (['internal_links_allowed', 'cta_slots'] as $field) {
+            foreach ([$manifestPage, $frontmatter] as $source) {
+                $value = $source[$field] ?? null;
+                if (is_array($value)) {
+                    foreach ($value as $entry) {
+                        if (is_string($entry)) {
+                            $routes[] = $entry;
+                        } elseif (is_array($entry) && is_string($entry['route'] ?? null)) {
+                            $routes[] = $entry['route'];
+                        }
+                    }
+                }
+            }
+        }
+
+        return array_values(array_unique(array_map(static fn (string $route): string => trim($route), $routes)));
+    }
+
+    private function isAllowedPublicRoute(string $route): bool
+    {
+        if (! str_starts_with($route, '/') || str_starts_with($route, '//')) {
+            return false;
+        }
+        if ($this->hasPrivateUrlPattern($route)) {
+            return false;
+        }
+
+        foreach (self::ALLOWED_PUBLIC_ROUTE_PREFIXES as $prefix) {
+            if ($route === $prefix || str_starts_with($route, $prefix.'/')) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array{scope: string, code: string, message: string}>  $issues
+     */
+    private function hasIssueCode(array $issues, string $code): bool
+    {
+        return $this->hasAnyIssueCode($issues, [$code]);
+    }
+
+    /**
+     * @param  list<array{scope: string, code: string, message: string}>  $issues
+     * @param  list<string>  $codes
+     */
+    private function hasAnyIssueCode(array $issues, array $codes): bool
+    {
+        foreach ($issues as $issue) {
+            if (in_array($issue['code'], $codes, true)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array{scope: string, code: string, message: string}>  $issues
+     */
+    private function hasIssueCodePrefix(array $issues, string $prefix): bool
+    {
+        foreach ($issues as $issue) {
+            if (str_starts_with($issue['code'], $prefix)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @return array{scope: string, code: string, message: string}
+     */
+    private function issue(string $scope, string $code, string $message): array
+    {
+        return [
+            'scope' => $scope,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
@@ -1,0 +1,201 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\ContentPage;
+use App\Services\Cms\ScienceContentPagePreImportQaService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ScienceContentPagePreImportQaCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function pre_import_qa_passes_draft_package_but_blocks_real_import_and_publish(): void
+    {
+        $package = $this->writeSciencePackage();
+
+        $this->artisan('content-pages:science-pre-import-qa', [
+            '--package' => $package,
+        ])
+            ->expectsOutputToContain('task=SCIENCE-CONTENTPAGE-PRE-IMPORT-QA-01')
+            ->expectsOutputToContain('mode=read_only_pre_real_import_qa_gate')
+            ->expectsOutputToContain('decision=NO-GO')
+            ->expectsOutputToContain('cms_mutation_performed=false')
+            ->expectsOutputToContain('database_writes_allowed=false')
+            ->expectsOutputToContain('content_import_performed=false')
+            ->expectsOutputToContain('publish_performed=false')
+            ->expectsOutputToContain('non_public_draft_import_qa_passed=true')
+            ->expectsOutputToContain('real_import_allowed=false')
+            ->expectsOutputToContain('publish_allowed=false')
+            ->expectsOutputToContain('natural_distribution_allowed=false')
+            ->expectsOutputToContain('package_pre_import_qa_issue_count=0')
+            ->expectsOutputToContain('dry_run_pages_blocked=1')
+            ->expectsOutputToContain('operator_publish_decision_ready=false')
+            ->expectsOutputToContain('blocking_reason=authority_reconciliation_required')
+            ->expectsOutputToContain('blocking_reason=operator_publish_decision_not_ready')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    #[Test]
+    public function service_blocks_forbidden_claim_private_route_and_hidden_schema_patterns_without_writes(): void
+    {
+        $package = $this->writeSciencePackage(pageBodySuffix: <<<'MD'
+
+schema_enabled: true
+
+这个草稿保证职业成功。
+
+允许链接：
+- /orders/real-order
+MD);
+
+        $payload = app(ScienceContentPagePreImportQaService::class)->check($package);
+
+        $this->assertSame('NO-GO', $payload['decision']);
+        $this->assertFalse($payload['non_public_draft_import_qa_passed']);
+        $this->assertFalse($payload['real_import_allowed']);
+        $this->assertFalse($payload['publish_allowed']);
+        $this->assertSame(0, ContentPage::query()->count());
+
+        $codes = array_column($payload['issues'], 'code');
+        $this->assertContains('forbidden_claim_pattern_present', $codes);
+        $this->assertContains('private_url_pattern_present', $codes);
+        $this->assertContains('hidden_faq_or_schema_pattern_present', $codes);
+        $this->assertContains('package_pre_import_qa_issues_present', $payload['blocking_reasons']);
+        $this->assertFalse($payload['guards']['forbidden_claims_absent']);
+        $this->assertFalse($payload['guards']['private_url_absent']);
+        $this->assertFalse($payload['guards']['faq_visible_only']);
+    }
+
+    private function writeSciencePackage(string $pageBodySuffix = ''): string
+    {
+        $root = storage_path('framework/testing/science-contentpage-pre-import-qa-'.str()->uuid());
+        $pagesDir = $root.DIRECTORY_SEPARATOR.'pages';
+        mkdir($pagesDir, 0777, true);
+
+        $pages = [
+            ['SCIENCE-HUB-CONTENT-01', '/science', 'science', 'trust_methodology_hub', 'science_review', true, true, '01-science-hub-content-01.md'],
+            ['METHOD-BOUNDARY-CONTENT-01', '/method-boundaries', 'boundary', 'trust_methodology_boundary', 'science_review', true, true, '02-method-boundary-content-01.md'],
+            ['ITEM-DESIGN-CONTENT-01', '/item-design-notes', 'methodology', 'item_design_notes', 'science_review', true, false, '03-item-design-content-01.md'],
+            ['RELIABILITY-VALIDITY-CONTENT-01', '/reliability-validity', 'methodology', 'evidence_measurement_error', 'science_review', true, false, '04-reliability-validity-content-01.md', '/evidence-measurement-error'],
+            ['DATA-NOTES-CONTENT-01', '/data-results-notes', 'privacy', 'data_results_notes', 'owner_review', false, true, '05-data-notes-content-01.md', '/data-privacy'],
+            ['MISCONCEPTIONS-CONTENT-01', '/common-misconceptions', 'boundary', 'misconceptions', 'science_review', true, false, '06-misconceptions-content-01.md'],
+        ];
+
+        $manifestPages = [];
+        foreach ($pages as $offset => $page) {
+            [$key, $slug, $pageType, $kind, $reviewState, $scienceReview, $legalReview, $file] = $page;
+            $fallback = $page[8] ?? $slug;
+            $manifestPages[] = [
+                'page_key' => $key,
+                'zh_title' => 'Draft '.$key,
+                'en_title' => 'Draft '.$key,
+                'proposed_slug' => $slug,
+                'fallback_slug' => $fallback,
+                'page_type' => $pageType,
+                'kind' => $kind,
+                'review_state' => $reviewState,
+                'science_review_required' => $scienceReview,
+                'legal_review_required' => $legalReview,
+                'file' => 'pages/'.$file,
+            ];
+
+            file_put_contents($pagesDir.DIRECTORY_SEPARATOR.$file, $this->pageMarkdown(
+                key: $key,
+                slug: $slug,
+                fallback: $fallback,
+                pageType: $pageType,
+                kind: $kind,
+                reviewState: $reviewState,
+                scienceReview: $scienceReview,
+                legalReview: $legalReview,
+                bodySuffix: $offset === 0 ? $pageBodySuffix : '',
+            ));
+        }
+
+        file_put_contents($root.DIRECTORY_SEPARATOR.'manifest.json', json_encode([
+            'package' => 'FermatMind Science / Methodology CMS Draft Package',
+            'status' => 'draft_only_not_for_publication',
+            'eligibility_defaults' => [
+                'is_public' => false,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'footer_eligible' => false,
+            ],
+            'pages' => $manifestPages,
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    private function pageMarkdown(
+        string $key,
+        string $slug,
+        string $fallback,
+        string $pageType,
+        string $kind,
+        string $reviewState,
+        bool $scienceReview,
+        bool $legalReview,
+        string $bodySuffix,
+    ): string {
+        $science = $scienceReview ? 'true' : 'false';
+        $legal = $legalReview ? 'true' : 'false';
+
+        return <<<MD
+---
+page_key: {$key}
+zh_title: Draft {$key}
+en_title: Draft {$key}
+proposed_slug: {$slug}
+fallback_slug_if_nested_route_not_supported: {$fallback}
+page_type: {$pageType}
+kind: {$kind}
+review_state: {$reviewState}
+science_review_required: {$science}
+legal_review_required: {$legal}
+is_public: false
+is_indexable: false
+sitemap_eligible: false
+llms_eligible: false
+footer_eligible: false
+meta_title_draft: Draft meta
+meta_description_draft: Draft description.
+internal_links_allowed:
+  - /tests
+  - /privacy
+  - /support
+forbidden_routes:
+  - /result/*
+  - /orders/*
+  - /share/*
+  - /pay/*
+  - /payment/*
+  - /history/*
+---
+
+# content_md
+
+Draft-only body for pre-import QA validation.
+{$bodySuffix}
+
+visible_faq_items:
+  - question: Is this publishable?
+    answer: No. This fixture is draft-only.
+
+claim_boundary_notes:
+  - Keep claims conservative.
+
+reviewer_checklist:
+  - Confirm review gates.
+MD;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -943,8 +943,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $changed = [
             'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
             'backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php',
+            'backend/app/Console/Commands/ScienceContentPagePreImportQaCommand.php',
             'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
             'backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php',
+            'backend/app/Services/Cms/ScienceContentPagePreImportQaService.php',
         ];
 
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
@@ -3809,8 +3811,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
             'backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php',
+            'backend/app/Console/Commands/ScienceContentPagePreImportQaCommand.php',
             'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
             'backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php',
+            'backend/app/Services/Cms/ScienceContentPagePreImportQaService.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added a read-only `content-pages:science-pre-import-qa` command for the Science ContentPage draft package.
- Added a QA service that composes the prior dry-run and operator readiness gates, then scans draft package files for unsupported claims, private URL patterns, hidden FAQ/schema patterns, unsafe CTA/internal routes, and sitemap/llms/footer exposure defaults.
- Added tests for the safe draft path and intentionally unsafe claim/private-route/schema patterns, with no ContentPage writes.
- Extended the BigFive runtime freeze allowlist for this no-write Science ContentPage gate.

## Why
This is the final safety gate before any future real CMS import/publish action. It confirms the draft package can pass content QA as a non-public draft while still blocking real import and publish until authority reconciliation and operator publish approval are resolved.

## Validation
- `php artisan test --filter ScienceContentPagePreImportQaCommandTest --compact --display-warnings`
- `php artisan content-pages:science-pre-import-qa --package="/Users/rainie/Desktop/science_contentpage_cms_draft_package 2" --json`
- `./vendor/bin/pint --test app/Services/Cms/ScienceContentPagePreImportQaService.php app/Console/Commands/ScienceContentPagePreImportQaCommand.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan route:list`
- `php artisan migrate --pretend`
- `php artisan test --filter BigFiveResultPageV2CoreBodyPreviewTest --compact`
- `bash scripts/ci_verify_mbti.sh`
- `git diff --check`

## Real package result
- `decision=NO-GO` for real import/publish
- `non_public_draft_import_qa_passed=true`
- `package_pre_import_qa_issue_count=0`
- `forbidden_claims_absent=true`
- `private_url_absent=true`
- `faq_visible_only=true`
- `cta_public_canonical_only=true`
- `sitemap_llms_footer_disabled=true`
- Blockers remain `authority_reconciliation_required` and `operator_publish_decision_not_ready`

## Deferred
- No CMS mutation, real import, publish, sitemap/llms/footer exposure, or deployment is included.
- Resolving `/method-boundaries` authority reconciliation and first-class operator publish approval fields remains outside this PR.