### PR TITLE
HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 docs(help): verify Help service production active SHA

### DIFF
--- a/backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json
+++ b/backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json
@@ -20,7 +20,7 @@
     ]
   },
   "local_target": {
-    "origin_main_sha": "92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef",
+    "origin_main_sha": "87afe2dfddfab1f8533512b8a2bdf1c347626000",
     "release_readiness_merge_commit": "b9279c12c1f40732bb9be8566f46b9515dcb02dd",
     "required_help_runtime_commits": [
       {
@@ -52,7 +52,7 @@
     "remote_git_head": "Unknown",
     "active_revision_known_to_local_git": true,
     "active_revision_is_ancestor_of_origin_main": true,
-    "commits_between_active_revision_and_origin_main": 43,
+    "commits_between_active_revision_and_origin_main": 45,
     "migration_status": {
       "2026_06_05_150000_add_help_service_fields_to_content_pages": {
         "status": "Ran",
@@ -90,7 +90,7 @@
     "production_contains_full_help_service_runtime_by_revision_graph": false,
     "production_runtime_identity_consistent": false,
     "notes": [
-      "The REVISION file reports e812d6f87f8b84b45d2e900d9d3844a0402635bc, which is 43 commits behind origin/main.",
+      "The REVISION file reports e812d6f87f8b84b45d2e900d9d3844a0402635bc, which is 45 commits behind origin/main.",
       "The reported production revision does not contain the merged Help service field/model/importer/publish-safety commits by local git ancestry.",
       "Remote file/status checks show a mixed runtime state: the Help service fields migration file is present and its migration is Ran, while the publish safety migration file is missing and its migration is Pending.",
       "Importer CLI exists with --upsert and --source-dir, but read-only grep did not confirm schema_enabled mapping in the active runtime."
@@ -104,9 +104,9 @@
     "deploy_allowed_now": false,
     "reason": "Current production active revision is known but does not prove full Help service runtime. Publish safety migration is pending and schema_enabled importer mapping is not confirmed in the active runtime."
   },
-  "next_safe_authorization_prompt": "I explicitly approve backend production deploy for exact SHA 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef release help-cms-service-fields-prod-20260608-92a94f06.",
+  "next_safe_authorization_prompt": "I explicitly approve backend production deploy for exact SHA 87afe2dfddfab1f8533512b8a2bdf1c347626000 release help-cms-service-fields-prod-20260608-87afe2df.",
   "post_deploy_required_read_only_checks": [
-    "Confirm production REVISION equals 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef or a newer explicitly approved SHA containing it.",
+    "Confirm production REVISION equals 87afe2dfddfab1f8533512b8a2bdf1c347626000 or a newer explicitly approved SHA containing it.",
     "Confirm Help service fields migration is Ran.",
     "Confirm publish safety fields migration is Ran.",
     "Confirm content-pages:import-local-baseline service-field mapping includes support_contact, policy_version, reviewer, faq_items, and schema_enabled."

--- a/backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json
+++ b/backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json
@@ -1,0 +1,127 @@
+{
+  "schema": "help-cms-service-fields-prod-sha-verify-01.v1",
+  "task": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01",
+  "generated_at": "2026-06-08",
+  "decision": "BLOCKED_RUNTIME_BEHIND_AND_PUBLISH_SAFETY_PENDING",
+  "scope": "Read-only production active SHA and migration-status verification only; no deploy, no migration execution, no CMS mutation, no publish.",
+  "authorization": {
+    "source": "user",
+    "allowed": "Approved read-only production method that reports only active release SHA and migration status for Help service field migrations.",
+    "forbidden": [
+      "deploy",
+      "CMS mutation",
+      "publish",
+      "search submission",
+      "private result/order/share/pay/payment/history URL access",
+      "secret/env/cookie/token value reading",
+      "payment/refund action",
+      "payment-provider behavior change",
+      "Operator approval claim"
+    ]
+  },
+  "local_target": {
+    "origin_main_sha": "92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef",
+    "release_readiness_merge_commit": "b9279c12c1f40732bb9be8566f46b9515dcb02dd",
+    "required_help_runtime_commits": [
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-01",
+        "sha": "6527cc9265f88bfd1bb281d6ae88f2f3bb7e2e05",
+        "contains_on_production_revision": false
+      },
+      {
+        "id": "HELP-CONTENTPAGE-IMPORTER-SERVICE-FIELDS-01",
+        "sha": "9cae1f45ee55acf11df43376e80387957c2049a3",
+        "contains_on_production_revision": false
+      },
+      {
+        "id": "SCIENCE-CONTENTPAGE-PUBLISH-FIELDS-01",
+        "sha": "13e62a0389124e4acb90f4b7467a26ea996cf24e",
+        "contains_on_production_revision": false
+      },
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-01",
+        "sha": "0dd12d8751b328cf502a28e586597d1ed4a4246f",
+        "contains_on_production_revision": false
+      }
+    ]
+  },
+  "production_read_only_evidence": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly",
+    "active_revision_source": "REVISION_FILE",
+    "active_revision_sha": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
+    "remote_git_head": "Unknown",
+    "active_revision_known_to_local_git": true,
+    "active_revision_is_ancestor_of_origin_main": true,
+    "commits_between_active_revision_and_origin_main": 43,
+    "migration_status": {
+      "2026_06_05_150000_add_help_service_fields_to_content_pages": {
+        "status": "Ran",
+        "batch": 45
+      },
+      "2026_06_08_010000_add_publish_safety_fields_to_content_pages": {
+        "status": "Pending",
+        "batch": null
+      }
+    },
+    "target_file_presence": {
+      "help_service_fields_migration": "present",
+      "publish_safety_fields_migration": "missing",
+      "content_pages_importer_command": "present",
+      "content_page_model": "present"
+    },
+    "importer_command": {
+      "present": true,
+      "options": {
+        "upsert": true,
+        "source_dir": true
+      },
+      "service_field_mapping_grep": {
+        "support_contact": "present",
+        "policy_version": "present",
+        "reviewer": "present",
+        "faq_items": "present",
+        "schema_enabled": "missing"
+      }
+    }
+  },
+  "assessment": {
+    "production_active_sha_verified": true,
+    "production_contains_current_origin_main": false,
+    "production_contains_full_help_service_runtime_by_revision_graph": false,
+    "production_runtime_identity_consistent": false,
+    "notes": [
+      "The REVISION file reports e812d6f87f8b84b45d2e900d9d3844a0402635bc, which is 43 commits behind origin/main.",
+      "The reported production revision does not contain the merged Help service field/model/importer/publish-safety commits by local git ancestry.",
+      "Remote file/status checks show a mixed runtime state: the Help service fields migration file is present and its migration is Ran, while the publish safety migration file is missing and its migration is Pending.",
+      "Importer CLI exists with --upsert and --source-dir, but read-only grep did not confirm schema_enabled mapping in the active runtime."
+    ]
+  },
+  "decision_detail": {
+    "deploy_needed_before_policy_cms_sync": true,
+    "cms_sync_allowed_now": false,
+    "publish_allowed_now": false,
+    "migration_execution_allowed_now": false,
+    "deploy_allowed_now": false,
+    "reason": "Current production active revision is known but does not prove full Help service runtime. Publish safety migration is pending and schema_enabled importer mapping is not confirmed in the active runtime."
+  },
+  "next_safe_authorization_prompt": "I explicitly approve backend production deploy for exact SHA 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef release help-cms-service-fields-prod-20260608-92a94f06.",
+  "post_deploy_required_read_only_checks": [
+    "Confirm production REVISION equals 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef or a newer explicitly approved SHA containing it.",
+    "Confirm Help service fields migration is Ran.",
+    "Confirm publish safety fields migration is Ran.",
+    "Confirm content-pages:import-local-baseline service-field mapping includes support_contact, policy_version, reviewer, faq_items, and schema_enabled."
+  ],
+  "scope_validation": {
+    "deploy_performed": false,
+    "migration_performed": false,
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION-01"
+}

--- a/backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md
+++ b/backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md
@@ -6,10 +6,10 @@ This is a read-only production verification for the Help service ContentPage fie
 
 ## Result
 
-- Current `origin/main`: `92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef`
+- Current `origin/main`: `87afe2dfddfab1f8533512b8a2bdf1c347626000`
 - Production active revision from `REVISION`: `e812d6f87f8b84b45d2e900d9d3844a0402635bc`
 - Production active revision is an ancestor of `origin/main`: yes
-- Commits between production active revision and `origin/main`: `43`
+- Commits between production active revision and `origin/main`: `45`
 - Remote git HEAD: `Unknown`
 
 ## Migration Status
@@ -45,12 +45,12 @@ Do not proceed with CMS sync, publish, or production mutation from this state.
 If you decide to deploy the current latest backend main, use this exact approval phrase:
 
 ```text
-I explicitly approve backend production deploy for exact SHA 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef release help-cms-service-fields-prod-20260608-92a94f06.
+I explicitly approve backend production deploy for exact SHA 87afe2dfddfab1f8533512b8a2bdf1c347626000 release help-cms-service-fields-prod-20260608-87afe2df.
 ```
 
 After deploy, run a separate read-only post-deploy verification before CMS sync:
 
-- production `REVISION` equals `92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef` or a newer explicitly approved SHA containing it
+- production `REVISION` equals `87afe2dfddfab1f8533512b8a2bdf1c347626000` or a newer explicitly approved SHA containing it
 - Help service fields migration is `Ran`
 - publish safety fields migration is `Ran`
 - importer mapping includes `support_contact`, `policy_version`, `reviewer`, `faq_items`, and `schema_enabled`

--- a/backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md
+++ b/backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md
@@ -1,0 +1,66 @@
+# HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01
+
+Decision: `BLOCKED_RUNTIME_BEHIND_AND_PUBLISH_SAFETY_PENDING`
+
+This is a read-only production verification for the Help service ContentPage fields lane. It reports the active release SHA and migration status only. It did not deploy, run migrations, mutate CMS rows, publish, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund actions, change payment-provider behavior, or claim Operator approval.
+
+## Result
+
+- Current `origin/main`: `92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef`
+- Production active revision from `REVISION`: `e812d6f87f8b84b45d2e900d9d3844a0402635bc`
+- Production active revision is an ancestor of `origin/main`: yes
+- Commits between production active revision and `origin/main`: `43`
+- Remote git HEAD: `Unknown`
+
+## Migration Status
+
+| migration | production status |
+| --- | --- |
+| `2026_06_05_150000_add_help_service_fields_to_content_pages` | `Ran`, batch `45` |
+| `2026_06_08_010000_add_publish_safety_fields_to_content_pages` | `Pending` |
+
+## Runtime Evidence
+
+| check | status |
+| --- | --- |
+| Help service fields migration file | present |
+| Publish safety fields migration file | missing |
+| `content-pages:import-local-baseline` command | present |
+| importer `--upsert` option | present |
+| importer `--source-dir` option | present |
+| `support_contact` mapping grep | present |
+| `policy_version` mapping grep | present |
+| `reviewer` mapping grep | present |
+| `faq_items` mapping grep | present |
+| `schema_enabled` mapping grep | missing |
+
+## Assessment
+
+Production active SHA is now known, but the runtime is not ready for the Help CMS policy sync. The `REVISION` file points to `e812d6f87f8b84b45d2e900d9d3844a0402635bc`, which does not contain the merged Help service runtime commits by local git ancestry. The remote runtime also shows a mixed state: Help service fields migration is already `Ran`, but publish safety migration is `Pending`, and `schema_enabled` importer mapping was not confirmed.
+
+Do not proceed with CMS sync, publish, or production mutation from this state.
+
+## Next Authorization
+
+If you decide to deploy the current latest backend main, use this exact approval phrase:
+
+```text
+I explicitly approve backend production deploy for exact SHA 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef release help-cms-service-fields-prod-20260608-92a94f06.
+```
+
+After deploy, run a separate read-only post-deploy verification before CMS sync:
+
+- production `REVISION` equals `92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef` or a newer explicitly approved SHA containing it
+- Help service fields migration is `Ran`
+- publish safety fields migration is `Ran`
+- importer mapping includes `support_contact`, `policy_version`, `reviewer`, `faq_items`, and `schema_enabled`
+
+## Validation
+
+```bash
+python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31850,7 +31850,7 @@
   "RESULT-EN-PARITY-06": {
     "repo": "fap-api",
     "branch": "codex/result-en-parity-06-bigfive-v2-en-assets",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "depends_on": [
       "RESULT-EN-PARITY-05"
     ],
@@ -49416,8 +49416,18 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "checks": []
+        "status": "pass",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "verify-bigfive",
+          "Semgrep blocking secrets",
+          "Semgrep OSS",
+          "semgrep sarif non-blocking upload"
+        ]
       }
     },
     "failure_reason": null,
@@ -49496,6 +49506,11 @@
         "at": "2026-06-08",
         "status": "commit_sha_pending_remote_head",
         "note": "After rebasing onto the refreshed origin/main target, commit_sha was set to pending_remote_pr_head to avoid self-referential amend hash churn before merge."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed after refreshing the target to origin/main 87afe2dfddfab1f8533512b8a2bdf1c347626000; PR merge state was clean."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49382,9 +49382,9 @@
         "active_revision_source": "REVISION_FILE",
         "active_revision_sha": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
         "remote_git_head": "Unknown",
-        "origin_main_sha": "92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef",
+        "origin_main_sha": "87afe2dfddfab1f8533512b8a2bdf1c347626000",
         "active_revision_is_ancestor_of_origin_main": true,
-        "commits_between_active_revision_and_origin_main": 43,
+        "commits_between_active_revision_and_origin_main": 45,
         "contains_help_service_fields_commit": false,
         "contains_help_importer_service_fields_commit": false,
         "contains_publish_safety_fields_commit": false,
@@ -49431,8 +49431,8 @@
       "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json",
       "operations_report": "backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md",
       "production_active_revision_sha": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
-      "origin_main_sha": "92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef",
-      "next_safe_authorization_prompt": "I explicitly approve backend production deploy for exact SHA 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef release help-cms-service-fields-prod-20260608-92a94f06.",
+      "origin_main_sha": "87afe2dfddfab1f8533512b8a2bdf1c347626000",
+      "next_safe_authorization_prompt": "I explicitly approve backend production deploy for exact SHA 87afe2dfddfab1f8533512b8a2bdf1c347626000 release help-cms-service-fields-prod-20260608-87afe2df.",
       "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION-01"
     },
     "scope_validation": {
@@ -49486,6 +49486,11 @@
         "at": "2026-06-08",
         "status": "pr_opened",
         "note": "Opened PR #1975 for HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "target_refreshed_after_main_advanced",
+        "note": "origin/main advanced to 87afe2dfddfab1f8533512b8a2bdf1c347626000 before merge, so the verification artifact and next deploy authorization prompt were refreshed. Production active revision remains e812d6f87f8b84b45d2e900d9d3844a0402635bc."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49356,5 +49356,132 @@
         "note": "PR #1966 merged on GitHub at 2026-06-08T02:09:49Z with merge commit b9279c12c1f40732bb9be8566f46b9515dcb02dd; origin/main contains the merge commit; the remote task branch is absent and the local task branch was deleted."
       }
     ]
+  },
+  "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-cms-service-fields-prod-sha-verify-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): verify Help service production active SHA",
+    "depends_on": [
+      "HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only active release SHA and migration status for Help service field migrations, without deploy, CMS mutation, publish, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, or Operator approval claim."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01 is merged and reconciled on origin/main."
+      },
+      "production_read_only": {
+        "status": "blocked_runtime_behind_and_publish_safety_pending",
+        "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly",
+        "active_revision_source": "REVISION_FILE",
+        "active_revision_sha": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
+        "remote_git_head": "Unknown",
+        "origin_main_sha": "92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef",
+        "active_revision_is_ancestor_of_origin_main": true,
+        "commits_between_active_revision_and_origin_main": 43,
+        "contains_help_service_fields_commit": false,
+        "contains_help_importer_service_fields_commit": false,
+        "contains_publish_safety_fields_commit": false,
+        "migration_status": {
+          "2026_06_05_150000_add_help_service_fields_to_content_pages": "Ran batch 45",
+          "2026_06_08_010000_add_publish_safety_fields_to_content_pages": "Pending"
+        },
+        "runtime_file_presence": {
+          "help_service_fields_migration": "present",
+          "publish_safety_fields_migration": "missing",
+          "content_pages_importer_command": "present",
+          "content_page_model": "present"
+        },
+        "importer_mapping_grep": {
+          "support_contact": "present",
+          "policy_version": "present",
+          "reviewer": "present",
+          "faq_items": "present",
+          "schema_enabled": "missing"
+        }
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "checks": []
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "BLOCKED_RUNTIME_BEHIND_AND_PUBLISH_SAFETY_PENDING",
+      "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json",
+      "operations_report": "backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md",
+      "production_active_revision_sha": "e812d6f87f8b84b45d2e900d9d3844a0402635bc",
+      "origin_main_sha": "92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef",
+      "next_safe_authorization_prompt": "I explicitly approve backend production deploy for exact SHA 92a94f0604adc14cad2d7b1f5a85a0ce91f0eeef release help-cms-service-fields-prod-20260608-92a94f06.",
+      "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION-01"
+    },
+    "scope_validation": {
+      "deploy_performed": false,
+      "migration_performed": false,
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-PROD-RUNTIME-IDENTITY-MIXED",
+        "status": "blocked",
+        "note": "REVISION reports e812d6f87f8b84b45d2e900d9d3844a0402635bc, but remote file/migration evidence is mixed; do not treat production as containing full Help service runtime."
+      },
+      {
+        "id": "HELP-CMS-SERVICE-FIELDS-PUBLISH-SAFETY-MIGRATION",
+        "status": "pending_on_production",
+        "note": "2026_06_08_010000_add_publish_safety_fields_to_content_pages is Pending on production."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+        "status": "blocked_until_runtime_deployed_or_confirmed",
+        "note": "CMS draft sync remains blocked until production runtime contains the full Help service field/importer/publish-safety target."
+      }
+    ],
+    "next_task": "HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User authorized read-only production active SHA and migration status verification."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "remote_read_only_verified_local_validation_pending",
+        "note": "Read-only production checks completed through SSH alias fap-api-prod. Active revision is e812d6f87f8b84b45d2e900d9d3844a0402635bc; Help service fields migration is Ran; publish safety migration is Pending; schema_enabled importer mapping was not confirmed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "JSON/YAML validation and scoped diff whitespace checks passed. No deploy, migration, CMS mutation, publish, private URL access, secret read, payment action, or Operator approval claim was performed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31850,7 +31850,7 @@
   "RESULT-EN-PARITY-06": {
     "repo": "fap-api",
     "branch": "codex/result-en-parity-06-bigfive-v2-en-assets",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "depends_on": [
       "RESULT-EN-PARITY-05"
     ],
@@ -49421,8 +49421,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "3682e0957f4d552da27a45e740366bbbf47fb750",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1975",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -49481,6 +49481,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "JSON/YAML validation and scoped diff whitespace checks passed. No deploy, migration, CMS mutation, publish, private URL access, secret read, payment action, or Operator approval claim was performed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1975 for HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49421,7 +49421,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "3682e0957f4d552da27a45e740366bbbf47fb750",
+    "commit_sha": "pending_remote_pr_head",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1975",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49491,6 +49491,11 @@
         "at": "2026-06-08",
         "status": "target_refreshed_after_main_advanced",
         "note": "origin/main advanced to 87afe2dfddfab1f8533512b8a2bdf1c347626000 before merge, so the verification artifact and next deploy authorization prompt were refreshed. Production active revision remains e812d6f87f8b84b45d2e900d9d3844a0402635bc."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "commit_sha_pending_remote_head",
+        "note": "After rebasing onto the refreshed origin/main target, commit_sha was set to pending_remote_pr_head to avoid self-referential amend hash churn before merge."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22098,6 +22098,47 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01
 
+  - id: HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01
+    repo: fap-api
+    depends_on:
+      - HELP-CMS-SERVICE-FIELDS-PROD-RELEASE-01
+    branch: codex/help-cms-service-fields-prod-sha-verify-01
+    title: "docs(help): verify Help service production active SHA"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Use the approved read-only production method to report only the active backend release SHA and migration status for the Help service ContentPage fields lane.
+      - Verify the Help service fields migration status, publish safety fields migration status, and content-pages:import-local-baseline command/service-field mapping evidence without mutating production.
+      - Record whether production can be treated as containing the Help service runtime target or whether deploy remains required.
+      - Do not deploy, run migrations, mutate CMS data, publish, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, add frontend fallback content, or claim Operator approval.
+    allowed_paths:
+      - backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json
+      - backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Deploy production, run migrations, mutate CMS data, publish, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, add frontend fallback content, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added a read-only Help service production SHA verification report.
- Added generated JSON evidence for active production revision, migration status, importer command evidence, and blocked decision.
- Registered HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 in the PR train manifest/state.

## Why
The Help CMS policy sync must not proceed until production runtime is confirmed to include the Help service field/runtime target. The approved read-only production check found the active revision is behind current main, publish safety migration is pending, and schema_enabled importer mapping is not confirmed in the active runtime.

## Validation
```bash
python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json >/dev/null
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-sha-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-sha-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
git diff --cached --check
```

## Intentionally deferred
- No deploy.
- No migration execution.
- No CMS mutation or draft sync.
- No publish or search submission.
- No private URL access.
- No secret/env/cookie/token read.
- No payment/refund action or payment-provider change.
- No Operator approval claim.

## Repository rule impact
Docs/ledger only. No content authority or runtime authority change. Help service content remains CMS/backend-authoritative.