### PR TITLE
HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01 feat(cms): map Help service fields in ContentPage importer

### DIFF
--- a/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
@@ -189,6 +189,11 @@ final class ContentPagesImportLocalBaseline extends Command
             'meta_description' => $this->nullableString($row['metaDescription'] ?? $row['meta_description'] ?? $row['summary'] ?? null),
             'seo_description' => $this->nullableString($row['seoDescription'] ?? $row['seo_description'] ?? $row['metaDescription'] ?? $row['meta_description'] ?? $row['summary'] ?? null),
             'canonical_path' => $this->nullableString($row['canonicalPath'] ?? $row['canonical_path'] ?? null),
+            'support_contact' => $this->nullableString($row['support_contact'] ?? $row['supportContact'] ?? null),
+            'policy_version' => $this->nullableString($row['policy_version'] ?? $row['policyVersion'] ?? null),
+            'reviewer' => $this->nullableString($row['reviewer'] ?? null),
+            'faq_items' => $this->normalizeFaqItems($row['faq_items'] ?? $row['faqItems'] ?? []),
+            'schema_enabled' => (bool) ($row['schema_enabled'] ?? $row['schemaEnabled'] ?? false),
             'status' => $status,
         ];
     }
@@ -299,6 +304,36 @@ final class ContentPagesImportLocalBaseline extends Command
         $trimmed = trim((string) $value);
 
         return $trimmed !== '' ? $trimmed : null;
+    }
+
+    /**
+     * @return list<array{question:string,answer:string}>
+     */
+    private function normalizeFaqItems(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $items = [];
+        foreach ($value as $item) {
+            if (! is_array($item)) {
+                continue;
+            }
+
+            $question = trim((string) ($item['question'] ?? $item['q'] ?? ''));
+            $answer = trim((string) ($item['answer'] ?? $item['a'] ?? ''));
+            if ($question === '' || $answer === '') {
+                continue;
+            }
+
+            $items[] = [
+                'question' => $question,
+                'answer' => $answer,
+            ];
+        }
+
+        return $items;
     }
 
     /**

--- a/backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json
+++ b/backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json
@@ -1,0 +1,73 @@
+{
+  "schema": "help-contentpage-importer-service-fields-01.v1",
+  "task": "HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01",
+  "generated_at": "2026-06-08",
+  "decision": "CONTENT_PAGE_BASELINE_IMPORTER_SUPPORTS_HELP_SERVICE_FIELDS_WITHOUT_CMS_MUTATION",
+  "depends_on": [
+    "HELP-CMS-SERVICE-FIELDS-01",
+    "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01"
+  ],
+  "implemented_fields": [
+    "support_contact",
+    "policy_version",
+    "reviewer",
+    "faq_items",
+    "schema_enabled"
+  ],
+  "runtime": {
+    "command": "content-pages:import-local-baseline",
+    "changed_file": "backend/app/Console/Commands/ContentPagesImportLocalBaseline.php",
+    "supports_dry_run": true,
+    "supports_upsert": true,
+    "supports_draft_status": true,
+    "cms_mutation_performed": false
+  },
+  "contract": {
+    "test_file": "backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php",
+    "focused_test": "test_help_service_importer_materializes_service_fields_on_draft_rows",
+    "source_package": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "expected_rows": 12,
+    "expected_support_contact": "support@fermatmind.com",
+    "expected_policy_version": "help_service_policy.v1",
+    "expected_reviewer": "Unknown",
+    "expected_faq_items_per_row": 4,
+    "expected_schema_enabled": false,
+    "expected_public_rows": 0,
+    "expected_indexable_rows": 0,
+    "expected_published_rows": 0
+  },
+  "runtime_freeze_scope_guard": {
+    "test_file": "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+    "existing_test": "test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes",
+    "changed_runtime_file_allowed": "backend/app/Console/Commands/ContentPagesImportLocalBaseline.php"
+  },
+  "no_go_checks": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01",
+      "status": "required_followup",
+      "note": "Production runtime must include this importer mapping before HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01 can write the revised fields into existing draft rows."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+      "status": "blocked_until_runtime_synced",
+      "note": "CMS draft sync remains blocked until production runtime contains the importer service-field mapping."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish remains blocked and requires Operator review, publish preflight, and exact publish authorization."
+    }
+  ],
+  "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01"
+}

--- a/backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md
+++ b/backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md
@@ -1,0 +1,46 @@
+# HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01
+
+Decision: `CONTENT_PAGE_BASELINE_IMPORTER_SUPPORTS_HELP_SERVICE_FIELDS_WITHOUT_CMS_MUTATION`
+
+This PR updates the backend `content-pages:import-local-baseline` importer so local ContentPage source rows can materialize the Help service fields already present on the `ContentPage` model and database schema. It does not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund actions, change payment-provider behavior, or claim Operator approval.
+
+## Scope
+
+- Importer field support:
+  - `support_contact`
+  - `policy_version`
+  - `reviewer`
+  - `faq_items`
+  - `schema_enabled`
+- Focused contract:
+  - Import the existing 12-row Help service source package in draft mode.
+  - Assert all 12 imported rows stay draft, non-public, non-indexable, unpublished, and `owner_review`.
+  - Assert all 12 rows receive `support@fermatmind.com`, `help_service_policy.v1`, `Unknown`, four FAQ items, and `schema_enabled=false`.
+- Runtime-freeze scope guard:
+  - Reuse the existing `ContentPagesImportLocalBaseline.php` allowlist evidence test.
+
+## Deferred
+
+- No CMS sync in this PR.
+- No production deploy/runtime sync in this PR.
+- No Operator review approval claim.
+- No publish.
+
+## Next Gate
+
+`HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01` should sync production runtime so the deployed importer includes these field mappings. After that, `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01` can be re-evaluated for scoped CMS draft sync.
+
+## Validation
+
+```bash
+php -l backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+php -l backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+python3 -m json.tool backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ContentPagePublicApiTest::test_help_service_importer_materializes_service_fields_on_draft_rows|ContentPagePublicApiTest::test_help_service_fields_are_first_class_content_page_contracts' --no-ansi
+cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+git diff --check -- backend/app/Console/Commands/ContentPagesImportLocalBaseline.php backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+++ b/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
@@ -288,6 +288,51 @@ final class ContentPagePublicApiTest extends TestCase
         ], $page->faq_items);
     }
 
+    public function test_help_service_importer_materializes_service_fields_on_draft_rows(): void
+    {
+        $this->artisan('content-pages:import-local-baseline', [
+            '--upsert' => true,
+            '--status' => ContentPage::STATUS_DRAFT,
+            '--source-dir' => 'docs/help/import-packages/content-pages-draft-source',
+        ])
+            ->expectsOutputToContain('files_found=1')
+            ->expectsOutputToContain('pages_found=12')
+            ->expectsOutputToContain('will_create=12')
+            ->assertExitCode(0);
+
+        $targetSlugs = [
+            'help-unlock-failure',
+            'help-payment-refund',
+            'help-result-recovery',
+            'help-privacy-data',
+            'help-use-boundaries',
+            'help-data-deletion',
+        ];
+
+        $rows = ContentPage::query()
+            ->withoutGlobalScopes()
+            ->whereIn('slug', $targetSlugs)
+            ->whereIn('locale', ['zh-CN', 'en'])
+            ->get();
+
+        $this->assertCount(12, $rows);
+
+        foreach ($rows as $row) {
+            $this->assertSame(ContentPage::STATUS_DRAFT, (string) $row->status);
+            $this->assertFalse((bool) $row->is_public);
+            $this->assertFalse((bool) $row->is_indexable);
+            $this->assertNull($row->published_at);
+            $this->assertSame('owner_review', (string) $row->review_state);
+            $this->assertSame('support@fermatmind.com', (string) $row->support_contact);
+            $this->assertSame('help_service_policy.v1', (string) $row->policy_version);
+            $this->assertSame('Unknown', (string) $row->reviewer);
+            $this->assertFalse((bool) $row->schema_enabled);
+            $this->assertCount(4, $row->faq_items ?? []);
+            $this->assertArrayHasKey('question', ($row->faq_items ?? [])[0] ?? []);
+            $this->assertArrayHasKey('answer', ($row->faq_items ?? [])[0] ?? []);
+        }
+    }
+
     /**
      * @param  list<string>  $permissions
      */

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45820,7 +45820,7 @@
     "repo": "fap-api",
     "branch": "codex/help-contentpage-importer-service-fields-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "feat(cms): map Help service fields in ContentPage importer",
     "depends_on": [
@@ -45882,11 +45882,26 @@
             "status": "pass"
           }
         ]
+      },
+      "github": {
+        "status": "pass",
+        "checks": [
+          "hygiene",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN"
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9fd75cfb04637e242fa33e3a8c4cac2c38a128dc",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1956",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -45942,6 +45957,16 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "PHP lint, JSON/YAML parse, focused ContentPage importer contract, runtime-freeze scope guard, and scoped diff whitespace checks passed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1956 for HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN. Scope remained importer mapping, focused contracts, generated artifact, operations report, and PR-train metadata only."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -45651,7 +45651,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-policy-revision-apply-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): apply Help policy answers to draft package",
     "depends_on": [
@@ -45741,11 +45741,11 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "65b4971023b99af993011894b4684ae8896d41d3",
+    "commit_sha": "bb0a3c1098060ae37dbde07fdb051ddb3d8fcf29",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1954",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-05T15:37:11Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "LOCAL_IMPORT_PACKAGE_REVISED_WITH_CMS_SYNC_AND_PUBLISH_BLOCKED",
       "generated_artifact": "backend/docs/help/generated/help-content-draft-policy-revision-apply-01.v1.json",
@@ -45808,6 +45808,140 @@
         "at": "2026-06-05",
         "status": "ready_to_merge",
         "note": "All GitHub checks passed and merge state was CLEAN. Scope remained local package/import artifact, docs, focused package contract, and PR-train metadata only."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged_status_reconciled",
+        "note": "Reconciled PR #1954 merge facts while preparing HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01; GitHub reported merge commit bb0a3c1098060ae37dbde07fdb051ddb3d8fcf29 and origin/main contains it."
+      }
+    ]
+  },
+  "HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-contentpage-importer-service-fields-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "feat(cms): map Help service fields in ContentPage importer",
+    "depends_on": [
+      "HELP-CMS-SERVICE-FIELDS-01",
+      "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized supplementing and executing HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01 with no CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider change, or Operator approval claim."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CMS-SERVICE-FIELDS-01 is merged; HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01 is reconciled as merged with merge commit bb0a3c1098060ae37dbde07fdb051ddb3d8fcf29 on origin/main."
+      },
+      "scope_preflight": {
+        "status": "pass",
+        "evidence": "Current scope changes importer field mapping, focused tests, runtime-freeze scope evidence, generated artifact, operations report, and PR-train metadata only. No CMS mutation, publish, deploy, search submission, private URL access, payment/refund action, payment-provider change, or secret/env/cookie/token read is allowed."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "php -l backend/app/Console/Commands/ContentPagesImportLocalBaseline.php",
+            "status": "pass"
+          },
+          {
+            "command": "php -l backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php",
+            "status": "pass"
+          },
+          {
+            "command": "php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "pass"
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ContentPagePublicApiTest::test_help_service_importer_materializes_service_fields_on_draft_rows|ContentPagePublicApiTest::test_help_service_fields_are_first_class_content_page_contracts' --no-ansi",
+            "status": "passed_with_warning",
+            "notes": "Exited 0 with 160 assertions and existing Laravel file_get_contents warnings."
+          },
+          {
+            "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+            "status": "passed_with_warning",
+            "notes": "Exited 0 with 4 assertions and existing Laravel file_get_contents warnings."
+          },
+          {
+            "command": "git diff --check -- backend/app/Console/Commands/ContentPagesImportLocalBaseline.php backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "pass"
+          }
+        ]
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "CONTENT_PAGE_BASELINE_IMPORTER_SUPPORTS_HELP_SERVICE_FIELDS_WITHOUT_CMS_MUTATION",
+      "generated_artifact": "backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json",
+      "operations_report": "backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md",
+      "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "operator_approval_claimed": false,
+      "frontend_fallback_content_added": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01",
+        "status": "required_followup",
+        "note": "Production runtime must include this importer mapping before policy CMS sync can write revised fields."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+        "status": "blocked_until_runtime_synced",
+        "note": "CMS draft sync remains blocked until production runtime contains this importer service-field mapping."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish remains blocked and requires Operator review, publish preflight, and exact publish authorization."
+      }
+    ],
+    "next_task": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User authorized HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01 manifest/state entry and execution."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Added importer field mapping, focused import contract, generated artifact, operations report, and PR-train metadata; local validation pending."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "PHP lint, JSON/YAML parse, focused ContentPage importer contract, runtime-freeze scope guard, and scoped diff whitespace checks passed."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -21965,6 +21965,57 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
 
+  - id: HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01
+    repo: fap-api
+    depends_on:
+      - HELP-CMS-SERVICE-FIELDS-01
+      - HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01
+    branch: codex/help-contentpage-importer-service-fields-01
+    title: "feat(cms): map Help service fields in ContentPage importer"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Make content-pages:import-local-baseline materialize support_contact, policy_version, reviewer, faq_items, and schema_enabled from ContentPage source rows.
+      - Add focused contract coverage using the existing 12-row Help service source package.
+      - Preserve draft-only, non-public, non-indexable, unpublished, and schema_enabled=false gates for the Help service package.
+      - Reuse the existing runtime-freeze scope guard for ContentPagesImportLocalBaseline.php.
+      - Reconcile HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01 merged state because it blocks this follow-up train item.
+    allowed_paths:
+      - backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+      - backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json
+      - backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS data, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, add frontend fallback content, or claim Operator approval.
+    validation:
+      - php -l backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+      - php -l backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+      - php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - python3 -m json.tool backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ContentPagePublicApiTest::test_help_service_importer_materializes_service_fields_on_draft_rows|ContentPagePublicApiTest::test_help_service_fields_are_first_class_content_page_contracts' --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi
+      - git diff --check -- backend/app/Console/Commands/ContentPagesImportLocalBaseline.php backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added `support_contact`, `policy_version`, `reviewer`, `faq_items`, and `schema_enabled` mapping to `content-pages:import-local-baseline`.
- Added a focused ContentPage importer contract using the existing 12-row Help service source package.
- Added generated audit artifact, operations report, and PR-train manifest/state entry.
- Reconciled `HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01` merge state in the ledger because it blocks this follow-up train item.

## Why
- Production schema now has the Help service fields, but the deployed/importer runtime must support materializing those fields before `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01` can safely sync the revised draft package.

## Validation
- `php -l backend/app/Console/Commands/ContentPagesImportLocalBaseline.php`
- `php -l backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php`
- `php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `python3 -m json.tool backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='ContentPagePublicApiTest::test_help_service_importer_materializes_service_fields_on_draft_rows|ContentPagePublicApiTest::test_help_service_fields_are_first_class_content_page_contracts' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_content_pages_local_baseline_import_package_changes|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff' --no-ansi`
- `git diff --check -- backend/app/Console/Commands/ContentPagesImportLocalBaseline.php backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/help/generated/help-contentpage-importer-service-fields-01.v1.json backend/docs/operations/help-contentpage-importer-service-fields-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation or draft sync.
- No deploy/runtime sync.
- No publish, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider change, or Operator approval claim.
- `HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01` remains the next gate before CMS draft sync.

## Repository rule impact
- Content authority remains CMS/backend. This PR extends the backend importer so CMS-owned Help service fields can be materialized from backend-owned source rows; it does not add frontend fallback content.
