### PR TITLE
docs(seo): record RIASEC references gate preflight

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json
@@ -1,0 +1,182 @@
+{
+  "schema": "riasec-explanation-references-source-gate-preflight.v1",
+  "task_id": "RIASEC-EXPLANATION-REFERENCES-SOURCE-GATE-PREFLIGHT-01",
+  "generated_at": "2026-06-08T10:15:16+08:00",
+  "decision": "GO_PUBLISH_PREFLIGHT_DRY_RUN_PASSED_PUBLISH_STILL_NOT_AUTHORIZED",
+  "cms_mutation_performed": true,
+  "references_source_gate_reconciled": true,
+  "article_content_rewrite_performed": false,
+  "draft_revision_approval_performed": true,
+  "publish_preflight_performed": true,
+  "publish_preflight_dry_run": true,
+  "publish_preflight_ok": true,
+  "publish_performed": false,
+  "search_submission_performed": false,
+  "deploy_performed": false,
+  "private_url_accessed": false,
+  "source_set": [
+    {
+      "label": "O*NET Interest Profiler Manual",
+      "url": "https://www.onetcenter.org/reports/IP_Manual.html",
+      "http_status": 200,
+      "role": "primary_model_background"
+    },
+    {
+      "label": "The O*NET Content Model",
+      "url": "https://www.onetcenter.org/content.html",
+      "http_status": 200,
+      "role": "career_information_systems"
+    },
+    {
+      "label": "O*NET Interests Data Dictionary",
+      "url": "https://www.onetcenter.org/dictionary/20.2/text/interests.html",
+      "http_status": 200,
+      "role": "career_information_systems"
+    },
+    {
+      "label": "O*NET Interest Profiler API Reference",
+      "url": "https://services.onetcenter.org/reference/mpp/ip",
+      "http_status": 200,
+      "role": "career_information_systems"
+    },
+    {
+      "label": "APA Dictionary: Five-Factor Personality Model",
+      "url": "https://dictionary.apa.org/five-factor-personality-model",
+      "http_status": 200,
+      "role": "comparison_context"
+    }
+  ],
+  "source_gate": {
+    "references_count_after": 5,
+    "references_status_after": "complete",
+    "source_review_status": "accepted",
+    "source_review_scope": "RIASEC V2 source gate reconciliation",
+    "non_endorsement_boundary": true,
+    "no_diagnosis_boundary": true,
+    "no_deterministic_career_result_boundary": true,
+    "official_affiliation_not_implied": true
+  },
+  "article_mutations": [
+    {
+      "article_id": 40,
+      "locale": "zh",
+      "import_id": 11,
+      "status_after": "draft",
+      "is_public_after": false,
+      "is_indexable_after": false,
+      "translation_status_after": "approved",
+      "working_revision_id": 45,
+      "working_revision_status_after": "approved",
+      "reviewed_by": 1,
+      "references_count_after": 5,
+      "references_status_after": "complete",
+      "seo_references_count_after": 5,
+      "media_status_after": "complete"
+    },
+    {
+      "article_id": 41,
+      "locale": "en",
+      "import_id": 12,
+      "status_after": "draft",
+      "is_public_after": false,
+      "is_indexable_after": false,
+      "translation_status_after": "approved",
+      "working_revision_id": 46,
+      "working_revision_status_after": "approved",
+      "reviewed_by": 1,
+      "references_count_after": 5,
+      "references_status_after": "complete",
+      "seo_references_count_after": 5,
+      "media_status_after": "complete"
+    }
+  ],
+  "publish_preflight": {
+    "ok": true,
+    "dry_run": true,
+    "make_indexable": true,
+    "article_ids": [
+      40,
+      41
+    ],
+    "published_article_ids": [],
+    "errors": [],
+    "articles": [
+      {
+        "article_id": 40,
+        "locale": "zh",
+        "slug": "riasec-holland-career-interest-test-explained",
+        "status": "draft",
+        "working_revision_id": 45,
+        "working_revision_status": "approved",
+        "import_id": 11,
+        "import_status": "warning",
+        "claim_status": "warning",
+        "claim_warning_acknowledged": true,
+        "claim_matches_count": 2,
+        "references_count": 5,
+        "media_status": "complete",
+        "graph_status": "complete",
+        "cta_count": 1,
+        "faq_count": 6,
+        "ok": true,
+        "errors": []
+      },
+      {
+        "article_id": 41,
+        "locale": "en",
+        "slug": "what-is-riasec-holland-code-career-interest-test",
+        "status": "draft",
+        "working_revision_id": 46,
+        "working_revision_status": "approved",
+        "import_id": 12,
+        "import_status": "warning",
+        "claim_status": "passed",
+        "claim_warning_acknowledged": false,
+        "claim_matches_count": 0,
+        "references_count": 5,
+        "media_status": "complete",
+        "graph_status": "complete",
+        "cta_count": 1,
+        "faq_count": 6,
+        "ok": true,
+        "errors": []
+      }
+    ]
+  },
+  "public_absence_postcheck": {
+    "zh_article_public_api_http_status": 404,
+    "en_article_public_api_http_status": 404,
+    "articles_remain_non_public": true,
+    "articles_remain_non_indexable": true
+  },
+  "remaining_blockers": [
+    {
+      "id": "controlled_publish_not_authorized",
+      "status": "blocked",
+      "owner": "operator",
+      "required_input": "Exact controlled publish authorization is required before any publish command."
+    },
+    {
+      "id": "search_submission_not_authorized",
+      "status": "blocked",
+      "owner": "operator",
+      "required_input": "Search submission requires separate exact authorization after publish and post-publish smoke."
+    }
+  ],
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_publish": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "public_canonical_routes_only": true,
+    "no_private_or_tokenized_url_access": true
+  },
+  "next_step": {
+    "id": "SEO-ARTICLE-RIASEC-V2-CONTROLLED-PUBLISH-01",
+    "status": "blocked_until_exact_publish_authorization",
+    "post_publish_required_after_publish": [
+      "SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-01",
+      "SEO-ARTICLE-RIASEC-V2-SEARCH-SUBMISSION-PREFLIGHT-01"
+    ]
+  }
+}

--- a/backend/docs/seo/riasec-explanation-references-source-gate-preflight.md
+++ b/backend/docs/seo/riasec-explanation-references-source-gate-preflight.md
@@ -1,0 +1,58 @@
+# RIASEC Explanation V2 References Source Gate and Publish Preflight
+
+Task: `RIASEC-EXPLANATION-REFERENCES-SOURCE-GATE-PREFLIGHT-01`
+
+Decision: **GO for controlled publish preflight dry-run; publish is still blocked until exact publish authorization.**
+
+This task reconciled the accepted source set into the two RIASEC V2 draft import gates, refreshed draft approval state, and reran controlled publish preflight in dry-run mode. It did not rewrite article body/title/H1/meta/FAQ/CTA, publish, submit search URLs, deploy, or access private result/order/share/pay/payment/history URLs.
+
+## CMS Mutation
+
+The latest import gates for articles `40` and `41` were updated:
+
+| Locale | Article ID | Import ID | References | References status | SEO metadata references | Public | Indexable |
+| --- | ---: | ---: | ---: | --- | ---: | --- | --- |
+| zh | `40` | `11` | `5` | `complete` | `5` | `false` | `false` |
+| en | `41` | `12` | `5` | `complete` | `5` | `false` | `false` |
+
+The accepted source URLs returned HTTP 200 in public checks:
+
+- `https://www.onetcenter.org/reports/IP_Manual.html`
+- `https://www.onetcenter.org/content.html`
+- `https://www.onetcenter.org/dictionary/20.2/text/interests.html`
+- `https://services.onetcenter.org/reference/mpp/ip`
+- `https://dictionary.apa.org/five-factor-personality-model`
+
+These are background/source-gate references only. They do not imply endorsement, certification, partnership, diagnosis, deterministic career results, or official affiliation.
+
+## Publish Preflight
+
+Command:
+
+```bash
+php artisan articles:publish-controlled --article=40 --article=41 --ack-claim-warning=40 --make-indexable --dry-run --json --no-ansi
+```
+
+Result: `ok=true`.
+
+Dry-run passed for both articles:
+
+- working revisions are approved
+- zh claim warning was acknowledged for dry-run
+- references count is `5`
+- media status is `complete`
+- graph metadata is `complete`
+- CTA slots are present
+- FAQ items are present
+
+No publish was performed. The command reported `published_article_ids=[]`.
+
+## Public Safety
+
+Public article API postcheck still returns 404 for both draft articles. The articles remain non-public and non-indexable.
+
+No sitemap, llms, search submission, or publish action was performed.
+
+## Next Step
+
+Controlled publish is now the next gate, but it requires separate exact publish authorization. After publish, post-publish smoke and search-submission preflight must run before any search submission.

--- a/backend/tests/Feature/SEO/RiasecExplanationReferencesSourceGatePreflightTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationReferencesSourceGatePreflightTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationReferencesSourceGatePreflightTest extends TestCase
+{
+    public function test_references_source_gate_is_reconciled_without_publish(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json');
+
+        $this->assertSame('RIASEC-EXPLANATION-REFERENCES-SOURCE-GATE-PREFLIGHT-01', $artifact['task_id']);
+        $this->assertSame('GO_PUBLISH_PREFLIGHT_DRY_RUN_PASSED_PUBLISH_STILL_NOT_AUTHORIZED', $artifact['decision']);
+        $this->assertTrue($artifact['cms_mutation_performed']);
+        $this->assertTrue($artifact['references_source_gate_reconciled']);
+        $this->assertTrue($artifact['draft_revision_approval_performed']);
+        $this->assertFalse($artifact['article_content_rewrite_performed']);
+        $this->assertFalse($artifact['publish_performed']);
+        $this->assertFalse($artifact['search_submission_performed']);
+        $this->assertFalse($artifact['deploy_performed']);
+        $this->assertFalse($artifact['private_url_accessed']);
+    }
+
+    public function test_source_set_is_complete_and_publicly_verified(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json');
+
+        $this->assertSame(5, $artifact['source_gate']['references_count_after']);
+        $this->assertSame('complete', $artifact['source_gate']['references_status_after']);
+        $this->assertSame('accepted', $artifact['source_gate']['source_review_status']);
+        $this->assertTrue($artifact['source_gate']['non_endorsement_boundary']);
+        $this->assertTrue($artifact['source_gate']['no_diagnosis_boundary']);
+        $this->assertTrue($artifact['source_gate']['no_deterministic_career_result_boundary']);
+        $this->assertTrue($artifact['source_gate']['official_affiliation_not_implied']);
+
+        $this->assertCount(5, $artifact['source_set']);
+        foreach ($artifact['source_set'] as $source) {
+            $this->assertSame(200, $source['http_status']);
+            $this->assertStringStartsWith('https://', $source['url']);
+        }
+    }
+
+    public function test_both_drafts_have_complete_references_and_stay_private(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json');
+        $articles = collect($artifact['article_mutations'])->keyBy('article_id');
+
+        foreach ([40, 41] as $articleId) {
+            $this->assertArrayHasKey($articleId, $articles);
+            $article = $articles[$articleId];
+            $this->assertSame('draft', $article['status_after']);
+            $this->assertFalse($article['is_public_after']);
+            $this->assertFalse($article['is_indexable_after']);
+            $this->assertSame('approved', $article['translation_status_after']);
+            $this->assertSame('approved', $article['working_revision_status_after']);
+            $this->assertSame(5, $article['references_count_after']);
+            $this->assertSame('complete', $article['references_status_after']);
+            $this->assertSame(5, $article['seo_references_count_after']);
+            $this->assertSame('complete', $article['media_status_after']);
+        }
+    }
+
+    public function test_publish_preflight_passes_but_does_not_publish(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json');
+        $preflight = $artifact['publish_preflight'];
+
+        $this->assertTrue($artifact['publish_preflight_performed']);
+        $this->assertTrue($artifact['publish_preflight_dry_run']);
+        $this->assertTrue($artifact['publish_preflight_ok']);
+        $this->assertTrue($preflight['ok']);
+        $this->assertTrue($preflight['dry_run']);
+        $this->assertSame([], $preflight['errors']);
+        $this->assertSame([], $preflight['published_article_ids']);
+
+        foreach ($preflight['articles'] as $article) {
+            $this->assertTrue($article['ok']);
+            $this->assertSame([], $article['errors']);
+            $this->assertSame(5, $article['references_count']);
+            $this->assertSame('complete', $article['media_status']);
+            $this->assertSame('complete', $article['graph_status']);
+            $this->assertSame(1, $article['cta_count']);
+            $this->assertSame(6, $article['faq_count']);
+        }
+    }
+
+    public function test_public_absence_and_hard_boundaries_remain_closed(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json');
+
+        $this->assertSame(404, $artifact['public_absence_postcheck']['zh_article_public_api_http_status']);
+        $this->assertSame(404, $artifact['public_absence_postcheck']['en_article_public_api_http_status']);
+        $this->assertTrue($artifact['public_absence_postcheck']['articles_remain_non_public']);
+        $this->assertTrue($artifact['public_absence_postcheck']['articles_remain_non_indexable']);
+
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_publish']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['public_canonical_routes_only']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+    }
+
+    public function test_artifact_contains_no_forbidden_route_or_identifier_patterns(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Recorded the RIASEC V2 references/source gate reconciliation for draft articles 40 and 41.
- Added a generated artifact showing references_count=5, references status complete, and SEO metadata references synced.
- Added focused tests proving the dry-run publish preflight now passes while publish/search/deploy remain closed.

## Runtime action already performed
- Updated latest production import gates 11 and 12 with the accepted public source set.
- Synced ArticleSeoMeta editorial package references for both drafts.
- Refreshed draft working revision approval state for revisions 45 and 46.
- Confirmed both articles remain draft, non-public, and non-indexable.

## Publish preflight result
- Controlled publish dry-run returned ok=true for article ids 40 and 41.
- published_article_ids remained empty.
- Controlled publish still requires separate exact publish authorization.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationReferencesSourceGatePreflightTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationReferencesSourceGatePreflightTest --no-ansi --display-warnings`
- `git diff --check -- backend/docs/seo/generated/riasec-explanation-references-source-gate-preflight.v1.json backend/docs/seo/riasec-explanation-references-source-gate-preflight.md backend/tests/Feature/SEO/RiasecExplanationReferencesSourceGatePreflightTest.php`

## Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No CMS publish.
- No search submission.
- No deploy.
- No private result/order/share/pay/payment/history/tokenized URL access.
- Post-publish smoke and search-submission preflight remain future gates after exact publish approval.
