### PR TITLE
SEO-ARTICLE-RIASEC-V2-ZH-LOCALE-CONTRACT-FIX-01 zh locale contract fix evidence

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json
@@ -1,0 +1,210 @@
+{
+  "schema": "riasec-explanation-zh-locale-contract-fix.v1",
+  "task_id": "SEO-ARTICLE-RIASEC-V2-ZH-LOCALE-CONTRACT-FIX-01",
+  "generated_at": "2026-06-08T11:18:00+08:00",
+  "decision": "GO_ZH_CANONICAL_200_SEARCH_SUBMISSION_STILL_BLOCKED",
+  "scope": {
+    "summary": "Normalize the published Chinese RIASEC article CMS locale contract so the public canonical zh article route returns 200.",
+    "cms_mutation_performed": true,
+    "article_content_rewrite_performed": false,
+    "publish_performed_in_this_task": false,
+    "search_submission_performed": false,
+    "deploy_performed": false,
+    "frontend_deploy_performed": false,
+    "private_or_tokenized_url_accessed": false,
+    "public_canonical_routes_only": true
+  },
+  "target_article": {
+    "article_id": 40,
+    "slug": "riasec-holland-career-interest-test-explained",
+    "canonical_url": "https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained",
+    "status": "published",
+    "is_public": true,
+    "is_indexable": true,
+    "published_revision_id": 45,
+    "translation_group_id": "riasec-explanation-article-2026-06-v2"
+  },
+  "production_locale_state": {
+    "before": {
+      "article_id": 40,
+      "article_locale": "zh",
+      "source_locale": "zh",
+      "seo_meta_locale": "zh",
+      "editorial_import_locale": "zh",
+      "article_test_edge_locales": [
+        "zh"
+      ],
+      "article_translation_revision_locales": [
+        "zh"
+      ],
+      "api_locale_zh_status": 200,
+      "api_locale_zh_cn_status": 404,
+      "frontend_zh_canonical_status": 404
+    },
+    "after": {
+      "article_id": 40,
+      "article_locale": "zh-CN",
+      "source_locale": "zh-CN",
+      "seo_meta_locale": "zh-CN",
+      "editorial_import_locale": "zh-CN",
+      "article_test_edge_locales": [
+        "zh-CN"
+      ],
+      "article_translation_revision_locales": [
+        "zh-CN"
+      ],
+      "api_locale_zh_status": 404,
+      "api_locale_zh_cn_status": 200,
+      "frontend_zh_canonical_status": 200
+    }
+  },
+  "cms_mutation": {
+    "performed": true,
+    "runtime": "production artisan tinker bounded update",
+    "guardrails": [
+      "confirmed article id 40 and slug before update",
+      "confirmed article 40 was already published, public, and indexable",
+      "confirmed no conflicting org and slug record existed for locale zh-CN",
+      "updated locale fields only",
+      "did not modify article body, title, H1, meta copy, FAQ entries, CTA labels, references, media, publication state, or tracking"
+    ],
+    "tables_updated": [
+      "articles.locale",
+      "articles.source_locale",
+      "article_seo_meta.locale",
+      "article_editorial_package_imports.locale",
+      "article_test_edges.locale",
+      "article_translation_revisions.locale"
+    ],
+    "post_mutation_output": {
+      "article_id": 40,
+      "article_locale": "zh-CN",
+      "source_locale": "zh-CN",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "seo_locale": "zh-CN",
+      "import_locale": "zh-CN",
+      "edge_locales": [
+        "zh-CN"
+      ],
+      "revision_locales": [
+        "zh-CN"
+      ]
+    }
+  },
+  "post_fix_http_smoke": {
+    "api": [
+      {
+        "surface": "backend_public_article_api",
+        "article_id": 40,
+        "locale_query": "zh-CN",
+        "http_status": 200,
+        "body_bytes": 43265,
+        "status": "passed"
+      },
+      {
+        "surface": "backend_public_article_api",
+        "article_id": 40,
+        "locale_query": "zh",
+        "http_status": 404,
+        "body_bytes": 68,
+        "status": "expected_after_locale_normalization"
+      }
+    ],
+    "frontend": [
+      {
+        "surface": "frontend_public_article_detail",
+        "article_id": 40,
+        "locale_segment": "zh",
+        "http_status": 200,
+        "body_bytes": 172515,
+        "status": "passed"
+      },
+      {
+        "surface": "frontend_public_article_detail",
+        "article_id": 41,
+        "locale_segment": "en",
+        "http_status": 200,
+        "body_bytes": 175026,
+        "status": "passed"
+      }
+    ]
+  },
+  "post_fix_cms_state": [
+    {
+      "article_id": 40,
+      "locale": "zh-CN",
+      "source_locale": "zh-CN",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_revision_id": 45,
+      "seo_locale": "zh-CN",
+      "seo_canonical_url": "https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained",
+      "seo_robots": "index,follow"
+    },
+    {
+      "article_id": 41,
+      "locale": "en",
+      "source_locale": "en",
+      "status": "published",
+      "is_public": true,
+      "is_indexable": true,
+      "published_revision_id": 46,
+      "seo_locale": "en",
+      "seo_canonical_url": "https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test",
+      "seo_robots": "index,follow"
+    }
+  ],
+  "sitemap_llms_smoke": {
+    "sitemap_xml": {
+      "url": "https://fermatmind.com/sitemap.xml",
+      "body_bytes": 333760,
+      "contains_zh_article": false,
+      "contains_en_article": false
+    },
+    "llms_txt": {
+      "url": "https://fermatmind.com/llms.txt",
+      "body_bytes": 160546,
+      "contains_zh_article": false,
+      "contains_en_article": true
+    },
+    "llms_full_txt": {
+      "url": "https://fermatmind.com/llms-full.txt",
+      "body_bytes": 525411,
+      "contains_zh_article": false,
+      "contains_en_article": true
+    },
+    "search_submission_allowed": false,
+    "convergence_status": "not_fully_converged"
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_publish_in_this_task": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "no_frontend_deploy": true,
+    "no_private_or_tokenized_url_access": true,
+    "public_canonical_routes_only": true
+  },
+  "remaining_blockers": [
+    {
+      "id": "sitemap_llms_not_fully_converged",
+      "status": "blocked",
+      "evidence": "The zh canonical route now returns 200, but sitemap.xml and llms outputs do not yet consistently enumerate both RIASEC article slugs.",
+      "next_check": "Run a separate post-publish smoke after cache or enumeration convergence."
+    },
+    {
+      "id": "search_submission_not_authorized",
+      "status": "hard_gate",
+      "evidence": "No GSC, Baidu, IndexNow, or search submission action was authorized or performed in this task.",
+      "next_check": "Only run search submission preflight after post-publish smoke passes and separate exact authorization is provided."
+    }
+  ],
+  "next_step": {
+    "recommended_task_id": "SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-02",
+    "scope": "Re-run post-publish public smoke for zh and en article routes, schema, sitemap, llms, CTA public route, and tracking path. Do not submit search URLs.",
+    "search_submission_status": "blocked"
+  }
+}

--- a/backend/docs/seo/riasec-explanation-zh-locale-contract-fix.md
+++ b/backend/docs/seo/riasec-explanation-zh-locale-contract-fix.md
@@ -1,0 +1,49 @@
+# RIASEC V2 zh Locale Contract Fix
+
+Task: `SEO-ARTICLE-RIASEC-V2-ZH-LOCALE-CONTRACT-FIX-01`
+
+Decision: `GO_ZH_CANONICAL_200_SEARCH_SUBMISSION_STILL_BLOCKED`
+
+## Scope
+
+This task fixed the published Chinese RIASEC article locale contract only. The goal was to make the public canonical route return 200:
+
+- `https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained`
+
+The fix did not rewrite article body, title, H1, meta copy, FAQ entries, CTA labels, references, media, publication state, or tracking.
+
+## Production Fix
+
+Article `40` was already published, public, and indexable, but its backend locale fields used `zh`. Existing article/public API contracts expect Chinese article records to use `zh-CN`, while the frontend public route segment remains `/zh`.
+
+The bounded production CMS update normalized locale fields only:
+
+| Record | Before | After |
+| --- | --- | --- |
+| `articles.locale` | `zh` | `zh-CN` |
+| `articles.source_locale` | `zh` | `zh-CN` |
+| `article_seo_meta.locale` | `zh` | `zh-CN` |
+| `article_editorial_package_imports.locale` | `zh` | `zh-CN` |
+| `article_test_edges.locale` | `zh` | `zh-CN` |
+| `article_translation_revisions.locale` | `zh` | `zh-CN` |
+
+## Smoke Result
+
+| Surface | URL/query | Status |
+| --- | --- | --- |
+| backend article API | article 40, `locale=zh-CN` | 200 |
+| backend article API | article 40, `locale=zh` | 404, expected after normalization |
+| frontend zh canonical | `/zh/articles/riasec-holland-career-interest-test-explained` | 200 |
+| frontend en canonical | `/en/articles/what-is-riasec-holland-code-career-interest-test` | 200 |
+
+## Remaining Gates
+
+Search submission is still blocked. Sitemap and llms outputs were not fully converged after the locale fix:
+
+- `sitemap.xml`: zh article absent, en article absent
+- `llms.txt`: zh article absent, en article present
+- `llms-full.txt`: zh article absent, en article present
+
+Recommended next task: `SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-02`.
+
+Do not run GSC, Baidu, IndexNow, or any search submission until a separate post-publish smoke passes and separate exact search submission authorization is provided.

--- a/backend/tests/Feature/SEO/RiasecExplanationZhLocaleContractFixTest.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationZhLocaleContractFixTest.php
@@ -1,0 +1,115 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationZhLocaleContractFixTest extends TestCase
+{
+    public function test_zh_locale_contract_fix_is_recorded_without_content_publish_search_or_deploy_scope(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-ZH-LOCALE-CONTRACT-FIX-01', $artifact['task_id']);
+        $this->assertSame('GO_ZH_CANONICAL_200_SEARCH_SUBMISSION_STILL_BLOCKED', $artifact['decision']);
+        $this->assertTrue($artifact['scope']['cms_mutation_performed']);
+        $this->assertFalse($artifact['scope']['article_content_rewrite_performed']);
+        $this->assertFalse($artifact['scope']['publish_performed_in_this_task']);
+        $this->assertFalse($artifact['scope']['search_submission_performed']);
+        $this->assertFalse($artifact['scope']['deploy_performed']);
+        $this->assertFalse($artifact['scope']['frontend_deploy_performed']);
+        $this->assertFalse($artifact['scope']['private_or_tokenized_url_accessed']);
+        $this->assertTrue($artifact['scope']['public_canonical_routes_only']);
+    }
+
+    public function test_article_40_locale_fields_are_normalized_to_zh_cn(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json');
+
+        $before = $artifact['production_locale_state']['before'];
+        $after = $artifact['production_locale_state']['after'];
+
+        $this->assertSame('zh', $before['article_locale']);
+        $this->assertSame('zh', $before['source_locale']);
+        $this->assertSame('zh', $before['seo_meta_locale']);
+        $this->assertSame(['zh'], $before['article_test_edge_locales']);
+        $this->assertSame(['zh'], $before['article_translation_revision_locales']);
+
+        $this->assertSame('zh-CN', $after['article_locale']);
+        $this->assertSame('zh-CN', $after['source_locale']);
+        $this->assertSame('zh-CN', $after['seo_meta_locale']);
+        $this->assertSame('zh-CN', $after['editorial_import_locale']);
+        $this->assertSame(['zh-CN'], $after['article_test_edge_locales']);
+        $this->assertSame(['zh-CN'], $after['article_translation_revision_locales']);
+    }
+
+    public function test_public_zh_canonical_route_now_passes_and_en_remains_live(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json');
+        $api = collect($artifact['post_fix_http_smoke']['api'])->keyBy('locale_query');
+        $frontend = collect($artifact['post_fix_http_smoke']['frontend'])->keyBy('locale_segment');
+
+        $this->assertSame(200, $api['zh-CN']['http_status']);
+        $this->assertSame('passed', $api['zh-CN']['status']);
+        $this->assertSame(404, $api['zh']['http_status']);
+        $this->assertSame('expected_after_locale_normalization', $api['zh']['status']);
+
+        $this->assertSame(200, $frontend['zh']['http_status']);
+        $this->assertSame('passed', $frontend['zh']['status']);
+        $this->assertSame(200, $frontend['en']['http_status']);
+        $this->assertSame('passed', $frontend['en']['status']);
+    }
+
+    public function test_search_submission_remains_blocked_until_sitemap_and_llms_converge(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json');
+
+        $this->assertFalse($artifact['sitemap_llms_smoke']['search_submission_allowed']);
+        $this->assertSame('not_fully_converged', $artifact['sitemap_llms_smoke']['convergence_status']);
+        $this->assertFalse($artifact['sitemap_llms_smoke']['sitemap_xml']['contains_zh_article']);
+        $this->assertFalse($artifact['sitemap_llms_smoke']['sitemap_xml']['contains_en_article']);
+        $this->assertFalse($artifact['sitemap_llms_smoke']['llms_txt']['contains_zh_article']);
+        $this->assertTrue($artifact['sitemap_llms_smoke']['llms_txt']['contains_en_article']);
+        $this->assertFalse($artifact['sitemap_llms_smoke']['llms_full_txt']['contains_zh_article']);
+        $this->assertTrue($artifact['sitemap_llms_smoke']['llms_full_txt']['contains_en_article']);
+
+        $blockers = collect($artifact['remaining_blockers'])->pluck('id')->all();
+        $this->assertContains('sitemap_llms_not_fully_converged', $blockers);
+        $this->assertContains('search_submission_not_authorized', $blockers);
+    }
+
+    public function test_hard_boundaries_remain_closed(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json');
+
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_publish_in_this_task']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['no_frontend_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+        $this->assertTrue($artifact['hard_boundaries']['public_canonical_routes_only']);
+    }
+
+    public function test_artifact_contains_no_forbidden_route_or_identifier_patterns(): void
+    {
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json') ?: '';
+
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added a generated JSON artifact recording the bounded production zh locale normalization for article 40.
- Added a short SEO ops note documenting the before/after locale contract and public route smoke.
- Added a focused PHPUnit contract test for the evidence artifact and hard boundaries.

## Why
The previous RIASEC post-publish smoke found that `/zh/articles/riasec-holland-career-interest-test-explained` returned 404 because article 40 used backend locale `zh` while the existing article/API contract expects Chinese CMS article records to use `zh-CN` behind the `/zh` public route segment. The production CMS locale fields were normalized under the narrow user authorization, and this PR records that evidence.

## Validation commands
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-zh-locale-contract-fix.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationZhLocaleContractFixTest.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationZhLocaleContractFixTest --no-ansi --display-warnings`
- `git diff --cached --check`

## Intentionally deferred
- No article body/title/H1/meta/FAQ/CTA rewrite.
- No publish action in this task.
- No search submission to GSC, Baidu, IndexNow, or any search platform.
- No backend or frontend deploy.
- No private/tokenized URL access.
- Re-run post-publish smoke separately before considering search submission preflight.

## Repository rule impact
This PR records a CMS/backend-authoritative article locale contract correction. It does not introduce a new content surface or frontend fallback.