### PR TITLE
SCIENCE-CONTENTPAGE-REAL-IMPORT-COMMAND-ENABLEMENT-01 feat(cms): enable controlled draft import

### DIFF
--- a/backend/app/Console/Commands/ScienceContentPageImportDraftsCommand.php
+++ b/backend/app/Console/Commands/ScienceContentPageImportDraftsCommand.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ScienceContentPageDraftImportService;
+use Illuminate\Console\Command;
+use Throwable;
+
+final class ScienceContentPageImportDraftsCommand extends Command
+{
+    protected $signature = 'content-pages:science-import-drafts
+        {--package= : Path to the Science ContentPage CMS draft package directory}
+        {--dry-run : Validate and plan without writing to the database}
+        {--execute : Import missing Science ContentPage rows as non-public drafts}
+        {--approval-phrase= : Required exact phrase when --execute is used}
+        {--json : Emit machine-readable JSON only}';
+
+    protected $description = 'Controlled Science ContentPage draft import command; defaults to no-write dry-run.';
+
+    public function handle(ScienceContentPageDraftImportService $service): int
+    {
+        try {
+            $execute = (bool) $this->option('execute');
+            $dryRun = (bool) $this->option('dry-run');
+            if ($execute && $dryRun) {
+                return $this->finish([
+                    'ok' => false,
+                    'command' => ScienceContentPageDraftImportService::COMMAND,
+                    'mode' => 'invalid_options',
+                    'dry_run' => true,
+                    'writes_committed' => false,
+                    'errors' => [[
+                        'field' => 'options',
+                        'code' => 'execute_dry_run_conflict',
+                        'message' => '--execute and --dry-run cannot be combined.',
+                    ]],
+                ]);
+            }
+
+            $package = trim((string) $this->option('package'));
+            if ($package === '') {
+                throw new \RuntimeException('--package is required.');
+            }
+
+            $payload = $execute
+                ? $service->execute($package, (string) $this->option('approval-phrase'))
+                : $service->dryRun($package);
+
+            return $this->finish($payload);
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'ok' => false,
+                'command' => ScienceContentPageDraftImportService::COMMAND,
+                'mode' => 'runtime_error',
+                'dry_run' => true,
+                'writes_committed' => false,
+                'errors' => [[
+                    'field' => 'command',
+                    'code' => 'runtime_error',
+                    'message' => $throwable->getMessage(),
+                ]],
+            ]);
+        }
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return ($payload['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+        }
+
+        $this->line('ok='.(($payload['ok'] ?? false) ? '1' : '0'));
+        $this->line('mode='.(string) ($payload['mode'] ?? 'Unknown'));
+        $this->line('dry_run='.(($payload['dry_run'] ?? true) ? '1' : '0'));
+        $this->line('writes_committed='.(($payload['writes_committed'] ?? false) ? '1' : '0'));
+        $this->line('pages_seen='.(string) ($payload['pages_seen'] ?? 0));
+        $this->line('planned_create_count='.(string) ($payload['planned_create_count'] ?? 0));
+        $this->line('skipped_existing_count='.(string) ($payload['skipped_existing_count'] ?? 0));
+        $this->line('authority_revision_only_count='.(string) ($payload['authority_revision_only_count'] ?? 0));
+        $this->line('blocked_count='.(string) ($payload['blocked_count'] ?? 0));
+        $this->line('created_count='.(string) ($payload['created_count'] ?? 0));
+        $this->line('publish_allowed='.(($payload['publish_allowed'] ?? false) ? '1' : '0'));
+        $this->line('discoverability_allowed='.(($payload['discoverability_allowed'] ?? false) ? '1' : '0'));
+
+        foreach (($payload['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line(sprintf(
+                    'error field=%s code=%s message=%s',
+                    (string) ($error['field'] ?? 'Unknown'),
+                    (string) ($error['code'] ?? 'Unknown'),
+                    (string) ($error['message'] ?? 'Unknown'),
+                ));
+            }
+        }
+
+        return ($payload['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Services/Cms/ScienceContentPageDraftImportService.php
+++ b/backend/app/Services/Cms/ScienceContentPageDraftImportService.php
@@ -1,0 +1,412 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\ContentPage;
+use Illuminate\Support\Facades\DB;
+use Symfony\Component\Yaml\Yaml;
+
+final class ScienceContentPageDraftImportService
+{
+    public const COMMAND = 'content-pages:science-import-drafts';
+
+    public const APPROVAL_PHRASE = 'SCIENCE_CONTENTPAGE_NON_PUBLIC_DRAFT_IMPORT_APPROVED';
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function dryRun(string $packagePath): array
+    {
+        return $this->buildPlan($packagePath, false);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function execute(string $packagePath, string $approvalPhrase): array
+    {
+        if (trim($approvalPhrase) !== self::APPROVAL_PHRASE) {
+            return [
+                'ok' => false,
+                'command' => self::COMMAND,
+                'mode' => 'execute',
+                'dry_run' => false,
+                'writes_committed' => false,
+                'errors' => [[
+                    'field' => 'approval_phrase',
+                    'code' => 'approval_phrase_mismatch',
+                    'message' => '--approval-phrase must equal '.self::APPROVAL_PHRASE.' when --execute is used.',
+                ]],
+            ];
+        }
+
+        $plan = $this->buildPlan($packagePath, true);
+        if (($plan['ok'] ?? false) !== true) {
+            return $plan;
+        }
+
+        $created = DB::transaction(function () use ($plan): array {
+            $createdRows = [];
+
+            foreach ($plan['pages'] as $page) {
+                if (($page['action'] ?? '') !== 'create_missing_non_public_draft') {
+                    continue;
+                }
+
+                $attributes = $page['content_page_attributes'] ?? null;
+                if (! is_array($attributes)) {
+                    continue;
+                }
+
+                $createdRows[] = ContentPage::query()->withoutGlobalScopes()->create($attributes);
+            }
+
+            return $createdRows;
+        });
+
+        return array_merge($plan, [
+            'mode' => 'execute',
+            'dry_run' => false,
+            'writes_committed' => count($created) > 0,
+            'created_count' => count($created),
+            'created_ids' => array_values(array_map(
+                static fn (ContentPage $page): int => (int) $page->getKey(),
+                $created,
+            )),
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function buildPlan(string $packagePath, bool $execute): array
+    {
+        $root = rtrim($packagePath, DIRECTORY_SEPARATOR);
+        $dryRun = app(ScienceContentPageDraftDryRunService::class)->dryRun($root);
+        $operator = app(ScienceContentPageOperatorReviewReadinessService::class)->review($root);
+        $preImportQa = app(ScienceContentPagePreImportQaService::class)->check($root);
+
+        $errors = [];
+        if (($dryRun['status'] ?? '') !== 'pass_no_write_dry_run') {
+            $errors[] = $this->error('dry_run', 'dry_run_not_passed', 'Science draft dry-run must pass before import command execution.');
+        }
+        if (($operator['operator_review_ready_for_non_public_draft'] ?? false) !== true) {
+            $errors[] = $this->error('operator_review', 'operator_review_not_ready', 'Operator review fields must be ready for non-public draft import.');
+        }
+        if (($preImportQa['non_public_draft_import_qa_passed'] ?? false) !== true || (int) ($preImportQa['package_pre_import_qa_issue_count'] ?? 0) !== 0) {
+            $errors[] = $this->error('pre_import_qa', 'pre_import_qa_not_passed', 'Pre-import QA must pass with zero package issues.');
+        }
+
+        $pages = [];
+        foreach (($dryRun['pages'] ?? []) as $page) {
+            if (! is_array($page)) {
+                continue;
+            }
+
+            $pages[] = $this->planPage($root, $page, $execute);
+        }
+
+        $blockedPages = array_values(array_filter(
+            $pages,
+            static fn (array $page): bool => ($page['blocked'] ?? false) === true,
+        ));
+        if ($blockedPages !== []) {
+            $errors[] = $this->error('pages', 'blocked_pages_present', 'One or more page plans are blocked.');
+        }
+
+        $plannedCreates = array_values(array_filter(
+            $pages,
+            static fn (array $page): bool => ($page['action'] ?? '') === 'create_missing_non_public_draft',
+        ));
+        $skippedExisting = array_values(array_filter(
+            $pages,
+            static fn (array $page): bool => ($page['action'] ?? '') === 'skip_existing_content_page',
+        ));
+        $authorityRevisionOnly = array_values(array_filter(
+            $pages,
+            static fn (array $page): bool => ($page['action'] ?? '') === 'skip_existing_authority_revision_only',
+        ));
+
+        return [
+            'ok' => $errors === [],
+            'command' => self::COMMAND,
+            'mode' => $execute ? 'execute_plan' : 'dry_run',
+            'dry_run' => ! $execute,
+            'writes_committed' => false,
+            'approval_phrase_required' => self::APPROVAL_PHRASE,
+            'package_path' => $root,
+            'package_status' => $dryRun['package_status'] ?? 'Unknown',
+            'pre_import_qa_decision' => $preImportQa['decision'] ?? 'Unknown',
+            'non_public_draft_import_qa_passed' => $preImportQa['non_public_draft_import_qa_passed'] ?? false,
+            'publish_allowed' => false,
+            'discoverability_allowed' => false,
+            'pages_seen' => count($pages),
+            'planned_create_count' => count($plannedCreates),
+            'skipped_existing_count' => count($skippedExisting),
+            'authority_revision_only_count' => count($authorityRevisionOnly),
+            'blocked_count' => count($blockedPages),
+            'created_count' => 0,
+            'pages' => $pages,
+            'errors' => $errors,
+            'hard_guards' => [
+                'draft_only' => true,
+                'is_public_false' => true,
+                'is_indexable_false' => true,
+                'publish_allowed_false' => true,
+                'faq_schema_eligible_false' => true,
+                'sitemap_llms_footer_unchanged' => true,
+                'method_boundaries_write_blocked' => true,
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $dryRunPage
+     * @return array<string, mixed>
+     */
+    private function planPage(string $root, array $dryRunPage, bool $execute): array
+    {
+        $normalized = is_array($dryRunPage['normalized_content_page'] ?? null)
+            ? $dryRunPage['normalized_content_page']
+            : [];
+        $slug = (string) ($normalized['slug'] ?? '');
+        $locale = (string) ($normalized['locale'] ?? 'zh-CN');
+        $pageKey = (string) ($dryRunPage['page_key'] ?? 'Unknown');
+
+        if (($dryRunPage['planned_action'] ?? '') === 'preserve_existing_authority_revision_only') {
+            return [
+                'page_key' => $pageKey,
+                'slug' => $slug,
+                'locale' => $locale,
+                'action' => 'skip_existing_authority_revision_only',
+                'blocked' => false,
+                'reason' => 'existing authority route must not be overwritten by this draft import command.',
+            ];
+        }
+
+        $existing = null;
+        $existingLookupStatus = 'available';
+        try {
+            $existing = ContentPage::query()
+                ->withoutGlobalScopes()
+                ->where('org_id', 0)
+                ->where('slug', $slug)
+                ->where('locale', $locale)
+                ->first();
+        } catch (\Throwable $throwable) {
+            if ($execute) {
+                throw $throwable;
+            }
+
+            $existingLookupStatus = 'Unknown';
+        }
+
+        if ($existing instanceof ContentPage) {
+            return [
+                'page_key' => $pageKey,
+                'slug' => $slug,
+                'locale' => $locale,
+                'action' => 'skip_existing_content_page',
+                'blocked' => false,
+                'existing_content_page_id' => (int) $existing->getKey(),
+                'existing_status' => (string) $existing->status,
+                'existing_is_public' => (bool) $existing->is_public,
+                'existing_is_indexable' => (bool) $existing->is_indexable,
+            ];
+        }
+
+        $file = (string) ($dryRunPage['file'] ?? '');
+        $filePath = $root.DIRECTORY_SEPARATOR.str_replace(['/', '\\'], DIRECTORY_SEPARATOR, $file);
+        if ($file === '' || ! is_file($filePath)) {
+            return [
+                'page_key' => $pageKey,
+                'slug' => $slug,
+                'locale' => $locale,
+                'action' => 'blocked_missing_page_file',
+                'blocked' => true,
+            ];
+        }
+
+        [$frontmatter, $body] = $this->readFrontmatter($filePath);
+        $attributes = $this->contentPageAttributes($normalized, $frontmatter, $body, $file);
+
+        return [
+            'page_key' => $pageKey,
+            'slug' => $slug,
+            'locale' => $locale,
+            'action' => 'create_missing_non_public_draft',
+            'blocked' => false,
+            'existing_lookup_status' => $existingLookupStatus,
+            'content_page_attributes' => $attributes,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $normalized
+     * @param  array<string, mixed>  $frontmatter
+     * @return array<string, mixed>
+     */
+    private function contentPageAttributes(array $normalized, array $frontmatter, string $body, string $file): array
+    {
+        $slug = (string) ($normalized['slug'] ?? '');
+        $path = (string) ($normalized['path'] ?? ('/'.$slug));
+        $title = $this->cleanString($frontmatter['zh_title'] ?? $frontmatter['h1'] ?? $slug);
+        $metaDescription = $this->cleanString($frontmatter['meta_description_draft'] ?? '');
+        $content = $this->cleanString($body);
+
+        return [
+            'org_id' => 0,
+            'slug' => $slug,
+            'path' => $path,
+            'canonical_path' => (string) ($normalized['canonical_path'] ?? $path),
+            'kind' => ContentPage::KIND_POLICY,
+            'page_type' => (string) ($normalized['page_type'] ?? 'methodology'),
+            'title' => $title,
+            'summary' => $metaDescription !== '' ? $metaDescription : null,
+            'template' => 'policy',
+            'animation_profile' => 'editorial',
+            'locale' => (string) ($normalized['locale'] ?? 'zh-CN'),
+            'translation_group_id' => 'science-contentpage-'.$slug.'-zh-CN',
+            'source_locale' => 'zh-CN',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_SOURCE,
+            'source_doc' => 'science-contentpage-gpt55-review-draft-2026-06-08/'.$file,
+            'is_public' => false,
+            'is_indexable' => false,
+            'review_state' => (string) ($normalized['review_state'] ?? 'science_review'),
+            'owner' => 'Fermat Institute',
+            'legal_review_required' => (bool) ($normalized['legal_review_required'] ?? true),
+            'science_review_required' => (bool) ($normalized['science_review_required'] ?? true),
+            'headings_json' => $this->headings($content),
+            'content_md' => $content,
+            'content_html' => '',
+            'seo_title' => $this->nullableString($frontmatter['meta_title_draft'] ?? null),
+            'meta_description' => $metaDescription !== '' ? $metaDescription : null,
+            'seo_description' => $metaDescription !== '' ? $metaDescription : null,
+            'faq_items' => $this->visibleFaqItems($content),
+            'schema_enabled' => false,
+            'publish_allowed' => false,
+            'operator_approval_required' => true,
+            'operator_approved_at' => null,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+            'status' => ContentPage::STATUS_DRAFT,
+        ];
+    }
+
+    /**
+     * @return array{0: array<string, mixed>, 1: string}
+     */
+    private function readFrontmatter(string $path): array
+    {
+        $content = (string) file_get_contents($path);
+        if (! preg_match('/\A---\R(?P<yaml>.*?)\R---\R(?P<body>.*)\z/s', $content, $matches)) {
+            throw new \RuntimeException('Page file is missing YAML frontmatter: '.$path);
+        }
+
+        $frontmatter = Yaml::parse((string) $matches['yaml']);
+        if (! is_array($frontmatter)) {
+            throw new \RuntimeException('Page frontmatter must parse to an object: '.$path);
+        }
+
+        return [$frontmatter, (string) $matches['body']];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function headings(string $body): array
+    {
+        preg_match_all('/^#{1,3}\s+(.+)$/m', $body, $matches);
+
+        return array_values(array_map(
+            fn (string $heading): string => $this->cleanString($heading),
+            $matches[1] ?? [],
+        ));
+    }
+
+    /**
+     * @return list<array{question: string, answer: string}>
+     */
+    private function visibleFaqItems(string $body): array
+    {
+        $marker = "\nvisible_faq_items:\n";
+        $position = strpos($body, $marker);
+        if ($position === false) {
+            return [];
+        }
+
+        $faqBody = trim(substr($body, $position + strlen($marker)));
+        $lines = array_values(array_filter(array_map(
+            static fn (string $line): string => trim($line),
+            preg_split('/\R/', $faqBody) ?: [],
+        ), static fn (string $line): bool => $line !== ''));
+
+        $items = [];
+        for ($index = 0; $index < count($lines) - 1; $index++) {
+            $question = $this->cleanString($lines[$index]);
+            if (! str_ends_with($question, '?') && ! str_ends_with($question, '？')) {
+                continue;
+            }
+
+            $items[] = [
+                'question' => $question,
+                'answer' => $this->cleanString($lines[$index + 1]),
+            ];
+            $index++;
+        }
+
+        return $items;
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $string = $this->cleanString($value);
+
+        return $string !== '' ? $string : null;
+    }
+
+    private function cleanString(mixed $value): string
+    {
+        $string = trim((string) $value);
+        if ($string === '') {
+            return '';
+        }
+
+        if (preg_match('//u', $string) === 1) {
+            return $string;
+        }
+
+        if (function_exists('mb_convert_encoding')) {
+            $converted = mb_convert_encoding($string, 'UTF-8', 'UTF-8');
+            if (is_string($converted) && preg_match('//u', $converted) === 1) {
+                return trim($converted);
+            }
+        }
+
+        $cleaned = @iconv('UTF-8', 'UTF-8//IGNORE', $string);
+        if (is_string($cleaned) && preg_match('//u', $cleaned) === 1) {
+            return trim($cleaned);
+        }
+
+        $encoded = json_encode($string, JSON_INVALID_UTF8_SUBSTITUTE | JSON_UNESCAPED_UNICODE);
+        $decoded = is_string($encoded) ? json_decode($encoded, true) : null;
+
+        return is_string($decoded) ? trim($decoded) : '';
+    }
+
+    /**
+     * @return array{field: string, code: string, message: string}
+     */
+    private function error(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/docs/seo/generated/science-contentpage-real-import-command-enablement-01.v1.json
+++ b/backend/docs/seo/generated/science-contentpage-real-import-command-enablement-01.v1.json
@@ -1,0 +1,65 @@
+{
+  "schema_version": "science-contentpage-real-import-command-enablement-01.v1",
+  "task": "SCIENCE-CONTENTPAGE-REAL-IMPORT-COMMAND-ENABLEMENT-01",
+  "mode": "controlled_command_enablement_only",
+  "created_at": "2026-06-08T00:00:00Z",
+  "command": "content-pages:science-import-drafts",
+  "approval_phrase_required": "SCIENCE_CONTENTPAGE_NON_PUBLIC_DRAFT_IMPORT_APPROVED",
+  "default_mode": {
+    "dry_run": true,
+    "writes_committed": false,
+    "requires_package": true
+  },
+  "execute_mode": {
+    "requires_execute_flag": true,
+    "requires_exact_approval_phrase": true,
+    "creates_missing_rows_only": true,
+    "upsert_existing_rows": false,
+    "publish_allowed": false,
+    "discoverability_allowed": false
+  },
+  "scope": {
+    "package": "backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08",
+    "candidate_pages": 6,
+    "create_missing_non_public_draft_candidates": 5,
+    "existing_authority_revision_only": [
+      "/method-boundaries"
+    ],
+    "cms_mutation_in_this_pr": false,
+    "production_import_executed": false
+  },
+  "runtime_guards": [
+    "dry-run is default when --execute is absent",
+    "--execute and --dry-run are mutually exclusive",
+    "--execute requires exact approval phrase",
+    "pre-import QA must pass with zero package issues",
+    "operator review must be ready for non-public draft import",
+    "dry-run can continue no-write with existing-row lookup marked Unknown when the local DB is unavailable",
+    "execute mode still requires a live database connection",
+    "existing ContentPage rows are skipped, not updated",
+    "/method-boundaries is skipped as existing authority revision-only",
+    "created rows are draft, non-public, non-indexable, publish_allowed=false",
+    "faq_schema_eligible remains false",
+    "published_at/operator_approved_at/schema_eligibility_reviewed_at remain null"
+  ],
+  "hard_no_go": [
+    "no production import in this PR",
+    "no publish",
+    "no sitemap",
+    "no llms",
+    "no footer",
+    "no private URL",
+    "no upsert of existing public authority rows",
+    "no DailyGiving amplification"
+  ],
+  "next_task": {
+    "id": "SCIENCE-CONTENTPAGE-CONTROLLED-CMS-DRAFT-IMPORT-01",
+    "requires": [
+      "GitHub checks green for command enablement PR",
+      "operator exact approval phrase",
+      "production no-write command output reviewed",
+      "controlled execution command scoped to non-public drafts"
+    ]
+  },
+  "final_decision": "GO_FOR_CONTROLLED_CMS_DRAFT_IMPORT_AFTER_MERGE_AND_EXACT_APPROVAL"
+}

--- a/backend/docs/seo/science-contentpage-real-import-command-enablement-01.md
+++ b/backend/docs/seo/science-contentpage-real-import-command-enablement-01.md
@@ -1,0 +1,44 @@
+# SCIENCE-CONTENTPAGE-REAL-IMPORT-COMMAND-ENABLEMENT-01
+
+## Decision
+GO for controlled CMS draft import after this PR is merged, GitHub checks are green, and the operator provides the exact approval phrase.
+
+NO-GO for production import, publish, sitemap, llms, footer, search submission, or social distribution inside this PR.
+
+## Command
+`content-pages:science-import-drafts`
+
+Default no-write dry-run:
+
+```bash
+cd backend && php artisan content-pages:science-import-drafts --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08
+```
+
+Controlled execute form for a later task:
+
+```bash
+cd backend && php artisan content-pages:science-import-drafts --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08 --execute --approval-phrase=SCIENCE_CONTENTPAGE_NON_PUBLIC_DRAFT_IMPORT_APPROVED
+```
+
+## Guardrails
+- `--execute` and `--dry-run` cannot be combined.
+- `--execute` requires exact approval phrase: `SCIENCE_CONTENTPAGE_NON_PUBLIC_DRAFT_IMPORT_APPROVED`.
+- Dry-run can continue no-write when local DB lookup is unavailable; existing-row status is then `Unknown`.
+- Execute mode still requires a live database connection.
+- Existing ContentPage rows are skipped, not updated.
+- `/method-boundaries` is skipped as existing authority revision-only.
+- Created rows are draft, non-public, non-indexable, and `publish_allowed=false`.
+- `faq_schema_eligible=false` and `schema_enabled=false`.
+- `published_at`, `operator_approved_at`, and `schema_eligibility_reviewed_at` stay null.
+
+## Expected Plan
+- Create missing non-public draft candidates: 5.
+- Existing authority revision-only: 1.
+- Publish/discoverability: blocked.
+- Private routes: blocked by prior pre-import QA gate.
+
+## Deferred
+- Controlled CMS draft import.
+- Post-import QA.
+- Publish/discoverability gate.
+- Production no-write shell evidence.

--- a/backend/tests/Feature/Console/ScienceContentPageImportDraftsCommandTest.php
+++ b/backend/tests/Feature/Console/ScienceContentPageImportDraftsCommandTest.php
@@ -1,0 +1,161 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\ContentPage;
+use App\Services\Cms\ScienceContentPageDraftImportService;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class ScienceContentPageImportDraftsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const PACKAGE_PATH = 'docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08';
+
+    #[Test]
+    public function default_mode_is_dry_run_and_writes_zero_content_pages(): void
+    {
+        [$exitCode, $payload] = $this->runImport();
+
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('dry_run', $payload['mode']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(6, $payload['pages_seen']);
+        $this->assertSame(5, $payload['planned_create_count']);
+        $this->assertSame(1, $payload['authority_revision_only_count']);
+        $this->assertSame(0, $payload['blocked_count']);
+        $this->assertFalse($payload['publish_allowed']);
+        $this->assertFalse($payload['discoverability_allowed']);
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+    }
+
+    #[Test]
+    public function execute_requires_exact_approval_phrase_and_writes_nothing_on_mismatch(): void
+    {
+        [$exitCode, $payload] = $this->runImport([
+            '--execute' => true,
+            '--approval-phrase' => 'approve',
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('approval_phrase_mismatch', data_get($payload, 'errors.0.code'));
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+    }
+
+    #[Test]
+    public function execute_and_dry_run_options_are_mutually_exclusive(): void
+    {
+        [$exitCode, $payload] = $this->runImport([
+            '--execute' => true,
+            '--dry-run' => true,
+            '--approval-phrase' => ScienceContentPageDraftImportService::APPROVAL_PHRASE,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame('execute_dry_run_conflict', data_get($payload, 'errors.0.code'));
+        $this->assertSame(0, ContentPage::query()->withoutGlobalScopes()->count());
+    }
+
+    #[Test]
+    public function approved_execute_creates_only_missing_non_public_non_indexable_drafts(): void
+    {
+        [$exitCode, $payload] = $this->runImport([
+            '--execute' => true,
+            '--approval-phrase' => ScienceContentPageDraftImportService::APPROVAL_PHRASE,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('execute', $payload['mode']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertTrue($payload['writes_committed']);
+        $this->assertSame(5, $payload['planned_create_count']);
+        $this->assertSame(1, $payload['authority_revision_only_count']);
+        $this->assertSame(5, $payload['created_count']);
+        $this->assertFalse($payload['publish_allowed']);
+        $this->assertFalse($payload['discoverability_allowed']);
+
+        $this->assertSame(5, ContentPage::query()->withoutGlobalScopes()->count());
+        $this->assertDatabaseMissing('content_pages', [
+            'slug' => 'method-boundaries',
+            'locale' => 'zh-CN',
+        ]);
+
+        foreach (['science', 'item-design-notes', 'reliability-validity', 'data-privacy', 'common-misconceptions'] as $slug) {
+            $page = ContentPage::query()
+                ->withoutGlobalScopes()
+                ->where('slug', $slug)
+                ->where('locale', 'zh-CN')
+                ->firstOrFail();
+
+            $this->assertSame(ContentPage::STATUS_DRAFT, $page->status);
+            $this->assertFalse((bool) $page->is_public);
+            $this->assertFalse((bool) $page->is_indexable);
+            $this->assertFalse((bool) $page->publish_allowed);
+            $this->assertTrue((bool) $page->operator_approval_required);
+            $this->assertSame('not_reviewed', $page->claim_gate_status);
+            $this->assertFalse((bool) $page->faq_schema_eligible);
+            $this->assertFalse((bool) $page->schema_enabled);
+            $this->assertNull($page->published_at);
+            $this->assertNull($page->operator_approved_at);
+            $this->assertNull($page->schema_eligibility_reviewed_at);
+            $this->assertSame('policy', $page->kind);
+            $this->assertSame('zh-CN', $page->locale);
+            $this->assertStringStartsWith('/'.trim((string) $page->slug, '/'), (string) $page->path);
+            $this->assertStringContainsString('science-contentpage-gpt55-review-draft-2026-06-08/pages/', (string) $page->source_doc);
+        }
+
+        $science = ContentPage::query()->withoutGlobalScopes()->where('slug', 'science')->firstOrFail();
+        $this->assertGreaterThan(0, count($science->faq_items ?? []));
+        $this->assertStringContainsString('visible_faq_items:', (string) $science->content_md);
+    }
+
+    #[Test]
+    public function repeated_execute_skips_existing_rows_without_duplicates_or_upsert(): void
+    {
+        $this->runImport([
+            '--execute' => true,
+            '--approval-phrase' => ScienceContentPageDraftImportService::APPROVAL_PHRASE,
+        ]);
+
+        [$exitCode, $payload] = $this->runImport([
+            '--execute' => true,
+            '--approval-phrase' => ScienceContentPageDraftImportService::APPROVAL_PHRASE,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['writes_committed']);
+        $this->assertSame(0, $payload['planned_create_count']);
+        $this->assertSame(5, $payload['skipped_existing_count']);
+        $this->assertSame(1, $payload['authority_revision_only_count']);
+        $this->assertSame(0, $payload['created_count']);
+        $this->assertSame(5, ContentPage::query()->withoutGlobalScopes()->count());
+    }
+
+    /**
+     * @return array{0:int, 1:array<string,mixed>}
+     */
+    private function runImport(array $options = []): array
+    {
+        $exitCode = Artisan::call('content-pages:science-import-drafts', array_merge([
+            '--package' => base_path(self::PACKAGE_PATH),
+            '--json' => true,
+        ], $options));
+
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return [$exitCode, $payload];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -3828,9 +3828,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/ScienceContentPageDraftDryRunCommand.php',
+            'backend/app/Console/Commands/ScienceContentPageImportDraftsCommand.php',
             'backend/app/Console/Commands/ScienceContentPageOperatorReviewReadinessCommand.php',
             'backend/app/Console/Commands/ScienceContentPagePreImportQaCommand.php',
             'backend/app/Services/Cms/ScienceContentPageDraftDryRunService.php',
+            'backend/app/Services/Cms/ScienceContentPageDraftImportService.php',
             'backend/app/Services/Cms/ScienceContentPageOperatorReviewReadinessService.php',
             'backend/app/Services/Cms/ScienceContentPagePreImportQaService.php',
         ], true);


### PR DESCRIPTION
## What changed
- Added `content-pages:science-import-drafts`, a controlled Science ContentPage draft import command that defaults to no-write dry-run.
- Added `ScienceContentPageDraftImportService` to reuse existing dry-run/operator/pre-import QA gates, create missing draft rows only, skip existing rows, and preserve `/method-boundaries` as existing authority revision-only.
- Added focused tests for dry-run, approval mismatch, mutually exclusive options, approved test-DB execution, repeated execution idempotency, and draft safety fields.
- Added generated/docs gate records for the command enablement task.

## Why
- This is task 4 in the Science ContentPage line: enable the real import command contract without performing production import or publishing.

## Validation
- `python3 -m json.tool backend/docs/seo/generated/science-contentpage-real-import-command-enablement-01.v1.json >/dev/null`
- `cd backend && vendor/bin/pint --test app/Console/Commands/ScienceContentPageImportDraftsCommand.php app/Services/Cms/ScienceContentPageDraftImportService.php tests/Feature/Console/ScienceContentPageImportDraftsCommandTest.php`
- `cd backend && php artisan test tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/Console/ScienceContentPageOperatorReviewReadinessCommandTest.php tests/Feature/Console/ScienceContentPagePreImportQaCommandTest.php tests/Feature/Console/ScienceContentPageProductionDryRunNowriteTest.php tests/Feature/Console/ScienceContentPageImportDraftsCommandTest.php --no-ansi`
- `cd backend && php artisan content-pages:science-import-drafts --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08`
- `cd backend && php artisan content-pages:science-import-drafts --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08 --execute --approval-phrase=approve` (expected failure, zero writes)
- `cd backend && php artisan list --no-ansi | rg "content-pages:science-import-drafts"`
- `cd backend && php artisan route:list --no-ansi >/dev/null`
- `git diff --check`

Note: PHPUnit exits 0; local warnings are from missing `backend/.env` in this worktree and also appear on existing Science command tests.

## Intentionally deferred
- Controlled CMS draft import against production.
- Post-import QA.
- Publish, sitemap, llms, footer, search submission, or social distribution.

## Repository rule impact
- Backend remains the ContentPage authority. This PR adds a controlled backend command; it does not add frontend content, CMS fallback content, publish state, or discoverability exposure.