### PR TITLE
SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-02 rerun article smoke

### DIFF
--- a/backend/docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json
+++ b/backend/docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json
@@ -1,0 +1,216 @@
+{
+  "schema": "riasec-explanation-post-publish-smoke-02.v1",
+  "task_id": "SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-02",
+  "generated_at": "2026-06-08T11:01:24+08:00",
+  "decision": "NO_GO_SEARCH_SUBMISSION_SITEMAP_LLMS_NOT_FULLY_CONVERGED",
+  "source_fix": {
+    "task_id": "SEO-ARTICLE-RIASEC-V2-ZH-LOCALE-CONTRACT-FIX-01",
+    "merge_commit": "f66853df400d43b66916eb18486438cf1916274c",
+    "summary": "The zh canonical article route was fixed before this smoke rerun."
+  },
+  "scope": {
+    "public_read_only_smoke": true,
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "search_submission_performed": false,
+    "deploy_performed": false,
+    "frontend_deploy_performed": false,
+    "article_content_rewrite_performed": false,
+    "private_or_tokenized_url_accessed": false
+  },
+  "target_articles": [
+    {
+      "article_id": 40,
+      "locale": "zh-CN",
+      "public_locale_segment": "zh",
+      "slug": "riasec-holland-career-interest-test-explained",
+      "canonical_url": "https://fermatmind.com/zh/articles/riasec-holland-career-interest-test-explained"
+    },
+    {
+      "article_id": 41,
+      "locale": "en",
+      "public_locale_segment": "en",
+      "slug": "what-is-riasec-holland-code-career-interest-test",
+      "canonical_url": "https://fermatmind.com/en/articles/what-is-riasec-holland-code-career-interest-test"
+    }
+  ],
+  "public_route_smoke": [
+    {
+      "surface": "backend_public_article_api",
+      "article_id": 40,
+      "locale_query": "zh-CN",
+      "http_status": 200,
+      "status": "passed"
+    },
+    {
+      "surface": "backend_public_article_api",
+      "article_id": 41,
+      "locale_query": "en",
+      "http_status": 200,
+      "status": "passed"
+    },
+    {
+      "surface": "frontend_public_article_detail",
+      "article_id": 40,
+      "http_status": 200,
+      "status": "passed"
+    },
+    {
+      "surface": "frontend_public_article_detail",
+      "article_id": 41,
+      "http_status": 200,
+      "status": "passed"
+    }
+  ],
+  "schema_smoke": [
+    {
+      "article_id": 40,
+      "locale": "zh-CN",
+      "json_ld_types": [
+        "Article",
+        "BreadcrumbList",
+        "FAQPage"
+      ],
+      "faq_jsonld_count": 6,
+      "api_visible_faq_count": 6,
+      "faq_schema_matches_visible_faq": true,
+      "robots": "index, follow",
+      "canonical_link_present": true,
+      "status": "passed"
+    },
+    {
+      "article_id": 41,
+      "locale": "en",
+      "json_ld_types": [
+        "Article",
+        "BreadcrumbList",
+        "FAQPage"
+      ],
+      "faq_jsonld_count": 6,
+      "api_visible_faq_count": 6,
+      "faq_schema_matches_visible_faq": true,
+      "robots": "index, follow",
+      "canonical_link_present": true,
+      "status": "passed"
+    }
+  ],
+  "cta_tracking_smoke": [
+    {
+      "article_id": 40,
+      "locale": "zh-CN",
+      "api_start_test_target": "/zh/tests/holland-career-interest-test-riasec",
+      "api_cta_bundle_count": 1,
+      "api_primary_test_edge": {
+        "test_slug": "holland-career-interest-test-riasec",
+        "role": "primary",
+        "locale": "zh-CN",
+        "visibility": "public"
+      },
+      "frontend_cta_count": 3,
+      "frontend_cta_public_canonical_count": 3,
+      "frontend_cta_tracking_params_present": true,
+      "tracking_event_code_path": "SeoTrackedCtaLink renders TrackedEntryCtaLink with eventName article_to_test_click for article_detail.",
+      "tracking_source_refs": [
+        "fap-web:app/(localized)/[locale]/articles/[slug]/page.tsx:420",
+        "fap-web:components/cta/SeoTrackedCtaLink.tsx:155",
+        "fap-web:components/analytics/TrackedEntryCtaLink.tsx:19"
+      ],
+      "status": "passed"
+    },
+    {
+      "article_id": 41,
+      "locale": "en",
+      "api_start_test_target": "/en/tests/holland-career-interest-test-riasec",
+      "api_cta_bundle_count": 1,
+      "api_primary_test_edge": {
+        "test_slug": "holland-career-interest-test-riasec",
+        "role": "primary",
+        "locale": "en",
+        "visibility": "public"
+      },
+      "frontend_cta_count": 3,
+      "frontend_cta_public_canonical_count": 3,
+      "frontend_cta_tracking_params_present": true,
+      "tracking_event_code_path": "SeoTrackedCtaLink renders TrackedEntryCtaLink with eventName article_to_test_click for article_detail.",
+      "tracking_source_refs": [
+        "fap-web:app/(localized)/[locale]/articles/[slug]/page.tsx:420",
+        "fap-web:components/cta/SeoTrackedCtaLink.tsx:155",
+        "fap-web:components/analytics/TrackedEntryCtaLink.tsx:19"
+      ],
+      "status": "passed"
+    }
+  ],
+  "sitemap_llms_smoke": {
+    "backend_sitemap_source": {
+      "url": "https://api.fermatmind.com/api/v0.5/seo/sitemap-source",
+      "http_status": 200,
+      "source": "backend_sitemap_generator",
+      "count": 2389,
+      "contains_zh_article": false,
+      "contains_en_article": false,
+      "status": "blocked"
+    },
+    "sitemap_xml": {
+      "url": "https://fermatmind.com/sitemap.xml",
+      "http_status": 200,
+      "body_bytes": 333760,
+      "contains_zh_article": false,
+      "contains_en_article": false,
+      "status": "blocked"
+    },
+    "llms_txt": {
+      "url": "https://fermatmind.com/llms.txt",
+      "http_status": 200,
+      "body_bytes": 161390,
+      "contains_zh_article": true,
+      "contains_en_article": true,
+      "status": "passed"
+    },
+    "llms_full_txt": {
+      "url": "https://fermatmind.com/llms-full.txt",
+      "http_status": 200,
+      "body_bytes": 525411,
+      "contains_zh_article": false,
+      "contains_en_article": true,
+      "status": "blocked"
+    },
+    "fully_converged": false,
+    "search_submission_allowed": false
+  },
+  "hard_boundaries": {
+    "no_article_body_title_h1_meta_faq_cta_rewrite": true,
+    "no_publish": true,
+    "no_search_submission": true,
+    "no_deploy": true,
+    "no_frontend_deploy": true,
+    "no_private_or_tokenized_url_access": true,
+    "cta_public_canonical_only": true
+  },
+  "remaining_blockers": [
+    {
+      "id": "backend_sitemap_source_missing_articles",
+      "status": "blocked",
+      "evidence": "The backend sitemap-source response returned 200 but contained 0 matches for both RIASEC article slugs."
+    },
+    {
+      "id": "sitemap_xml_missing_articles",
+      "status": "blocked",
+      "evidence": "The production sitemap.xml returned 200 but contained 0 matches for both RIASEC article slugs."
+    },
+    {
+      "id": "llms_full_missing_zh_article",
+      "status": "blocked",
+      "evidence": "llms-full.txt returned 200 and contained the English article but not the Chinese article."
+    },
+    {
+      "id": "search_submission_not_authorized_or_ready",
+      "status": "hard_gate",
+      "evidence": "Search submission was not authorized and is not ready while sitemap and llms-full are not fully converged."
+    }
+  ],
+  "next_step": {
+    "recommended_task_id": "SEO-ARTICLE-RIASEC-V2-SITEMAP-LLMS-CONVERGENCE-FIX-01",
+    "scope": "Diagnose why published Article ids 40 and 41 are not fully represented in backend sitemap-source, sitemap.xml, and llms-full.txt. Do not submit search URLs.",
+    "search_submission_preflight": "blocked"
+  }
+}

--- a/backend/docs/seo/riasec-explanation-post-publish-smoke-02.md
+++ b/backend/docs/seo/riasec-explanation-post-publish-smoke-02.md
@@ -1,0 +1,56 @@
+# RIASEC V2 Post-Publish Smoke 02
+
+Task: `SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-02`
+
+Decision: `NO_GO_SEARCH_SUBMISSION_SITEMAP_LLMS_NOT_FULLY_CONVERGED`
+
+## Summary
+
+The article runtime itself is healthy after the zh locale contract fix:
+
+- zh article API: 200
+- en article API: 200
+- zh article page: 200
+- en article page: 200
+- Article, BreadcrumbList, and FAQPage JSON-LD are present on both pages
+- FAQ JSON-LD count matches visible API FAQ count on both pages
+- RIASEC CTA routes are public canonical test routes
+- Article CTA tracking path is wired through `article_to_test_click`
+
+Search submission remains blocked because sitemap and llms surfaces are not fully converged.
+
+## Passed
+
+| Gate | zh | en |
+| --- | --- | --- |
+| backend public article API | 200 | 200 |
+| frontend article canonical | 200 | 200 |
+| robots | `index, follow` | `index, follow` |
+| canonical link | present | present |
+| JSON-LD types | Article, BreadcrumbList, FAQPage | Article, BreadcrumbList, FAQPage |
+| FAQ schema vs visible FAQ | 6 / 6 | 6 / 6 |
+| public RIASEC CTA | present | present |
+| CTA attribution params | present | present |
+
+Tracking evidence:
+
+- `app/(localized)/[locale]/articles/[slug]/page.tsx` renders article test CTAs through `SeoTrackedCtaLink`.
+- `components/cta/SeoTrackedCtaLink.tsx` uses `article_to_test_click` for `article_detail`.
+- `components/analytics/TrackedEntryCtaLink.tsx` calls `trackEvent` on click.
+
+## Blocked
+
+| Surface | zh article | en article | Status |
+| --- | --- | --- | --- |
+| backend sitemap-source | absent | absent | blocked |
+| sitemap.xml | absent | absent | blocked |
+| llms.txt | present | present | passed |
+| llms-full.txt | absent | present | blocked |
+
+## Decision
+
+Do not run search submission preflight yet.
+
+Recommended next task: `SEO-ARTICLE-RIASEC-V2-SITEMAP-LLMS-CONVERGENCE-FIX-01`.
+
+That task should diagnose why published Article ids `40` and `41` are not fully represented in backend sitemap-source, sitemap.xml, and llms-full.txt. It should not submit URLs to search platforms.

--- a/backend/tests/Feature/SEO/RiasecExplanationPostPublishSmoke02Test.php
+++ b/backend/tests/Feature/SEO/RiasecExplanationPostPublishSmoke02Test.php
@@ -1,0 +1,118 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use Tests\TestCase;
+
+final class RiasecExplanationPostPublishSmoke02Test extends TestCase
+{
+    public function test_post_publish_smoke_02_records_no_go_for_search_submission(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json');
+
+        $this->assertSame('SEO-ARTICLE-RIASEC-V2-POST-PUBLISH-SMOKE-02', $artifact['task_id']);
+        $this->assertSame('NO_GO_SEARCH_SUBMISSION_SITEMAP_LLMS_NOT_FULLY_CONVERGED', $artifact['decision']);
+        $this->assertFalse($artifact['scope']['cms_mutation_performed']);
+        $this->assertFalse($artifact['scope']['publish_performed']);
+        $this->assertFalse($artifact['scope']['search_submission_performed']);
+        $this->assertFalse($artifact['scope']['deploy_performed']);
+        $this->assertFalse($artifact['scope']['frontend_deploy_performed']);
+        $this->assertFalse($artifact['scope']['article_content_rewrite_performed']);
+        $this->assertFalse($artifact['scope']['private_or_tokenized_url_accessed']);
+    }
+
+    public function test_public_article_routes_and_api_pass_for_both_locales(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json');
+
+        foreach ($artifact['public_route_smoke'] as $smoke) {
+            $this->assertSame(200, $smoke['http_status']);
+            $this->assertSame('passed', $smoke['status']);
+        }
+    }
+
+    public function test_schema_and_visible_faq_match_for_both_articles(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json');
+
+        foreach ($artifact['schema_smoke'] as $schema) {
+            $this->assertSame('passed', $schema['status']);
+            $this->assertContains('Article', $schema['json_ld_types']);
+            $this->assertContains('BreadcrumbList', $schema['json_ld_types']);
+            $this->assertContains('FAQPage', $schema['json_ld_types']);
+            $this->assertSame(6, $schema['faq_jsonld_count']);
+            $this->assertSame($schema['api_visible_faq_count'], $schema['faq_jsonld_count']);
+            $this->assertTrue($schema['faq_schema_matches_visible_faq']);
+            $this->assertSame('index, follow', $schema['robots']);
+            $this->assertTrue($schema['canonical_link_present']);
+        }
+    }
+
+    public function test_cta_and_tracking_contract_pass_for_public_riasec_test_routes(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json');
+
+        foreach ($artifact['cta_tracking_smoke'] as $cta) {
+            $this->assertSame('passed', $cta['status']);
+            $this->assertSame(1, $cta['api_cta_bundle_count']);
+            $this->assertSame(3, $cta['frontend_cta_count']);
+            $this->assertSame(3, $cta['frontend_cta_public_canonical_count']);
+            $this->assertTrue($cta['frontend_cta_tracking_params_present']);
+            $this->assertSame('holland-career-interest-test-riasec', $cta['api_primary_test_edge']['test_slug']);
+            $this->assertSame('public', $cta['api_primary_test_edge']['visibility']);
+            $this->assertStringContainsString('article_to_test_click', $cta['tracking_event_code_path']);
+        }
+    }
+
+    public function test_sitemap_and_llms_are_not_fully_converged(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json');
+        $surfaces = $artifact['sitemap_llms_smoke'];
+
+        $this->assertFalse($surfaces['fully_converged']);
+        $this->assertFalse($surfaces['search_submission_allowed']);
+        $this->assertSame('blocked', $surfaces['backend_sitemap_source']['status']);
+        $this->assertFalse($surfaces['backend_sitemap_source']['contains_zh_article']);
+        $this->assertFalse($surfaces['backend_sitemap_source']['contains_en_article']);
+        $this->assertSame('blocked', $surfaces['sitemap_xml']['status']);
+        $this->assertFalse($surfaces['sitemap_xml']['contains_zh_article']);
+        $this->assertFalse($surfaces['sitemap_xml']['contains_en_article']);
+        $this->assertSame('passed', $surfaces['llms_txt']['status']);
+        $this->assertTrue($surfaces['llms_txt']['contains_zh_article']);
+        $this->assertTrue($surfaces['llms_txt']['contains_en_article']);
+        $this->assertSame('blocked', $surfaces['llms_full_txt']['status']);
+        $this->assertFalse($surfaces['llms_full_txt']['contains_zh_article']);
+        $this->assertTrue($surfaces['llms_full_txt']['contains_en_article']);
+    }
+
+    public function test_hard_boundaries_remain_closed_and_artifact_has_no_forbidden_route_patterns(): void
+    {
+        $artifact = $this->readJson(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json');
+
+        $this->assertTrue($artifact['hard_boundaries']['no_article_body_title_h1_meta_faq_cta_rewrite']);
+        $this->assertTrue($artifact['hard_boundaries']['no_publish']);
+        $this->assertTrue($artifact['hard_boundaries']['no_search_submission']);
+        $this->assertTrue($artifact['hard_boundaries']['no_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['no_frontend_deploy']);
+        $this->assertTrue($artifact['hard_boundaries']['no_private_or_tokenized_url_access']);
+        $this->assertTrue($artifact['hard_boundaries']['cta_public_canonical_only']);
+
+        $contents = file_get_contents(__DIR__.'/../../../docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json') ?: '';
+        $this->assertDoesNotMatchRegularExpression('#(?<![A-Za-z0-9_-])/(?:zh/|en/)?(?:result|results|orders|order|share|pay|payment|history|private)(?:/|\\?)#i', $contents);
+        $this->assertDoesNotMatchRegularExpression('/\\b(?:orderNo|order_id|resultId|attemptId|reportId|payment_id|transaction_id|auth_token|session_id|share_id)\\b/i', $contents);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readJson(string $path): array
+    {
+        $decoded = json_decode(file_get_contents($path) ?: '', true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}


### PR DESCRIPTION
## What changed
- Added a generated JSON artifact for the RIASEC V2 post-publish smoke rerun after the zh locale contract fix.
- Added a short SEO ops report summarizing passed article/schema/CTA/tracking gates and blocked sitemap/llms gates.
- Added a focused PHPUnit contract test for the smoke artifact and hard boundaries.

## Why
The zh canonical article route now returns 200, so the post-publish smoke was rerun before any search submission preflight. Article routes, schema, FAQ consistency, CTA, and tracking attribution pass. Search submission remains blocked because backend sitemap-source, sitemap.xml, and llms-full.txt are not fully converged.

## Validation commands
- `python3 -m json.tool backend/docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json >/dev/null`
- `php -l backend/tests/Feature/SEO/RiasecExplanationPostPublishSmoke02Test.php`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=RiasecExplanationPostPublishSmoke02Test --no-ansi --display-warnings`
- `git diff --check -- backend/docs/seo/generated/riasec-explanation-post-publish-smoke-02.v1.json backend/docs/seo/riasec-explanation-post-publish-smoke-02.md backend/tests/Feature/SEO/RiasecExplanationPostPublishSmoke02Test.php`

## Intentionally deferred
- No CMS mutation.
- No publish.
- No search submission to GSC, Baidu, IndexNow, or any search platform.
- No backend or frontend deploy.
- No article body/title/H1/meta/FAQ/CTA rewrite.
- Next recommended task is a sitemap/llms convergence diagnosis, not search submission.

## Repository rule impact
This PR records a backend/CMS-authoritative post-publish smoke result. It does not introduce a new content surface, local editorial fallback, or frontend sitemap/llms authority.