### PR TITLE
docs(seo): record RIASEC controlled publish smoke

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json
@@ -1,0 +1,155 @@
+{
+  "schema": "riasec-explanation-controlled-publish-postpublish-smoke.v1",
+  "task_id": "SEO-ARTICLE-RIASEC-V2-CONTROLLED-PUBLISH-01",
+  "generated_at": "2026-06-08T10:31:32+08:00",
+  "decision": "CONDITIONAL_GO_PUBLISH_DONE_NO_GO_SEARCH_SUBMISSION_ZH_FRONTEND_404",
+  "exact_publish_authorization": "I explicitly approve Codex to publish article ids 40,41 after preflight passes.",
+  "preflight_rerun_before_publish": {
+    "ok": true,
+    "dry_run": true,
+    "article_ids": [
+      40,
+      41
+    ],
+    "errors": [],
+    "published_article_ids": []
+  },
+  "controlled_publish": {
+    "performed": true,
+    "ok": true,
+    "dry_run": false,
+    "article_ids": [
+      40,
+      41
+    ],
+    "published_article_ids": [
+      40,
+      41
+    ],
+    "errors": [],
+    "make_indexable": true,
+    "search_submission_performed": false,
+    "deploy_performed": false
+  },
+  "article_state_post_publish": [
+    {
+      "article_id": 40,
+      "locale": "zh",
+      "slug": "riasec-holland-career-interest-test-explained",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-06-08T02:28:33+00:00",
+      "published_revision_id": 45,
+      "working_revision_id": 45,
+      "seo_robots": "index,follow",
+      "seo_indexable": true,
+      "references_count": 5,
+      "references_status": "complete",
+      "media_status": "complete"
+    },
+    {
+      "article_id": 41,
+      "locale": "en",
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_at": "2026-06-08T02:28:34+00:00",
+      "published_revision_id": 46,
+      "working_revision_id": 46,
+      "seo_robots": "index,follow",
+      "seo_indexable": true,
+      "references_count": 5,
+      "references_status": "complete",
+      "media_status": "complete"
+    }
+  ],
+  "post_publish_smoke": {
+    "api": [
+      {
+        "surface": "backend_public_article_api",
+        "article_id": 40,
+        "locale_query": "zh",
+        "http_status": 200,
+        "body_bytes": 43032
+      },
+      {
+        "surface": "backend_public_article_api",
+        "article_id": 41,
+        "locale_query": "en",
+        "http_status": 200,
+        "body_bytes": 27363
+      }
+    ],
+    "frontend": [
+      {
+        "surface": "frontend_public_article_detail",
+        "article_id": 40,
+        "locale_segment": "zh",
+        "http_status": 404,
+        "body_bytes": 23249,
+        "status": "blocked",
+        "blocker": "zh_frontend_canonical_404"
+      },
+      {
+        "surface": "frontend_public_article_detail",
+        "article_id": 41,
+        "locale_segment": "en",
+        "http_status": 200,
+        "body_bytes": 174696,
+        "status": "passed"
+      }
+    ],
+    "locale_contract_evidence": {
+      "published_chinese_article_locale": "zh",
+      "existing_chinese_canary_locale": "zh-CN",
+      "zh_api_with_locale_zh_status": 200,
+      "zh_api_with_locale_zh_cn_status": 404,
+      "existing_canary_api_with_locale_zh_cn_status": 200,
+      "likely_blocker": "fap-web production zh article route expects zh-CN API locale, while article 40 was imported and published as locale zh."
+    },
+    "sitemap_llms": {
+      "sitemap_contains_zh_article": false,
+      "sitemap_contains_en_article": false,
+      "llms_convergence_status": "not_converged_or_inconsistent",
+      "search_submission_allowed": false
+    }
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "no_frontend_deploy": true,
+    "no_private_or_tokenized_url_access": true,
+    "public_canonical_routes_only": true
+  },
+  "remaining_blockers": [
+    {
+      "id": "zh_frontend_canonical_404",
+      "status": "blocked",
+      "owner": "cms_operator_or_frontend_api_contract_owner",
+      "evidence": "Backend public API returns 200 for article 40 with locale=zh, but frontend canonical /zh/articles/riasec-holland-career-interest-test-explained returns 404. Existing Chinese article canary uses backend locale zh-CN.",
+      "required_input": "Authorize a narrow locale/API contract correction before search submission."
+    },
+    {
+      "id": "sitemap_llms_not_converged",
+      "status": "blocked",
+      "owner": "seo_operator",
+      "evidence": "Sitemap and llms checks did not consistently enumerate both newly published article slugs immediately after publish.",
+      "required_input": "Recheck after zh frontend canonical route passes; do not submit search URLs before convergence."
+    },
+    {
+      "id": "search_submission_not_authorized",
+      "status": "hard_gate",
+      "owner": "operator",
+      "required_input": "Search submission requires separate exact authorization after post-publish smoke passes."
+    }
+  ],
+  "next_step": {
+    "recommended_task_id": "SEO-ARTICLE-RIASEC-V2-ZH-LOCALE-CONTRACT-FIX-01",
+    "scope": "Fix or normalize the published zh RIASEC article route/API locale contract so the public canonical zh article page returns 200, without rewriting article content and without search submission.",
+    "publish_status": "articles_40_41_published",
+    "search_submission_status": "blocked"
+  }
+}

--- a/backend/docs/seo/riasec-explanation-controlled-publish-postpublish-smoke.md
+++ b/backend/docs/seo/riasec-explanation-controlled-publish-postpublish-smoke.md
@@ -1,0 +1,63 @@
+# RIASEC Explanation V2 Controlled Publish and Post-Publish Smoke
+
+Task: `SEO-ARTICLE-RIASEC-V2-CONTROLLED-PUBLISH-01`
+
+Decision: **Publish completed; search submission remains NO-GO because the zh frontend canonical article route returns 404.**
+
+## Controlled Publish
+
+Exact authorization received:
+
+```text
+I explicitly approve Codex to publish article ids 40,41 after preflight passes.
+```
+
+The controlled publish command first reran dry-run preflight. It passed with `ok=true`.
+
+The actual controlled publish then completed with:
+
+- `ok=true`
+- `published_article_ids=[40,41]`
+- `make_indexable=true`
+- no command errors
+
+No search submission, deploy, frontend deploy, private URL access, or article body/title/H1/meta/FAQ/CTA rewrite was performed.
+
+## Post-Publish State
+
+| Article ID | Locale | Status | Public | Indexable | Published revision | References | Media |
+| ---: | --- | --- | --- | --- | ---: | ---: | --- |
+| `40` | `zh` | `published` | `true` | `true` | `45` | `5` | `complete` |
+| `41` | `en` | `published` | `true` | `true` | `46` | `5` | `complete` |
+
+## Smoke Results
+
+Backend public article API:
+
+| Article ID | Locale query | HTTP |
+| ---: | --- | ---: |
+| `40` | `zh` | `200` |
+| `41` | `en` | `200` |
+
+Frontend public article detail:
+
+| Article ID | Locale segment | HTTP | Decision |
+| ---: | --- | ---: | --- |
+| `40` | `zh` | `404` | blocked |
+| `41` | `en` | `200` | passed |
+
+The likely blocker is locale contract mismatch: article `40` is published with backend locale `zh`, while the existing Chinese canary article uses backend locale `zh-CN` and the fap-web zh route appears to expect `zh-CN`.
+
+## Search Submission Gate
+
+Search submission remains blocked.
+
+Reasons:
+
+- zh frontend canonical route is 404
+- sitemap/llms enumeration was not consistently converged immediately after publish
+- search submission still requires separate exact authorization
+
+## Next Step
+
+Run a narrow locale/API contract correction before any search submission. Do not rewrite article content.

--- a/backend/tests/Feature/SEO/RiasecExplanationControlledPublishPostpublishSmokeTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationControlledPublishPostpublishSmokeTest.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationControlledPublishPostpublishSmokeTest extends TestCase
+{
+    public function test_controlled_publish_is_recorded_without_search_or_deploy(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-CONTROLLED-PUBLISH-01', $artifact['task_id']);
+        $this->assertSame('CONDITIONAL_GO_PUBLISH_DONE_NO_GO_SEARCH_SUBMISSION_ZH_FRONTEND_404', $artifact['decision']);
+        $this->assertTrue($artifact['preflight_rerun_before_publish']['ok']);
+        $this->assertTrue($artifact['preflight_rerun_before_publish']['dry_run']);
+        $this->assertTrue($artifact['controlled_publish']['performed']);
+        $this->assertTrue($artifact['controlled_publish']['ok']);
+        $this->assertFalse($artifact['controlled_publish']['dry_run']);
+        $this->assertSame([40, 41], $artifact['controlled_publish']['published_article_ids']);
+        $this->assertFalse($artifact['controlled_publish']['search_submission_performed']);
+        $this->assertFalse($artifact['controlled_publish']['deploy_performed']);
+    }
+
+    public function test_both_articles_are_published_and_indexable_in_cms_state(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json');
+        $articles = collect($artifact['article_state_post_publish'])->keyBy('article_id');
+
+        foreach ([40, 41] as $articleId) {
+            $this->assertArrayHasKey($articleId, $articles);
+            $article = $articles[$articleId];
+            $this->assertSame('published', $article['status']);
+            $this->assertTrue($article['is_public']);
+            $this->assertTrue($article['is_indexable']);
+            $this->assertSame('index,follow', $article['seo_robots']);
+            $this->assertTrue($article['seo_indexable']);
+            $this->assertSame(5, $article['references_count']);
+            $this->assertSame('complete', $article['references_status']);
+            $this->assertSame('complete', $article['media_status']);
+        }
+    }
+
+    public function test_post_publish_smoke_blocks_search_submission_until_zh_frontend_passes(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json');
+
+        $api = collect($artifact['post_publish_smoke']['api'])->keyBy('article_id');
+        $frontend = collect($artifact['post_publish_smoke']['frontend'])->keyBy('article_id');
+
+        $this->assertSame(200, $api[40]['http_status']);
+        $this->assertSame(200, $api[41]['http_status']);
+        $this->assertSame(404, $frontend[40]['http_status']);
+        $this->assertSame('blocked', $frontend[40]['status']);
+        $this->assertSame('zh_frontend_canonical_404', $frontend[40]['blocker']);
+        $this->assertSame(200, $frontend[41]['http_status']);
+        $this->assertSame('passed', $frontend[41]['status']);
+
+        $this->assertFalse($artifact['post_publish_smoke']['sitemap_llms']['search_submission_allowed']);
+        $blockers = collect($artifact['remaining_blockers'])->pluck('id')->all();
+        $this->assertContains('zh_frontend_canonical_404', $blockers);
+        $this->assertContains('sitemap_llms_not_converged', $blockers);
+        $this->assertContains('search_submission_not_authorized', $blockers);
+    }
+
+    public function test_locale_contract_evidence_is_recorded(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json');
+        $locale = $artifact['post_publish_smoke']['locale_contract_evidence'];
+
+        $this->assertSame('zh', $locale['published_chinese_article_locale']);
+        $this->assertSame('zh-CN', $locale['existing_chinese_canary_locale']);
+        $this->assertSame(200, $locale['zh_api_with_locale_zh_status']);
+        $this->assertSame(404, $locale['zh_api_with_locale_zh_cn_status']);
+        $this->assertSame(200, $locale['existing_canary_api_with_locale_zh_cn_status']);
+    }
+
+    public function test_hard_boundaries_remain_closed(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json');
+
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['no_frontend_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+        $this->assertTrue($artifact['hard_boundaries']['public_canonical_routes_only']);
+    }
+
+    public function test_artifact_contains_no_forbidden_route_or_identifier_patterns(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Recorded exact controlled publish authorization and production publish result for article ids 40 and 41.
- Added post-publish smoke evidence for CMS state, backend public API, frontend article routes, and sitemap/llms gate status.
- Added focused tests proving publish happened while search submission, deploy, and article rewriting remained closed.

## Runtime action already performed
- Reran controlled publish dry-run preflight: ok=true.
- Executed controlled publish with exact confirmation.
- Published article ids 40 and 41 with make_indexable=true.

## Post-publish smoke result
- Backend public API: article 40 = 200, article 41 = 200.
- Frontend public route: article 41 en = 200.
- Frontend public route: article 40 zh = 404.
- Likely blocker: article 40 is published as backend locale zh, while existing Chinese article canary uses zh-CN and fap-web zh route appears to expect zh-CN.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationControlledPublishPostpublishSmokeTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationControlledPublishPostpublishSmokeTest --no-ansi --display-warnings`
- `git diff --check -- backend/docs/seo/generated/riasec-explanation-controlled-publish-postpublish-smoke.v1.json backend/docs/seo/riasec-explanation-controlled-publish-postpublish-smoke.md backend/tests/Feature/SEO/RiasecExplanationControlledPublishPostpublishSmokeTest.php`

## Intentionally deferred
- No search submission.
- No deploy or frontend deploy.
- No private result/order/share/pay/payment/history/tokenized URL access.
- No article body/title/H1/meta/FAQ/CTA rewrite.
- zh locale/API contract correction is the next narrow blocker before search submission.
