### PR TITLE
HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01 docs(help): refresh production release readiness

### DIFF
--- a/backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
+++ b/backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
@@ -1,0 +1,78 @@
+{
+  "schema": "help-cms-service-fields-prod-release-01.v1",
+  "task": "HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01",
+  "generated_at": "2026-06-08",
+  "decision": "DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN",
+  "scope": "Fresh deploy readiness only; no deploy, no migration, no CMS mutation, no publish.",
+  "target_resolution": {
+    "repo": "fermatmind/fap-api",
+    "origin_main_sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+    "deploy_class_if_active_sha_known": "deploy_latest_main",
+    "requested_target_is_latest_origin_main": true,
+    "included_required_help_runtime_prs": [
+      {
+        "pr": 1956,
+        "sha": "9cae1f45ee55acf11df43376e80387957c2049a3",
+        "reason": "ContentPage baseline importer maps Help service fields."
+      },
+      {
+        "pr": 1959,
+        "sha": "13e62a0389124e4acb90f4b7467a26ea996cf24e",
+        "reason": "ContentPage publish safety fields are present."
+      },
+      {
+        "pr": 1962,
+        "sha": "0dd12d8751b328cf502a28e586597d1ed4a4246f",
+        "reason": "Help service fields production runtime readiness was recorded."
+      }
+    ],
+    "newer_main_commits_included": [
+      {
+        "pr": 1963,
+        "sha": "a5509759",
+        "summary": "fix(media): persist Filament uploads through media library"
+      },
+      {
+        "pr": 1965,
+        "sha": "3acd4de7",
+        "summary": "docs(seo): record RIASEC CMS media import"
+      },
+      {
+        "pr": 1964,
+        "sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+        "summary": "docs(codex): close HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01 ledger"
+      }
+    ]
+  },
+  "production_readiness": {
+    "api_root_status": 200,
+    "healthz_status": 404,
+    "help_content_page_public_status": 404,
+    "production_active_sha": "Unknown",
+    "production_contains_target_sha": "Unknown",
+    "release_sha_publicly_visible": false,
+    "deploy_authorization_acceptable_now": false,
+    "blocker": "The production deploy targeting SOP requires current production release SHA. Public read-only checks did not expose it."
+  },
+  "required_before_deploy": [
+    "Obtain current production active SHA through an approved read-only operator method that does not expose secrets/env/cookies/tokens.",
+    "Confirm whether production already contains 01de36c41ff5180e269ca324bb5cc666eac2babf.",
+    "If production does not contain it, provide exact deploy authorization for the current latest origin/main SHA at that time."
+  ],
+  "stale_prompt_do_not_use_without_refresh": "I explicitly approve backend production deploy for exact SHA 01de36c41ff5180e269ca324bb5cc666eac2babf release help-cms-service-fields-prod-release-20260608-01de36c4.",
+  "safe_next_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
+  "scope_validation": {
+    "deploy_performed": false,
+    "migration_performed": false,
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false,
+    "frontend_fallback_content_added": false
+  },
+  "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01"
+}

--- a/backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
+++ b/backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
@@ -6,7 +6,7 @@
   "scope": "Fresh deploy readiness only; no deploy, no migration, no CMS mutation, no publish.",
   "target_resolution": {
     "repo": "fermatmind/fap-api",
-    "origin_main_sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+    "origin_main_sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
     "deploy_class_if_active_sha_known": "deploy_latest_main",
     "requested_target_is_latest_origin_main": true,
     "included_required_help_runtime_prs": [
@@ -41,6 +41,16 @@
         "pr": 1964,
         "sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
         "summary": "docs(codex): close HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01 ledger"
+      },
+      {
+        "pr": null,
+        "sha": "8a905835",
+        "summary": "docs(seo): record RIASEC draft cover preflight"
+      },
+      {
+        "pr": 1967,
+        "sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
+        "summary": "docs(seo): summarize science contentpage line status"
       }
     ]
   },
@@ -56,10 +66,10 @@
   },
   "required_before_deploy": [
     "Obtain current production active SHA through an approved read-only operator method that does not expose secrets/env/cookies/tokens.",
-    "Confirm whether production already contains 01de36c41ff5180e269ca324bb5cc666eac2babf.",
+    "Confirm whether production already contains ee040639233985adce6cc599bb8b3a38f7d87750.",
     "If production does not contain it, provide exact deploy authorization for the current latest origin/main SHA at that time."
   ],
-  "stale_prompt_do_not_use_without_refresh": "I explicitly approve backend production deploy for exact SHA 01de36c41ff5180e269ca324bb5cc666eac2babf release help-cms-service-fields-prod-release-20260608-01de36c4.",
+  "stale_prompt_do_not_use_without_refresh": "I explicitly approve backend production deploy for exact SHA ee040639233985adce6cc599bb8b3a38f7d87750 release help-cms-service-fields-prod-release-20260608-ee040639.",
   "safe_next_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
   "scope_validation": {
     "deploy_performed": false,

--- a/backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
+++ b/backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
@@ -6,7 +6,7 @@
   "scope": "Fresh deploy readiness only; no deploy, no migration, no CMS mutation, no publish.",
   "target_resolution": {
     "repo": "fermatmind/fap-api",
-    "origin_main_sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
+    "origin_main_sha": "14f92cba66da60acf6c1bc5777058ceb33323319",
     "deploy_class_if_active_sha_known": "deploy_latest_main",
     "requested_target_is_latest_origin_main": true,
     "included_required_help_runtime_prs": [
@@ -51,6 +51,11 @@
         "pr": 1967,
         "sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
         "summary": "docs(seo): summarize science contentpage line status"
+      },
+      {
+        "pr": 1969,
+        "sha": "14f92cba66da60acf6c1bc5777058ceb33323319",
+        "summary": "docs(benefit): refresh Foundation DailyGiving line summary"
       }
     ]
   },
@@ -66,10 +71,10 @@
   },
   "required_before_deploy": [
     "Obtain current production active SHA through an approved read-only operator method that does not expose secrets/env/cookies/tokens.",
-    "Confirm whether production already contains ee040639233985adce6cc599bb8b3a38f7d87750.",
+    "Confirm whether production already contains 14f92cba66da60acf6c1bc5777058ceb33323319.",
     "If production does not contain it, provide exact deploy authorization for the current latest origin/main SHA at that time."
   ],
-  "stale_prompt_do_not_use_without_refresh": "I explicitly approve backend production deploy for exact SHA ee040639233985adce6cc599bb8b3a38f7d87750 release help-cms-service-fields-prod-release-20260608-ee040639.",
+  "stale_prompt_do_not_use_without_refresh": "I explicitly approve backend production deploy for exact SHA 14f92cba66da60acf6c1bc5777058ceb33323319 release help-cms-service-fields-prod-release-20260608-14f92cba.",
   "safe_next_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
   "scope_validation": {
     "deploy_performed": false,

--- a/backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
+++ b/backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
@@ -6,7 +6,7 @@ This is a fresh deploy-readiness check for the Help service ContentPage fields r
 
 ## Current Target
 
-- Current `origin/main`: `01de36c41ff5180e269ca324bb5cc666eac2babf`
+- Current `origin/main`: `ee040639233985adce6cc599bb8b3a38f7d87750`
 - Deploy class if production active SHA is known and behind target: `deploy_latest_main`
 - Required Help runtime commits included:
   - PR #1956: `9cae1f45ee55acf11df43376e80387957c2049a3`
@@ -16,6 +16,8 @@ This is a fresh deploy-readiness check for the Help service ContentPage fields r
   - PR #1963: `a5509759`
   - PR #1965: `3acd4de7`
   - PR #1964: `01de36c41ff5180e269ca324bb5cc666eac2babf`
+  - Unknown PR: `8a905835`
+  - PR #1967: `ee040639233985adce6cc599bb8b3a38f7d87750`
 
 ## Public Production Evidence
 
@@ -42,7 +44,7 @@ I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an app
 Do not use this without refreshing `origin/main` and production active SHA again:
 
 ```text
-I explicitly approve backend production deploy for exact SHA 01de36c41ff5180e269ca324bb5cc666eac2babf release help-cms-service-fields-prod-release-20260608-01de36c4.
+I explicitly approve backend production deploy for exact SHA ee040639233985adce6cc599bb8b3a38f7d87750 release help-cms-service-fields-prod-release-20260608-ee040639.
 ```
 
 ## Validation

--- a/backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
+++ b/backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
@@ -6,7 +6,7 @@ This is a fresh deploy-readiness check for the Help service ContentPage fields r
 
 ## Current Target
 
-- Current `origin/main`: `ee040639233985adce6cc599bb8b3a38f7d87750`
+- Current `origin/main`: `14f92cba66da60acf6c1bc5777058ceb33323319`
 - Deploy class if production active SHA is known and behind target: `deploy_latest_main`
 - Required Help runtime commits included:
   - PR #1956: `9cae1f45ee55acf11df43376e80387957c2049a3`
@@ -18,6 +18,7 @@ This is a fresh deploy-readiness check for the Help service ContentPage fields r
   - PR #1964: `01de36c41ff5180e269ca324bb5cc666eac2babf`
   - Unknown PR: `8a905835`
   - PR #1967: `ee040639233985adce6cc599bb8b3a38f7d87750`
+  - PR #1969: `14f92cba66da60acf6c1bc5777058ceb33323319`
 
 ## Public Production Evidence
 
@@ -44,7 +45,7 @@ I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an app
 Do not use this without refreshing `origin/main` and production active SHA again:
 
 ```text
-I explicitly approve backend production deploy for exact SHA ee040639233985adce6cc599bb8b3a38f7d87750 release help-cms-service-fields-prod-release-20260608-ee040639.
+I explicitly approve backend production deploy for exact SHA 14f92cba66da60acf6c1bc5777058ceb33323319 release help-cms-service-fields-prod-release-20260608-14f92cba.
 ```
 
 ## Validation

--- a/backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
+++ b/backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
@@ -1,0 +1,60 @@
+# HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01
+
+Decision: `DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN`
+
+This is a fresh deploy-readiness check for the Help service ContentPage fields release. It refreshes the current exact `origin/main` SHA and applies the production deploy targeting SOP. It does not deploy, run migrations, mutate CMS rows, publish, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund actions, change payment-provider behavior, or claim Operator approval.
+
+## Current Target
+
+- Current `origin/main`: `01de36c41ff5180e269ca324bb5cc666eac2babf`
+- Deploy class if production active SHA is known and behind target: `deploy_latest_main`
+- Required Help runtime commits included:
+  - PR #1956: `9cae1f45ee55acf11df43376e80387957c2049a3`
+  - PR #1959: `13e62a0389124e4acb90f4b7467a26ea996cf24e`
+  - PR #1962: `0dd12d8751b328cf502a28e586597d1ed4a4246f`
+- Newer main commits included:
+  - PR #1963: `a5509759`
+  - PR #1965: `3acd4de7`
+  - PR #1964: `01de36c41ff5180e269ca324bb5cc666eac2babf`
+
+## Public Production Evidence
+
+- API root status: `200`
+- Public `/api/healthz` status: `404`
+- Public draft Help content page route status: `404`
+- Production active SHA: `Unknown`
+- Production contains target SHA: `Unknown`
+
+The public Help page 404 is compatible with draft/non-public state and does not prove runtime SHA.
+
+## Decision
+
+Do not deploy from this readiness pass. The production deploy targeting SOP requires current production release SHA before accepting a deploy approval. Public read-only checks did not expose that SHA.
+
+## Next Safe Authorization
+
+```text
+I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.
+```
+
+## Stale Deploy Prompt
+
+Do not use this without refreshing `origin/main` and production active SHA again:
+
+```text
+I explicitly approve backend production deploy for exact SHA 01de36c41ff5180e269ca324bb5cc666eac2babf release help-cms-service-fields-prod-release-20260608-01de36c4.
+```
+
+## Validation
+
+```bash
+git rev-parse origin/main
+git merge-base --is-ancestor 9cae1f45ee55acf11df43376e80387957c2049a3 origin/main
+git merge-base --is-ancestor 13e62a0389124e4acb90f4b7467a26ea996cf24e origin/main
+git merge-base --is-ancestor 0dd12d8751b328cf502a28e586597d1ed4a4246f origin/main
+python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49176,7 +49176,7 @@
       },
       "target_resolution": {
         "status": "pass",
-        "origin_main_sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
+        "origin_main_sha": "14f92cba66da60acf6c1bc5777058ceb33323319",
         "contains_pr_1956": true,
         "contains_pr_1959": true,
         "contains_pr_1962": true,
@@ -49185,7 +49185,8 @@
           "3acd4de7 PR #1965",
           "01de36c41ff5180e269ca324bb5cc666eac2babf PR #1964",
           "8a905835 Unknown PR",
-          "ee040639233985adce6cc599bb8b3a38f7d87750 PR #1967"
+          "ee040639233985adce6cc599bb8b3a38f7d87750 PR #1967",
+          "14f92cba66da60acf6c1bc5777058ceb33323319 PR #1969"
         ]
       },
       "public_production_runtime": {
@@ -49215,7 +49216,7 @@
           {
             "command": "git rev-parse origin/main",
             "status": "pass",
-            "output": "ee040639233985adce6cc599bb8b3a38f7d87750"
+            "output": "14f92cba66da60acf6c1bc5777058ceb33323319"
           },
           {
             "command": "git merge-base --is-ancestor 9cae1f45ee55acf11df43376e80387957c2049a3 origin/main",
@@ -49253,11 +49254,11 @@
       "github": {
         "status": "pending_after_rebase",
         "checks": [],
-        "note": "PR rebased after origin/main advanced to ee040639233985adce6cc599bb8b3a38f7d87750; GitHub checks must rerun before merge."
+        "note": "PR rebased after origin/main advanced to 14f92cba66da60acf6c1bc5777058ceb33323319; GitHub checks must rerun before merge."
       }
     },
     "failure_reason": null,
-    "commit_sha": "14987c0c0a15851c1999bd639788791bfdb3c179",
+    "commit_sha": "5746baec0c66fe1f05ffb0eec740c2c1cf7ec6fa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1966",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49266,7 +49267,7 @@
       "decision": "DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN",
       "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json",
       "operations_report": "backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md",
-    "current_origin_main_sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
+    "current_origin_main_sha": "14f92cba66da60acf6c1bc5777058ceb33323319",
       "next_safe_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
       "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01"
     },
@@ -49332,6 +49333,11 @@
         "at": "2026-06-08",
         "status": "target_refreshed_after_main_advanced",
         "note": "origin/main advanced to ee040639233985adce6cc599bb8b3a38f7d87750 before merge, so the PR was rebased and the release readiness target was refreshed. Public checks still do not expose production active SHA."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "target_refreshed_after_main_advanced",
+        "note": "origin/main advanced again to 14f92cba66da60acf6c1bc5777058ceb33323319 before merge, so the PR was rebased and the release readiness target was refreshed again. Public checks still do not expose production active SHA."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49154,5 +49154,167 @@
         "note": "PR #1962 merged on GitHub at 2026-06-07T22:06:03Z with merge commit 0dd12d8751b328cf502a28e586597d1ed4a4246f; origin/main contains the merge commit; remote branch was already deleted and local task branch cleanup was completed."
       }
     ]
+  },
+  "HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-cms-service-fields-prod-release-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): refresh Help service fields production release readiness",
+    "depends_on": [
+      "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User requested HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01 fresh deploy readiness to refresh current exact SHA before deciding whether to authorize deploy. No deploy, migration, CMS mutation, publish, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider change, or Operator approval claim is allowed."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01 is merged and reconciled on origin/main."
+      },
+      "target_resolution": {
+        "status": "pass",
+        "origin_main_sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+        "contains_pr_1956": true,
+        "contains_pr_1959": true,
+        "contains_pr_1962": true,
+        "newer_main_commits_included": [
+          "a5509759 PR #1963",
+          "3acd4de7 PR #1965",
+          "01de36c41ff5180e269ca324bb5cc666eac2babf PR #1964"
+        ]
+      },
+      "public_production_runtime": {
+        "status": "blocked_unknown_active_sha",
+        "api_root_status": 200,
+        "healthz_status": 404,
+        "help_content_page_public_status": 404,
+        "production_active_sha": "Unknown",
+        "production_contains_target_sha": "Unknown",
+        "evidence": "Public unauthenticated checks did not expose production active release SHA; deploy authorization cannot be accepted under the production deploy targeting SOP."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          {
+            "command": "python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "pass"
+          },
+          {
+            "command": "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+            "status": "pass"
+          },
+          {
+            "command": "git rev-parse origin/main",
+            "status": "pass",
+            "output": "01de36c41ff5180e269ca324bb5cc666eac2babf"
+          },
+          {
+            "command": "git merge-base --is-ancestor 9cae1f45ee55acf11df43376e80387957c2049a3 origin/main",
+            "status": "pass"
+          },
+          {
+            "command": "git merge-base --is-ancestor 13e62a0389124e4acb90f4b7467a26ea996cf24e origin/main",
+            "status": "pass"
+          },
+          {
+            "command": "git merge-base --is-ancestor 0dd12d8751b328cf502a28e586597d1ed4a4246f origin/main",
+            "status": "pass"
+          },
+          {
+            "command": "curl -sS -m 10 -o /tmp/fap-api-release-root.out -w '%{http_code}\\n' https://api.fermatmind.com/",
+            "status": "pass",
+            "output": "200"
+          },
+          {
+            "command": "curl -sS -m 10 -o /tmp/fap-api-release-healthz.out -w '%{http_code}\\n' https://api.fermatmind.com/api/healthz",
+            "status": "pass",
+            "output": "404"
+          },
+          {
+            "command": "curl -sS -m 10 -o /tmp/fap-api-release-content-page.out -w '%{http_code}\\n' 'https://api.fermatmind.com/api/v0.5/content-pages/help-payment-refund?locale=en'",
+            "status": "pass",
+            "output": "404"
+          },
+          {
+            "command": "git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+            "status": "pass"
+          }
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "checks": []
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN",
+      "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json",
+      "operations_report": "backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md",
+      "current_origin_main_sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+      "next_safe_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
+      "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01"
+    },
+    "scope_validation": {
+      "deploy_performed": false,
+      "migration_performed": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "frontend_fallback_content_added": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01",
+        "status": "required_before_deploy",
+        "note": "Need approved read-only production active SHA evidence before deploy authorization can be accepted."
+      },
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION",
+        "status": "blocked",
+        "note": "Do not deploy from this readiness pass because production active SHA is Unknown."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+        "status": "blocked_until_runtime_deployed_or_confirmed",
+        "note": "CMS sync remains blocked until production runtime is confirmed to include the Help service fields target."
+      }
+    ],
+    "next_task": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User requested fresh deploy readiness for HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_artifacts_created_validation_pending",
+        "note": "Created release readiness artifact, operations report, manifest entry, and state entry; local validation pending."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "JSON/YAML validation, target containment checks, public read-only status checks, and scoped diff whitespace checks passed. Deploy remains blocked because production active SHA is Unknown."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49159,7 +49159,7 @@
     "repo": "fap-api",
     "branch": "codex/help-cms-service-fields-prod-release-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): refresh Help service fields production release readiness",
     "depends_on": [
@@ -49254,8 +49254,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "bbb2b77c19ee0f6a7ae4ae683c1c57f2463f642d",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1966",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -49314,6 +49314,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "JSON/YAML validation, target containment checks, public read-only status checks, and scoped diff whitespace checks passed. Deploy remains blocked because production active SHA is Unknown."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1966 for HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -32664,7 +32664,7 @@
     ]
   },
   "GLOBAL-EN-ZH-CONTENT-PAGES-HUMAN-REVISION-01A-FOUNDATION-GOVERNANCE-FACT-RECONCILE": {
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "repo": "fap-api",
     "branch": "codex/global-en-zh-content-pages-human-revision-01a-foundation-governance",
     "base": "main",
@@ -49249,12 +49249,24 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "checks": []
+        "status": "pass",
+        "checks": [
+          "hygiene",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN",
+        "head_ref_oid_checked": "c96dd45d8722d1d1eb6fd087c554ab16ac216b18"
       }
     },
     "failure_reason": null,
-    "commit_sha": "bbb2b77c19ee0f6a7ae4ae683c1c57f2463f642d",
+    "commit_sha": "c96dd45d8722d1d1eb6fd087c554ab16ac216b18",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1966",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49319,6 +49331,11 @@
         "at": "2026-06-08",
         "status": "pr_opened",
         "note": "Opened PR #1966 for HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed, merge state was clean, and origin/main had not advanced beyond the refreshed exact SHA 01de36c41ff5180e269ca324bb5cc666eac2babf. Deploy remains blocked because production active SHA is Unknown."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31850,7 +31850,7 @@
   "RESULT-EN-PARITY-06": {
     "repo": "fap-api",
     "branch": "codex/result-en-parity-06-bigfive-v2-en-assets",
-    "status": "ready_to_merge",
+    "status": "local_checks_passed",
     "depends_on": [
       "RESULT-EN-PARITY-05"
     ],
@@ -49176,14 +49176,16 @@
       },
       "target_resolution": {
         "status": "pass",
-        "origin_main_sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+        "origin_main_sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
         "contains_pr_1956": true,
         "contains_pr_1959": true,
         "contains_pr_1962": true,
         "newer_main_commits_included": [
           "a5509759 PR #1963",
           "3acd4de7 PR #1965",
-          "01de36c41ff5180e269ca324bb5cc666eac2babf PR #1964"
+          "01de36c41ff5180e269ca324bb5cc666eac2babf PR #1964",
+          "8a905835 Unknown PR",
+          "ee040639233985adce6cc599bb8b3a38f7d87750 PR #1967"
         ]
       },
       "public_production_runtime": {
@@ -49213,7 +49215,7 @@
           {
             "command": "git rev-parse origin/main",
             "status": "pass",
-            "output": "01de36c41ff5180e269ca324bb5cc666eac2babf"
+            "output": "ee040639233985adce6cc599bb8b3a38f7d87750"
           },
           {
             "command": "git merge-base --is-ancestor 9cae1f45ee55acf11df43376e80387957c2049a3 origin/main",
@@ -49249,24 +49251,13 @@
         ]
       },
       "github": {
-        "status": "pass",
-        "checks": [
-          "hygiene",
-          "Semgrep blocking secrets",
-          "semgrep sarif non-blocking upload",
-          "supply-chain",
-          "content-pack-build-validate",
-          "verify-bigfive",
-          "verify-mbti-legacy",
-          "verify-mbti-v2",
-          "Semgrep OSS"
-        ],
-        "merge_state": "CLEAN",
-        "head_ref_oid_checked": "c96dd45d8722d1d1eb6fd087c554ab16ac216b18"
+        "status": "pending_after_rebase",
+        "checks": [],
+        "note": "PR rebased after origin/main advanced to ee040639233985adce6cc599bb8b3a38f7d87750; GitHub checks must rerun before merge."
       }
     },
     "failure_reason": null,
-    "commit_sha": "c96dd45d8722d1d1eb6fd087c554ab16ac216b18",
+    "commit_sha": "14987c0c0a15851c1999bd639788791bfdb3c179",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1966",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49275,7 +49266,7 @@
       "decision": "DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN",
       "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json",
       "operations_report": "backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md",
-      "current_origin_main_sha": "01de36c41ff5180e269ca324bb5cc666eac2babf",
+    "current_origin_main_sha": "ee040639233985adce6cc599bb8b3a38f7d87750",
       "next_safe_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
       "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01"
     },
@@ -49336,6 +49327,11 @@
         "at": "2026-06-08",
         "status": "ready_to_merge",
         "note": "GitHub checks passed, merge state was clean, and origin/main had not advanced beyond the refreshed exact SHA 01de36c41ff5180e269ca324bb5cc666eac2babf. Deploy remains blocked because production active SHA is Unknown."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "target_refreshed_after_main_advanced",
+        "note": "origin/main advanced to ee040639233985adce6cc599bb8b3a38f7d87750 before merge, so the PR was rebased and the release readiness target was refreshed. Public checks still do not expose production active SHA."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22057,6 +22057,47 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
 
+  - id: HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01
+    repo: fap-api
+    depends_on:
+      - HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01
+    branch: codex/help-cms-service-fields-prod-release-01
+    title: "docs(help): refresh Help service fields production release readiness"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Refresh the current exact origin/main SHA for a potential backend production deploy that would include ContentPage Help service fields, publish safety fields, and importer service-field mapping.
+      - Apply the production deploy targeting SOP and record whether deploy authorization can be accepted.
+      - Use public/read-only checks only; if production active SHA is not visible, record Unknown and stop before deploy.
+      - Do not deploy, run migrations, mutate CMS data, publish, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, add frontend fallback content, or claim Operator approval.
+    allowed_paths:
+      - backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json
+      - backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy production, run migrations, mutate CMS data, publish, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, add frontend fallback content, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed

- Added `HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01` to the PR train manifest/state.
- Added a fresh Help service fields production release readiness artifact.
- Added an operations report with the current exact `origin/main` SHA and deployment gate decision.

## Why

The previous runtime readiness report contained a stale deploy prompt after `main` advanced. This refresh resolves the current exact SHA before any deploy authorization decision.

Decision: `DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN`.

Public production checks do not expose the active release SHA, and the production deploy targeting SOP requires that value before accepting deploy authorization.

## Validation

```bash
python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json >/dev/null
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
git rev-parse origin/main
git merge-base --is-ancestor 9cae1f45ee55acf11df43376e80387957c2049a3 origin/main
git merge-base --is-ancestor 13e62a0389124e4acb90f4b7467a26ea996cf24e origin/main
git merge-base --is-ancestor 0dd12d8751b328cf502a28e586597d1ed4a4246f origin/main
curl -sS -m 10 -o /tmp/fap-api-release-root.out -w '%{http_code}\n' https://api.fermatmind.com/
curl -sS -m 10 -o /tmp/fap-api-release-healthz.out -w '%{http_code}\n' https://api.fermatmind.com/api/healthz
curl -sS -m 10 -o /tmp/fap-api-release-content-page.out -w '%{http_code}\n' 'https://api.fermatmind.com/api/v0.5/content-pages/help-payment-refund?locale=en'
git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
git diff --cached --check
```

## Intentionally deferred

- No production deploy.
- No migration execution.
- No CMS mutation.
- No publish.
- No search submission.
- No private URL access.
- No secret/env/cookie/token read.
- No payment/refund action or payment-provider behavior change.
- No Operator approval claim.

## Repository rule impact

Docs-only deploy readiness. CMS/backend remains the ContentPage authority; no frontend fallback content is added.
