### PR TITLE
docs(seo): record RIASEC draft cover preflight

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json
@@ -1,0 +1,163 @@
+{
+  "schema": "riasec-explanation-draft-cover-attach-publish-preflight.v1",
+  "task_id": "RIASEC-EXPLANATION-DRAFT-COVER-ATTACH-PUBLISH-PREFLIGHT-01",
+  "generated_at": "2026-06-08T09:50:00+08:00",
+  "decision": "NO_GO_REFERENCES_MISSING",
+  "operator_authorization": "cms_media_asset_6_attach_to_riasec_drafts_then_draft_approval_publish_preflight_authorized_2026-06-08",
+  "cms_mutation_performed": true,
+  "article_cover_attach_performed": true,
+  "draft_revision_approval_performed": true,
+  "article_content_rewrite_performed": false,
+  "publish_preflight_performed": true,
+  "publish_preflight_dry_run": true,
+  "publish_preflight_ok": false,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "private_url_accessed": false,
+  "media_asset": {
+    "asset_id": 6,
+    "asset_key": "article.riasec.explanation.cover.v1",
+    "cdn_status": "verified",
+    "cover_image_url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg",
+    "og_image_url": "https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg",
+    "cover_image_alt": "Abstract career-interest map with six work activity icons around a compass.",
+    "variant_keys": [
+      "hero",
+      "card",
+      "thumbnail",
+      "og",
+      "preload"
+    ]
+  },
+  "article_mutations": [
+    {
+      "locale": "zh",
+      "article_id": 40,
+      "working_revision_id": 45,
+      "slug": "riasec-holland-career-interest-test-explained",
+      "status_after": "draft",
+      "is_public_after": false,
+      "is_indexable_after": false,
+      "translation_status_after": "approved",
+      "working_revision_status_after": "approved",
+      "reviewed_by": 1,
+      "approved_at": "2026-06-08T01:44:05.000000Z",
+      "cover_image_attached": true,
+      "seo_og_image_attached": true,
+      "import_media_status_after": "complete",
+      "references_count": 0
+    },
+    {
+      "locale": "en",
+      "article_id": 41,
+      "working_revision_id": 46,
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "status_after": "draft",
+      "is_public_after": false,
+      "is_indexable_after": false,
+      "translation_status_after": "approved",
+      "working_revision_status_after": "approved",
+      "reviewed_by": 1,
+      "approved_at": "2026-06-08T01:44:05.000000Z",
+      "cover_image_attached": true,
+      "seo_og_image_attached": true,
+      "import_media_status_after": "complete",
+      "references_count": 0
+    }
+  ],
+  "publish_preflight": {
+    "command": "php artisan articles:publish-controlled --article=40 --article=41 --ack-claim-warning=40 --make-indexable --dry-run --json --no-ansi",
+    "exit_code": 1,
+    "ok": false,
+    "dry_run": true,
+    "make_indexable": true,
+    "expected_confirmation": "I explicitly approve Codex to publish article ids 40,41 after preflight passes.",
+    "published_article_ids": [],
+    "articles": [
+      {
+        "article_id": 40,
+        "locale": "zh",
+        "working_revision_status": "approved",
+        "import_status": "warning",
+        "claim_status": "warning",
+        "claim_warning_acknowledged": true,
+        "claim_matches_count": 2,
+        "references_count": 0,
+        "media_status": "complete",
+        "graph_status": "complete",
+        "cta_count": 1,
+        "faq_count": 6,
+        "ok": false,
+        "errors": [
+          {
+            "field": "references",
+            "code": "references_missing"
+          }
+        ]
+      },
+      {
+        "article_id": 41,
+        "locale": "en",
+        "working_revision_status": "approved",
+        "import_status": "warning",
+        "claim_status": "passed",
+        "claim_warning_acknowledged": false,
+        "claim_matches_count": 0,
+        "references_count": 0,
+        "media_status": "complete",
+        "graph_status": "complete",
+        "cta_count": 1,
+        "faq_count": 6,
+        "ok": false,
+        "errors": [
+          {
+            "field": "references",
+            "code": "references_missing"
+          }
+        ]
+      }
+    ],
+    "blocking_error_codes": [
+      "references_missing"
+    ]
+  },
+  "public_absence_postcheck": {
+    "zh_article_public_api_http_status": 404,
+    "en_article_public_api_http_status": 404,
+    "articles_remain_non_public": true,
+    "articles_remain_non_indexable": true
+  },
+  "remaining_blockers": [
+    {
+      "id": "references_missing",
+      "status": "blocked",
+      "owner": "editor_or_import_gate_operator",
+      "required_input": "Populate or reconcile accepted references into the latest ArticleEditorialPackageImport gate for articles 40 and 41. Current references_count is 0 for both articles."
+    },
+    {
+      "id": "controlled_publish_not_authorized",
+      "status": "blocked",
+      "owner": "operator",
+      "required_input": "Controlled publish still requires exact publish approval after publish preflight passes."
+    }
+  ],
+  "next_step": {
+    "id": "RIASEC_V2_REFERENCES_GATE_RECONCILIATION_REQUIRED",
+    "recommended_action": "Do not publish. Reconcile references_count and reference payloads for the latest import gates, then rerun controlled publish preflight.",
+    "not_authorized_yet": [
+      "controlled publish",
+      "search submission",
+      "deploy",
+      "article content rewrite"
+    ]
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_publish": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "public_canonical_routes_only": true,
+    "no_private_or_tokenized_url_access": true
+  }
+}

--- a/backend/docs/seo/riasec-explanation-draft-cover-attach-publish-preflight.md
+++ b/backend/docs/seo/riasec-explanation-draft-cover-attach-publish-preflight.md
@@ -1,0 +1,64 @@
+# RIASEC Explanation V2 Draft Cover Attach and Publish Preflight
+
+Task: `RIASEC-EXPLANATION-DRAFT-COVER-ATTACH-PUBLISH-PREFLIGHT-01`
+
+Decision: **NO-GO: controlled publish preflight is still blocked by missing references.**
+
+This task performed only the authorized CMS draft cover attachment and draft revision approval mutation, then ran controlled publish preflight in dry-run mode. It did not rewrite article body/title/H1/meta/FAQ/CTA, publish, submit search URLs, deploy, or access private result/order/share/pay/payment/history URLs.
+
+## CMS Mutation
+
+CMS media asset `6` was attached to both RIASEC draft articles:
+
+| Locale | Article ID | Revision ID | Draft status | Revision status | Cover | Public | Indexable |
+| --- | ---: | ---: | --- | --- | --- | --- | --- |
+| zh | `40` | `45` | `draft` | `approved` | attached | `false` | `false` |
+| en | `41` | `46` | `draft` | `approved` | attached | `false` | `false` |
+
+Attached media:
+
+- asset key: `article.riasec.explanation.cover.v1`
+- cover URL: `https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg`
+- OG URL: `https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg`
+- alt: `Abstract career-interest map with six work activity icons around a compass.`
+- required variants present: `hero`, `card`, `thumbnail`, `og`, `preload`
+
+The latest import gate media status for both articles is now `complete`.
+
+## Publish Preflight
+
+Command:
+
+```bash
+php artisan articles:publish-controlled --article=40 --article=41 --ack-claim-warning=40 --make-indexable --dry-run --json --no-ansi
+```
+
+Result: `ok=false`.
+
+What passed in dry-run:
+
+- zh/en working revisions are approved
+- zh claim warning was acknowledged for dry-run
+- media status is complete
+- graph metadata is complete
+- CTA slots are present
+- FAQ items are present
+
+Blocking issue:
+
+| Article ID | Locale | Blocker |
+| ---: | --- | --- |
+| `40` | zh | `references_missing` |
+| `41` | en | `references_missing` |
+
+Both latest import gates still have `references_count=0`.
+
+## Public Safety
+
+Public article API postcheck still returns 404 for both draft articles. The articles remain non-public and non-indexable.
+
+No sitemap, llms, search submission, or publish action was performed.
+
+## Next Step
+
+Do not publish yet. Reconcile accepted references into the latest import gates for articles `40` and `41`, then rerun controlled publish preflight. Controlled publish still requires a separate exact publish approval after preflight passes.

--- a/backend/tests/Feature/SEO/RiasecExplanationDraftCoverAttachPublishPreflightTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationDraftCoverAttachPublishPreflightTest.php
@@ -1,0 +1,106 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationDraftCoverAttachPublishPreflightTest extends TestCase
+{
+    public function test_cover_attach_and_revision_approval_are_recorded_without_publish(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json');
+
+        $this->assertSame('RIASEC-EXPLANATION-DRAFT-COVER-ATTACH-PUBLISH-PREFLIGHT-01', $artifact['task_id']);
+        $this->assertSame('NO_GO_REFERENCES_MISSING', $artifact['decision']);
+        $this->assertTrue($artifact['cms_mutation_performed']);
+        $this->assertTrue($artifact['article_cover_attach_performed']);
+        $this->assertTrue($artifact['draft_revision_approval_performed']);
+        $this->assertTrue($artifact['publish_preflight_performed']);
+        $this->assertTrue($artifact['publish_preflight_dry_run']);
+        $this->assertFalse($artifact['publish_preflight_ok']);
+        $this->assertFalse($artifact['publish_performed']);
+        $this->assertFalse($artifact['search_submission_performed']);
+        $this->assertFalse($artifact['deploy_performed']);
+        $this->assertFalse($artifact['private_url_accessed']);
+        $this->assertFalse($artifact['article_content_rewrite_performed']);
+    }
+
+    public function test_both_articles_have_cover_and_approved_revision_state(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json');
+        $articles = collect($artifact['article_mutations'])->keyBy('article_id');
+
+        foreach ([40, 41] as $articleId) {
+            $this->assertArrayHasKey($articleId, $articles);
+            $article = $articles[$articleId];
+            $this->assertSame('draft', $article['status_after']);
+            $this->assertFalse($article['is_public_after']);
+            $this->assertFalse($article['is_indexable_after']);
+            $this->assertSame('approved', $article['translation_status_after']);
+            $this->assertSame('approved', $article['working_revision_status_after']);
+            $this->assertSame(1, $article['reviewed_by']);
+            $this->assertTrue($article['cover_image_attached']);
+            $this->assertTrue($article['seo_og_image_attached']);
+            $this->assertSame('complete', $article['import_media_status_after']);
+            $this->assertSame(0, $article['references_count']);
+        }
+    }
+
+    public function test_publish_preflight_is_blocked_only_by_references_in_artifact(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json');
+        $preflight = $artifact['publish_preflight'];
+
+        $this->assertFalse($preflight['ok']);
+        $this->assertTrue($preflight['dry_run']);
+        $this->assertSame(1, $preflight['articles'][0]['cta_count']);
+        $this->assertSame(6, $preflight['articles'][0]['faq_count']);
+        $this->assertSame('complete', $preflight['articles'][0]['media_status']);
+        $this->assertSame('complete', $preflight['articles'][1]['media_status']);
+        $this->assertSame(['references_missing'], $preflight['blocking_error_codes']);
+
+        foreach ($preflight['articles'] as $article) {
+            $this->assertSame(0, $article['references_count']);
+            $this->assertSame('references_missing', $article['errors'][0]['code']);
+        }
+    }
+
+    public function test_public_absence_and_hard_boundaries_remain_closed(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json');
+
+        $this->assertSame(404, $artifact['public_absence_postcheck']['zh_article_public_api_http_status']);
+        $this->assertSame(404, $artifact['public_absence_postcheck']['en_article_public_api_http_status']);
+        $this->assertTrue($artifact['public_absence_postcheck']['articles_remain_non_public']);
+        $this->assertTrue($artifact['public_absence_postcheck']['articles_remain_non_indexable']);
+
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_publish']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['public_canonical_routes_only']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+    }
+
+    public function test_artifact_contains_no_forbidden_route_or_identifier_patterns(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Recorded the authorized production CMS media cover attach for the two RIASEC V2 draft articles.
- Recorded draft revision approval state for articles 40 and 41.
- Added a generated publish-preflight artifact and focused regression tests for the dry-run result.

## Runtime action already performed
- Attached CMS media asset `6` to article `40` and article `41` cover fields.
- Approved working revisions `45` and `46`.
- Confirmed both articles remain draft, non-public, and non-indexable.

## Publish preflight result
- Controlled publish dry-run returned NO-GO.
- Remaining blocker: `references_missing` for both articles; `references_count=0`.
- No publish was performed.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationDraftCoverAttachPublishPreflightTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationDraftCoverAttachPublishPreflightTest --no-ansi --display-warnings`
- `git diff --check -- backend/docs/seo/generated/riasec-explanation-draft-cover-attach-publish-preflight.v1.json backend/docs/seo/riasec-explanation-draft-cover-attach-publish-preflight.md backend/tests/Feature/SEO/RiasecExplanationDraftCoverAttachPublishPreflightTest.php`
- `git diff --cached --check`

## Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No CMS publish.
- No search submission.
- No deploy.
- No private result/order/share/pay/payment/history/tokenized URL access.
- No reference reconciliation; this remains the next gate before publish preflight can pass.
