### PR TITLE
HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01 ops(help): sync Help policy fields to CMS drafts

### DIFF
--- a/backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json
@@ -1,0 +1,129 @@
+{
+  "schema": "help-content-draft-policy-cms-sync-01.v1",
+  "task": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01",
+  "generated_at": "2026-06-08",
+  "decision": "CMS_DRAFT_POLICY_SYNC_COMPLETE_PUBLISH_BLOCKED",
+  "scope": "Sync revised v01 Help service policy fields and content fields into the existing 12 Help ContentPage CMS drafts only.",
+  "authorization": {
+    "source": "user",
+    "allowed": "CMS mutation only for the existing 12 Help draft rows and the support_contact, policy_version, reviewer, faq_items, schema_enabled, and revised local package content fields.",
+    "forbidden": [
+      "publish",
+      "deploy",
+      "search submission",
+      "private result/order/share/pay/payment/history URL access",
+      "secret/env/cookie/token value reading",
+      "payment/refund action",
+      "payment-provider behavior change",
+      "Operator approval claim"
+    ]
+  },
+  "source_package": {
+    "path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "sha256": "7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453",
+    "rows": 12,
+    "local_contract_check": {
+      "command": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+      "status": "pass",
+      "assertions": 524
+    },
+    "private_url_boundary_check": {
+      "status": "pass",
+      "notes": "Keyword hits were boundary language telling users not to post full order numbers, payment identifiers, result links, history links, or private URLs publicly. No raw order number, payment id, transaction id, tokenized URL, or private URL value was recorded."
+    }
+  },
+  "production_execution": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode",
+    "runtime_revision_sha": "a98788512c1513750931504d4162d528ad19cc54",
+    "temporary_source_dir": "/tmp/fm-help-policy-cms-sync.IjY3nH",
+    "temporary_source_removed": true,
+    "dry_run": {
+      "command": "php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fm-help-policy-cms-sync.IjY3nH --no-ansi",
+      "exit_code": 0,
+      "files_found": 1,
+      "pages_found": 12,
+      "will_create": 0,
+      "will_update": 12,
+      "will_skip": 0
+    },
+    "import": {
+      "command": "php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fm-help-policy-cms-sync.IjY3nH --no-ansi",
+      "exit_code": 0,
+      "files_found": 1,
+      "pages_found": 12,
+      "will_create": 0,
+      "will_update": 12,
+      "will_skip": 0
+    }
+  },
+  "post_sync_cms_state": {
+    "checked_rows": 12,
+    "draft": 12,
+    "non_public": 12,
+    "non_indexable": 12,
+    "unpublished": 12,
+    "owner_review": 12,
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_items_count_4": 12,
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "locales": [
+      "en",
+      "zh-CN"
+    ]
+  },
+  "public_absence_checks": {
+    "method": "Python urllib GET with public canonical routes only",
+    "status": "pass",
+    "routes_checked": 12,
+    "expected_status": 404,
+    "results": [
+      {"route": "/zh/help/unlock-failure", "status": 404},
+      {"route": "/en/help/unlock-failure", "status": 404},
+      {"route": "/zh/help/payment-refund", "status": 404},
+      {"route": "/en/help/payment-refund", "status": 404},
+      {"route": "/zh/help/result-recovery", "status": 404},
+      {"route": "/en/help/result-recovery", "status": 404},
+      {"route": "/zh/help/privacy-data", "status": 404},
+      {"route": "/en/help/privacy-data", "status": 404},
+      {"route": "/zh/help/use-boundaries", "status": 404},
+      {"route": "/en/help/use-boundaries", "status": 404},
+      {"route": "/zh/help/data-deletion", "status": 404},
+      {"route": "/en/help/data-deletion", "status": 404}
+    ]
+  },
+  "scope_validation": {
+    "cms_mutation_performed": true,
+    "cms_mutation_limited_to_existing_12_help_drafts": true,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01",
+      "status": "ready_for_separate_review_request",
+      "note": "The 12 CMS drafts now contain the revised policy fields. Operator review is still not passed and must be requested separately."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish remains blocked until Operator review passes, publish preflight passes, and exact publish authorization is provided."
+    }
+  ],
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01"
+}

--- a/backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md
@@ -1,0 +1,93 @@
+# HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
+
+Date: 2026-06-08
+
+Decision: `CMS_DRAFT_POLICY_SYNC_COMPLETE_PUBLISH_BLOCKED`
+
+## Scope
+
+This PR synced the revised v01 Help service source package into the existing 12 Help `ContentPage` CMS drafts.
+
+Allowed CMS mutation was limited to the existing 12 Help draft rows and the revised source content plus first-class Help service fields:
+
+- `support_contact`
+- `policy_version`
+- `reviewer`
+- `faq_items`
+- `schema_enabled`
+
+No publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider behavior change, or Operator approval claim was performed.
+
+## Source Evidence
+
+- Source file: `backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json`
+- Source SHA-256: `7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453`
+- Source rows: 12
+- Local contract check: `HelpContentImportPackageTest` passed with 524 assertions.
+
+Keyword checks found Help boundary language that tells users not to post full order numbers, payment identifiers, result links, history links, or private URLs publicly. No raw private ID or private URL value was recorded in this report.
+
+## Production Execution
+
+Runtime revision: `a98788512c1513750931504d4162d528ad19cc54`
+
+Temporary source dir: `/tmp/fm-help-policy-cms-sync.IjY3nH`
+
+Dry-run command:
+
+```text
+php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fm-help-policy-cms-sync.IjY3nH --no-ansi
+```
+
+Dry-run result:
+
+```text
+files_found=1
+pages_found=12
+will_create=0
+will_update=12
+will_skip=0
+```
+
+Import command:
+
+```text
+php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fm-help-policy-cms-sync.IjY3nH --no-ansi
+```
+
+Import result:
+
+```text
+files_found=1
+pages_found=12
+will_create=0
+will_update=12
+will_skip=0
+```
+
+Temporary source dir was removed after import.
+
+## Post-Sync State
+
+Post-sync read-only CMS check returned:
+
+- checked rows: 12
+- draft: 12
+- non-public: 12
+- non-indexable: 12
+- unpublished: 12
+- owner review: 12
+- `support_contact=support@fermatmind.com`: 12
+- `policy_version=help_service_policy.v1`: 12
+- `reviewer=Unknown`: 12
+- `schema_enabled=false`: 12
+- `faq_items` count 4: 12
+
+Public canonical route absence check returned 404 for all 12 zh/en Help routes.
+
+## Remaining Gates
+
+- Operator review is still not passed.
+- Publish remains blocked.
+- Search submission remains blocked.
+- Next recommended task: `HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01`.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49278,7 +49278,7 @@
       "decision": "DEPLOY_AUTHORIZATION_BLOCKED_PRODUCTION_ACTIVE_SHA_UNKNOWN",
       "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-release-01.v1.json",
       "operations_report": "backend/docs/operations/help-cms-service-fields-prod-release-2026-06-08.md",
-    "current_origin_main_sha": "14f92cba66da60acf6c1bc5777058ceb33323319",
+      "current_origin_main_sha": "14f92cba66da60acf6c1bc5777058ceb33323319",
       "next_safe_authorization_prompt": "I authorize Codex to run HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01 using an approved read-only production method that reports only the active release SHA and migration status for the Help service field migrations, without reading secret/env/cookie/token values and without deploy, CMS mutation, publish, search submission, private URL access, payment/refund action, payment-provider change, or Operator approval claim.",
       "next_task_recommendation": "HELP-CMS-SERVICE-FIELDS-PROD-SHA-VERIFY-01"
     },
@@ -49660,7 +49660,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-policy-cms-sync-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync Help policy fields to CMS drafts",
     "depends_on": [
@@ -49740,8 +49740,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "794ba1369955fd6d660db4473d1bef14970dab5d",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1985",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -49797,6 +49797,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "JSON/YAML validation, HelpContentImportPackageTest, and scoped diff whitespace checks passed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1985 for HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49523,7 +49523,7 @@
     "repo": "fap-api",
     "branch": "codex/help-cms-service-fields-prod-postdeploy-verify-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): verify Help service fields production postdeploy",
     "depends_on": [
@@ -49572,7 +49572,7 @@
       },
       "github": {
         "status": "pass",
-        "head_sha": "8a29260158d85e1c7674ba84b66d4904799fed56",
+        "head_sha": "d19a413f2b6a9d351a21f6371853bdf76d68403b",
         "passed_checks": [
           "hygiene",
           "supply-chain",
@@ -49585,15 +49585,16 @@
           "verify-mbti-v2"
         ],
         "merge_state": "UNKNOWN",
-        "failure_reason": null
+        "failure_reason": null,
+        "merge_commit": "8a050d476f84929e8fedeca31030c06e89aae0e4"
       }
     },
     "failure_reason": null,
-    "commit_sha": "0ddbee354227d0d98a8e51ed3f1907cd8141a364",
+    "commit_sha": "8a050d476f84929e8fedeca31030c06e89aae0e4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1984",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-08T05:08:15Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "POSTDEPLOY_READY_FOR_POLICY_CMS_SYNC",
       "generated_artifact": "backend/docs/help/generated/help-cms-service-fields-prod-postdeploy-verify-01.v1.json",
@@ -49647,6 +49648,155 @@
         "at": "2026-06-08",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1984 head 8a29260158d85e1c7674ba84b66d4904799fed56; PR is ready for merge after final scope revalidation."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged_reconciled",
+        "note": "Reconciled during HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01: GitHub shows PR #1984 merged at 2026-06-08T05:08:15Z with merge commit 8a050d476f84929e8fedeca31030c06e89aae0e4; origin/main contains the merge commit and the remote branch is deleted."
+      }
+    ]
+  },
+  "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-policy-cms-sync-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "ops(help): sync Help policy fields to CMS drafts",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01",
+      "HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01 with CMS mutation limited to the existing 12 Help CMS draft rows and support_contact, policy_version, reviewer, faq_items, schema_enabled, and revised local package content fields. Publish, deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, and Operator approval claim are forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01 is merged. HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01 is reconciled as merged with merge commit 8a050d476f84929e8fedeca31030c06e89aae0e4, and production runtime was verified ready for policy CMS sync."
+      },
+      "source_package": {
+        "status": "pass",
+        "path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+        "sha256": "7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453",
+        "rows": 12,
+        "private_boundary": "pass: keyword hits were boundary language advising users not to post private identifiers or URLs publicly; no raw private ID or private URL value was recorded."
+      },
+      "production_cms_sync": {
+        "status": "pass",
+        "connection_method": "ssh_alias_fap-api-prod_batchmode",
+        "runtime_revision_sha": "a98788512c1513750931504d4162d528ad19cc54",
+        "temporary_source_dir": "/tmp/fm-help-policy-cms-sync.IjY3nH",
+        "temporary_source_removed": true,
+        "dry_run": {
+          "files_found": 1,
+          "pages_found": 12,
+          "will_create": 0,
+          "will_update": 12,
+          "will_skip": 0
+        },
+        "import": {
+          "files_found": 1,
+          "pages_found": 12,
+          "will_create": 0,
+          "will_update": 12,
+          "will_skip": 0
+        }
+      },
+      "post_sync_cms_state": {
+        "status": "pass",
+        "checked_rows": 12,
+        "draft": 12,
+        "non_public": 12,
+        "non_indexable": 12,
+        "unpublished": 12,
+        "owner_review": 12,
+        "support_contact": 12,
+        "policy_version": 12,
+        "reviewer_unknown": 12,
+        "schema_disabled": 12,
+        "faq_items_4": 12
+      },
+      "public_absence": {
+        "status": "pass",
+        "routes_checked": 12,
+        "all_404": true
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "checks": []
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "CMS_DRAFT_POLICY_SYNC_COMPLETE_PUBLISH_BLOCKED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md",
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": true,
+      "cms_mutation_limited_to_existing_12_help_drafts": true,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01",
+        "status": "ready_for_separate_review_request",
+        "note": "The revised policy fields are now synced to CMS drafts; Operator review is still not passed."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish remains blocked until Operator review passes, publish preflight passes, and exact publish authorization is provided."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User requested execution of HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01 with prior explicit CMS mutation authorization."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "production_dry_run_passed",
+        "note": "content-pages:import-local-baseline dry-run found 12 pages, will_create=0, will_update=12."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "cms_sync_complete",
+        "note": "Imported with --upsert --status=draft against the scoped 12-row source; post-sync CMS check kept all 12 rows draft, non-public, non-indexable, unpublished, owner_review, and schema_enabled=false."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "JSON/YAML validation, HelpContentImportPackageTest, and scoped diff whitespace checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49660,7 +49660,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-policy-cms-sync-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync Help policy fields to CMS drafts",
     "depends_on": [
@@ -49735,12 +49735,25 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "checks": []
+        "status": "pass",
+        "head_sha": "72eb488f00226832f9063fad154d42f284ec9eb7",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "failure_reason": null
       }
     },
     "failure_reason": null,
-    "commit_sha": "794ba1369955fd6d660db4473d1bef14970dab5d",
+    "commit_sha": "72eb488f00226832f9063fad154d42f284ec9eb7",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1985",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49802,6 +49815,11 @@
         "at": "2026-06-08",
         "status": "pr_opened",
         "note": "Opened PR #1985 for HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1985 head 72eb488f00226832f9063fad154d42f284ec9eb7; merge state CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22146,7 +22146,7 @@ prs:
     branch: codex/help-cms-service-fields-prod-postdeploy-verify-01
     title: "docs(help): verify Help service fields production postdeploy"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     scope:
       - Record read-only production evidence that current REVISION, Help service fields migration, publish safety migration, and content-pages:import-local-baseline service-field mapping are ready.
       - Use this as the precondition evidence for HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01.
@@ -22178,6 +22178,51 @@ prs:
     frontend_fallback_authority: false
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
+
+  - id: HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-POLICY-REVISION-APPLY-01
+      - HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01
+    branch: codex/help-content-draft-policy-cms-sync-01
+    title: "ops(help): sync Help policy fields to CMS drafts"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Sync the revised v01 Help service import package to the existing 12 Help ContentPage CMS drafts.
+      - Use the controlled content-pages:import-local-baseline --upsert --status=draft path.
+      - Limit CMS mutation to the existing 12 Help draft rows and the support_contact, policy_version, reviewer, faq_items, schema_enabled, and revised local package content fields.
+      - Preserve draft, non-public, non-indexable, unpublished, and schema_enabled=false safety gates.
+      - Record dry-run output, import output, post-sync CMS draft state, public absence checks, package/source hash evidence, and sidecar issues.
+      - Reconcile HELP-CMS-SERVICE-FIELDS-PROD-POSTDEPLOY-VERIFY-01 merged state because it is a direct dependency.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json
+      - backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi
+      - git diff --check -- backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    database_mutation: true
+    payment_provider_call: false
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01
 
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Synced the revised v01 Help service source package to the existing 12 production Help ContentPage CMS drafts via `content-pages:import-local-baseline --upsert --status=draft`.
- Added a machine-readable sync artifact and operations report.
- Added the missing PR-train manifest/state entry and reconciled #1984 as merged because it is a direct dependency.

## Why
- Production runtime now has the Help service fields and importer mapping; this sync materializes the revised policy fields into the existing draft-only CMS rows.

## Validation
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi`
- `git diff --check -- backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json backend/docs/operations/help-content-draft-policy-cms-sync-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Production evidence
- Dry-run: `pages_found=12`, `will_create=0`, `will_update=12`.
- Import: `pages_found=12`, `will_create=0`, `will_update=12`.
- Post-sync CMS check: 12/12 draft, non-public, non-indexable, unpublished, owner_review, `schema_enabled=false`, `support_contact=support@fermatmind.com`, `policy_version=help_service_policy.v1`, 4 FAQ items.
- Public canonical route absence check: 12/12 returned 404.

## Intentionally deferred
- No publish.
- No deploy.
- No search submission.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token read.
- No payment/refund action or payment-provider behavior change.
- No Operator approval claim; `HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01` remains next.