### PR TITLE
docs(seo): record RIASEC media selection blocker

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json
@@ -1,0 +1,166 @@
+{
+  "schema": "riasec-explanation-media-selection-readiness.v1",
+  "task_id": "RIASEC-EXPLANATION-MEDIA-SELECTION-READINESS-01",
+  "generated_at": "2026-06-08T05:15:00+08:00",
+  "decision": "NO_GO_NO_REUSABLE_CMS_MEDIA_CANDIDATE",
+  "media_selection_ready": false,
+  "cms_media_id_ready": false,
+  "publish_preflight_allowed": false,
+  "cms_mutation_allowed": false,
+  "media_upload_allowed": false,
+  "publish_allowed": false,
+  "search_submission_allowed": false,
+  "deploy_allowed": false,
+  "content_rewrite_allowed": false,
+  "cms_mutation_performed": false,
+  "media_upload_performed": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "content_rewrite_performed": false,
+  "private_url_accessed": false,
+  "inputs_reviewed": [
+    "backend/docs/seo/generated/riasec-explanation-operator-input-media-blocker.v1.json",
+    "backend/docs/seo/generated/riasec-explanation-cms-draft-approval-preflight.v1.json",
+    "content_baselines/media_assets/default_media_assets.json",
+    "backend/app/Filament/Ops/Resources/ArticleResource.php",
+    "backend/app/Models/MediaAsset.php",
+    "backend/app/Models/MediaVariant.php",
+    "backend/app/Services/Cms/MediaVariantGenerator.php"
+  ],
+  "article_targets": [
+    {
+      "locale": "zh",
+      "article_id": 40,
+      "working_revision_id": 45,
+      "slug": "riasec-holland-career-interest-test-explained",
+      "media_status": "blocked"
+    },
+    {
+      "locale": "en",
+      "article_id": 41,
+      "working_revision_id": 46,
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "media_status": "blocked"
+    }
+  ],
+  "article_cover_runtime_requirements": {
+    "source": "ArticleResource mediaAssetOptions and articleCoverReadinessFailures",
+    "requirements": [
+      "MediaAsset exists in org_id 0 context",
+      "MediaAsset status is published",
+      "MediaAsset is_public is true",
+      "MediaAsset cdn_status is verified",
+      "MediaAsset source URL is accepted by PublicMediaUrlGuard",
+      "MediaAsset alt is non-empty and reviewed",
+      "All required generated variants exist: hero, card, thumbnail, og, preload",
+      "Each required variant cdn_status is verified",
+      "Each required variant URL is accepted by PublicMediaUrlGuard",
+      "Each required variant has positive width and height",
+      "Each required variant MIME type starts with image/",
+      "The image is topically appropriate for a RIASEC / Holland career-interest article",
+      "The image does not imply diagnosis, guaranteed career fit, official certification, or official endorsement"
+    ],
+    "required_variant_keys": [
+      "hero",
+      "card",
+      "thumbnail",
+      "og",
+      "preload"
+    ]
+  },
+  "repo_media_inventory_scan": {
+    "default_media_assets_count": 6,
+    "reusable_candidate_count": 0,
+    "candidate_decision": "no_existing_repo_baseline_asset_is_acceptable_for_riasec_article_cover",
+    "rejected_existing_assets": [
+      {
+        "asset_key": "share.mbti.default",
+        "reason": "MBTI-specific social cover; not topically appropriate for a RIASEC / Holland career-interest article."
+      },
+      {
+        "asset_key": "social.wechat.official_qr",
+        "reason": "QR code social asset; not an article cover and not a RIASEC career-interest visual."
+      },
+      {
+        "asset_key": "social.wechat.qr",
+        "reason": "QR code social asset; not an article cover and not a RIASEC career-interest visual."
+      },
+      {
+        "asset_key": "iq-beta30-original-card",
+        "reason": "IQ-specific landing card; not topically appropriate for a RIASEC / Holland career-interest article."
+      },
+      {
+        "asset_key": "iq-beta30-original-og",
+        "reason": "IQ-specific social preview; not topically appropriate for a RIASEC / Holland career-interest article."
+      },
+      {
+        "asset_key": "iq-full-report-cover",
+        "reason": "IQ-specific report cover; not topically appropriate for a RIASEC / Holland career-interest article."
+      }
+    ]
+  },
+  "recommended_media_request": {
+    "asset_key_suggestion": "article.riasec.explanation.cover.v1",
+    "surface": "article_cover",
+    "locale_strategy": "one bilingual-safe visual can serve zh and en if alt text is localized in CMS fields; otherwise supply locale variants after human visual review",
+    "visual_direction": [
+      "career-interest exploration",
+      "six-area structure or neutral work-environment exploration",
+      "no official O*NET, DOL, APA, Holland, or MBTI branding",
+      "no diagnostic or medical imagery",
+      "no guarantee, ranking, or job-outcome implication"
+    ],
+    "required_operator_inputs": [
+      "cms_media_id",
+      "cover_image_url",
+      "cover_image_alt_reviewed",
+      "og_image_ready",
+      "twitter_image_ready",
+      "media_reviewed_by",
+      "media_reviewed_at"
+    ],
+    "alt_review_boundary": "Alt text must describe the image plainly and must not promise career fit, diagnosis, certification, or official endorsement."
+  },
+  "remaining_blockers": [
+    {
+      "id": "cms_media_id_unknown",
+      "status": "blocked",
+      "owner": "cms_operator_or_design_owner",
+      "required_input": "Select or upload a CMS Media Library asset that satisfies ArticleResource cover readiness, then provide its CMS media ID."
+    },
+    {
+      "id": "cover_url_unknown",
+      "status": "blocked",
+      "owner": "cms_operator_or_design_owner",
+      "required_input": "Provide public cover URL resolved from the CMS MediaAsset payload."
+    },
+    {
+      "id": "alt_and_social_images_unknown",
+      "status": "blocked",
+      "owner": "cms_operator_or_design_owner",
+      "required_input": "Confirm reviewed alt text plus OG and Twitter image readiness."
+    },
+    {
+      "id": "revision_approval_held_until_media",
+      "status": "blocked",
+      "owner": "operator_editor",
+      "required_input": "Do not approve zh revision 45 or en revision 46 until media readiness is supplied."
+    }
+  ],
+  "next_step": {
+    "id": "RIASEC_V2_CMS_MEDIA_INPUT_REQUIRED",
+    "recommended_action": "Operator supplies a reviewed CMS Media Library asset ID and readiness fields, or separately authorizes a CMS media upload/import step.",
+    "not_recommended_yet": "SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01"
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_cms_mutation": true,
+    "no_media_upload": true,
+    "no_publish": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "public_canonical_routes_only": true,
+    "no_private_or_tokenized_url_access": true
+  }
+}

--- a/backend/docs/seo/riasec-explanation-media-selection-readiness.md
+++ b/backend/docs/seo/riasec-explanation-media-selection-readiness.md
@@ -1,0 +1,84 @@
+# RIASEC Explanation V2 Media Selection Readiness
+
+Task: `RIASEC-EXPLANATION-MEDIA-SELECTION-READINESS-01`
+
+Decision: **NO-GO: no reusable CMS media candidate is available from repository baselines.**
+
+This ad-hoc PR records the media-readiness blocker after the operator input recording PR. It does not upload media, mutate CMS records, approve revisions, publish, submit search URLs, deploy, read secrets, or access user-specific URLs.
+
+## Result
+
+The current repository baseline has no suitable reusable media asset for the RIASEC explanation article cover.
+
+Existing baseline assets are MBTI, IQ, or QR-code assets. They should not be reused as a RIASEC / Holland career-interest article cover because that would create topical mismatch and weaken the CMS media authority boundary.
+
+## Article Cover Requirements
+
+An acceptable Article cover media asset must satisfy the backend ArticleResource readiness rules:
+
+- MediaAsset exists in `org_id=0` context.
+- MediaAsset status is `published`.
+- MediaAsset is public.
+- MediaAsset CDN status is `verified`.
+- Source URL is public-safe.
+- Alt text is non-empty and reviewed.
+- Required variants exist: `hero`, `card`, `thumbnail`, `og`, `preload`.
+- Every required variant is CDN-verified.
+- Every required variant has a public-safe URL.
+- Every required variant has positive width and height.
+- Every required variant MIME type is an image.
+- The image is topically appropriate for a RIASEC / Holland career-interest article.
+
+## Rejected Existing Baseline Assets
+
+| Asset key | Decision |
+| --- | --- |
+| `share.mbti.default` | reject: MBTI-specific |
+| `social.wechat.official_qr` | reject: QR code, not article cover |
+| `social.wechat.qr` | reject: QR code, not article cover |
+| `iq-beta30-original-card` | reject: IQ-specific |
+| `iq-beta30-original-og` | reject: IQ-specific |
+| `iq-full-report-cover` | reject: IQ-specific |
+
+## Recommended Media Request
+
+Recommended asset key: `article.riasec.explanation.cover.v1`
+
+Visual direction:
+
+- career-interest exploration
+- six-area structure or neutral work-environment exploration
+- no official O*NET, DOL, APA, Holland, or MBTI branding
+- no diagnostic or medical imagery
+- no guarantee, ranking, or job-outcome implication
+
+Required operator inputs:
+
+- `cms_media_id`
+- `cover_image_url`
+- `cover_image_alt_reviewed`
+- `og_image_ready`
+- `twitter_image_ready`
+- `media_reviewed_by`
+- `media_reviewed_at`
+
+Alt text must describe the image plainly and must not promise career fit, diagnosis, certification, or official endorsement.
+
+## Next Step
+
+Next step is **CMS media input**, not publish preflight.
+
+The operator should either:
+
+- supply a reviewed CMS Media Library asset ID and readiness fields, or
+- separately authorize a CMS media upload/import step.
+
+Hard gates still closed:
+
+- no CMS mutation
+- no media upload
+- no publish
+- no search submission
+- no deploy
+- no article content rewrite
+- no user-specific URL access

--- a/backend/tests/Feature/SEO/RiasecExplanationMediaSelectionReadinessTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationMediaSelectionReadinessTest.php
@@ -1,0 +1,142 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationMediaSelectionReadinessTest extends TestCase
+{
+    public function test_media_selection_remains_blocked_without_reusable_candidate(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json');
+
+        $this->assertSame('RIASEC-EXPLANATION-MEDIA-SELECTION-READINESS-01', $artifact['task_id']);
+        $this->assertSame('NO_GO_NO_REUSABLE_CMS_MEDIA_CANDIDATE', $artifact['decision']);
+        $this->assertFalse($artifact['media_selection_ready']);
+        $this->assertFalse($artifact['cms_media_id_ready']);
+        $this->assertFalse($artifact['publish_preflight_allowed']);
+        $this->assertFalse($artifact['cms_mutation_allowed']);
+        $this->assertFalse($artifact['media_upload_allowed']);
+        $this->assertFalse($artifact['publish_allowed']);
+        $this->assertFalse($artifact['search_submission_allowed']);
+        $this->assertFalse($artifact['deploy_allowed']);
+        $this->assertFalse($artifact['content_rewrite_allowed']);
+    }
+
+    public function test_article_cover_runtime_requirements_match_backend_readiness_contract(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json');
+        $requirements = $artifact['article_cover_runtime_requirements'];
+
+        $this->assertSame('ArticleResource mediaAssetOptions and articleCoverReadinessFailures', $requirements['source']);
+        $this->assertSame([
+            'hero',
+            'card',
+            'thumbnail',
+            'og',
+            'preload',
+        ], $requirements['required_variant_keys']);
+
+        foreach ([
+            'MediaAsset status is published',
+            'MediaAsset is_public is true',
+            'MediaAsset cdn_status is verified',
+            'MediaAsset source URL is accepted by PublicMediaUrlGuard',
+            'MediaAsset alt is non-empty and reviewed',
+            'All required generated variants exist: hero, card, thumbnail, og, preload',
+            'Each required variant cdn_status is verified',
+            'Each required variant URL is accepted by PublicMediaUrlGuard',
+        ] as $expectedRequirement) {
+            $this->assertContains($expectedRequirement, $requirements['requirements']);
+        }
+    }
+
+    public function test_existing_baseline_assets_are_rejected_for_topical_mismatch(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json');
+        $scan = $artifact['repo_media_inventory_scan'];
+        $rejected = collect($scan['rejected_existing_assets'])->keyBy('asset_key');
+
+        $this->assertSame(6, $scan['default_media_assets_count']);
+        $this->assertSame(0, $scan['reusable_candidate_count']);
+        $this->assertSame('no_existing_repo_baseline_asset_is_acceptable_for_riasec_article_cover', $scan['candidate_decision']);
+
+        foreach ([
+            'share.mbti.default',
+            'social.wechat.official_qr',
+            'social.wechat.qr',
+            'iq-beta30-original-card',
+            'iq-beta30-original-og',
+            'iq-full-report-cover',
+        ] as $assetKey) {
+            $this->assertArrayHasKey($assetKey, $rejected);
+            $this->assertNotEmpty($rejected[$assetKey]['reason']);
+        }
+    }
+
+    public function test_next_step_is_media_input_not_publish_preflight(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json');
+        $request = $artifact['recommended_media_request'];
+        $blockers = collect($artifact['remaining_blockers'])->keyBy('id');
+
+        $this->assertSame('article.riasec.explanation.cover.v1', $request['asset_key_suggestion']);
+        $this->assertSame('article_cover', $request['surface']);
+        $this->assertContains('cms_media_id', $request['required_operator_inputs']);
+        $this->assertContains('cover_image_url', $request['required_operator_inputs']);
+        $this->assertContains('cover_image_alt_reviewed', $request['required_operator_inputs']);
+        $this->assertContains('og_image_ready', $request['required_operator_inputs']);
+        $this->assertContains('twitter_image_ready', $request['required_operator_inputs']);
+
+        $this->assertSame('blocked', $blockers['cms_media_id_unknown']['status']);
+        $this->assertSame('blocked', $blockers['cover_url_unknown']['status']);
+        $this->assertSame('blocked', $blockers['alt_and_social_images_unknown']['status']);
+        $this->assertSame('blocked', $blockers['revision_approval_held_until_media']['status']);
+        $this->assertSame('RIASEC_V2_CMS_MEDIA_INPUT_REQUIRED', $artifact['next_step']['id']);
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-PUBLISH-PREFLIGHT-01', $artifact['next_step']['not_recommended_yet']);
+    }
+
+    public function test_hard_boundaries_remain_closed(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json');
+
+        $this->assertFalse($artifact['cms_mutation_performed']);
+        $this->assertFalse($artifact['media_upload_performed']);
+        $this->assertFalse($artifact['publish_performed']);
+        $this->assertFalse($artifact['search_submission_performed']);
+        $this->assertFalse($artifact['deploy_performed']);
+        $this->assertFalse($artifact['content_rewrite_performed']);
+        $this->assertFalse($artifact['private_url_accessed']);
+
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_cms_mutation']);
+        $this->assertTrue($artifact['hard_boundaries']['no_media_upload']);
+        $this->assertTrue($artifact['hard_boundaries']['no_publish']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['public_canonical_routes_only']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+    }
+
+    public function test_artifact_contains_no_forbidden_route_or_identifier_patterns(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added a generated RIASEC V2 media selection readiness artifact.
- Added an operator-facing media blocker report that records why existing baseline assets are not reusable for the article cover.
- Added a focused SEO artifact test that locks the no-go decision, ArticleResource cover requirements, remaining blocker list, and hard boundaries.

## Why
The RIASEC V2 article pipeline still needs reviewed CMS media before publish preflight. This PR keeps the train moving by recording the media input blocker without pretending a reusable asset exists.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-media-selection-readiness.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationMediaSelectionReadinessTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationMediaSelectionReadinessTest --no-ansi --display-warnings`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No media upload.
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No revision approval.
- No publish preflight.
- No publish.
- No search submission.
- No deploy.
- No private, tokenized, result, order, share, payment, or history URL access.