### PR TITLE
HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01 docs(help): record operator approval R2

### DIFF
--- a/backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json
@@ -1,0 +1,68 @@
+{
+  "schema": "help-content-draft-operator-approval-r2-01.v1",
+  "task": "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01",
+  "generated_at": "2026-06-08",
+  "decision": "OPERATOR_APPROVED_PUBLISH_PREFLIGHT_ALLOWED_NOT_PUBLISH",
+  "operator_review_status": "approved",
+  "operator_approval_recorded": true,
+  "publish_preflight_allowed": true,
+  "publish_allowed": false,
+  "scope": "Read-only record of the external Operator approval decision for the second-round Help CMS draft review.",
+  "approval_source": {
+    "source": "user_message",
+    "message": "approve",
+    "recorded_by": "Codex",
+    "interpretation": "Operator approval for the 12 Help CMS draft rows reviewed by HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01.",
+    "not_interpreted_as": [
+      "publish authorization",
+      "CMS mutation authorization",
+      "deploy authorization",
+      "search submission authorization",
+      "payment/refund authorization"
+    ]
+  },
+  "dependency_evidence": {
+    "HELP_CONTENT_DRAFT_OPERATOR_REVIEW_R2_01": {
+      "status": "merged",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/1987",
+      "merge_commit": "61cb3b9ae539f0379801d0bf41406472eb81e3dd",
+      "review_status_before_approval": "review_requested",
+      "operator_approval_claimed_by_codex": false,
+      "publish_allowed_before_approval": false
+    }
+  },
+  "approved_review_scope": {
+    "draft_rows": 12,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "source_package_sha256": "7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453",
+    "import_package_sha256": "82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65"
+  },
+  "remaining_gates": {
+    "publish_preflight_required": true,
+    "exact_publish_authorization_required": true,
+    "faq_schema_runtime_gate_required": true,
+    "current_publish_status": "blocked_until_publish_preflight_and_exact_publish_authorization"
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false
+  },
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01"
+}

--- a/backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md
@@ -1,0 +1,42 @@
+# HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01
+
+Date: 2026-06-08
+
+Decision: `OPERATOR_APPROVED_PUBLISH_PREFLIGHT_ALLOWED_NOT_PUBLISH`
+
+## Scope
+
+This PR records the external Operator approval decision for the second-round Help CMS draft review.
+
+The recorded approval applies to the 12 Help CMS draft rows covered by `HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01`.
+
+It does not authorize publish, CMS mutation, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or payment-provider behavior changes.
+
+## Approval Source
+
+Approval source: user message `approve`.
+
+Interpretation: Operator approval for the R2 Help CMS draft review.
+
+Not interpreted as:
+
+- publish authorization
+- CMS mutation authorization
+- deploy authorization
+- search submission authorization
+- payment/refund authorization
+
+## Approved Review Scope
+
+- Draft rows: 12
+- Locales: `en`, `zh-CN`
+- Slugs: `help-data-deletion`, `help-payment-refund`, `help-privacy-data`, `help-result-recovery`, `help-unlock-failure`, `help-use-boundaries`
+- Source package SHA-256: `7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453`
+- Import package SHA-256: `82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65`
+
+## Remaining Gates
+
+- Publish preflight is required.
+- Exact publish authorization is required before any publish action.
+- FAQ schema runtime gate remains separate.
+- Current publish status remains blocked until publish preflight passes and exact publish authorization is provided.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50000,7 +50000,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-approval-r2-01",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help draft operator approval R2",
     "depends_on": [
@@ -50033,15 +50033,25 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "head_sha": "cca77dbc981f236553efea582af7d221ea01cdf7",
-        "passed_checks": [],
+        "status": "pass",
+        "head_sha": "28017c7be849cab616c5adc16a1df456836aac2b",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
         "failure_reason": null,
         "merge_commit": null
       }
     },
     "failure_reason": null,
-    "commit_sha": "cca77dbc981f236553efea582af7d221ea01cdf7",
+    "commit_sha": "28017c7be849cab616c5adc16a1df456836aac2b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1990",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -50095,6 +50105,11 @@
         "at": "2026-06-08",
         "status": "pr_opened",
         "note": "Opened PR #1990 for HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1990 head 28017c7be849cab616c5adc16a1df456836aac2b; merge state CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50000,7 +50000,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-approval-r2-01",
     "base": "origin/main",
-    "status": "in_progress",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help draft operator approval R2",
     "depends_on": [
@@ -50034,15 +50034,15 @@
       },
       "github": {
         "status": "pending",
-        "head_sha": null,
+        "head_sha": "cca77dbc981f236553efea582af7d221ea01cdf7",
         "passed_checks": [],
         "failure_reason": null,
         "merge_commit": null
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "cca77dbc981f236553efea582af7d221ea01cdf7",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1990",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -50090,6 +50090,11 @@
         "at": "2026-06-08",
         "status": "approval_recorded",
         "note": "Generated read-only approval record artifact. Publish remains blocked until publish preflight passes and exact publish authorization is provided."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1990 for HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -49995,5 +49995,102 @@
         "note": "PR #1987 merged at 2026-06-08T06:21:27Z with merge commit 61cb3b9ae539f0379801d0bf41406472eb81e3dd; origin/main contains the merge commit, remote task branch is deleted, local task branch was deleted, and this worktree was left clean on a detached origin/main-derived closeout branch because local main is owned by another worktree."
       }
     ]
+  },
+  "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-operator-approval-r2-01",
+    "base": "origin/main",
+    "status": "in_progress",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): record Help draft operator approval R2",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User replied approve after HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01. This is recorded as external Operator approval for the 12 Help CMS draft rows, not publish authorization."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01 is merged in PR #1987 with merge commit 61cb3b9ae539f0379801d0bf41406472eb81e3dd."
+      },
+      "approval_record": {
+        "status": "pass",
+        "operator_review_status": "approved",
+        "operator_approval_recorded": true,
+        "publish_preflight_allowed": true,
+        "publish_allowed": false
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "OPERATOR_APPROVED_PUBLISH_PREFLIGHT_ALLOWED_NOT_PUBLISH",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md",
+      "operator_review_status": "approved",
+      "operator_approval_recorded": true,
+      "publish_preflight_allowed": true,
+      "publish_allowed": false,
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+        "status": "ready_for_separate_read_only_preflight",
+        "note": "Operator approval is now recorded. Publish preflight may run separately, but publish still requires exact publish authorization."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-AUTHORIZATION",
+        "status": "not_provided",
+        "note": "The user approval was not interpreted as publish authorization."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User replied approve, interpreted narrowly as external Operator approval for the R2 Help CMS draft review."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "approval_recorded",
+        "note": "Generated read-only approval record artifact. Publish remains blocked until publish preflight passes and exact publish authorization is provided."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22264,6 +22264,46 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01
 
+  - id: HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-OPERATOR-REVIEW-R2-01
+    branch: codex/help-content-draft-operator-approval-r2-01
+    title: "docs(help): record Help draft operator approval R2"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Record the external Operator approval decision for the second-round Help CMS draft review.
+      - Preserve that approval enables publish preflight only and is not publish authorization.
+      - Do not mutate CMS rows, publish, deploy, submit search URLs, access private URLs, read secrets, or claim any action beyond the user-provided approval decision.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json
+      - backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or treat approval as publish authorization.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01 to the PR train manifest/state.
- Recorded the user-provided Operator approval for the R2 Help CMS draft review.
- Added a generated approval artifact and operations summary.

## Why
The previous R2 task only requested Operator review. The user has now replied `approve`, so this PR records that approval as the external decision needed before publish preflight.

## Validation
- python3 -m json.tool backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json backend/docs/operations/help-content-draft-operator-approval-r2-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- This is not publish authorization.
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or payment-provider change.
- Next task is read-only publish preflight.