### PR TITLE
docs(codex): close HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49660,7 +49660,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-policy-cms-sync-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync Help policy fields to CMS drafts",
     "depends_on": [
@@ -49736,7 +49736,7 @@
       },
       "github": {
         "status": "pass",
-        "head_sha": "72eb488f00226832f9063fad154d42f284ec9eb7",
+        "head_sha": "7439690def326dee9f26bb5f91f231b037b7d021",
         "passed_checks": [
           "hygiene",
           "supply-chain",
@@ -49749,15 +49749,16 @@
           "verify-mbti-v2"
         ],
         "merge_state": "CLEAN",
-        "failure_reason": null
+        "failure_reason": null,
+        "merge_commit": "fedc82fd5c379e0e0c50547bc86b3f96acec89e3"
       }
     },
     "failure_reason": null,
-    "commit_sha": "72eb488f00226832f9063fad154d42f284ec9eb7",
+    "commit_sha": "fedc82fd5c379e0e0c50547bc86b3f96acec89e3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1985",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-08T05:50:04Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "CMS_DRAFT_POLICY_SYNC_COMPLETE_PUBLISH_BLOCKED",
       "generated_artifact": "backend/docs/help/generated/help-content-draft-policy-cms-sync-01.v1.json",
@@ -49820,6 +49821,11 @@
         "at": "2026-06-08",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1985 head 72eb488f00226832f9063fad154d42f284ec9eb7; merge state CLEAN."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged",
+        "note": "PR #1985 merged at 2026-06-08T05:50:04Z with merge commit fedc82fd5c379e0e0c50547bc86b3f96acec89e3; origin/main contains the merge commit, remote task branch is deleted, local task branch was deleted, and local main worktree is synced to origin/main."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22187,7 +22187,7 @@ prs:
     branch: codex/help-content-draft-policy-cms-sync-01
     title: "ops(help): sync Help policy fields to CMS drafts"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     scope:
       - Sync the revised v01 Help service import package to the existing 12 Help ContentPage CMS drafts.
       - Use the controlled content-pages:import-local-baseline --upsert --status=draft path.


### PR DESCRIPTION
## What changed
- Closed the PR-train manifest/state facts for `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01` after #1985 merged.
- Recorded merge commit, merged timestamp, branch cleanup, and local cleanup facts.

## Why
- Branch protection prevents writing final merged facts into `main` after the original PR merge. This ledger-only follow-up keeps the PR train state accurate without adding a new train item.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No publish.
- No deploy.
- No search submission.
- No private URL access.
- No secret/env/cookie/token read.
- No payment/refund action or Operator approval claim.