### PR TITLE
fix(media): persist Filament uploads through media library

### DIFF
--- a/backend/app/Filament/Ops/Resources/MediaAssetResource.php
+++ b/backend/app/Filament/Ops/Resources/MediaAssetResource.php
@@ -80,19 +80,11 @@ class MediaAssetResource extends Resource
                     Forms\Components\FileUpload::make('uploaded_source')
                         ->label('Upload source image')
                         ->disk('public')
-                        ->directory('media-library/sources/inbox')
-                        ->visibility('public')
+                        ->storeFiles(false)
                         ->image()
                         ->acceptedFileTypes(['image/jpeg', 'image/png', 'image/webp'])
                         ->maxSize(10240)
                         ->dehydrated(false)
-                        ->afterStateUpdated(function (mixed $state, Forms\Set $set): void {
-                            $path = is_array($state) ? (string) reset($state) : (string) $state;
-                            if ($path !== '') {
-                                $set('disk', 'public');
-                                $set('path', $path);
-                            }
-                        })
                         ->helperText('Uploading a source image generates hero, card, thumbnail, og, and preload variants after save.')
                         ->columnSpanFull(),
                     Forms\Components\TextInput::make('asset_key')

--- a/backend/app/Filament/Ops/Resources/MediaAssetResource/Pages/CreateMediaAsset.php
+++ b/backend/app/Filament/Ops/Resources/MediaAssetResource/Pages/CreateMediaAsset.php
@@ -9,6 +9,7 @@ use App\Models\MediaAsset;
 use App\Services\Cms\MediaAssetStorageSyncService;
 use App\Services\Cms\MediaVariantGenerator;
 use Filament\Resources\Pages\CreateRecord;
+use Illuminate\Http\UploadedFile;
 
 class CreateMediaAsset extends CreateRecord
 {
@@ -17,11 +18,36 @@ class CreateMediaAsset extends CreateRecord
     protected function afterCreate(): void
     {
         if ($this->record instanceof MediaAsset) {
-            $generator = app(MediaVariantGenerator::class);
-            if ($generator->canGenerate($this->record)) {
-                $asset = $generator->generate($this->record);
-                app(MediaAssetStorageSyncService::class)->syncAndVerify($asset);
-            }
+            $this->processMediaAssetSourceUpload($this->record);
         }
+    }
+
+    private function processMediaAssetSourceUpload(MediaAsset $record): void
+    {
+        $generator = app(MediaVariantGenerator::class);
+        $uploadedSource = $this->uploadedSourceFile();
+
+        if ($uploadedSource instanceof UploadedFile) {
+            $asset = $generator->storeUploadAndGenerate($record, $uploadedSource);
+            app(MediaAssetStorageSyncService::class)->syncAndVerify($asset);
+
+            return;
+        }
+
+        if ($generator->canGenerate($record)) {
+            $asset = $generator->generate($record);
+            app(MediaAssetStorageSyncService::class)->syncAndVerify($asset);
+        }
+    }
+
+    private function uploadedSourceFile(): ?UploadedFile
+    {
+        $state = data_get($this->form->getRawState(), 'uploaded_source');
+
+        if (is_array($state)) {
+            $state = reset($state);
+        }
+
+        return $state instanceof UploadedFile ? $state : null;
     }
 }

--- a/backend/app/Filament/Ops/Resources/MediaAssetResource/Pages/EditMediaAsset.php
+++ b/backend/app/Filament/Ops/Resources/MediaAssetResource/Pages/EditMediaAsset.php
@@ -10,6 +10,7 @@ use App\Services\Cms\MediaAssetStorageSyncService;
 use App\Services\Cms\MediaVariantGenerator;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
+use Illuminate\Http\UploadedFile;
 
 class EditMediaAsset extends EditRecord
 {
@@ -26,11 +27,36 @@ class EditMediaAsset extends EditRecord
     protected function afterSave(): void
     {
         if ($this->record instanceof MediaAsset) {
-            $generator = app(MediaVariantGenerator::class);
-            if ($generator->canGenerate($this->record)) {
-                $asset = $generator->generate($this->record);
-                app(MediaAssetStorageSyncService::class)->syncAndVerify($asset);
-            }
+            $this->processMediaAssetSourceUpload($this->record);
         }
+    }
+
+    private function processMediaAssetSourceUpload(MediaAsset $record): void
+    {
+        $generator = app(MediaVariantGenerator::class);
+        $uploadedSource = $this->uploadedSourceFile();
+
+        if ($uploadedSource instanceof UploadedFile) {
+            $asset = $generator->storeUploadAndGenerate($record, $uploadedSource);
+            app(MediaAssetStorageSyncService::class)->syncAndVerify($asset);
+
+            return;
+        }
+
+        if ($generator->canGenerate($record)) {
+            $asset = $generator->generate($record);
+            app(MediaAssetStorageSyncService::class)->syncAndVerify($asset);
+        }
+    }
+
+    private function uploadedSourceFile(): ?UploadedFile
+    {
+        $state = data_get($this->form->getRawState(), 'uploaded_source');
+
+        if (is_array($state)) {
+            $state = reset($state);
+        }
+
+        return $state instanceof UploadedFile ? $state : null;
     }
 }

--- a/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+++ b/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Tests\Feature\MediaLibrary;
 
 use App\Filament\Ops\Resources\ArticleResource;
+use App\Filament\Ops\Resources\MediaAssetResource\Pages\CreateMediaAsset;
 use App\Models\AdminUser;
 use App\Models\MediaAsset;
 use App\Models\MediaVariant;
@@ -12,16 +13,26 @@ use App\Models\Permission;
 use App\Models\Role;
 use App\Services\Cms\MediaVariantGenerator;
 use App\Support\Rbac\PermissionNames;
+use Filament\Facades\Filament;
+use Filament\PanelRegistry;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Http\UploadedFile;
 use Illuminate\Support\Facades\Storage;
 use Illuminate\Support\Str;
+use Livewire\Livewire;
 use ReflectionMethod;
 use Tests\TestCase;
 
 final class MediaLibraryPublicApiTest extends TestCase
 {
     use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Filament::setCurrentPanel(app(PanelRegistry::class)->get('ops'));
+    }
 
     public function test_baseline_import_creates_media_assets_and_variants(): void
     {
@@ -157,6 +168,56 @@ final class MediaLibraryPublicApiTest extends TestCase
             $this->assertStringStartsWith('https://assets.fermatmind.com/storage/media-library/variants/articleshero/', (string) $variant->url);
             Storage::disk('public')->assertExists((string) $variant->path);
         }
+    }
+
+    public function test_filament_upload_generates_public_media_path_instead_of_temporary_path(): void
+    {
+        Storage::fake('public');
+
+        $this->actingAsContentWriter();
+
+        Livewire::test(CreateMediaAsset::class)
+            ->fillForm([
+                'org_id' => 0,
+                'uploaded_source' => UploadedFile::fake()->image('receipt.png', 1239, 1280),
+                'asset_key' => 'daily-giving-unicef-receipt-2026-06-05',
+                'disk' => 'public_static',
+                'path' => null,
+                'url' => null,
+                'alt' => 'UNICEF donation receipt proof image',
+                'caption' => null,
+                'credit' => null,
+                'status' => MediaAsset::STATUS_DRAFT,
+                'is_public' => true,
+                'payload_json' => [],
+                'variants' => [],
+            ])
+            ->call('create')
+            ->assertHasNoFormErrors();
+
+        $asset = MediaAsset::query()
+            ->withoutGlobalScopes()
+            ->where('asset_key', 'daily-giving-unicef-receipt-2026-06-05')
+            ->firstOrFail();
+
+        $this->assertSame('public', (string) $asset->disk);
+        $this->assertStringStartsWith(
+            'media-library/sources/daily-giving-unicef-receipt-2026-06-05/source-',
+            (string) $asset->path
+        );
+        $this->assertFalse(str_starts_with((string) $asset->path, '/tmp/'));
+        $this->assertStringStartsWith(
+            'https://assets.fermatmind.com/storage/media-library/sources/daily-giving-unicef-receipt-2026-06-05/source-',
+            (string) $asset->url
+        );
+        $this->assertSame(1239, (int) $asset->width);
+        $this->assertSame(1280, (int) $asset->height);
+        $this->assertSame('image/png', (string) $asset->mime_type);
+        $this->assertSame(MediaAsset::SYNC_SKIPPED, (string) $asset->sync_status);
+        $this->assertSame(MediaAsset::CDN_SKIPPED, (string) $asset->cdn_status);
+        $this->assertSame(6, $asset->variants()->count());
+
+        Storage::disk('public')->assertExists((string) $asset->path);
     }
 
     public function test_article_cover_binding_requires_verified_public_standard_variants(): void


### PR DESCRIPTION
## What changed
- Stop the Filament Media Library upload field from writing temporary Livewire paths into media_assets.path.
- Route CMS create/edit uploads through MediaVariantGenerator::storeUploadAndGenerate(), then run the existing storage sync/verification service.
- Preserve existing manual path generation behavior when no new source upload is present.
- Add a Filament regression test that verifies CMS uploads persist under media-library/sources/... instead of /tmp/... and generate standard variants.

## Why
The CMS Media Library could publish a broken public URL when FileUpload state was saved as a temporary /tmp/... path before the media generator handled the file. This fixes the upload chain so operator-approved proof/media uploads become stable public media paths.

## Validation
- composer install --no-interaction --prefer-dist
- php artisan test --filter test_filament_upload_generates_public_media_path_instead_of_temporary_path --no-ansi --display-warnings
- php artisan test --filter 'test_(filament_upload_generates_public_media_path_instead_of_temporary_path|internal_upload_generates_standard_media_variants)' --no-ansi
- php artisan test --filter MediaLibraryOssSyncTest --no-ansi
- ./vendor/bin/pint --dirty
- git diff --check HEAD~1..HEAD

Notes: PHPUnit reported warnings only because this temporary worktree has no backend/.env; the targeted tests exited 0. Running the whole MediaLibraryPublicApiTest file locally still hits an unrelated baseline count assertion on this worktree and was not used as the scoped gate.

## Deferred
- No real proof/media upload.
- No CMS mutation.
- No DailyGiving record activation.
- No publish/index/sitemap/llms/trust badge/social/search action.