### PR TITLE
docs(seo): confirm Science reliability route governance

### DIFF
--- a/backend/app/Services/Cms/ScienceContentPagePreImportQaService.php
+++ b/backend/app/Services/Cms/ScienceContentPagePreImportQaService.php
@@ -24,6 +24,7 @@ final class ScienceContentPagePreImportQaService
         '/item-design-notes',
         '/method-boundaries',
         '/privacy',
+        '/reliability-validity',
         '/science',
         '/support',
         '/tests',

--- a/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/codex_qa.md
+++ b/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/codex_qa.md
@@ -89,7 +89,7 @@ blocking_reason=real_import_requires_separate_operator_approval_and_import_comma
 
 ## Route Mapping Note
 
-`/reliability-validity` remains the page slug in the manifest and dry-run output. It was removed from `internal_links_allowed` frontmatter fields because the current backend pre-import route allowlist does not accept it as an internal-link route field. Treat this as a route-governance follow-up before publish/discoverability, not as a blocker for no-write draft validation.
+`/reliability-validity` remains the page slug in the manifest and dry-run output. It is allowed as a public canonical route for Science ContentPage internal-link fields after the route governance update. Publish and discoverability still require separate operator approval and route smoke checks against real CMS content.
 
 ## Hard NO-GO
 

--- a/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/01-science-hub-content-01.md
+++ b/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/01-science-hub-content-01.md
@@ -22,6 +22,7 @@ sitemap_eligible: false
 llms_eligible: false
 footer_eligible: false
 internal_links_allowed:
+  - /reliability-validity
   - /method-boundaries
   - /item-design-notes
   - /tests/holland-career-interest-test-riasec

--- a/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/02-method-boundary-content-01.md
+++ b/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/02-method-boundary-content-01.md
@@ -23,6 +23,7 @@ llms_eligible: false
 footer_eligible: false
 revision_mode: existing_authority_revision_proposal
 internal_links_allowed:
+  - /reliability-validity
   - /science
   - /item-design-notes
 ---

--- a/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/03-item-design-content-01.md
+++ b/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/03-item-design-content-01.md
@@ -22,6 +22,7 @@ sitemap_eligible: false
 llms_eligible: false
 footer_eligible: false
 internal_links_allowed:
+  - /reliability-validity
   - /science
   - /method-boundaries
 ---

--- a/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/06-misconceptions-content-01.md
+++ b/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/pages/06-misconceptions-content-01.md
@@ -22,6 +22,7 @@ sitemap_eligible: false
 llms_eligible: false
 footer_eligible: false
 internal_links_allowed:
+  - /reliability-validity
   - /science
   - /method-boundaries
   - /tests/mbti-personality-test-16-personality-types

--- a/backend/tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
@@ -208,6 +208,7 @@ internal_links_allowed:
   - /tests
   - /privacy
   - /support
+  - /reliability-validity
 forbidden_routes:
   - /result/*
   - /orders/*


### PR DESCRIPTION
## What changed
- Added `/reliability-validity` to the Science ContentPage pre-import public route allowlist.
- Added focused test fixture coverage so the pre-import QA accepts `/reliability-validity` as a public canonical internal-link route.
- Restored `/reliability-validity` internal link mappings in the Science ContentPage review draft package.
- Updated the package QA note to record the route governance confirmation.

## Why
The Science package already uses `/reliability-validity` as a page slug and fap-web has a guarded route wrapper. The backend pre-import QA should not force content candidates to omit that public canonical route from internal-link fields.

## Validation
```bash
cd backend && vendor/bin/pint --test app/Services/Cms/ScienceContentPagePreImportQaService.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php
cd backend && php artisan test tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php --no-ansi
cd backend && php artisan content-pages:science-pre-import-qa --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08
python3 -m json.tool backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/manifest.json >/dev/null
git diff --check
```

Key result: pre-import QA reports `non_public_draft_import_qa_passed=true`, `package_pre_import_qa_issue_count=0`, `real_import_allowed=false`, and `publish_allowed=false`.

## Intentionally deferred
- No CMS mutation.
- No database import.
- No real import command enablement.
- No publish.
- No sitemap/llms/footer/search submission/social distribution.
- No deployment.

## Repository rule impact
Narrow route-governance update for backend pre-import QA. Content remains backend/CMS-authoritative; this PR does not enable import, publish, discoverability, or frontend fallback content.