### PR TITLE
SCIENCE-CONTENTPAGE-PRODUCTION-DRY-RUN-NOWRITE-01 docs(seo): record no-write gate

### DIFF
--- a/backend/docs/seo/generated/science-contentpage-production-dry-run-nowrite-01.v1.json
+++ b/backend/docs/seo/generated/science-contentpage-production-dry-run-nowrite-01.v1.json
@@ -1,0 +1,121 @@
+{
+  "schema_version": "science-contentpage-production-dry-run-nowrite-01.v1",
+  "task": "SCIENCE-CONTENTPAGE-PRODUCTION-DRY-RUN-NOWRITE-01",
+  "mode": "production_dry_run_no_write_gate",
+  "created_at": "2026-06-08T00:00:00Z",
+  "runtime_use": "not_runtime",
+  "production_use_allowed": false,
+  "ready_for_production_import": false,
+  "production_rollout_enabled": false,
+  "cms_mutation_allowed": false,
+  "database_writes_allowed": false,
+  "content_import_allowed": false,
+  "publish_allowed": false,
+  "natural_distribution_allowed": false,
+  "package": {
+    "path": "backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08",
+    "status": "draft_only_not_for_publication",
+    "source_pages": 6,
+    "cms_draft_candidate_glob": "pages/*.md",
+    "non_candidate_files": [
+      "review_audit.md",
+      "operator_review.md",
+      "codex_qa.md",
+      "README.md"
+    ]
+  },
+  "local_no_write_dry_run": {
+    "executed": true,
+    "command": "cd backend && php artisan content-pages:science-draft-dry-run --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08 --json",
+    "status": "pass_no_write_dry_run",
+    "dry_run": true,
+    "would_write": false,
+    "database_writes_allowed": false,
+    "pages_seen": 6,
+    "pages_expected": 6,
+    "pages_ready_for_non_public_draft_import": 5,
+    "pages_reconciled_existing_authority": 1,
+    "pages_blocked": 0,
+    "issue_count": 0,
+    "content_page_rows_written_in_test": 0
+  },
+  "operator_review_gate": {
+    "executed": true,
+    "command": "cd backend && php artisan content-pages:science-operator-review-readiness --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08 --json",
+    "decision": "CONDITIONAL",
+    "operator_review_ready_for_non_public_draft": true,
+    "operator_publish_decision_ready": false,
+    "publish_allowed_default": false,
+    "missing_first_class_publish_safety_fields": []
+  },
+  "pre_import_qa_gate": {
+    "executed": true,
+    "command": "cd backend && php artisan content-pages:science-pre-import-qa --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08 --json",
+    "decision": "NO-GO",
+    "non_public_draft_import_qa_passed": true,
+    "real_import_allowed": false,
+    "publish_allowed": false,
+    "package_pre_import_qa_issue_count": 0,
+    "blocking_reasons": [
+      "operator_publish_decision_not_ready",
+      "real_import_requires_separate_operator_approval_and_import_command"
+    ],
+    "guards": {
+      "forbidden_claims_absent": true,
+      "private_url_absent": true,
+      "faq_visible_only": true,
+      "cta_public_canonical_only": true,
+      "draft_exposure_disabled": true,
+      "sitemap_llms_footer_disabled": true
+    }
+  },
+  "production_no_write_execution": {
+    "production_shell_accessed": false,
+    "production_dry_run_executed": false,
+    "production_database_mutated": false,
+    "production_cms_import_performed": false,
+    "production_publish_performed": false,
+    "production_backend_sha": "Unknown",
+    "production_artisan_output": "Unknown",
+    "reason": "This PR records and tests the no-write dry-run gate only. A later explicitly scoped task must run any production no-write command after import command enablement and operator approval."
+  },
+  "route_mapping": {
+    "create_non_public_draft": [
+      "/science",
+      "/item-design-notes",
+      "/reliability-validity",
+      "/data-privacy",
+      "/common-misconceptions"
+    ],
+    "existing_authority_revision_only": [
+      "/method-boundaries"
+    ],
+    "private_routes_allowed": []
+  },
+  "hard_no_go": [
+    "no_cms_mutation",
+    "no_database_write",
+    "no_real_import",
+    "no_publish",
+    "no_sitemap_llms_footer_exposure",
+    "no_private_url",
+    "no_hidden_faq_schema",
+    "no_unsupported_claims",
+    "no_dailygiving_amplification"
+  ],
+  "next_task": {
+    "id": "SCIENCE-CONTENTPAGE-REAL-IMPORT-COMMAND-ENABLEMENT-01",
+    "allowed_after": [
+      "local_no_write_dry_run.status == pass_no_write_dry_run",
+      "pre_import_qa_gate.package_pre_import_qa_issue_count == 0",
+      "operator_review_gate.operator_review_ready_for_non_public_draft == true"
+    ],
+    "still_required": [
+      "implement explicit real import command gate",
+      "require exact approval phrase before writes",
+      "keep default mode dry-run/no-write",
+      "block publish and discoverability"
+    ]
+  },
+  "final_decision": "GO_FOR_REAL_IMPORT_COMMAND_ENABLEMENT_ONLY"
+}

--- a/backend/docs/seo/science-contentpage-production-dry-run-nowrite-01.md
+++ b/backend/docs/seo/science-contentpage-production-dry-run-nowrite-01.md
@@ -1,0 +1,89 @@
+# SCIENCE-CONTENTPAGE-PRODUCTION-DRY-RUN-NOWRITE-01
+
+## Decision
+GO for the next technical PR only: real import command enablement.
+
+NO-GO for real import, publish, sitemap, llms, footer, social distribution, or any production CMS mutation in this PR.
+
+## Scope
+This is a no-write dry-run evidence gate for the Science ContentPage package:
+
+- Package: `backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08`
+- Candidate inputs: `pages/*.md` only
+- Runtime mutation: none
+- CMS import: none
+- Publish/discoverability: none
+
+## Local No-Write Evidence
+Command:
+
+```bash
+cd backend && php artisan content-pages:science-draft-dry-run --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08 --json
+```
+
+Observed status:
+
+- `status=pass_no_write_dry_run`
+- `dry_run=true`
+- `would_write=false`
+- `database_writes_allowed=false`
+- `pages_seen=6`
+- `pages_ready_for_non_public_draft_import=5`
+- `pages_reconciled_existing_authority=1`
+- `pages_blocked=0`
+- `issue_count=0`
+
+## Operator And QA Gates
+Operator review readiness is CONDITIONAL:
+
+- Core ContentPage fields exist.
+- Publish safety fields exist.
+- CMS/API editing surfaces expose the needed fields.
+- `operator_publish_decision_ready=false`.
+- `publish_allowed_default=false`.
+
+Pre-import QA is still NO-GO for writes:
+
+- `non_public_draft_import_qa_passed=true`
+- `real_import_allowed=false`
+- `publish_allowed=false`
+- `package_pre_import_qa_issue_count=0`
+- Blockers:
+  - `operator_publish_decision_not_ready`
+  - `real_import_requires_separate_operator_approval_and_import_command`
+
+## Route Mapping
+Draft-create candidates:
+
+- `/science`
+- `/item-design-notes`
+- `/reliability-validity`
+- `/data-privacy`
+- `/common-misconceptions`
+
+Existing authority revision only:
+
+- `/method-boundaries`
+
+Forbidden:
+
+- private result/order/share/pay/payment/history/tokenized routes
+- publish routes
+- sitemap/llms/footer exposure
+
+## Production Boundary
+This PR did not access a production shell, production database, CMS admin, or private result/order/share/payment URL.
+
+Production dry-run execution remains `Unknown` because this PR is only the repository-side no-write gate and test proof. Any production command must be a later explicitly scoped step after real import command enablement and exact operator approval.
+
+## Next PR
+`SCIENCE-CONTENTPAGE-REAL-IMPORT-COMMAND-ENABLEMENT-01`
+
+Required properties:
+
+- default dry-run/no-write behavior
+- exact approval phrase required before any database write
+- draft-only import target
+- publish remains blocked
+- sitemap/llms/footer remain blocked
+- `/method-boundaries` stays existing-authority revision only

--- a/backend/tests/Feature/Console/ScienceContentPageProductionDryRunNowriteTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPageProductionDryRunNowriteTest.php
@@ -1,0 +1,121 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\ContentPage;
+use App\Services\Cms\ScienceContentPageDraftDryRunService;
+use App\Services\Cms\ScienceContentPageOperatorReviewReadinessService;
+use App\Services\Cms\ScienceContentPagePreImportQaService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ScienceContentPageProductionDryRunNowriteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PACKAGE_PATH = 'docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08';
+
+    private const REPORT_PATH = 'docs/seo/generated/science-contentpage-production-dry-run-nowrite-01.v1.json';
+
+    #[Test]
+    public function production_nowrite_gate_report_keeps_runtime_and_import_disabled(): void
+    {
+        $report = $this->report();
+
+        $this->assertSame('SCIENCE-CONTENTPAGE-PRODUCTION-DRY-RUN-NOWRITE-01', $report['task'] ?? null);
+        $this->assertSame('not_runtime', $report['runtime_use'] ?? null);
+        $this->assertFalse((bool) ($report['production_use_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['ready_for_production_import'] ?? true));
+        $this->assertFalse((bool) ($report['production_rollout_enabled'] ?? true));
+        $this->assertFalse((bool) ($report['cms_mutation_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['database_writes_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['content_import_allowed'] ?? true));
+        $this->assertFalse((bool) ($report['publish_allowed'] ?? true));
+    }
+
+    #[Test]
+    public function science_package_dry_run_passes_without_content_page_writes(): void
+    {
+        $this->artisan('content-pages:science-draft-dry-run', [
+            '--package' => $this->packagePath(),
+        ])
+            ->expectsOutputToContain('status=pass_no_write_dry_run')
+            ->expectsOutputToContain('dry_run=true')
+            ->expectsOutputToContain('would_write=false')
+            ->expectsOutputToContain('pages_seen=6')
+            ->expectsOutputToContain('pages_ready_for_non_public_draft_import=5')
+            ->expectsOutputToContain('pages_reconciled_existing_authority=1')
+            ->expectsOutputToContain('pages_blocked=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, ContentPage::query()->count());
+    }
+
+    #[Test]
+    public function generated_report_matches_current_dry_run_and_pre_import_qa_gates(): void
+    {
+        $report = $this->report();
+        $dryRun = app(ScienceContentPageDraftDryRunService::class)->dryRun($this->packagePath());
+        $operator = app(ScienceContentPageOperatorReviewReadinessService::class)->review($this->packagePath());
+        $preImportQa = app(ScienceContentPagePreImportQaService::class)->check($this->packagePath());
+
+        $this->assertSame($dryRun['status'], $report['local_no_write_dry_run']['status']);
+        $this->assertTrue($report['local_no_write_dry_run']['dry_run']);
+        $this->assertFalse($report['local_no_write_dry_run']['would_write']);
+        $this->assertFalse($report['local_no_write_dry_run']['database_writes_allowed']);
+        $this->assertSame($dryRun['pages_seen'], $report['local_no_write_dry_run']['pages_seen']);
+        $this->assertSame($dryRun['pages_expected'], $report['local_no_write_dry_run']['pages_expected']);
+        $this->assertSame($dryRun['pages_ready_for_non_public_draft_import'], $report['local_no_write_dry_run']['pages_ready_for_non_public_draft_import']);
+        $this->assertSame($dryRun['pages_reconciled_existing_authority'], $report['local_no_write_dry_run']['pages_reconciled_existing_authority']);
+        $this->assertSame($dryRun['pages_blocked'], $report['local_no_write_dry_run']['pages_blocked']);
+        $this->assertSame($dryRun['issue_count'], $report['local_no_write_dry_run']['issue_count']);
+
+        $this->assertSame($operator['decision'], $report['operator_review_gate']['decision']);
+        $this->assertSame($operator['operator_review_ready_for_non_public_draft'], $report['operator_review_gate']['operator_review_ready_for_non_public_draft']);
+        $this->assertSame($operator['operator_publish_decision_ready'], $report['operator_review_gate']['operator_publish_decision_ready']);
+        $this->assertSame($operator['missing_first_class_publish_safety_fields'], $report['operator_review_gate']['missing_first_class_publish_safety_fields']);
+
+        $this->assertSame($preImportQa['decision'], $report['pre_import_qa_gate']['decision']);
+        $this->assertSame($preImportQa['non_public_draft_import_qa_passed'], $report['pre_import_qa_gate']['non_public_draft_import_qa_passed']);
+        $this->assertSame($preImportQa['real_import_allowed'], $report['pre_import_qa_gate']['real_import_allowed']);
+        $this->assertSame($preImportQa['publish_allowed'], $report['pre_import_qa_gate']['publish_allowed']);
+        $this->assertSame($preImportQa['package_pre_import_qa_issue_count'], $report['pre_import_qa_gate']['package_pre_import_qa_issue_count']);
+        $this->assertSame($preImportQa['blocking_reasons'], $report['pre_import_qa_gate']['blocking_reasons']);
+    }
+
+    #[Test]
+    public function report_does_not_claim_production_execution_or_private_route_access(): void
+    {
+        $report = $this->report();
+
+        $this->assertFalse((bool) data_get($report, 'production_no_write_execution.production_shell_accessed', true));
+        $this->assertFalse((bool) data_get($report, 'production_no_write_execution.production_dry_run_executed', true));
+        $this->assertFalse((bool) data_get($report, 'production_no_write_execution.production_database_mutated', true));
+        $this->assertFalse((bool) data_get($report, 'production_no_write_execution.production_cms_import_performed', true));
+        $this->assertFalse((bool) data_get($report, 'production_no_write_execution.production_publish_performed', true));
+        $this->assertSame('Unknown', data_get($report, 'production_no_write_execution.production_backend_sha'));
+        $this->assertSame([], data_get($report, 'route_mapping.private_routes_allowed'));
+        $this->assertContains('no_private_url', $report['hard_no_go'] ?? []);
+        $this->assertContains('no_database_write', $report['hard_no_go'] ?? []);
+        $this->assertSame('GO_FOR_REAL_IMPORT_COMMAND_ENABLEMENT_ONLY', $report['final_decision'] ?? null);
+    }
+
+    private function packagePath(): string
+    {
+        return base_path(self::PACKAGE_PATH);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function report(): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path(self::REPORT_PATH)), true, flags: JSON_THROW_ON_ERROR);
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added a generated no-write production dry-run gate report for the Science ContentPage draft package.
- Added a docs report that records route mapping, local dry-run evidence, operator/QA state, and production Unknown boundaries.
- Added a focused PHPUnit test proving the current Science package dry-run still writes zero ContentPage rows and that the generated report does not claim production execution.

## Why
- This is task 3 in the Science ContentPage line: prove the package is safe for the next technical PR without performing real import, publish, sitemap, llms, footer, or CMS mutation.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/science-contentpage-production-dry-run-nowrite-01.v1.json >/dev/null`
- `cd backend && vendor/bin/pint --test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php tests/Feature/Console/ScienceContentPageProductionDryRunNowriteTest.php`
- `cd backend && php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php tests/Feature/Console/ScienceContentPageProductionDryRunNowriteTest.php --no-ansi`
- `cd backend && php artisan content-pages:science-draft-dry-run --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08`
- `cd backend && php artisan content-pages:science-operator-review-readiness --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08`
- `cd backend && php artisan content-pages:science-pre-import-qa --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08`
- `git diff --check`

Note: PHPUnit exits 0; local warnings are from missing `backend/.env` in this worktree, also present on existing Science command tests.

## Intentionally deferred
- Real import command enablement.
- Controlled CMS draft import.
- Production no-write shell execution.
- Any database writes, publish, sitemap, llms, footer, search submission, or social distribution.

## Repository rule impact
- No content authority change. This PR only records no-write gate evidence and test coverage for an existing backend-authoritative ContentPage draft package.