### PR TITLE
HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 docs(help): request operator review R2

### DIFF
--- a/backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json
@@ -1,0 +1,172 @@
+{
+  "schema": "help-content-draft-operator-review-r2-01.v1",
+  "task": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01",
+  "generated_at": "2026-06-08",
+  "decision": "REVIEW_REQUESTED_OPERATOR_APPROVAL_REQUIRED",
+  "review_status": "review_requested",
+  "review_passed": false,
+  "operator_approval_claimed": false,
+  "publish_allowed": false,
+  "scope": "Read-only second-round Operator review request for the synced 12 Help ContentPage CMS drafts and revised v01 source package.",
+  "authorization": {
+    "source": "user",
+    "allowed": "Read-only generation of the second-round Help CMS draft Operator review request artifact and blocker checks.",
+    "forbidden": [
+      "CMS mutation",
+      "publish",
+      "deploy",
+      "search submission",
+      "private result/order/share/pay/payment/history URL access",
+      "secret/env/cookie/token value reading",
+      "payment/refund action",
+      "payment-provider behavior change",
+      "Operator approval claim"
+    ]
+  },
+  "dependency_evidence": {
+    "HELP_CONTENT_DRAFT_POLICY_CMS_SYNC_01": {
+      "status": "merged",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1985",
+      "merge_commit": "fedc82fd5c379e0e0c50547bc86b3f96acec89e3"
+    }
+  },
+  "source_package": {
+    "path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "sha256": "7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453",
+    "rows": 12,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_items_count_4": 12
+  },
+  "import_package": {
+    "path": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "sha256": "82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65"
+  },
+  "private_boundary_check": {
+    "status": "pass",
+    "method": "JSON string walk for concrete disallowed private URL/path values plus raw ID regex checks; broad Help keyword hits were not treated as blockers unless they formed a concrete private route or raw identifier.",
+    "concrete_private_url_or_route_hits": 0,
+    "raw_order_no_hits": 0,
+    "payment_id_hits": 0,
+    "transaction_id_hits": 0,
+    "tokenized_url_hits": 0
+  },
+  "production_cms_read_only_check": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode",
+    "command_type": "read_only_laravel_tinker_summary_without_body_output",
+    "checked_rows": 12,
+    "draft": 12,
+    "non_public": 12,
+    "non_indexable": 12,
+    "unpublished": 12,
+    "owner_review": 12,
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_items_count_4": 12,
+    "field_hashes_recorded": [
+      "support_contact_sha256",
+      "policy_version_sha256",
+      "reviewer_sha256",
+      "faq_sha256"
+    ],
+    "content_body_output": false
+  },
+  "public_route_checks": {
+    "base": "https://fermatmind.com",
+    "www_to_apex_redirect": "pass: https://www.fermatmind.com returned 308 to public apex canonical routes only.",
+    "help_draft_routes": {
+      "expected_status": 404,
+      "routes_checked": 12,
+      "all_404": true,
+      "results": [
+        {"route": "/zh/help/unlock-failure", "status": 404},
+        {"route": "/en/help/unlock-failure", "status": 404},
+        {"route": "/zh/help/payment-refund", "status": 404},
+        {"route": "/en/help/payment-refund", "status": 404},
+        {"route": "/zh/help/result-recovery", "status": 404},
+        {"route": "/en/help/result-recovery", "status": 404},
+        {"route": "/zh/help/privacy-data", "status": 404},
+        {"route": "/en/help/privacy-data", "status": 404},
+        {"route": "/zh/help/use-boundaries", "status": 404},
+        {"route": "/en/help/use-boundaries", "status": 404},
+        {"route": "/zh/help/data-deletion", "status": 404},
+        {"route": "/en/help/data-deletion", "status": 404}
+      ]
+    },
+    "support_routes": {
+      "expected_status": 200,
+      "routes_checked": 2,
+      "all_200": true,
+      "results": [
+        {"route": "/zh/support", "status": 200},
+        {"route": "/en/support", "status": 200}
+      ]
+    }
+  },
+  "operator_review_request": {
+    "status": "review_requested",
+    "requested_scope": [
+      "Review the 12 Help CMS draft rows in zh-CN and en.",
+      "Confirm policy owner answers were applied correctly.",
+      "Confirm the drafts can remain draft, non-public, non-indexable, unpublished, and schema_enabled=false until publish preflight.",
+      "Approve or reject editorial readiness outside Codex."
+    ],
+    "codex_must_not_claim": [
+      "Operator review passed",
+      "publish approved",
+      "search submission approved"
+    ]
+  },
+  "publish_gates": {
+    "operator_review_required": true,
+    "publish_preflight_required": true,
+    "exact_publish_authorization_required": true,
+    "faq_schema_runtime_gate_required": true,
+    "current_publish_status": "blocked"
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2",
+      "status": "required_external_operator_input",
+      "note": "Operator must review the 12 synced CMS drafts and provide explicit approval or rejection. Codex did not claim approval."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+      "status": "blocked_until_operator_approval",
+      "note": "Publish preflight should not start until Operator review is explicitly approved."
+    },
+    {
+      "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+      "status": "deferred_gate",
+      "note": "The current drafts keep schema_enabled=false; FAQ schema runtime enablement remains a separate gate."
+    }
+  ],
+  "next_task_recommendation": "WAIT_FOR_OPERATOR_REVIEW_DECISION_THEN_HELP_CONTENT_DRAFT_PUBLISH_PREFLIGHT_01"
+}

--- a/backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md
@@ -1,0 +1,71 @@
+# HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01
+
+Date: 2026-06-08
+
+Decision: `REVIEW_REQUESTED_OPERATOR_APPROVAL_REQUIRED`
+
+## Scope
+
+This is a read-only second-round Operator review request for the 12 synced Help `ContentPage` CMS drafts.
+
+No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider behavior change, or Operator approval claim was performed.
+
+## Evidence
+
+- Dependency: `HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01` is merged in PR #1985.
+- Source package: `backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json`
+- Source SHA-256: `7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453`
+- Import package SHA-256: `82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65`
+- Source rows: 12
+- Locales: `en`, `zh-CN`
+- Slugs: `help-data-deletion`, `help-payment-refund`, `help-privacy-data`, `help-result-recovery`, `help-unlock-failure`, `help-use-boundaries`
+
+## Production Draft State
+
+Read-only production CMS summary returned:
+
+- checked rows: 12
+- draft: 12
+- non-public: 12
+- non-indexable: 12
+- unpublished: 12
+- owner review: 12
+- `support_contact=support@fermatmind.com`: 12
+- `policy_version=help_service_policy.v1`: 12
+- `reviewer=Unknown`: 12
+- `schema_enabled=false`: 12
+- `faq_items` count 4: 12
+
+The production check emitted field hashes only and did not output Help body copy.
+
+## Public Route Checks
+
+`https://www.fermatmind.com` redirects to the public apex canonical host. On `https://fermatmind.com`:
+
+- 12 Help draft routes returned 404.
+- `/zh/support` returned 200.
+- `/en/support` returned 200.
+
+## Boundary Checks
+
+Concrete private URL/path checks found 0 hits for private result/order/share/pay/payment/history routes.
+
+Raw identifier checks found 0 hits for:
+
+- raw `orderNo`
+- payment id
+- transaction id
+- tokenized URL parameters
+
+## Review Request
+
+Status: `review_requested`
+
+Codex has not reviewed or approved the content as Operator. The Operator must independently approve or reject the 12 CMS drafts before publish preflight.
+
+## Remaining Gates
+
+- Operator review approval is required.
+- Publish preflight is required after Operator approval.
+- Exact publish authorization is required before any publish action.
+- FAQ schema runtime enablement remains a separate gate; current drafts keep `schema_enabled=false`.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49833,7 +49833,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-review-r2-01",
     "base": "origin/main",
-    "status": "in_progress",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): request Help draft operator review R2",
     "depends_on": [
@@ -49906,15 +49906,15 @@
       },
       "github": {
         "status": "pending",
-        "head_sha": null,
+        "head_sha": "dbc59c73a6c3a5f875c5465db63768a1bc43affa",
         "passed_checks": [],
         "failure_reason": null,
         "merge_commit": null
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "dbc59c73a6c3a5f875c5465db63768a1bc43affa",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1987",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -49968,6 +49968,11 @@
         "at": "2026-06-08",
         "status": "review_requested",
         "note": "Generated second-round Operator review request artifact from synced 12 Help CMS drafts and revised v01 source package evidence. No Operator approval was claimed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1987 for HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49833,7 +49833,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-review-r2-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): request Help draft operator review R2",
     "depends_on": [
@@ -49905,15 +49905,25 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "head_sha": "dbc59c73a6c3a5f875c5465db63768a1bc43affa",
-        "passed_checks": [],
+        "status": "pass",
+        "head_sha": "9626cf69d157c4ab1ef3fb1b0af2bc59de43ec15",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
         "failure_reason": null,
         "merge_commit": null
       }
     },
     "failure_reason": null,
-    "commit_sha": "dbc59c73a6c3a5f875c5465db63768a1bc43affa",
+    "commit_sha": "9626cf69d157c4ab1ef3fb1b0af2bc59de43ec15",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1987",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -49973,6 +49983,11 @@
         "at": "2026-06-08",
         "status": "pr_opened",
         "note": "Opened PR #1987 for HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1987 head 9626cf69d157c4ab1ef3fb1b0af2bc59de43ec15; merge state CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49828,5 +49828,147 @@
         "note": "PR #1985 merged at 2026-06-08T05:50:04Z with merge commit fedc82fd5c379e0e0c50547bc86b3f96acec89e3; origin/main contains the merge commit, remote task branch is deleted, local task branch was deleted, and local main worktree is synced to origin/main."
       }
     ]
+  },
+  "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-operator-review-r2-01",
+    "base": "origin/main",
+    "status": "in_progress",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): request Help draft operator review R2",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized adding and executing HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 as a read-only Operator review request artifact. CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, and Operator approval claim are forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01 is merged in PR #1985 with merge commit fedc82fd5c379e0e0c50547bc86b3f96acec89e3."
+      },
+      "source_package": {
+        "status": "pass",
+        "path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+        "sha256": "7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453",
+        "rows": 12,
+        "support_contact": 12,
+        "policy_version": 12,
+        "reviewer_unknown": 12,
+        "schema_disabled": 12,
+        "faq_items_4": 12
+      },
+      "import_package": {
+        "status": "pass",
+        "path": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+        "sha256": "82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65"
+      },
+      "private_boundary": {
+        "status": "pass",
+        "concrete_private_url_or_route_hits": 0,
+        "raw_order_no_hits": 0,
+        "payment_id_hits": 0,
+        "transaction_id_hits": 0,
+        "tokenized_url_hits": 0
+      },
+      "production_cms_read_only": {
+        "status": "pass",
+        "checked_rows": 12,
+        "draft": 12,
+        "non_public": 12,
+        "non_indexable": 12,
+        "unpublished": 12,
+        "owner_review": 12,
+        "support_contact": 12,
+        "policy_version": 12,
+        "reviewer_unknown": 12,
+        "schema_disabled": 12,
+        "faq_items_4": 12
+      },
+      "public_routes": {
+        "status": "pass",
+        "help_draft_routes_checked": 12,
+        "help_draft_routes_all_404": true,
+        "support_routes_checked": 2,
+        "support_routes_all_200": true,
+        "www_to_apex_redirect": true
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "REVIEW_REQUESTED_OPERATOR_APPROVAL_REQUIRED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md",
+      "review_status": "review_requested",
+      "review_passed": false,
+      "operator_approval_claimed": false,
+      "publish_allowed": false,
+      "next_task_recommendation": "WAIT_FOR_OPERATOR_REVIEW_DECISION_THEN_HELP_CONTENT_DRAFT_PUBLISH_PREFLIGHT_01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2",
+        "status": "required_external_operator_input",
+        "note": "Operator must independently approve or reject the 12 synced CMS drafts. Codex did not claim approval."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+        "status": "blocked_until_operator_approval",
+        "note": "Publish preflight must wait for explicit Operator approval."
+      },
+      {
+        "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+        "status": "deferred_gate",
+        "note": "Current drafts keep schema_enabled=false; FAQ schema runtime enablement remains a separate gate."
+      }
+    ],
+    "next_task": "WAIT_FOR_OPERATOR_REVIEW_DECISION_THEN_HELP_CONTENT_DRAFT_PUBLISH_PREFLIGHT_01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User authorized adding and executing HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 with read-only scope."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "review_requested",
+        "note": "Generated second-round Operator review request artifact from synced 12 Help CMS drafts and revised v01 source package evidence. No Operator approval was claimed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22224,6 +22224,46 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01
 
+  - id: HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-POLICY-CMS-SYNC-01
+    branch: codex/help-content-draft-operator-review-r2-01
+    title: "docs(help): request Help draft operator review R2"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Generate the second-round Operator review request artifact for the synced 12 Help ContentPage CMS drafts and revised v01 source package.
+      - Check draft-only, public absence, support contact, policy version, FAQ structure, schema disabled, and private URL/private ID boundaries.
+      - Record review_requested status only; do not claim Operator approval, publish readiness, or review passed.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json
+      - backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added the HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 PR-train manifest/state entry.
- Added a read-only R2 Operator review request artifact for the synced 12 Help CMS drafts.
- Added an operations summary with package hashes, draft-state counts, public route checks, and remaining gates.

## Why
Window 9 Help service content is synced to CMS drafts, but Operator editorial approval is still external and must not be claimed by Codex. This PR records the review_requested handoff without publishing or mutating CMS.

## Validation
- python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json backend/docs/operations/help-content-draft-operator-review-r2-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No Operator approval claimed.
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or payment-provider change.
- Publish preflight remains blocked until explicit Operator approval.