### PR TITLE
docs(codex): close Help operator review R2

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31850,7 +31850,7 @@
   "RESULT-EN-PARITY-06": {
     "repo": "fap-api",
     "branch": "codex/result-en-parity-06-bigfive-v2-en-assets",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [
       "RESULT-EN-PARITY-05"
     ],
@@ -49906,7 +49906,7 @@
       },
       "github": {
         "status": "pass",
-        "head_sha": "9626cf69d157c4ab1ef3fb1b0af2bc59de43ec15",
+        "head_sha": "b3ec328a880fecd1b63df60f73e4ffb3f1aae519",
         "passed_checks": [
           "hygiene",
           "supply-chain",
@@ -49919,15 +49919,15 @@
           "verify-mbti-v2"
         ],
         "failure_reason": null,
-        "merge_commit": null
+        "merge_commit": "61cb3b9ae539f0379801d0bf41406472eb81e3dd"
       }
     },
     "failure_reason": null,
-    "commit_sha": "9626cf69d157c4ab1ef3fb1b0af2bc59de43ec15",
+    "commit_sha": "61cb3b9ae539f0379801d0bf41406472eb81e3dd",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1987",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-08T06:21:27Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "REVIEW_REQUESTED_OPERATOR_APPROVAL_REQUIRED",
       "generated_artifact": "backend/docs/help/generated/help-content-draft-operator-review-r2-01.v1.json",
@@ -49988,6 +49988,11 @@
         "at": "2026-06-08",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1987 head 9626cf69d157c4ab1ef3fb1b0af2bc59de43ec15; merge state CLEAN."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged",
+        "note": "PR #1987 merged at 2026-06-08T06:21:27Z with merge commit 61cb3b9ae539f0379801d0bf41406472eb81e3dd; origin/main contains the merge commit, remote task branch is deleted, local task branch was deleted, and this worktree was left clean on a detached origin/main-derived closeout branch because local main is owned by another worktree."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22231,7 +22231,7 @@ prs:
     branch: codex/help-content-draft-operator-review-r2-01
     title: "docs(help): request Help draft operator review R2"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     scope:
       - Generate the second-round Operator review request artifact for the synced 12 Help ContentPage CMS drafts and revised v01 source package.
       - Check draft-only, public absence, support contact, policy version, FAQ structure, schema disabled, and private URL/private ID boundaries.


### PR DESCRIPTION
## What changed
- Marked HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 as merged in the PR-train manifest/state.
- Recorded PR #1987 merge commit, merged_at, remote branch deletion, and local task branch cleanup facts.

## Why
PR #1987 was squash-merged after required checks passed, but branch protection requires a follow-up ledger-only PR to persist final merge/cleanup state. No new PR-train id is introduced.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider change, or Operator approval claim.