### PR TITLE
SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01: reconcile method-boundaries authority

### DIFF
--- a/backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php
+++ b/backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php
@@ -39,6 +39,7 @@ final class ScienceContentPageDraftDryRunCommand extends Command
             $this->line('pages_seen='.$summary['pages_seen']);
             $this->line('pages_expected='.$summary['pages_expected']);
             $this->line('pages_ready_for_non_public_draft_import='.$summary['pages_ready_for_non_public_draft_import']);
+            $this->line('pages_reconciled_existing_authority='.$summary['pages_reconciled_existing_authority']);
             $this->line('pages_blocked='.$summary['pages_blocked']);
             $this->line('issue_count='.$summary['issue_count']);
             $this->line('status='.$summary['status']);

--- a/backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php
+++ b/backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php
@@ -40,6 +40,7 @@ final class ScienceContentPageOperatorReviewReadinessCommand extends Command
             $this->line('publish_allowed_default='.(($summary['publish_allowed_default'] ?? true) ? 'true' : 'false'));
             $this->line('draft_pages_reviewable='.data_get($summary, 'draft_package.pages_reviewable_as_non_public_draft', 'Unknown'));
             $this->line('draft_pages_requiring_authority_reconciliation='.data_get($summary, 'draft_package.pages_requiring_authority_reconciliation', 'Unknown'));
+            $this->line('draft_pages_reconciled_existing_authority='.data_get($summary, 'draft_package.pages_reconciled_existing_authority', 'Unknown'));
 
             foreach (($summary['missing_first_class_publish_safety_fields'] ?? []) as $field) {
                 $this->line('missing_first_class_publish_safety_field='.$field);

--- a/backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php
+++ b/backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php
@@ -90,7 +90,11 @@ final class ScienceContentPageDraftDryRunService
 
         $blockingPages = array_values(array_filter(
             $pages,
-            static fn (array $page): bool => ($page['draft_import_decision'] ?? '') !== 'draft_import_ready'
+            static fn (array $page): bool => ($page['blocks_package_dry_run'] ?? true) === true
+        ));
+        $reconciledAuthorityPages = array_values(array_filter(
+            $pages,
+            static fn (array $page): bool => ($page['draft_import_decision'] ?? '') === 'existing_authority_reconciliation_ready'
         ));
 
         return [
@@ -103,7 +107,11 @@ final class ScienceContentPageDraftDryRunService
             'package_status' => (string) ($manifest['status'] ?? 'Unknown'),
             'pages_seen' => count($pages),
             'pages_expected' => count(self::EXPECTED_PAGE_KEYS),
-            'pages_ready_for_non_public_draft_import' => count($pages) - count($blockingPages),
+            'pages_ready_for_non_public_draft_import' => count(array_filter(
+                $pages,
+                static fn (array $page): bool => ($page['draft_import_decision'] ?? '') === 'draft_import_ready'
+            )),
+            'pages_reconciled_existing_authority' => count($reconciledAuthorityPages),
             'pages_blocked' => count($blockingPages),
             'issue_count' => count($issues),
             'status' => $issues === [] ? 'pass_no_write_dry_run' : 'blocked_no_write_dry_run',
@@ -218,12 +226,14 @@ final class ScienceContentPageDraftDryRunService
 
         $action = 'create_non_public_draft';
         $decision = 'draft_import_ready';
+        $blocksPackageDryRun = false;
         if ($canonicalPath === '/method-boundaries') {
-            $action = 'reconcile_existing_authority_only';
-            $decision = 'blocked_existing_authority_reconciliation_required';
+            $action = 'preserve_existing_authority_revision_only';
+            $decision = 'existing_authority_reconciliation_ready';
         }
-        if ($issues !== [] && $decision === 'draft_import_ready') {
+        if ($issues !== []) {
             $decision = 'blocked_schema_or_package_validation';
+            $blocksPackageDryRun = true;
         }
 
         return [
@@ -232,6 +242,7 @@ final class ScienceContentPageDraftDryRunService
             'file' => $file,
             'draft_import_decision' => $decision,
             'planned_action' => $action,
+            'blocks_package_dry_run' => $blocksPackageDryRun,
             'normalized_content_page' => $normalized,
             'issues' => $issues,
         ];

--- a/backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php
+++ b/backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php
@@ -145,6 +145,9 @@ final class ScienceContentPageOperatorReviewReadinessService
         $reconciliationPages = $draftDryRun === null
             ? 'Unknown'
             : (int) ($draftDryRun['pages_blocked'] ?? 0);
+        $reconciledAuthorityPages = $draftDryRun === null
+            ? 'Unknown'
+            : (int) ($draftDryRun['pages_reconciled_existing_authority'] ?? 0);
 
         $coreReady = $this->allPresent($coreFields)
             && $this->allPresent($reviewStates)
@@ -166,6 +169,7 @@ final class ScienceContentPageOperatorReviewReadinessService
                 'pages_seen' => $draftDryRun['pages_seen'] ?? 'Unknown',
                 'pages_reviewable_as_non_public_draft' => $draftPagesReviewable,
                 'pages_requiring_authority_reconciliation' => $reconciliationPages,
+                'pages_reconciled_existing_authority' => $reconciledAuthorityPages,
                 'would_write' => $draftDryRun['would_write'] ?? false,
             ],
             'operator_review_ready_for_non_public_draft' => $coreReady,

--- a/backend/app/Services/Cms/ScienceContentPagePreImportQaService.php
+++ b/backend/app/Services/Cms/ScienceContentPagePreImportQaService.php
@@ -106,6 +106,7 @@ final class ScienceContentPagePreImportQaService
                 'status' => $dryRun['status'] ?? 'Unknown',
                 'pages_seen' => $dryRun['pages_seen'] ?? 'Unknown',
                 'pages_ready_for_non_public_draft_import' => $dryRun['pages_ready_for_non_public_draft_import'] ?? 'Unknown',
+                'pages_reconciled_existing_authority' => $dryRun['pages_reconciled_existing_authority'] ?? 'Unknown',
                 'pages_blocked' => $dryRunBlockers,
                 'would_write' => $dryRun['would_write'] ?? false,
             ],

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -7280,6 +7280,119 @@
           ]
         }
       }
+    },
+    "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "local_checks_passed",
+      "branch": "codex/science-contentpage-authority-reconciliation-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "title": "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01: reconcile method-boundaries authority",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/ScienceContentPageDraftDryRunCommand.php app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php app/Services/Cms/ScienceContentPageDraftDryRunService.php app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi",
+            "status": "passed",
+            "details": "7 tests, 117 assertions."
+          },
+          {
+            "command": "php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'",
+            "status": "passed",
+            "details": "pages_seen=6, pages_ready_for_non_public_draft_import=5, pages_reconciled_existing_authority=1, pages_blocked=0, would_write=false."
+          },
+          {
+            "command": "php artisan content-pages:science-pre-import-qa --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'",
+            "status": "passed",
+            "details": "decision=NO-GO, non_public_draft_import_qa_passed=true, real_import_allowed=false, blocking_reason=operator_publish_decision_not_ready."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "in_progress",
+          "summary": "Initialized after explicit user authorization to add and execute the Science ContentPage authority, publish-fields, real-import dry-run lock, and discoverability gate train sequence. Scope is backend-only method-boundaries authority reconciliation with no CMS mutation, real import, publish, sitemap, llms, footer, or production exposure."
+        },
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Resolved method-boundaries as existing-authority revision-only in the Science dry-run contract. Focused Pint, PHPUnit, real package dry-run, pre-import QA, JSON/YAML, and diff checks passed with no writes, real import, publish, sitemap, llms, or footer changes."
+        }
+      ]
+    },
+    "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "planned",
+      "branch": "codex/science-contentpage-publish-fields-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "title": "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01: add publish safety fields",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "planned",
+          "summary": "Planned after explicit user authorization. Depends on SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01."
+        }
+      ]
+    },
+    "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "planned",
+      "branch": "codex/science-contentpage-real-import-dry-run-lock-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "title": "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01: lock pre-import contract",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "planned",
+          "summary": "Planned after explicit user authorization. Depends on SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01."
+        }
+      ]
+
     }
   },
   "status": "initialized",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -3785,7 +3785,7 @@
             "result": "25 modifiers, 12 synergies, 30 facets, 23 precision rules, 40 action rules, 8 coverage profiles"
           },
           {
-            "command": "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|assertiveness|\u4f60\u5929\u751f\u6ce8\u5b9a|\u4f60\u6c38\u8fdc\u90fd\u4f1a|\u4f60\u53ea\u80fd\u8fd9\u6837\u6d3b|\u4f60\u592a\u73bb\u7483\u5fc3|\u4f60\u6709\u95ee\u9898|\u4f60\u4e0d\u6b63\u5e38\" backend/content_assets/big5/v1/expanded || true",
+            "command": "rg -n \"Profile Summary|Domain Deep Dive|Norms Comparison|Methodology and Access|A compact overview|Focused read|Near-term actions|assertiveness|你天生注定|你永远都会|你只能这样活|你太玻璃心|你有问题|你不正常\" backend/content_assets/big5/v1/expanded || true",
             "status": "passed",
             "result": "no matches in expanded assets"
           },
@@ -4377,7 +4377,7 @@
             "status": "passed"
           },
           {
-            "command": "php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/\u7b2c\u516b\u7248_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
+            "command": "php artisan career:align-selected-authority-crosswalks --file=/Users/rainie/Desktop/第八版_d5a_8_repaired.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
             "status": "passed_local_db_unavailable_plan",
             "details": "Local authority DB is unavailable; dry-run completed read-only from the D5a repaired workbook, validated all 8 selected slugs, reported would_create_occupation_count=8 and would_create_crosswalk_count=16, and wrote no DB rows."
           },
@@ -4438,9 +4438,9 @@
             "status": "passed"
           },
           {
-            "command": "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/\u7b2c\u4e5d\u7248.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
+            "command": "php artisan career:import-selected-display-assets --file=/Users/rainie/Desktop/第九版.xlsx --slugs=actuaries,financial-analysts,high-school-teachers,market-research-analysts,architectural-and-engineering-managers,civil-engineers,biomedical-engineers,dentists --dry-run --json",
             "status": "failed_workbook_contract_outside_scope",
-            "details": "Draft PR exception: unsupported slug error is gone; all 8 D5 slugs were requested, validated, and generated payload summaries, but \u7b2c\u4e5d\u7248.xlsx still fails workbook contract validation for CTA/source labels, CN job-posting sample terms, and biomedical Product substring. This PR is not mergeable until the workbook source passes or the manifest acceptance is updated."
+            "details": "Draft PR exception: unsupported slug error is gone; all 8 D5 slugs were requested, validated, and generated payload summaries, but 第九版.xlsx still fails workbook contract validation for CTA/source labels, CN job-posting sample terms, and biomedical Product substring. This PR is not mergeable until the workbook source passes or the manifest acceptance is updated."
           },
           {
             "command": "git diff --check && git diff --cached --check",
@@ -4476,17 +4476,17 @@
         {
           "at": "2026-05-03T18:33:57Z",
           "status": "failed_local_check",
-          "summary": "Updated D5c1 validation source to \u7b2c\u4e5d\u7248.xlsx. Scoped code checks passed and unsupported slug errors are gone, but real workbook dry-run fails due workbook contract blockers outside allowlist scope."
+          "summary": "Updated D5c1 validation source to 第九版.xlsx. Scoped code checks passed and unsupported slug errors are gone, but real workbook dry-run fails due workbook contract blockers outside allowlist scope."
         },
         {
           "at": "2026-05-03T18:36:47Z",
           "status": "draft_exception_ready",
-          "summary": "Review pass: scope limited to allowlist/tests/train metadata. Open draft PR under documented exception because \u7b2c\u4e5d\u7248 workbook dry-run fails only on data contract blockers outside this PR."
+          "summary": "Review pass: scope limited to allowlist/tests/train metadata. Open draft PR under documented exception because 第九版 workbook dry-run fails only on data contract blockers outside this PR."
         },
         {
           "at": "2026-05-03T18:38:31Z",
           "status": "draft_open_workbook_blocked",
-          "summary": "Opened draft PR #1114. GitHub checks are pending; mergeStateStatus is UNSTABLE because the PR is draft/pending and the real \u7b2c\u4e5d\u7248 workbook dry-run remains blocked by workbook contract data."
+          "summary": "Opened draft PR #1114. GitHub checks are pending; mergeStateStatus is UNSTABLE because the PR is draft/pending and the real 第九版 workbook dry-run remains blocked by workbook contract data."
         },
         {
           "at": "2026-05-03T18:40:10Z",
@@ -4674,12 +4674,12 @@
         {
           "at": "2026-05-04T05:20:00Z",
           "status": "in_progress",
-          "summary": "Initialized PR-D6 ledger entry for the read-only \u7b2c\u4e5d\u7248 full display workbook intake validator after D5e live validation passed."
+          "summary": "Initialized PR-D6 ledger entry for the read-only 第九版 full display workbook intake validator after D5e live validation passed."
         },
         {
           "at": "2026-05-04T05:45:00Z",
           "status": "scope_extended",
-          "summary": "Extended PR-D6 scope to include a read-only Strategic Architecture Gap Scan for protocol sections \u00a71 through \u00a75 without implementing architecture modules or changing release gates."
+          "summary": "Extended PR-D6 scope to include a read-only Strategic Architecture Gap Scan for protocol sections §1 through §5 without implementing architecture modules or changing release gates."
         },
         {
           "at": "2026-05-04T06:05:00Z",
@@ -5947,6 +5947,160 @@
           "at": "2026-05-23T23:58:00+08:00",
           "status": "pr_open",
           "summary": "Opened https://github.com/fermatmind/fap-api/pull/1624 from codex/pr-api-sec-09-docs-heredoc-guard after push; initial GitHub checks are pending."
+        }
+      ]
+    },
+    "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "ready_to_merge",
+      "branch": "codex/science-contentpage-authority-reconciliation-01",
+      "commit_sha": "4812c079",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1958",
+      "title": "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01: reconcile method-boundaries authority",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/ScienceContentPageDraftDryRunCommand.php app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php app/Services/Cms/ScienceContentPageDraftDryRunService.php app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi",
+            "status": "passed",
+            "details": "7 tests, 117 assertions."
+          },
+          {
+            "command": "php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'",
+            "status": "passed",
+            "details": "pages_seen=6, pages_ready_for_non_public_draft_import=5, pages_reconciled_existing_authority=1, pages_blocked=0, would_write=false."
+          },
+          {
+            "command": "php artisan content-pages:science-pre-import-qa --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'",
+            "status": "passed",
+            "details": "decision=NO-GO, non_public_draft_import_qa_passed=true, real_import_allowed=false, blocking_reason=operator_publish_decision_not_ready."
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": [
+          {
+            "name": "Semgrep OSS",
+            "status": "passed"
+          },
+          {
+            "name": "Semgrep blocking secrets",
+            "status": "passed"
+          },
+          {
+            "name": "content-pack-build-validate",
+            "status": "passed"
+          },
+          {
+            "name": "hygiene",
+            "status": "passed"
+          },
+          {
+            "name": "semgrep sarif non-blocking upload",
+            "status": "passed"
+          },
+          {
+            "name": "supply-chain",
+            "status": "passed"
+          },
+          {
+            "name": "verify-bigfive",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "passed"
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "passed"
+          }
+        ]
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "in_progress",
+          "summary": "Initialized after explicit user authorization to add and execute the Science ContentPage authority, publish-fields, real-import dry-run lock, and discoverability gate train sequence. Scope is backend-only method-boundaries authority reconciliation with no CMS mutation, real import, publish, sitemap, llms, footer, or production exposure."
+        },
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "local_checks_passed",
+          "summary": "Resolved method-boundaries as existing-authority revision-only in the Science dry-run contract. Focused Pint, PHPUnit, real package dry-run, pre-import QA, JSON/YAML, and diff checks passed with no writes, real import, publish, sitemap, llms, or footer changes."
+        },
+        {
+          "at": "2026-06-08T04:57:00+08:00",
+          "status": "ready_to_merge",
+          "summary": "PR #1958 is clean against latest origin/main and GitHub checks passed. Scope remains backend Science authority reconciliation only; no CMS mutation, real import, publish, sitemap, llms, footer, or production exposure."
+        }
+      ]
+    },
+    "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "planned",
+      "branch": "codex/science-contentpage-publish-fields-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "title": "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01: add publish safety fields",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "planned",
+          "summary": "Planned after explicit user authorization. Depends on SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01."
+        }
+      ]
+    },
+    "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "planned",
+      "branch": "codex/science-contentpage-real-import-dry-run-lock-01",
+      "commit_sha": "",
+      "pr_url": "",
+      "title": "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01: lock pre-import contract",
+      "checks": {
+        "local": [],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": null,
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-08T00:00:00+08:00",
+          "status": "planned",
+          "summary": "Planned after explicit user authorization. Depends on SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01."
         }
       ]
     }
@@ -7280,119 +7434,6 @@
           ]
         }
       }
-    },
-    "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01": {
-      "repo": "fap-api",
-      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "local_checks_passed",
-      "branch": "codex/science-contentpage-authority-reconciliation-01",
-      "commit_sha": "",
-      "pr_url": "",
-      "title": "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01: reconcile method-boundaries authority",
-      "checks": {
-        "local": [
-          {
-            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
-            "status": "passed"
-          },
-          {
-            "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'",
-            "status": "passed"
-          },
-          {
-            "command": "vendor/bin/pint --test app/Console/Commands/ScienceContentPageDraftDryRunCommand.php app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php app/Services/Cms/ScienceContentPageDraftDryRunService.php app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php",
-            "status": "passed"
-          },
-          {
-            "command": "php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi",
-            "status": "passed",
-            "details": "7 tests, 117 assertions."
-          },
-          {
-            "command": "php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'",
-            "status": "passed",
-            "details": "pages_seen=6, pages_ready_for_non_public_draft_import=5, pages_reconciled_existing_authority=1, pages_blocked=0, would_write=false."
-          },
-          {
-            "command": "php artisan content-pages:science-pre-import-qa --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'",
-            "status": "passed",
-            "details": "decision=NO-GO, non_public_draft_import_qa_passed=true, real_import_allowed=false, blocking_reason=operator_publish_decision_not_ready."
-          },
-          {
-            "command": "git diff --check && git diff --cached --check",
-            "status": "passed"
-          }
-        ],
-        "github": []
-      },
-      "failure_reason": "",
-      "resume_policy": "manual_only",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
-      "history": [
-        {
-          "at": "2026-06-08T00:00:00+08:00",
-          "status": "in_progress",
-          "summary": "Initialized after explicit user authorization to add and execute the Science ContentPage authority, publish-fields, real-import dry-run lock, and discoverability gate train sequence. Scope is backend-only method-boundaries authority reconciliation with no CMS mutation, real import, publish, sitemap, llms, footer, or production exposure."
-        },
-        {
-          "at": "2026-06-08T00:00:00+08:00",
-          "status": "local_checks_passed",
-          "summary": "Resolved method-boundaries as existing-authority revision-only in the Science dry-run contract. Focused Pint, PHPUnit, real package dry-run, pre-import QA, JSON/YAML, and diff checks passed with no writes, real import, publish, sitemap, llms, or footer changes."
-        }
-      ]
-    },
-    "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01": {
-      "repo": "fap-api",
-      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
-      "branch": "codex/science-contentpage-publish-fields-01",
-      "commit_sha": "",
-      "pr_url": "",
-      "title": "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01: add publish safety fields",
-      "checks": {
-        "local": [],
-        "github": []
-      },
-      "failure_reason": "",
-      "resume_policy": "manual_only",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
-      "history": [
-        {
-          "at": "2026-06-08T00:00:00+08:00",
-          "status": "planned",
-          "summary": "Planned after explicit user authorization. Depends on SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01."
-        }
-      ]
-    },
-    "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01": {
-      "repo": "fap-api",
-      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "planned",
-      "branch": "codex/science-contentpage-real-import-dry-run-lock-01",
-      "commit_sha": "",
-      "pr_url": "",
-      "title": "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01: lock pre-import contract",
-      "checks": {
-        "local": [],
-        "github": []
-      },
-      "failure_reason": "",
-      "resume_policy": "manual_only",
-      "merged_at": null,
-      "remote_branch_deleted": false,
-      "local_cleanup_executed": false,
-      "history": [
-        {
-          "at": "2026-06-08T00:00:00+08:00",
-          "status": "planned",
-          "summary": "Planned after explicit user authorization. Depends on SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01."
-        }
-      ]
-
     }
   },
   "status": "initialized",

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -3637,3 +3637,105 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/science-contentpage-authority-reconciliation-01
+    base: main
+    depends_on: []
+    mode: execute
+    title: "SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01: reconcile method-boundaries authority"
+    scope: >
+      Backend-only Science ContentPage authority reconciliation. Treat
+      METHOD-BOUNDARY-CONTENT-01 as an existing /method-boundaries authority
+      revision-only input instead of a new ContentPage import blocker, while
+      preserving no-write dry-run behavior and keeping real import, publish,
+      sitemap, llms, footer, and CMS mutation blocked.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'"
+      - "vendor/bin/pint --test app/Console/Commands/ScienceContentPageDraftDryRunCommand.php app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php app/Services/Cms/ScienceContentPageDraftDryRunService.php app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php"
+      - "php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi"
+      - "php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'"
+      - "php artisan content-pages:science-pre-import-qa --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
+  - id: SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/science-contentpage-publish-fields-01
+    base: main
+    depends_on: ["SCIENCE-CONTENTPAGE-AUTHORITY-RECONCILIATION-01"]
+    mode: execute
+    title: "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01: add publish safety fields"
+    scope: >
+      Backend-only ContentPage publish safety fields for Science pages. Add
+      first-class operator approval, publish permission, claim gate, forbidden
+      claims, and FAQ schema eligibility fields to the ContentPage model,
+      internal API, and Ops CMS resource, and prevent publication when required
+      publish safety gates are not satisfied. Do not import content, mutate CMS
+      records beyond schema support, publish pages, change fap-web, sitemap,
+      llms, footer, or generated public content.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'"
+      - "vendor/bin/pint --test app/Models/ContentPage.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Filament/Ops/Resources/ContentPageResource.php app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/ContentPages/ContentPagePublicApiTest.php"
+      - "php artisan test tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/ContentPages/ContentPagePublicApiTest.php --no-ansi"
+      - "php artisan migrate --pretend --no-ansi --force"
+      - "php artisan route:list --path=content-pages --no-ansi"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true
+
+  - id: SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/science-contentpage-real-import-dry-run-lock-01
+    base: main
+    depends_on: ["SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01"]
+    mode: execute
+    title: "SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01: lock pre-import contract"
+    scope: >
+      Backend-only real-import dry-run lock for Science ContentPages. Harden the
+      pre-real-import QA contract so the six-page Science draft package remains
+      dry-run/no-write until publish safety fields, operator approval, claim
+      gate, visible FAQ/schema gate, public canonical routes, and private URL
+      scans are satisfied. Do not perform real import, publish, CMS mutation,
+      fap-web changes, sitemap, llms, footer, search submission, or content
+      distribution.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'"
+      - "vendor/bin/pint --test app/Console/Commands/ScienceContentPagePreImportQaCommand.php app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php"
+      - "php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi"
+      - "php artisan content-pages:science-pre-import-qa --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/backend/tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php
@@ -27,8 +27,9 @@ final class ScienceContentPageDraftDryRunCommandTest extends TestCase
             ->expectsOutputToContain('would_write=false')
             ->expectsOutputToContain('pages_seen=6')
             ->expectsOutputToContain('pages_ready_for_non_public_draft_import=5')
-            ->expectsOutputToContain('pages_blocked=1')
-            ->expectsOutputToContain('page=METHOD-BOUNDARY-CONTENT-01 action=reconcile_existing_authority_only decision=blocked_existing_authority_reconciliation_required')
+            ->expectsOutputToContain('pages_reconciled_existing_authority=1')
+            ->expectsOutputToContain('pages_blocked=0')
+            ->expectsOutputToContain('page=METHOD-BOUNDARY-CONTENT-01 action=preserve_existing_authority_revision_only decision=existing_authority_reconciliation_ready')
             ->expectsOutputToContain('kind=policy status=draft public=false indexable=false')
             ->assertExitCode(0);
 
@@ -54,7 +55,8 @@ final class ScienceContentPageDraftDryRunCommandTest extends TestCase
         $this->assertFalse($payload['database_writes_allowed']);
         $this->assertSame(6, $payload['pages_seen']);
         $this->assertSame(5, $payload['pages_ready_for_non_public_draft_import']);
-        $this->assertSame(1, $payload['pages_blocked']);
+        $this->assertSame(1, $payload['pages_reconciled_existing_authority']);
+        $this->assertSame(0, $payload['pages_blocked']);
         $this->assertFalse($payload['non_runtime_guarantees']['cms_mutation_performed']);
 
         $scienceHub = collect($payload['pages'])->firstWhere('page_key', 'SCIENCE-HUB-CONTENT-01');
@@ -68,6 +70,11 @@ final class ScienceContentPageDraftDryRunCommandTest extends TestCase
 
         $dataNotes = collect($payload['pages'])->firstWhere('page_key', 'DATA-NOTES-CONTENT-01');
         $this->assertSame('data-privacy', $dataNotes['normalized_content_page']['slug']);
+
+        $methodBoundaries = collect($payload['pages'])->firstWhere('page_key', 'METHOD-BOUNDARY-CONTENT-01');
+        $this->assertSame('preserve_existing_authority_revision_only', $methodBoundaries['planned_action']);
+        $this->assertSame('existing_authority_reconciliation_ready', $methodBoundaries['draft_import_decision']);
+        $this->assertFalse($methodBoundaries['blocks_package_dry_run']);
 
         $this->assertSame(0, ContentPage::query()->count());
     }

--- a/backend/tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php
@@ -33,7 +33,8 @@ final class ScienceContentPageOperatorReviewReadinessCommandTest extends TestCas
             ->expectsOutputToContain('operator_publish_decision_ready=false')
             ->expectsOutputToContain('publish_allowed_default=false')
             ->expectsOutputToContain('draft_pages_reviewable=5')
-            ->expectsOutputToContain('draft_pages_requiring_authority_reconciliation=1')
+            ->expectsOutputToContain('draft_pages_requiring_authority_reconciliation=0')
+            ->expectsOutputToContain('draft_pages_reconciled_existing_authority=1')
             ->expectsOutputToContain('missing_first_class_publish_safety_field=publish_allowed')
             ->expectsOutputToContain('missing_first_class_publish_safety_field=claim_gate_status')
             ->expectsOutputToContain('missing_first_class_publish_safety_field=faq_schema_eligible')
@@ -56,7 +57,8 @@ final class ScienceContentPageOperatorReviewReadinessCommandTest extends TestCas
         $this->assertFalse($payload['publish_allowed_default']);
         $this->assertFalse($payload['natural_distribution_allowed']);
         $this->assertSame(5, $payload['draft_package']['pages_reviewable_as_non_public_draft']);
-        $this->assertSame(1, $payload['draft_package']['pages_requiring_authority_reconciliation']);
+        $this->assertSame(0, $payload['draft_package']['pages_requiring_authority_reconciliation']);
+        $this->assertSame(1, $payload['draft_package']['pages_reconciled_existing_authority']);
         $this->assertFalse($payload['draft_package']['would_write']);
 
         foreach (['review_state', 'science_review_required', 'legal_review_required', 'is_public', 'is_indexable'] as $field) {

--- a/backend/tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
@@ -34,9 +34,8 @@ final class ScienceContentPagePreImportQaCommandTest extends TestCase
             ->expectsOutputToContain('publish_allowed=false')
             ->expectsOutputToContain('natural_distribution_allowed=false')
             ->expectsOutputToContain('package_pre_import_qa_issue_count=0')
-            ->expectsOutputToContain('dry_run_pages_blocked=1')
+            ->expectsOutputToContain('dry_run_pages_blocked=0')
             ->expectsOutputToContain('operator_publish_decision_ready=false')
-            ->expectsOutputToContain('blocking_reason=authority_reconciliation_required')
             ->expectsOutputToContain('blocking_reason=operator_publish_decision_not_ready')
             ->assertExitCode(0);
 


### PR DESCRIPTION
## What changed
- Reclassified `METHOD-BOUNDARY-CONTENT-01` as an existing `/method-boundaries` authority revision-only input instead of a package blocker.
- Added dry-run output for `pages_reconciled_existing_authority` and propagated it through operator review / pre-import QA summaries.
- Added the authorized Science ContentPage backend PR-train entries and initialized state for this sequence.

## Why
`/method-boundaries` already has an existing public ContentPage authority. The Science draft package must not create a second record, but that authority conflict should be resolved as a revision-only contract rather than keeping the whole package blocked for draft QA.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`
- `vendor/bin/pint --test app/Console/Commands/ScienceContentPageDraftDryRunCommand.php app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php app/Services/Cms/ScienceContentPageDraftDryRunService.php app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php`
- `php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi`
- `php artisan content-pages:science-draft-dry-run --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'`
- `php artisan content-pages:science-pre-import-qa --package='/Users/rainie/Desktop/science_contentpage_cms_draft_package 2'`
- `git diff --check && git diff --cached --check`

## Intentionally deferred
- No CMS mutation or real ContentPage import.
- No publish, sitemap, llms, footer, search submission, or fap-web discoverability exposure.
- Publish safety fields remain for `SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01`.
- Real-import dry-run lock remains for `SCIENCE-CONTENTPAGE-REAL-IMPORT-DRY-RUN-LOCK-01`.
