### PR TITLE
docs(codex): correct Help operator review R2 status

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49833,7 +49833,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-review-r2-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): request Help draft operator review R2",
     "depends_on": [


### PR DESCRIPTION
## What changed
- Corrected the top-level state for HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 from ready_to_merge to merged.

## Why
The closeout PR recorded merge facts, branch deletion, and cleanup, but the top-level state field stayed stale. This PR is a one-field ledger correction with no new PR-train id.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- git diff --check -- docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider change, or Operator approval claim.