### PR TITLE
fix(seo): flush article discoverability caches

### DIFF
--- a/backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php
+++ b/backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php
@@ -29,8 +29,8 @@ final class WarmSitemapSourceCacheCommand extends Command
             $count = (int) ($payload['count'] ?? 0);
             $elapsed = round(microtime(true) - $start, 3);
 
-            Cache::put('seo:sitemap-source:v1:fresh', $payload, 600);
-            Cache::put('seo:sitemap-source:v1:stale', $payload, 86400);
+            Cache::put(SitemapSourceController::CACHE_KEY_FRESH, $payload, SitemapSourceController::FRESH_TTL_SECONDS);
+            Cache::put(SitemapSourceController::CACHE_KEY_STALE, $payload, SitemapSourceController::STALE_TTL_SECONDS);
 
             if ((bool) $this->option('json')) {
                 $this->line((string) json_encode([

--- a/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
+++ b/backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php
@@ -14,15 +14,15 @@ use Illuminate\Support\Facades\Cache;
 
 class SitemapSourceController extends Controller
 {
-    private const CACHE_KEY_FRESH = 'seo:sitemap-source:v1:fresh';
+    public const CACHE_KEY_FRESH = 'seo:sitemap-source:v1:fresh';
 
-    private const CACHE_KEY_STALE = 'seo:sitemap-source:v1:stale';
+    public const CACHE_KEY_STALE = 'seo:sitemap-source:v1:stale';
 
-    private const CACHE_KEY_LOCK = 'seo:sitemap-source:v1:lock';
+    public const CACHE_KEY_LOCK = 'seo:sitemap-source:v1:lock';
 
-    private const FRESH_TTL_SECONDS = 600;
+    public const FRESH_TTL_SECONDS = 600;
 
-    private const STALE_TTL_SECONDS = 86400;
+    public const STALE_TTL_SECONDS = 86400;
 
     private const LOCK_TTL_SECONDS = 120;
 

--- a/backend/app/Services/Cms/ArticlePublishService.php
+++ b/backend/app/Services/Cms/ArticlePublishService.php
@@ -7,12 +7,17 @@ namespace App\Services\Cms;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\Article;
 use App\Models\ArticleTranslationRevision;
+use App\Services\SEO\SeoDiscoverabilityCacheInvalidator;
 use Illuminate\Support\Facades\DB;
 use InvalidArgumentException;
 use RuntimeException;
 
 final class ArticlePublishService
 {
+    public function __construct(
+        private readonly SeoDiscoverabilityCacheInvalidator $seoDiscoverabilityCacheInvalidator,
+    ) {}
+
     public function publishArticle(int $articleId, string $source = 'article_publish_service'): Article
     {
         if ($articleId <= 0) {
@@ -48,6 +53,7 @@ final class ArticlePublishService
         });
 
         ContentReleaseAudit::log('article', $article, $source);
+        $this->seoDiscoverabilityCacheInvalidator->flushArticleDiscoverabilityCaches();
 
         return $article;
     }
@@ -58,7 +64,7 @@ final class ArticlePublishService
             throw new InvalidArgumentException('article_id must be positive.');
         }
 
-        return DB::transaction(function () use ($articleId): Article {
+        $article = DB::transaction(function () use ($articleId): Article {
             $article = Article::query()
                 ->withoutGlobalScopes()
                 ->where('id', $articleId)
@@ -75,6 +81,10 @@ final class ArticlePublishService
 
             return $article->fresh() ?? $article;
         });
+
+        $this->seoDiscoverabilityCacheInvalidator->flushArticleDiscoverabilityCaches();
+
+        return $article;
     }
 
     private function assertPublishable(Article $article): void

--- a/backend/app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php
+++ b/backend/app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SEO;
+
+use App\Http\Controllers\API\V0_5\SEO\SitemapSourceController;
+use Illuminate\Support\Facades\Cache;
+
+final class SeoDiscoverabilityCacheInvalidator
+{
+    /**
+     * @return list<string>
+     */
+    public function flushArticleDiscoverabilityCaches(): array
+    {
+        $keys = [
+            SitemapSourceController::CACHE_KEY_FRESH,
+            SitemapSourceController::CACHE_KEY_STALE,
+            SitemapCache::XML_CACHE_KEY,
+            SitemapCache::ETAG_CACHE_KEY,
+        ];
+
+        foreach ($keys as $key) {
+            Cache::forget($key);
+        }
+
+        return $keys;
+    }
+}

--- a/backend/docs/seo/riasec-v2-sitemap-llms-convergence-diagnosis-fix-2026-06-08.md
+++ b/backend/docs/seo/riasec-v2-sitemap-llms-convergence-diagnosis-fix-2026-06-08.md
@@ -1,0 +1,43 @@
+# RIASEC V2 Sitemap / LLMS Convergence Diagnosis Fix
+
+Date: 2026-06-08
+
+Scope: article ids 40 and 41 discoverability convergence after controlled publish.
+
+## Decision
+
+CONDITIONAL. Backend publish/unpublish now invalidates the backend discoverability caches that can hide newly published articles from sitemap-source and backend XML sitemap generation. Production convergence still requires backend deployment and post-deploy smoke checks.
+
+## Diagnosis
+
+- `Article::publiclyIndexable()` is the backend authority for article sitemap inclusion.
+- Public article APIs can expose article ids 40 and 41 while `/api/v0.5/seo/sitemap-source` still serves a stale cached payload.
+- The backend sitemap-source cache uses separate fresh and stale keys.
+- The backend XML sitemap cache uses separate XML and ETag keys.
+- Before this fix, `ArticlePublishService` updated article publish state but did not flush either backend discoverability cache layer.
+
+## Fix
+
+- Added a shared SEO discoverability cache invalidator.
+- Article publish now flushes sitemap-source fresh/stale caches and backend XML sitemap XML/ETag caches after successful audit logging.
+- Article unpublish now flushes the same cache layers after the database transaction commits.
+- The sitemap-source warm command now reuses the shared controller cache constants instead of duplicate string literals.
+
+## Not Changed
+
+- No article body, title, H1, meta, FAQ, CTA, or CMS content was changed.
+- No CMS draft mutation was performed.
+- No publish action was performed.
+- No search submission was performed.
+- No frontend deploy or revalidation was performed.
+- No private, result, order, share, pay, payment, history, tokenized, or user-specific URLs were accessed.
+
+## Required Follow-Up Validation
+
+After backend deployment of this fix:
+
+1. Warm or request `/api/v0.5/seo/sitemap-source` and verify both RIASEC article canonical URLs are present.
+2. Verify `X-Fermat-Cache` is not serving a pre-fix stale payload.
+3. Verify public `sitemap.xml` convergence through the frontend/public sitemap authority.
+4. Verify `llms.txt` and `llms-full.txt` contain both public canonical article URLs.
+5. Only after all surfaces converge should search submission preflight be considered.

--- a/backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
+++ b/backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
@@ -1,0 +1,125 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SEO;
+
+use App\Http\Controllers\API\V0_5\SEO\SitemapSourceController;
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticlePublishService;
+use App\Services\SEO\SitemapCache;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Illuminate\Support\Facades\Cache;
+use Tests\TestCase;
+
+final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Cache::flush();
+    }
+
+    public function test_article_publish_flushes_sitemap_source_and_backend_xml_sitemap_caches(): void
+    {
+        $article = $this->createArticleWithRevision(ArticleTranslationRevision::STATUS_APPROVED);
+        $this->seedDiscoverabilityCaches();
+
+        app(ArticlePublishService::class)->publishArticle((int) $article->id, 'test_publish');
+
+        $this->assertDiscoverabilityCachesFlushed();
+    }
+
+    public function test_article_unpublish_flushes_sitemap_source_and_backend_xml_sitemap_caches(): void
+    {
+        $article = $this->createArticleWithRevision(ArticleTranslationRevision::STATUS_PUBLISHED, published: true);
+        $this->seedDiscoverabilityCaches();
+
+        app(ArticlePublishService::class)->unpublishArticle((int) $article->id);
+
+        $this->assertDiscoverabilityCachesFlushed();
+    }
+
+    private function seedDiscoverabilityCaches(): void
+    {
+        $payload = [
+            'ok' => true,
+            'source' => 'backend_sitemap_generator',
+            'count' => 0,
+            'items' => [],
+        ];
+
+        Cache::put(SitemapSourceController::CACHE_KEY_FRESH, $payload, SitemapSourceController::FRESH_TTL_SECONDS);
+        Cache::put(SitemapSourceController::CACHE_KEY_STALE, $payload, SitemapSourceController::STALE_TTL_SECONDS);
+        Cache::put(SitemapCache::XML_CACHE_KEY, '<urlset></urlset>', SitemapCache::TTL_SECONDS);
+        Cache::put(SitemapCache::ETAG_CACHE_KEY, '"stale-etag"', SitemapCache::TTL_SECONDS);
+    }
+
+    private function assertDiscoverabilityCachesFlushed(): void
+    {
+        $this->assertNull(Cache::get(SitemapSourceController::CACHE_KEY_FRESH));
+        $this->assertNull(Cache::get(SitemapSourceController::CACHE_KEY_STALE));
+        $this->assertNull(Cache::get(SitemapCache::XML_CACHE_KEY));
+        $this->assertNull(Cache::get(SitemapCache::ETAG_CACHE_KEY));
+    }
+
+    private function createArticleWithRevision(string $revisionStatus, bool $published = false): Article
+    {
+        $category = ArticleCategory::query()->create([
+            'org_id' => 0,
+            'slug' => 'career',
+            'name' => 'Career',
+            'description' => null,
+            'sort_order' => 0,
+            'is_active' => true,
+        ]);
+
+        $publishedAt = Carbon::create(2026, 6, 8, 8, 0, 0, 'UTC');
+        $article = Article::query()->create([
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'author_name' => 'FermatMind',
+            'slug' => 'riasec-cache-invalidation-test',
+            'locale' => 'en',
+            'title' => 'RIASEC cache invalidation test',
+            'excerpt' => 'Cache invalidation test excerpt.',
+            'content_md' => 'Cache invalidation test body.',
+            'status' => $published ? 'published' : 'draft',
+            'is_public' => $published,
+            'is_indexable' => true,
+            'published_at' => $published ? $publishedAt : null,
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'revision_number' => 1,
+            'revision_status' => $revisionStatus,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => 'RIASEC cache invalidation test',
+            'excerpt' => 'Cache invalidation test excerpt.',
+            'content_md' => 'Cache invalidation test body.',
+            'seo_title' => 'RIASEC cache invalidation test',
+            'seo_description' => 'Cache invalidation test description.',
+            'published_at' => $published ? $publishedAt : null,
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => $published ? (int) $revision->id : null,
+        ])->save();
+
+        return $article->fresh(['workingRevision', 'publishedRevision']) ?? $article;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -4460,6 +4460,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php',
             'backend/app/Services/Career/PublicCareerAuthorityResponseCache.php',
+            'backend/app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php',
             'backend/app/Services/SEO/SitemapGenerator.php',
             'backend/app/Services/SEO/SitemapCache.php',
         ], true);


### PR DESCRIPTION
## What changed
- Add `SeoDiscoverabilityCacheInvalidator` to flush backend article discoverability caches.
- Flush sitemap-source fresh/stale caches and backend XML sitemap XML/ETag caches after controlled article publish and unpublish.
- Reuse sitemap-source controller constants in the warm command instead of duplicate cache key literals.
- Add focused regression coverage for publish/unpublish cache invalidation.
- Add a short RIASEC V2 sitemap/llms convergence diagnosis note.

## Why
Article ids 40/41 are published and public article APIs can see them, but production `/api/v0.5/seo/sitemap-source` is still serving a stale pre-publish payload. Before this change, `ArticlePublishService` changed article state without invalidating backend discoverability cache layers, so newly published article URLs could remain absent until TTL expiry or manual cache clearing.

## Validation
- `php -l backend/app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php && php -l backend/app/Services/Cms/ArticlePublishService.php && php -l backend/app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php && php -l backend/app/Console/Commands/WarmSitemapSourceCacheCommand.php && php -l backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php`
- `./vendor/bin/pint app/Services/SEO/SeoDiscoverabilityCacheInvalidator.php app/Services/Cms/ArticlePublishService.php app/Http/Controllers/API/V0_5/SEO/SitemapSourceController.php app/Console/Commands/WarmSitemapSourceCacheCommand.php tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php --dirty`
- `php artisan route:list --path=seo/sitemap-source --no-ansi`
- `php artisan test tests/Feature/SEO/SitemapSourceCacheTest.php tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php --no-ansi`
- `php artisan test tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php --no-ansi`
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-migrate-pretend.sqlite php artisan migrate --pretend --no-ansi`
- `bash scripts/ci_verify_mbti.sh`
- public read-only check: `/api/v0.5/seo/sitemap-source` still serves `X-Fermat-Cache: stale` and production sitemap/llms surfaces are not converged before deploy.

## Intentionally deferred
- No production deploy in this PR.
- No frontend deploy or frontend cache revalidation.
- No CMS content mutation, publish action, or search submission.
- No article body/title/H1/meta/FAQ/CTA changes.
- No private/result/order/share/pay/payment/history/tokenized URL access.
