### PR TITLE
docs(codex): close Help operator approval R2

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -31994,7 +31994,7 @@
   "FERMAT-MARKETING-SKILLS-ADAPTATION-01": {
     "repo": "fap-api",
     "branch": "codex/fermat-marketing-skills-adaptation-01",
-    "status": "ready_to_merge",
+    "status": "merged",
     "depends_on": [
       "MARKETINGSKILLS-FERMATMIND-FIT-SCAN-00"
     ],
@@ -50000,7 +50000,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-operator-approval-r2-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): record Help draft operator approval R2",
     "depends_on": [
@@ -50047,15 +50047,15 @@
           "verify-mbti-v2"
         ],
         "failure_reason": null,
-        "merge_commit": null
+        "merge_commit": "9ba4edbe11382aeb29f1a9a53393137b5e7a2ae5"
       }
     },
     "failure_reason": null,
-    "commit_sha": "28017c7be849cab616c5adc16a1df456836aac2b",
+    "commit_sha": "9ba4edbe11382aeb29f1a9a53393137b5e7a2ae5",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1990",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-08T07:19:51Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "OPERATOR_APPROVED_PUBLISH_PREFLIGHT_ALLOWED_NOT_PUBLISH",
       "generated_artifact": "backend/docs/help/generated/help-content-draft-operator-approval-r2-01.v1.json",
@@ -50110,6 +50110,11 @@
         "at": "2026-06-08",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1990 head 28017c7be849cab616c5adc16a1df456836aac2b; merge state CLEAN."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged",
+        "note": "PR #1990 merged at 2026-06-08T07:19:51Z with merge commit 9ba4edbe11382aeb29f1a9a53393137b5e7a2ae5; origin/main contains the merge commit, remote task branch is deleted, local task branch was deleted, and this worktree was left clean on a detached origin/main-derived closeout branch because local main is owned by another worktree."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22271,7 +22271,7 @@ prs:
     branch: codex/help-content-draft-operator-approval-r2-01
     title: "docs(help): record Help draft operator approval R2"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     scope:
       - Record the external Operator approval decision for the second-round Help CMS draft review.
       - Preserve that approval enables publish preflight only and is not publish authorization.


### PR DESCRIPTION
## What changed
- Marked HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01 as merged in manifest/state.
- Recorded PR #1990 merge commit, merged_at, remote branch deletion, and local cleanup facts.

## Why
PR #1990 was squash-merged after required checks passed. Branch protection requires a ledger-only follow-up PR to persist final merge/cleanup state. No new PR-train id is introduced.

## Validation
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, or payment-provider change.