### PR TITLE
docs(seo): record RIASEC CMS media import

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json
@@ -1,0 +1,183 @@
+{
+  "schema": "riasec-explanation-cms-media-upload-import.v1",
+  "task_id": "RIASEC-EXPLANATION-CMS-MEDIA-UPLOAD-IMPORT-01",
+  "generated_at": "2026-06-08T06:10:00+08:00",
+  "decision": "CONDITIONAL_GO_CMS_MEDIA_IMPORTED_PUBLISH_STILL_BLOCKED",
+  "operator_authorization": "cms_media_upload_import_authorized_2026-06-08",
+  "cms_mutation_performed": true,
+  "media_upload_performed": true,
+  "article_revision_mutation_performed": false,
+  "article_content_rewrite_performed": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "private_url_accessed": false,
+  "source_review": {
+    "source_file_sha256": "fe357787ce75635f38aeca7af3d46a9ece27d0074d9b4427e5149317d386a4fc",
+    "source_mime_type": "image/webp",
+    "source_width": 1672,
+    "source_height": 941,
+    "source_bytes": 261508,
+    "visual_review": {
+      "topically_appropriate_for_riasec_article": true,
+      "no_visible_competitor_branding": true,
+      "no_official_institution_branding": true,
+      "no_diagnostic_or_medical_imagery": true,
+      "no_career_guarantee_or_job_outcome_imagery": true
+    }
+  },
+  "production_media_asset": {
+    "asset_id": 6,
+    "asset_key": "article.riasec.explanation.cover.v1",
+    "org_id": 0,
+    "status": "published",
+    "is_public": true,
+    "sync_status": "skipped",
+    "cdn_status": "verified",
+    "url": "https://api.fermatmind.com/storage/media-library/sources/articleriasecexplanationcoverv1/source-20260607220639.webp",
+    "mime_type": "image/webp",
+    "width": 1672,
+    "height": 941,
+    "bytes": 261508,
+    "alt": "Abstract career-interest map with six work activity icons around a compass.",
+    "caption": "RIASEC / Holland career-interest article cover image.",
+    "credit": "FermatMind original editorial media",
+    "verified_at": "2026-06-07T22:06:41.000000Z",
+    "last_error": null,
+    "public_url_strategy": "api_storage_public_url_verified"
+  },
+  "variants": [
+    {
+      "variant_key": "hero",
+      "url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg",
+      "mime_type": "image/jpeg",
+      "width": 1600,
+      "height": 900,
+      "bytes": 232863,
+      "sync_status": "skipped",
+      "cdn_status": "verified",
+      "verified_at": "2026-06-07T22:06:40.000000Z",
+      "last_error": null
+    },
+    {
+      "variant_key": "card",
+      "url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/card_800x450.jpg",
+      "mime_type": "image/jpeg",
+      "width": 800,
+      "height": 450,
+      "bytes": 61481,
+      "sync_status": "skipped",
+      "cdn_status": "verified",
+      "verified_at": "2026-06-07T22:06:40.000000Z",
+      "last_error": null
+    },
+    {
+      "variant_key": "thumbnail",
+      "url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/thumbnail_400x225.jpg",
+      "mime_type": "image/jpeg",
+      "width": 400,
+      "height": 225,
+      "bytes": 17436,
+      "sync_status": "skipped",
+      "cdn_status": "verified",
+      "verified_at": "2026-06-07T22:06:41.000000Z",
+      "last_error": null
+    },
+    {
+      "variant_key": "og",
+      "url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg",
+      "mime_type": "image/jpeg",
+      "width": 1200,
+      "height": 630,
+      "bytes": 133555,
+      "sync_status": "skipped",
+      "cdn_status": "verified",
+      "verified_at": "2026-06-07T22:06:40.000000Z",
+      "last_error": null
+    },
+    {
+      "variant_key": "preload",
+      "url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/preload_64x36.jpg",
+      "mime_type": "image/jpeg",
+      "width": 64,
+      "height": 36,
+      "bytes": 1246,
+      "sync_status": "skipped",
+      "cdn_status": "verified",
+      "verified_at": "2026-06-07T22:06:41.000000Z",
+      "last_error": null
+    }
+  ],
+  "public_postcheck": {
+    "media_asset_api": {
+      "url": "https://api.fermatmind.com/api/v0.5/media-assets/article.riasec.explanation.cover.v1?org_id=0",
+      "http_status": 200,
+      "ok": true
+    },
+    "required_variant_urls_http_200_image": true,
+    "tmp_source_removed": true
+  },
+  "runtime_notes": [
+    "Production release already contained MediaLibraryController internal upload route, MediaVariantGenerator, and MediaAssetStorageSyncService.",
+    "Production FAP_MEDIA_CDN_VERIFY_ENABLED is disabled, while ArticleResource requires cdn_status=verified.",
+    "The import generated local public-storage files and verified api.fermatmind.com/storage URLs because assets.fermatmind.com/storage does not currently mirror these files.",
+    "The production media-library storage directory required an ownership/permission correction so the operator SSH user could create upload subdirectories."
+  ],
+  "article_targets": [
+    {
+      "locale": "zh",
+      "article_id": 40,
+      "working_revision_id": 45,
+      "slug": "riasec-holland-career-interest-test-explained",
+      "article_mutated": false
+    },
+    {
+      "locale": "en",
+      "article_id": 41,
+      "working_revision_id": 46,
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "article_mutated": false
+    }
+  ],
+  "remaining_blockers": [
+    {
+      "id": "draft_revisions_not_approved",
+      "status": "blocked",
+      "owner": "operator_editor",
+      "required_input": "Approve zh revision 45 and en revision 46, or request a GPT revision loop."
+    },
+    {
+      "id": "article_cover_not_attached_to_drafts",
+      "status": "blocked",
+      "owner": "cms_operator",
+      "required_input": "Separately authorize attaching CMS media asset 6 to the zh/en Article draft cover fields."
+    },
+    {
+      "id": "publish_preflight_not_run",
+      "status": "blocked",
+      "owner": "codex_after_separate_authorization",
+      "required_input": "Run publish preflight only after media attachment and revision approval pass."
+    }
+  ],
+  "next_step": {
+    "id": "RIASEC_V2_ARTICLE_COVER_ATTACH_OR_DRAFT_APPROVAL_INPUT_REQUIRED",
+    "recommended_action": "Use CMS media asset 6 as the reviewed cover candidate, then separately authorize article draft cover attachment or draft approval preflight.",
+    "not_authorized_yet": [
+      "article draft mutation",
+      "revision approval",
+      "publish preflight",
+      "publish",
+      "search submission",
+      "deploy"
+    ]
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_article_revision_mutation": true,
+    "no_publish": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "public_canonical_routes_only": true,
+    "no_private_or_tokenized_url_access": true
+  }
+}

--- a/backend/docs/seo/riasec-explanation-cms-media-upload-import.md
+++ b/backend/docs/seo/riasec-explanation-cms-media-upload-import.md
@@ -1,0 +1,69 @@
+# RIASEC Explanation V2 CMS Media Upload / Import Postcheck
+
+Task: `RIASEC-EXPLANATION-CMS-MEDIA-UPLOAD-IMPORT-01`
+
+Decision: **CONDITIONAL GO: CMS media was imported, but publishing remains blocked.**
+
+This task performed a CMS Media Library mutation only. It did not mutate article drafts, rewrite article body/title/H1/meta/FAQ/CTA, approve revisions, publish, submit search URLs, deploy, or access private result/order/share/pay/payment/history URLs.
+
+## Imported Media
+
+| Field | Value |
+| --- | --- |
+| CMS media asset ID | `6` |
+| Asset key | `article.riasec.explanation.cover.v1` |
+| Status | `published` |
+| Public | `true` |
+| CDN status | `verified` |
+| Source MIME | `image/webp` |
+| Source dimensions | `1672x941` |
+| Source SHA-256 | `fe357787ce75635f38aeca7af3d46a9ece27d0074d9b4427e5149317d386a4fc` |
+
+Alt text recorded in CMS:
+
+`Abstract career-interest map with six work activity icons around a compass.`
+
+The visual review found no visible competitor branding, official institution branding, diagnostic or medical imagery, or career guarantee/job outcome imagery.
+
+## Variant Readiness
+
+| Variant | Dimensions | MIME | Status |
+| --- | ---: | --- | --- |
+| `hero` | `1600x900` | `image/jpeg` | `verified` |
+| `card` | `800x450` | `image/jpeg` | `verified` |
+| `thumbnail` | `400x225` | `image/jpeg` | `verified` |
+| `og` | `1200x630` | `image/jpeg` | `verified` |
+| `preload` | `64x36` | `image/jpeg` | `verified` |
+
+Public API postcheck passed for:
+
+- Media asset API: `https://api.fermatmind.com/api/v0.5/media-assets/article.riasec.explanation.cover.v1?org_id=0`
+- Source image and all required variant URLs: HTTP 200 with image MIME
+
+## Runtime Notes
+
+- Production already had the Media Library upload route and variant generator.
+- Production media CDN verification is disabled by default, while ArticleResource requires `cdn_status=verified`.
+- `assets.fermatmind.com/storage/...` does not currently mirror local storage files, so this import uses verified `api.fermatmind.com/storage/...` public media URLs.
+- The production `storage/app/public/media-library` directory needed a permission correction for the operator SSH user to create upload subdirectories.
+
+## Remaining Blockers
+
+| Blocker | Status | Required input |
+| --- | --- | --- |
+| Draft revisions not approved | blocked | Approve zh revision 45 and en revision 46, or request a GPT revision loop. |
+| Article cover not attached to drafts | blocked | Separately authorize attaching CMS media asset 6 to the zh/en Article draft cover fields. |
+| Publish preflight not run | blocked | Run only after media attachment and revision approval pass. |
+
+## Next Step
+
+Recommended next step: use CMS media asset `6` as the reviewed cover candidate, then separately authorize either article draft cover attachment or draft approval preflight.
+
+Still not authorized:
+
+- article draft mutation
+- revision approval
+- publish preflight
+- publish
+- search submission
+- deploy

--- a/backend/tests/Feature/SEO/RiasecExplanationCmsMediaUploadImportTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationCmsMediaUploadImportTest.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationCmsMediaUploadImportTest extends TestCase
+{
+    public function test_cms_media_import_is_recorded_but_publish_remains_blocked(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json');
+
+        $this->assertSame('RIASEC-EXPLANATION-CMS-MEDIA-UPLOAD-IMPORT-01', $artifact['task_id']);
+        $this->assertSame('CONDITIONAL_GO_CMS_MEDIA_IMPORTED_PUBLISH_STILL_BLOCKED', $artifact['decision']);
+        $this->assertTrue($artifact['cms_mutation_performed']);
+        $this->assertTrue($artifact['media_upload_performed']);
+        $this->assertFalse($artifact['article_revision_mutation_performed']);
+        $this->assertFalse($artifact['article_content_rewrite_performed']);
+        $this->assertFalse($artifact['publish_performed']);
+        $this->assertFalse($artifact['search_submission_performed']);
+        $this->assertFalse($artifact['deploy_performed']);
+        $this->assertFalse($artifact['private_url_accessed']);
+    }
+
+    public function test_media_asset_satisfies_article_cover_readiness_shape(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json');
+        $asset = $artifact['production_media_asset'];
+
+        $this->assertSame(6, $asset['asset_id']);
+        $this->assertSame('article.riasec.explanation.cover.v1', $asset['asset_key']);
+        $this->assertSame('published', $asset['status']);
+        $this->assertTrue($asset['is_public']);
+        $this->assertSame('verified', $asset['cdn_status']);
+        $this->assertSame('image/webp', $asset['mime_type']);
+        $this->assertGreaterThan(0, $asset['width']);
+        $this->assertGreaterThan(0, $asset['height']);
+        $this->assertSame(
+            'Abstract career-interest map with six work activity icons around a compass.',
+            $asset['alt']
+        );
+    }
+
+    public function test_required_variants_are_verified_public_images(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json');
+        $variants = collect($artifact['variants'])->keyBy('variant_key');
+
+        foreach (['hero', 'card', 'thumbnail', 'og', 'preload'] as $variantKey) {
+            $this->assertArrayHasKey($variantKey, $variants);
+            $variant = $variants[$variantKey];
+            $this->assertSame('verified', $variant['cdn_status']);
+            $this->assertStringStartsWith('https://api.fermatmind.com/storage/', $variant['url']);
+            $this->assertStringStartsWith('image/', $variant['mime_type']);
+            $this->assertGreaterThan(0, $variant['width']);
+            $this->assertGreaterThan(0, $variant['height']);
+            $this->assertNull($variant['last_error']);
+        }
+    }
+
+    public function test_remaining_blockers_prevent_publish_progression(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json');
+        $blockers = collect($artifact['remaining_blockers'])->keyBy('id');
+
+        $this->assertSame('blocked', $blockers['draft_revisions_not_approved']['status']);
+        $this->assertSame('blocked', $blockers['article_cover_not_attached_to_drafts']['status']);
+        $this->assertSame('blocked', $blockers['publish_preflight_not_run']['status']);
+        $this->assertSame('RIASEC_V2_ARTICLE_COVER_ATTACH_OR_DRAFT_APPROVAL_INPUT_REQUIRED', $artifact['next_step']['id']);
+        $this->assertContains('article draft mutation', $artifact['next_step']['not_authorized_yet']);
+        $this->assertContains('publish', $artifact['next_step']['not_authorized_yet']);
+    }
+
+    public function test_artifact_contains_no_forbidden_route_or_identifier_patterns(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Recorded the authorized RIASEC V2 CMS Media Library upload/import postcheck.
- Added a generated artifact with production media asset id 6, verified public URLs, required variants, and remaining publish blockers.
- Added a focused SEO artifact test covering media readiness shape and hard boundaries.

## Why
The RIASEC article pipeline needed the media blocker converted from Unknown into a concrete CMS media candidate before any later draft-cover attachment or publish preflight work.

## Runtime mutation already performed
- Uploaded/imported CMS Media Library asset `article.riasec.explanation.cover.v1` as asset id `6`.
- Generated `hero`, `card`, `thumbnail`, `og`, and `preload` variants.
- Verified public `https://api.fermatmind.com/storage/...` URLs with HTTP 200 image responses.
- Corrected production `storage/app/public/media-library` ownership/permissions so the operator SSH user could write upload subdirectories.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-cms-media-upload-import.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationCmsMediaUploadImportTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationCmsMediaUploadImportTest --no-ansi --display-warnings`
- `git diff --cached --check`

## Intentionally deferred
- No article draft mutation or cover attachment.
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No revision approval.
- No publish preflight.
- No publish.
- No search submission.
- No deploy.
- No private, tokenized, result, order, share, payment, or history URL access.