### PR TITLE
docs(codex): mark HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01 merged

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49159,7 +49159,7 @@
     "repo": "fap-api",
     "branch": "codex/help-cms-service-fields-prod-release-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): refresh Help service fields production release readiness",
     "depends_on": [


### PR DESCRIPTION
## What changed
- Corrects the top-level HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01 state from pr_opened to merged.

## Why
- PR #1966 is already merged and the closeout facts were recorded in #1970; this fixes the remaining top-level status mismatch.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check -- docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No deploy, migration, CMS mutation, publish, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider behavior change, or Operator approval claim.