### PR TITLE
HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01 docs(help): verify Help service fields production postdeploy

### DIFF
--- a/backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json
+++ b/backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json
@@ -1,0 +1,85 @@
+{
+  "schema": "help-cms-service-fields-prod-postdeploy-verify-01.v1",
+  "task": "HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01",
+  "generated_at": "2026-06-08",
+  "decision": "POSTDEPLOY_READY_FOR_POLICY_CMS_SYNC",
+  "scope": "Read-only post-deploy production verification for Help service ContentPage fields readiness before HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01.",
+  "authorization": {
+    "source": "user",
+    "allowed": "Add manifest/state entries and record read-only production readiness evidence for Help service fields before CMS draft policy sync.",
+    "forbidden": [
+      "CMS mutation",
+      "publish",
+      "deploy",
+      "search submission",
+      "private result/order/share/pay/payment/history URL access",
+      "secret/env/cookie/token value reading",
+      "payment/refund action",
+      "payment-provider behavior change",
+      "Operator approval claim"
+    ]
+  },
+  "target": {
+    "repo": "fap-api",
+    "origin_main_sha": "a98788512c1513750931504d4162d528ad19cc54",
+    "production_revision_sha": "a98788512c1513750931504d4162d528ad19cc54",
+    "production_matches_origin_main": true
+  },
+  "production_read_only_evidence": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly",
+    "active_revision_source": "REVISION_FILE",
+    "active_revision_sha": "a98788512c1513750931504d4162d528ad19cc54",
+    "migration_status": {
+      "2026_06_05_150000_add_help_service_fields_to_content_pages": {
+        "status": "Ran",
+        "batch": 45
+      },
+      "2026_06_08_010000_add_publish_safety_fields_to_content_pages": {
+        "status": "Ran",
+        "batch": 46
+      }
+    },
+    "content_pages_importer": {
+      "command_present": true,
+      "service_field_mapping": {
+        "schema_enabled": "present",
+        "support_contact": "present",
+        "policy_version": "present",
+        "reviewer": "present",
+        "faq_items": "present"
+      }
+    },
+    "content_page_model": {
+      "schema_enabled_fillable": "present",
+      "schema_enabled_cast": "present",
+      "schema_enabled_public_mapping": "present"
+    }
+  },
+  "assessment": {
+    "help_service_fields_migration_ready": true,
+    "publish_safety_fields_migration_ready": true,
+    "importer_service_field_mapping_ready": true,
+    "production_runtime_ready_for_policy_cms_sync": true,
+    "cms_sync_allowed_by_this_artifact": false,
+    "publish_allowed_by_this_artifact": false,
+    "notes": [
+      "Production REVISION matches origin/main at a98788512c1513750931504d4162d528ad19cc54.",
+      "Help service fields migration and publish safety migration are both Ran.",
+      "content-pages:import-local-baseline is available in production runtime.",
+      "support_contact, policy_version, reviewer, faq_items, and schema_enabled importer/model mapping is visible in production runtime.",
+      "This artifact only clears runtime readiness evidence; it does not perform or authorize CMS mutation."
+    ]
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed_in_this_pr": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01"
+}

--- a/backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md
+++ b/backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md
@@ -1,0 +1,43 @@
+# HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01
+
+Decision: `POSTDEPLOY_READY_FOR_POLICY_CMS_SYNC`
+
+This is a read-only post-deploy verification for the Help service ContentPage fields lane. It records that production runtime now has the Help service fields, publish safety fields, and importer service-field support needed before `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01`.
+
+It did not mutate CMS rows, publish content, deploy production, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund actions, change payment-provider behavior, or claim Operator approval.
+
+## Result
+
+- `origin/main`: `a98788512c1513750931504d4162d528ad19cc54`
+- Production `REVISION`: `a98788512c1513750931504d4162d528ad19cc54`
+- Production matches `origin/main`: yes
+
+## Production Evidence
+
+| check | status |
+| --- | --- |
+| `2026_06_05_150000_add_help_service_fields_to_content_pages` | `Ran`, batch `45` |
+| `2026_06_08_010000_add_publish_safety_fields_to_content_pages` | `Ran`, batch `46` |
+| `content-pages:import-local-baseline` command | present |
+| importer `support_contact` mapping | present |
+| importer `policy_version` mapping | present |
+| importer `reviewer` mapping | present |
+| importer `faq_items` mapping | present |
+| importer `schema_enabled` mapping | present |
+| `ContentPage` service field fillable/cast/public mapping | present |
+
+## Assessment
+
+Production runtime is ready for the next scoped task, `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01`.
+
+This readiness does not authorize publishing. The next task may only sync the revised v01 Help content package into the existing 12 Help CMS drafts if separately authorized under CMS mutation scope, and must keep those pages `draft / non-public / non-indexable / unpublished`.
+
+## Validation
+
+```bash
+python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json >/dev/null
+python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+git diff --cached --check
+```

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49523,7 +49523,7 @@
     "repo": "fap-api",
     "branch": "codex/help-cms-service-fields-prod-postdeploy-verify-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): verify Help service fields production postdeploy",
     "depends_on": [
@@ -49571,8 +49571,21 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "checks": []
+        "status": "pass",
+        "head_sha": "8a29260158d85e1c7674ba84b66d4904799fed56",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "UNKNOWN",
+        "failure_reason": null
       }
     },
     "failure_reason": null,
@@ -49629,6 +49642,11 @@
         "at": "2026-06-08",
         "status": "pr_opened",
         "note": "Opened PR #1984 for HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1984 head 8a29260158d85e1c7674ba84b66d4904799fed56; PR is ready for merge after final scope revalidation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49523,7 +49523,7 @@
     "repo": "fap-api",
     "branch": "codex/help-cms-service-fields-prod-postdeploy-verify-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): verify Help service fields production postdeploy",
     "depends_on": [
@@ -49576,8 +49576,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "0ddbee354227d0d98a8e51ed3f1907cd8141a364",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1984",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -49624,6 +49624,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "JSON/YAML validation and scoped diff whitespace checks passed. No CMS mutation, publish, deploy, search submission, private URL access, secret read, payment action, or Operator approval claim was performed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1984 for HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49518,5 +49518,113 @@
         "note": "PR #1975 merged on GitHub at 2026-06-08T02:58:31Z with merge commit 0b16e566de2bb6690d618f6622f2e321ab66465b; origin/main contains the merge commit; the remote task branch is absent and the local task branch was deleted."
       }
     ]
+  },
+  "HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-cms-service-fields-prod-postdeploy-verify-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): verify Help service fields production postdeploy",
+    "depends_on": [
+      "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized adding and executing HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01 manifest/state entries to record read-only production revision, Help service migration, publish safety migration, and importer service-field mapping readiness. CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, and Operator approval claim are forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 is merged on origin/main with commit 0b16e566de2bb6690d618f6622f2e321ab66465b."
+      },
+      "production_read_only": {
+        "status": "ready_for_policy_cms_sync",
+        "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly",
+        "active_revision_source": "REVISION_FILE",
+        "active_revision_sha": "a98788512c1513750931504d4162d528ad19cc54",
+        "origin_main_sha": "a98788512c1513750931504d4162d528ad19cc54",
+        "production_matches_origin_main": true,
+        "migration_status": {
+          "2026_06_05_150000_add_help_service_fields_to_content_pages": "Ran batch 45",
+          "2026_06_08_010000_add_publish_safety_fields_to_content_pages": "Ran batch 46"
+        },
+        "runtime_file_presence": {
+          "content_pages_importer_command": "present",
+          "content_page_model": "present"
+        },
+        "importer_mapping_grep": {
+          "support_contact": "present",
+          "policy_version": "present",
+          "reviewer": "present",
+          "faq_items": "present",
+          "schema_enabled": "present"
+        }
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "checks": []
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "POSTDEPLOY_READY_FOR_POLICY_CMS_SYNC",
+      "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json",
+      "operations_report": "backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md",
+      "production_active_revision_sha": "a98788512c1513750931504d4162d528ad19cc54",
+      "origin_main_sha": "a98788512c1513750931504d4162d528ad19cc54",
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+        "status": "ready_for_separate_authorized_execution",
+        "note": "Production runtime is ready for CMS draft policy sync, but this PR does not mutate CMS rows or authorize publishing."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User authorized manifest/state entry and read-only postdeploy verification."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "production_read_only_verified",
+        "note": "Production REVISION matches origin/main a98788512c1513750931504d4162d528ad19cc54; Help service fields and publish safety migrations are Ran; content-pages importer and support_contact/policy_version/reviewer/faq_items/schema_enabled mappings are visible."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "JSON/YAML validation and scoped diff whitespace checks passed. No CMS mutation, publish, deploy, search submission, private URL access, secret read, payment action, or Operator approval claim was performed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22139,6 +22139,46 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CMS-SERVICE-FIELDS-PROD-DEPLOY-AUTHORIZATION-01
 
+  - id: HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01
+    repo: fap-api
+    depends_on:
+      - HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01
+    branch: codex/help-cms-service-fields-prod-postdeploy-verify-01
+    title: "docs(help): verify Help service fields production postdeploy"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Record read-only production evidence that current REVISION, Help service fields migration, publish safety migration, and content-pages:import-local-baseline service-field mapping are ready.
+      - Use this as the precondition evidence for HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01.
+      - Do not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    allowed_paths:
+      - backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json
+      - backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added read-only postdeploy production verification for Help service ContentPage fields readiness.
- Added generated JSON evidence and operations report showing production REVISION, migration status, importer command presence, and service-field mapping readiness.
- Added HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01 to PR train manifest/state.

## Why
HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01 needs a durable production-runtime readiness record before any separately authorized CMS draft sync.

## Validation
```bash
python3 -m json.tool backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json >/dev/null
python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
git diff --check -- backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json backend/docs/operations/help-cms-service-fields-prod-postdeploy-verify-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
git diff --cached --check
```

## Intentionally deferred
- No CMS mutation or Help draft sync.
- No publish.
- No deploy.
- No search submission.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token read.
- No payment/refund action or payment-provider change.
- No Operator approval claim.

## Repository rule impact
Docs/ledger only. Help content remains CMS/backend-authoritative; this PR only records production readiness evidence.