### PR TITLE
docs(seo): record RIASEC operator media blocker

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json
@@ -1,0 +1,247 @@
+{
+  "schema": "riasec-explanation-operator-input-media-blocker.v1",
+  "task_id": "RIASEC-EXPLANATION-OPERATOR-INPUT-MEDIA-BLOCKER-01",
+  "generated_at": "2026-06-08T04:45:00+08:00",
+  "decision": "CONDITIONAL_GO_OPERATOR_INPUTS_RECORDED_MEDIA_BLOCKER",
+  "publish_preflight_allowed": false,
+  "cms_mutation_allowed": false,
+  "publish_allowed": false,
+  "search_submission_allowed": false,
+  "deploy_allowed": false,
+  "content_rewrite_allowed": false,
+  "operator_inputs_recorded_from_current_scan": true,
+  "operator_approval_claimed": false,
+  "content_rewrite_performed": false,
+  "cms_mutation_performed": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "private_url_accessed": false,
+  "source_reviews_used": [
+    "backend/docs/seo/generated/riasec-explanation-reference-source-review.v1.json",
+    "backend/docs/seo/generated/riasec-explanation-content-package-v2.validation.json",
+    "backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json",
+    "public read-only HTTP checks on FermatMind canonical routes",
+    "public O*NET and APA source checks"
+  ],
+  "draft_records": [
+    {
+      "locale": "zh",
+      "article_id": 40,
+      "working_revision_id": 45,
+      "slug": "riasec-holland-career-interest-test-explained",
+      "status": "draft",
+      "public": false,
+      "indexable": false,
+      "working_revision_status": "machine_draft",
+      "approval_decision": "hold_until_media_supplied"
+    },
+    {
+      "locale": "en",
+      "article_id": 41,
+      "working_revision_id": 46,
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "status": "draft",
+      "public": false,
+      "indexable": false,
+      "working_revision_status": "machine_draft",
+      "approval_decision": "hold_until_media_supplied"
+    }
+  ],
+  "operator_input_decisions": {
+    "reference_acceptance": {
+      "status": "accepted_for_operator_recording",
+      "citation_style": "cms_references_visible_reference_section",
+      "accepted_source_urls": [
+        "https://www.onetcenter.org/reports/IP_Manual.html",
+        "https://www.onetcenter.org/content.html",
+        "https://www.onetcenter.org/dictionary/20.2/text/interests.html",
+        "https://services.onetcenter.org/reference/mpp/ip",
+        "https://dictionary.apa.org/five-factor-personality-model"
+      ],
+      "accepted_source_titles": [
+        "O*NET Interest Profiler Manual",
+        "The O*NET Content Model",
+        "O*NET Interests Data Dictionary",
+        "O*NET Interest Profiler API Reference",
+        "APA Dictionary: Five-Factor Personality Model"
+      ],
+      "source_to_claim_acceptance": [
+        {
+          "source_url": "https://www.onetcenter.org/reports/IP_Manual.html",
+          "accepted_for": [
+            "RIASEC and Holland Code background",
+            "career exploration and career guidance context",
+            "non-deterministic vocational-interest framing"
+          ]
+        },
+        {
+          "source_url": "https://www.onetcenter.org/content.html",
+          "accepted_for": [
+            "career interests as broad types of work",
+            "distinction between career interests, abilities, and work styles"
+          ]
+        },
+        {
+          "source_url": "https://www.onetcenter.org/dictionary/20.2/text/interests.html",
+          "accepted_for": [
+            "RIASEC interest labels",
+            "occupation-to-interest data context"
+          ]
+        },
+        {
+          "source_url": "https://services.onetcenter.org/reference/mpp/ip",
+          "accepted_for": [
+            "career-exploration system context",
+            "Interest Profiler results and career-listing service categories"
+          ]
+        },
+        {
+          "source_url": "https://dictionary.apa.org/five-factor-personality-model",
+          "accepted_for": [
+            "Big Five comparison boundary only",
+            "no claim that Big Five replaces RIASEC"
+          ]
+        }
+      ],
+      "holland_hexagon_terms_acceptance": "accepted_with_exploratory_boundary",
+      "mbti_big_five_comparison_acceptance": "accepted_conservative_comparison_only",
+      "no_official_affiliation_acknowledgement": true,
+      "no_official_affiliation_note": "Do not imply endorsement, certification, partnership, licensing, or official association with O*NET, DOL, APA, Holland, MBTI publishers, or any official body."
+    },
+    "claim_warning_decision": {
+      "status": "acknowledged",
+      "zh_claim_warning_count": 2,
+      "en_claim_warning_count": 0,
+      "claim_warning_acknowledgement": true,
+      "gpt_revision_required": false,
+      "reason": "Current validation records claim_boundary=pass. Risk phrases are treated as limitation, negation, or boundary context rather than diagnosis, career guarantee, official certification, or deterministic matching."
+    },
+    "internal_link_decision": {
+      "status": "activate_public_canonical_links",
+      "conditional_links_activation_decision": "activate",
+      "activated_links": [
+        "/zh/career/jobs",
+        "/en/career/jobs"
+      ],
+      "reason": "Read-only production checks returned 200, canonical, indexable pages and sitemap plus llms enumeration for both career jobs index routes."
+    },
+    "cta_route_decision": {
+      "status": "accepted_public_canonical_routes_only",
+      "primary_cta_routes": [
+        "/zh/tests/holland-career-interest-test-riasec",
+        "/en/tests/holland-career-interest-test-riasec"
+      ],
+      "reason": "Read-only production checks returned 200, canonical, indexable pages and sitemap plus llms enumeration for both RIASEC test routes."
+    },
+    "product_availability_decision": {
+      "status": "conditional_pass",
+      "product_availability_confirmed": true,
+      "product_availability_scope": "public_riasec_cta_route_only",
+      "report_preview_language_confirmed": "conditional_pass_non_promissory",
+      "reason": "Article package language uses exploratory and non-promissory report framing. It must not be expanded into a guarantee that every report module is available or complete."
+    },
+    "media_resolution": {
+      "status": "blocked",
+      "cms_media_id": "Unknown",
+      "cover_image_url": "Unknown",
+      "cover_image_alt_reviewed": "Unknown",
+      "og_image_ready": "Unknown",
+      "twitter_image_ready": "Unknown",
+      "required_next_input": "Select or upload a CMS Media Library cover image, then record CMS media ID, public cover URL, reviewed alt, and social image readiness."
+    },
+    "revision_approval": {
+      "status": "hold",
+      "zh_revision_id": 45,
+      "en_revision_id": 46,
+      "approved_by": "Unknown",
+      "approved_at": "Unknown",
+      "approval_notes": "Hold revision approval until media_resolution status is no longer blocked. No Codex content rewrite was performed.",
+      "cms_draft_approval_allowed": false
+    }
+  },
+  "public_route_observations": {
+    "safe_public_routes": [
+      {
+        "route": "/zh/tests/holland-career-interest-test-riasec",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/zh/tests/holland-career-interest-test-riasec",
+        "robots": "index, follow",
+        "sitemap_count": 1,
+        "llms_count": 1
+      },
+      {
+        "route": "/en/tests/holland-career-interest-test-riasec",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/en/tests/holland-career-interest-test-riasec",
+        "robots": "index, follow",
+        "sitemap_count": 1,
+        "llms_count": 1
+      },
+      {
+        "route": "/zh/career/jobs",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/zh/career/jobs",
+        "robots": "index, follow",
+        "sitemap_count": "nonzero",
+        "llms_count": "nonzero"
+      },
+      {
+        "route": "/en/career/jobs",
+        "http_status": 200,
+        "canonical": "https://fermatmind.com/en/career/jobs",
+        "robots": "index, follow",
+        "sitemap_count": "nonzero",
+        "llms_count": "nonzero"
+      }
+    ],
+    "draft_route_exposure": [
+      {
+        "route": "/zh/articles/riasec-holland-career-interest-test-explained",
+        "http_status": 404,
+        "sitemap_count": 0,
+        "llms_count": 0
+      },
+      {
+        "route": "/en/articles/what-is-riasec-holland-code-career-interest-test",
+        "http_status": 404,
+        "sitemap_count": 0,
+        "llms_count": 0
+      }
+    ]
+  },
+  "remaining_blockers": [
+    {
+      "id": "cms_media_missing",
+      "status": "blocked",
+      "owner": "cms_operator_or_design_owner",
+      "required_input": "CMS Media Library cover image ID, public URL, reviewed alt text, OG image readiness, and Twitter image readiness."
+    },
+    {
+      "id": "revision_approval_held_until_media",
+      "status": "blocked",
+      "owner": "operator_editor",
+      "required_input": "Approve zh revision 45 and en revision 46 only after media_resolution is supplied."
+    },
+    {
+      "id": "publish_preflight_not_authorized",
+      "status": "hard_gate",
+      "owner": "operator",
+      "required_input": "Separate authorization is required before SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01."
+    }
+  ],
+  "next_step": {
+    "id": "RIASEC_V2_CMS_MEDIA_SELECTION_REQUIRED",
+    "recommended_action": "Supply CMS Media Library cover image inputs, then run a media-resolution recording PR or CMS draft approval update with separate explicit CMS mutation authorization if needed.",
+    "not_recommended_yet": "SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01"
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_cms_mutation": true,
+    "no_publish": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "public_canonical_routes_only": true,
+    "no_private_or_tokenized_url_access": true
+  }
+}

--- a/backend/docs/seo/riasec-explanation-operator-input-media-blocker.md
+++ b/backend/docs/seo/riasec-explanation-operator-input-media-blocker.md
@@ -1,0 +1,75 @@
+# RIASEC Explanation V2 Operator Input Recording and Media Blocker
+
+Task: `RIASEC-EXPLANATION-OPERATOR-INPUT-MEDIA-BLOCKER-01`
+
+Decision: **CONDITIONAL GO for recording operator inputs; NO-GO for publish preflight because CMS media is still missing.**
+
+This ad-hoc PR records decisions that can be made from repository artifacts, public route checks, and public source checks. It does not rewrite article content, mutate CMS records, approve revisions, publish, submit search URLs, deploy, read secrets, or access private user-specific URLs.
+
+## Decisions Recorded
+
+| Area | Decision |
+| --- | --- |
+| Reference source set | accepted for operator recording |
+| Citation style | CMS references field plus visible reference section |
+| Holland / RIASEC terms | accepted with exploratory boundary |
+| MBTI / Big Five comparison | accepted only as conservative use-case comparison |
+| Official affiliation | no endorsement, certification, partnership, or official association may be implied |
+| zh claim warnings | acknowledged; GPT revision is not required from current scan |
+| Conditional career links | activate `/zh/career/jobs` and `/en/career/jobs` as public canonical links |
+| RIASEC CTA routes | accept `/zh/tests/holland-career-interest-test-riasec` and `/en/tests/holland-career-interest-test-riasec` only |
+| Product availability | pass for public RIASEC CTA route; report-preview wording remains non-promissory |
+| Revision approval | hold until CMS media is supplied |
+| CMS media | blocked / Unknown |
+
+## Accepted Source Set
+
+- O*NET Interest Profiler Manual: `https://www.onetcenter.org/reports/IP_Manual.html`
+- The O*NET Content Model: `https://www.onetcenter.org/content.html`
+- O*NET Interests Data Dictionary: `https://www.onetcenter.org/dictionary/20.2/text/interests.html`
+- O*NET Interest Profiler API Reference: `https://services.onetcenter.org/reference/mpp/ip`
+- APA Dictionary: Five-Factor Personality Model: `https://dictionary.apa.org/five-factor-personality-model`
+
+These sources support background and boundary review only. They do not create any endorsement, certification, partnership, license claim, or official association for FermatMind.
+
+## Draft State
+
+| Locale | Article ID | Working revision | State | Decision |
+| --- | ---: | ---: | --- | --- |
+| zh | 40 | 45 | draft / non-public / non-indexable / machine_draft | hold |
+| en | 41 | 46 | draft / non-public / non-indexable / machine_draft | hold |
+
+## Media Blocker
+
+Publish preflight should not start yet. The remaining blocker is CMS Media Library readiness:
+
+- `cms_media_id`: Unknown
+- `cover_image_url`: Unknown
+- `cover_image_alt_reviewed`: Unknown
+- `og_image_ready`: Unknown
+- `twitter_image_ready`: Unknown
+
+Revision approval stays on hold until the media blocker is resolved.
+
+## Public Route Evidence
+
+Read-only public checks found:
+
+- RIASEC test routes return 200, canonical, indexable, and appear in sitemap/llms.
+- Career jobs index routes return 200, canonical, indexable, and appear in sitemap/llms.
+- The two RIASEC article draft slugs return 404 and are absent from sitemap/llms, which matches draft-only state.
+
+## Next Step
+
+Next step is **CMS media selection**, not publish preflight.
+
+After CMS media inputs are supplied, run a media-resolution recording step or a CMS draft approval update with separate explicit CMS mutation authorization if needed.
+
+Hard gates still closed:
+
+- no CMS mutation
+- no publish
+- no search submission
+- no deploy
+- no article content rewrite
+- no private or tokenized URL access

--- a/backend/tests/Feature/SEO/RiasecExplanationOperatorInputMediaBlockerTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationOperatorInputMediaBlockerTest.php
@@ -1,0 +1,130 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationOperatorInputMediaBlockerTest extends TestCase
+{
+    public function test_operator_inputs_are_recorded_without_opening_publish_preflight(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json');
+
+        $this->assertSame('RIASEC-EXPLANATION-OPERATOR-INPUT-MEDIA-BLOCKER-01', $artifact['task_id']);
+        $this->assertSame('CONDITIONAL_GO_OPERATOR_INPUTS_RECORDED_MEDIA_BLOCKER', $artifact['decision']);
+        $this->assertTrue($artifact['operator_inputs_recorded_from_current_scan']);
+        $this->assertFalse($artifact['publish_preflight_allowed']);
+        $this->assertFalse($artifact['cms_mutation_allowed']);
+        $this->assertFalse($artifact['publish_allowed']);
+        $this->assertFalse($artifact['search_submission_allowed']);
+        $this->assertFalse($artifact['deploy_allowed']);
+        $this->assertFalse($artifact['content_rewrite_allowed']);
+    }
+
+    public function test_reference_and_claim_decisions_are_explicitly_accepted(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json');
+        $reference = $artifact['operator_input_decisions']['reference_acceptance'];
+        $claim = $artifact['operator_input_decisions']['claim_warning_decision'];
+
+        $this->assertSame('accepted_for_operator_recording', $reference['status']);
+        $this->assertSame('cms_references_visible_reference_section', $reference['citation_style']);
+        $this->assertCount(5, $reference['accepted_source_urls']);
+        $this->assertContains('https://www.onetcenter.org/reports/IP_Manual.html', $reference['accepted_source_urls']);
+        $this->assertContains('https://dictionary.apa.org/five-factor-personality-model', $reference['accepted_source_urls']);
+        $this->assertSame('accepted_with_exploratory_boundary', $reference['holland_hexagon_terms_acceptance']);
+        $this->assertSame('accepted_conservative_comparison_only', $reference['mbti_big_five_comparison_acceptance']);
+        $this->assertTrue($reference['no_official_affiliation_acknowledgement']);
+
+        $this->assertSame('acknowledged', $claim['status']);
+        $this->assertSame(2, $claim['zh_claim_warning_count']);
+        $this->assertSame(0, $claim['en_claim_warning_count']);
+        $this->assertTrue($claim['claim_warning_acknowledgement']);
+        $this->assertFalse($claim['gpt_revision_required']);
+    }
+
+    public function test_media_remains_unknown_and_revision_approval_is_held(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json');
+        $media = $artifact['operator_input_decisions']['media_resolution'];
+        $revision = $artifact['operator_input_decisions']['revision_approval'];
+        $blockers = collect($artifact['remaining_blockers'])->keyBy('id');
+
+        $this->assertSame('blocked', $media['status']);
+        $this->assertSame('Unknown', $media['cms_media_id']);
+        $this->assertSame('Unknown', $media['cover_image_url']);
+        $this->assertSame('Unknown', $media['cover_image_alt_reviewed']);
+        $this->assertSame('Unknown', $media['og_image_ready']);
+        $this->assertSame('Unknown', $media['twitter_image_ready']);
+
+        $this->assertSame('hold', $revision['status']);
+        $this->assertSame(45, $revision['zh_revision_id']);
+        $this->assertSame(46, $revision['en_revision_id']);
+        $this->assertSame('Unknown', $revision['approved_by']);
+        $this->assertSame('Unknown', $revision['approved_at']);
+        $this->assertFalse($revision['cms_draft_approval_allowed']);
+
+        $this->assertSame('blocked', $blockers['cms_media_missing']['status']);
+        $this->assertSame('blocked', $blockers['revision_approval_held_until_media']['status']);
+        $this->assertSame('hard_gate', $blockers['publish_preflight_not_authorized']['status']);
+    }
+
+    public function test_public_routes_are_safe_and_draft_routes_are_not_exposed(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json');
+        $routes = collect($artifact['public_route_observations']['safe_public_routes'])->keyBy('route');
+        $drafts = collect($artifact['public_route_observations']['draft_route_exposure'])->keyBy('route');
+
+        foreach ([
+            '/zh/tests/holland-career-interest-test-riasec',
+            '/en/tests/holland-career-interest-test-riasec',
+            '/zh/career/jobs',
+            '/en/career/jobs',
+        ] as $route) {
+            $this->assertSame(200, $routes[$route]['http_status']);
+            $this->assertSame('index, follow', $routes[$route]['robots']);
+        }
+
+        $this->assertSame(404, $drafts['/zh/articles/riasec-holland-career-interest-test-explained']['http_status']);
+        $this->assertSame(404, $drafts['/en/articles/what-is-riasec-holland-code-career-interest-test']['http_status']);
+        $this->assertSame(0, $drafts['/zh/articles/riasec-holland-career-interest-test-explained']['sitemap_count']);
+        $this->assertSame(0, $drafts['/en/articles/what-is-riasec-holland-code-career-interest-test']['llms_count']);
+    }
+
+    public function test_next_step_is_media_selection_not_publish_preflight(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json');
+
+        $this->assertSame('RIASEC_V2_CMS_MEDIA_SELECTION_REQUIRED', $artifact['next_step']['id']);
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01', $artifact['next_step']['not_recommended_yet']);
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_cms_mutation']);
+        $this->assertTrue($artifact['hard_boundaries']['no_publish']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['public_canonical_routes_only']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+    }
+
+    public function test_artifact_contains_no_forbidden_private_routes_or_identifiers(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added a machine-readable RIASEC operator input recording artifact.
- Added a readable SEO operator/media blocker report.
- Added a focused PHPUnit contract test proving the accepted operator decisions, remaining CMS media blocker, held revision approval, public route safety, and hard no-publish boundaries.

## Why
This records the operator decisions that can be made from current repo artifacts, public route checks, and public source checks, while keeping publish preflight blocked until CMS Media Library cover image inputs are supplied.

## Validation commands
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationOperatorInputMediaBlockerTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationOperatorInputMediaBlockerTest --no-ansi`
- `git diff --check -- backend/docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json backend/docs/seo/riasec-explanation-operator-input-media-blocker.md backend/tests/Feature/SEO/RiasecExplanationOperatorInputMediaBlockerTest.php`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No revision approval.
- No publish preflight.
- No publish.
- No search submission.
- No deploy.
- No private or tokenized URL access.
- CMS media selection remains the next blocker: CMS media ID, public cover URL, reviewed alt, OG image readiness, and Twitter image readiness are still Unknown.

## Notes
The working tree had unrelated Science ContentPage local modifications outside this PR scope. They were not staged or included in this PR.
