### PR TITLE
HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01 docs(help): run Help draft publish preflight

### DIFF
--- a/backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json
@@ -1,0 +1,295 @@
+{
+  "schema_version": "help-content-draft-publish-preflight-01.v1",
+  "generated_at": "2026-06-08T07:49:40Z",
+  "task": {
+    "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01",
+    "repo": "fap-api",
+    "scope": "read_only_publish_preflight_for_12_help_content_page_drafts",
+    "status": "blocked"
+  },
+  "authorization": {
+    "user_authorized_manifest_state_entry": true,
+    "user_authorized_read_only_publish_preflight": true,
+    "cms_mutation_allowed": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "search_submission_allowed": false,
+    "private_url_access_allowed": false,
+    "secret_env_cookie_token_read_allowed": false,
+    "payment_or_refund_allowed": false,
+    "payment_provider_change_allowed": false
+  },
+  "dependency_evidence": {
+    "operator_approval_task": "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01",
+    "operator_approval_status": "approved",
+    "operator_approval_pr": "https://github.com/fermatmind/fap-api/pull/1990",
+    "operator_approval_merge_commit": "9ba4edbe11382aeb29f1a9a53393137b5e7a2ae5",
+    "operator_approval_closeout_commit": "6d0b250bb56e0876f8d806652b547a2d971a7f01",
+    "publish_preflight_allowed": true,
+    "publish_authorization_provided": false
+  },
+  "source_package": {
+    "import_package": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "import_package_sha256": "82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65",
+    "draft_source": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "draft_source_sha256": "7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453",
+    "source_count": 12,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "support_contact": "support@fermatmind.com",
+    "policy_version": "help_service_policy.v1",
+    "schema_enabled": false,
+    "robots": "noindex,nofollow"
+  },
+  "production_cms_read_only_check": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly_laravel_tinker_summary_without_body_output",
+    "content_body_output": false,
+    "checked_rows": 12,
+    "draft": 12,
+    "non_public": 12,
+    "non_indexable": 12,
+    "unpublished": 12,
+    "owner_review": 12,
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_schema_eligible_false": 12,
+    "publish_allowed_false": 12,
+    "operator_approval_required_true": 12,
+    "operator_approved_at_null": 12,
+    "faq_items_count_4": 12,
+    "locales": [
+      "en",
+      "zh-CN"
+    ],
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "paths": [
+      "/help/data-deletion",
+      "/help/payment-refund",
+      "/help/privacy-data",
+      "/help/result-recovery",
+      "/help/unlock-failure",
+      "/help/use-boundaries"
+    ],
+    "canonical_paths": [
+      "/help/data-deletion",
+      "/help/payment-refund",
+      "/help/privacy-data",
+      "/help/result-recovery",
+      "/help/unlock-failure",
+      "/help/use-boundaries"
+    ]
+  },
+  "private_boundary_check": {
+    "status": "blocked",
+    "method": "Server-side text scan over title, summary, markdown/html body, SEO fields, and canonical path; output limited to counts and slug/locale hits, no body text.",
+    "production_hits": {
+      "private_result_route": 0,
+      "private_order_route": 0,
+      "payment_id": 3,
+      "transaction_id": 0,
+      "tokenized_url": 0,
+      "raw_order_no": 0
+    },
+    "production_hit_rows": [
+      {
+        "slug": "help-data-deletion",
+        "locale": "en",
+        "payment_id_phrase_hit": true
+      },
+      {
+        "slug": "help-payment-refund",
+        "locale": "en",
+        "payment_id_phrase_hit": true
+      },
+      {
+        "slug": "help-unlock-failure",
+        "locale": "en",
+        "payment_id_phrase_hit": true
+      }
+    ],
+    "local_package_hits": [
+      {
+        "slug": "help-unlock-failure",
+        "locale": "en",
+        "hits": [
+          "payment_id"
+        ]
+      },
+      {
+        "slug": "help-payment-refund",
+        "locale": "en",
+        "hits": [
+          "payment_id"
+        ]
+      },
+      {
+        "slug": "help-data-deletion",
+        "locale": "en",
+        "hits": [
+          "payment_id"
+        ]
+      }
+    ]
+  },
+  "public_route_checks": {
+    "base": "https://fermatmind.com",
+    "help_draft_routes_expected_404": {
+      "routes_checked": 12,
+      "all_404": true,
+      "results": [
+        { "route": "/zh/help/unlock-failure", "status": 404 },
+        { "route": "/en/help/unlock-failure", "status": 404 },
+        { "route": "/zh/help/payment-refund", "status": 404 },
+        { "route": "/en/help/payment-refund", "status": 404 },
+        { "route": "/zh/help/result-recovery", "status": 404 },
+        { "route": "/en/help/result-recovery", "status": 404 },
+        { "route": "/zh/help/privacy-data", "status": 404 },
+        { "route": "/en/help/privacy-data", "status": 404 },
+        { "route": "/zh/help/use-boundaries", "status": 404 },
+        { "route": "/en/help/use-boundaries", "status": 404 },
+        { "route": "/zh/help/data-deletion", "status": 404 },
+        { "route": "/en/help/data-deletion", "status": 404 }
+      ]
+    },
+    "support_policy_routes": {
+      "results": [
+        { "route": "/zh/support", "status": 200 },
+        { "route": "/en/support", "status": 200 },
+        { "route": "/zh/privacy", "status": 200 },
+        { "route": "/en/privacy", "status": 200 },
+        { "route": "/zh/terms", "status": 200 },
+        { "route": "/en/terms", "status": 200 }
+      ]
+    },
+    "help_index_routes": {
+      "results": [
+        { "route": "/zh/help", "status": 308 },
+        { "route": "/en/help", "status": 308 }
+      ]
+    }
+  },
+  "sitemap_llms_checks": {
+    "status": "pass_for_unpublished_drafts",
+    "routes_checked": [
+      "/sitemap.xml",
+      "/llms.txt",
+      "/llms-full.txt"
+    ],
+    "help_service_slug_hits": {
+      "/help/unlock-failure": false,
+      "/help/payment-refund": false,
+      "/help/result-recovery": false,
+      "/help/privacy-data": false,
+      "/help/use-boundaries": false,
+      "/help/data-deletion": false
+    },
+    "private_pattern_counts": {
+      "/result/[^\\s<]+": 0,
+      "/orders/[^\\s<]+": 0,
+      "/pay/[^\\s<]+": 0,
+      "payment_id": 0,
+      "transaction_id": 0,
+      "[?&]token=": 0
+    }
+  },
+  "schema_runtime_check": {
+    "status": "blocked_runtime_gap",
+    "fap_web_read_only_source_check": {
+      "file": "app/(localized)/[locale]/help/[slug]/page.tsx",
+      "uses_backend_content_page": true,
+      "service_slugs_not_in_static_params": true,
+      "faq_schema_only_for_slug_faq": true,
+      "does_not_consume_schema_enabled_field": true,
+      "cms_faq_items_first_class_runtime_unconfirmed": true
+    },
+    "note": "Current Help detail runtime emits FAQPage only for /help/faq from visible markdown extraction. It does not yet prove CMS faq_items/schema_enabled authority for these six Help service topics."
+  },
+  "publish_runtime_check": {
+    "status": "blocked_runtime_gap",
+    "local_artisan_list": [
+      "content-pages:import-local-baseline",
+      "content-pages:publish-controlled",
+      "content-pages:science-draft-dry-run",
+      "content-pages:science-import-drafts",
+      "content-pages:science-operator-review-readiness",
+      "content-pages:science-pre-import-qa"
+    ],
+    "content_pages_publish_controlled_scope": {
+      "allows_help_service_keys": false,
+      "allows_zh_cn": false,
+      "current_allowed_keys": [
+        "brand",
+        "charter",
+        "foundation",
+        "careers",
+        "policies"
+      ]
+    },
+    "note": "No bounded controlled publish runtime currently allows exactly these 12 Help service ContentPage rows."
+  },
+  "decision": {
+    "status": "blocked",
+    "publish_preflight_result": "NO_GO_FOR_PUBLISH_EXECUTE",
+    "draft_count_checked": 12,
+    "package_hash_checked": true,
+    "publish_authorization_prompt_allowed": false,
+    "reasons": [
+      "Three English Help draft rows contain the blocked payment_id phrase pattern.",
+      "Help FAQ schema runtime does not yet consume CMS faq_items/schema_enabled for these service topics.",
+      "Existing content-pages:publish-controlled runtime does not allow the 12 Help service keys or zh-CN locale."
+    ]
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "allowed_paths_only": true
+  },
+  "sidecars": [
+    {
+      "id": "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01",
+      "status": "required_before_publish_preflight_rerun",
+      "note": "Revise the local/import/CMS drafts to remove blocked payment_id phrase hits without changing policy meaning, then resync only the affected draft rows."
+    },
+    {
+      "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+      "status": "required_before_publish_execute",
+      "note": "Make Help detail runtime consume CMS faq_items/schema_enabled while preserving visible FAQ and JSON-LD parity."
+    },
+    {
+      "id": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01",
+      "status": "required_before_publish_execute",
+      "note": "Add a bounded fail-closed controlled publish path for exactly the 12 approved Help service ContentPage draft rows."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01",
+      "status": "required_after_repairs",
+      "note": "Rerun read-only publish preflight after blocker repairs and before any exact publish authorization prompt."
+    }
+  ],
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01"
+}

--- a/backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md
@@ -1,0 +1,62 @@
+# HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01
+
+Status: `blocked`
+
+This read-only publish preflight checked the 12 Help service `ContentPage` CMS drafts after Operator approval R2. It did not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+
+## Decision
+
+`NO-GO_FOR_PUBLISH_EXECUTE`
+
+The preflight itself completed, but the Help service pages are not ready for publish execution.
+
+## Evidence
+
+| Check | Result |
+| --- | --- |
+| Source import package hash | `82a0d495f3fdd21df35696950eaa0b0a6b12d224d5dc7a8f82c8fa3e49cdcb65` |
+| Draft source hash | `7d034de0b0eb5dc2c78fbb0e1828f3820e36f1c1a03d8f1567722c336438b453` |
+| Production CMS rows checked | 12 |
+| Draft / non-public / non-indexable / unpublished | 12 / 12 / 12 / 12 |
+| Support contact | 12 rows match `support@fermatmind.com` |
+| Policy version | 12 rows match `help_service_policy.v1` |
+| FAQ items | 12 rows have 4 structured FAQ items |
+| Public draft routes | 12/12 still 404 |
+| `/zh/support` and `/en/support` | 200 |
+| `/zh/privacy`, `/en/privacy`, `/zh/terms`, `/en/terms` | 200 |
+| sitemap / llms / llms-full | no new Help service slug hits; no checked private-pattern hits |
+
+## Blockers
+
+1. Private-boundary phrase gate is blocked: three English Help draft rows contain the `payment_id` phrase pattern.
+   - `help-data-deletion` / `en`
+   - `help-payment-refund` / `en`
+   - `help-unlock-failure` / `en`
+
+2. FAQ schema runtime is not ready for these service topics. The current fap-web Help detail route emits `FAQPage` only for `/help/faq` from visible markdown extraction and does not yet prove CMS `faq_items` / `schema_enabled` authority for the six Help service topics.
+
+3. Controlled publish runtime is not ready for this exact scope. The existing `content-pages:publish-controlled` command is bounded to the old English five-page scope (`brand`, `charter`, `foundation`, `careers`, `policies`) and does not allow the 12 Help service rows or `zh-CN`.
+
+## Sidecars
+
+| Task | Status | Purpose |
+| --- | --- | --- |
+| `HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01` | required | Remove blocked `payment_id` phrase hits from local/import/CMS drafts without changing policy meaning. |
+| `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01` | required | Connect Help detail runtime to CMS `faq_items` / `schema_enabled` while preserving visible FAQ and JSON-LD parity. |
+| `HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01` | required | Add a fail-closed controlled publish path for exactly the 12 approved Help service rows. |
+| `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01` | required | Rerun read-only publish preflight after repairs. |
+
+## Scope Validation
+
+| Boundary | Result |
+| --- | --- |
+| CMS mutation | no |
+| Publish | no |
+| Deploy | no |
+| Search submission | no |
+| Private URL access | no |
+| Secret/env/cookie/token read | no |
+| Payment/refund action | no |
+| Payment provider change | no |
+
+Next recommendation: `HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01`.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50122,7 +50122,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-publish-preflight-01",
     "base": "origin/main",
-    "status": "blocked",
+    "status": "pr_opened",
     "train_scope": "window_9_help_service_content",
     "title": "docs(help): run Help draft publish preflight",
     "depends_on": [
@@ -50207,7 +50207,7 @@
     },
     "failure_reason": "Publish preflight blocked: three English Help draft rows contain the payment_id phrase pattern; fap-web FAQ schema runtime does not yet consume CMS faq_items/schema_enabled for these service topics; existing content-pages:publish-controlled runtime does not allow the 12 Help service keys or zh-CN.",
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1993",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -50286,6 +50286,11 @@
         "at": "2026-06-08",
         "status": "commit_sha_pending_pr_head",
         "note": "Commit SHA is left null inside the commit to avoid self-referential amend churn; PR head and merge closeout will provide immutable SHA evidence."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_opened",
+        "note": "Opened PR #1993 for HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1822,7 +1822,7 @@
       "sidecar_issues": [
         {
           "sidecar_id": "IQ-SIDECAR-COMMERCE-DEFERRED-001",
-          "title": "defer(iq): commerce unlock \u00a51.99 / \u00a55 implementation",
+          "title": "defer(iq): commerce unlock ¥1.99 / ¥5 implementation",
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
@@ -1841,7 +1841,7 @@
             "api/v0.3/webhooks/payment/*"
           ],
           "evidence": [
-            "User intentionally deferred the \u00a51.99 / \u00a55 commerce PR.",
+            "User intentionally deferred the ¥1.99 / ¥5 commerce PR.",
             "Paid unlock is not required for identity/scoring/report/SVG provenance foundation.",
             "The train can continue without checkout/SKU/webhook changes."
           ],
@@ -5056,7 +5056,7 @@
         },
         "forbidden_runtime_claim_grep": {
           "status": "pass",
-          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|\u66f4\u51c6\u786e|\u66f4\u51c6|\u5c97\u4f4d\u5339\u914d|\u804c\u4e1a\u63a8\u8350|\u804c\u4e1a\u6210\u529f\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
+          "command": "rg -n \"Matches|career recommendation|job fit|success prediction|success probability|hiring suitability|140Q more accurate|raw score delta|更准确|更准|岗位匹配|职业推荐|职业成功\" backend/app/Services/Riasec/RiasecPublicProjectionService.php backend/app/Services/Report/RiasecReportComposer.php || true",
           "evidence": "No runtime service hits."
         },
         "diff_check": {
@@ -5993,7 +5993,7 @@
     "PR-CMS-04": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-04-controlled-codex-publish-sop",
-      "title": "PR-CMS-04\uff5cControlled Codex-Assisted CMS Publish SOP",
+      "title": "PR-CMS-04｜Controlled Codex-Assisted CMS Publish SOP",
       "status": "pr_open",
       "depends_on": [
         "PR-CMS-01",
@@ -7865,7 +7865,7 @@
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
       "branch": "codex/pr-cms-fix-master-semantic-content-gate",
-      "title": "PR-CMS-FIX-MASTER\uff5cScalable Semantic Content Gate Architecture",
+      "title": "PR-CMS-FIX-MASTER｜Scalable Semantic Content Gate Architecture",
       "status": "pr_open",
       "depends_on": [
         "PR-CMS-01"
@@ -7953,7 +7953,7 @@
     "PR-GRAPH-01": {
       "repo": "fap-api",
       "branch": "codex/pr-graph-01-multi-test-edges",
-      "title": "PR-GRAPH-01\uff5cArticle Multi-Test Graph Edges",
+      "title": "PR-GRAPH-01｜Article Multi-Test Graph Edges",
       "status": "ci_fix_local_checks_passed",
       "depends_on": [
         "PR-CMS-01",
@@ -8053,7 +8053,7 @@
     "PR-MEDIA-01": {
       "repo": "fap-api",
       "branch": "codex/pr-media-01-oss-cdn",
-      "title": "PR-MEDIA-01\uff5cCMS Media Library OSS/CDN Upload Automation",
+      "title": "PR-MEDIA-01｜CMS Media Library OSS/CDN Upload Automation",
       "status": "pr_open",
       "depends_on": [
         "PR-CMS-01",
@@ -18228,7 +18228,7 @@
           "failed": [
             {
               "command": "cd backend && php artisan test --filter=PaymentWebhook",
-              "summary": "Sidecar only: Tests\\Feature\\V0_3\\PaymentWebhookCnCallbackTest::test_wechatpay_valid_callback_calls_processor_and_returns_success_ack fails on clean origin/main c87d9bc11f4e1cf90e60c06660b472e8afeb10a0 with the same 400 / \u7b7e\u540d\u5f02\u5e38: \u5fae\u4fe1\u7b7e\u540d\u4e3a\u7a7a error."
+              "summary": "Sidecar only: Tests\\Feature\\V0_3\\PaymentWebhookCnCallbackTest::test_wechatpay_valid_callback_calls_processor_and_returns_success_ack fails on clean origin/main c87d9bc11f4e1cf90e60c06660b472e8afeb10a0 with the same 400 / 签名异常: 微信签名为空 error."
             }
           ]
         },
@@ -18268,7 +18268,7 @@
           "branch": "codex/pr-audit-be-02-webhook-digest",
           "command_or_check": "php artisan test --filter=PaymentWebhook",
           "failing_test": "Tests\\Feature\\V0_3\\PaymentWebhookCnCallbackTest::test_wechatpay_valid_callback_calls_processor_and_returns_success_ack",
-          "evidence": "400 instead of 200; \u7b7e\u540d\u5f02\u5e38: \u5fae\u4fe1\u7b7e\u540d\u4e3a\u7a7a",
+          "evidence": "400 instead of 200; 签名异常: 微信签名为空",
           "baseline_verification": "Exact test also fails on clean origin/main",
           "baseline_commit": "c87d9bc11f4e1cf90e60c06660b472e8afeb10a0",
           "why_external_to_current_pr": "BE-02 diff only touches payload digest idempotency service/test and ledger; failure is in WeChatPay CN callback signature chain.",
@@ -18294,7 +18294,7 @@
         {
           "at": "2026-05-24T07:51:12.597Z",
           "status": "sidecar_verified",
-          "summary": "Verified WeChatPay CN callback exact failing test also fails on clean origin/main c87d9bc11f4e1cf90e60c06660b472e8afeb10a0 with the same 400 / \u7b7e\u540d\u5f02\u5e38: \u5fae\u4fe1\u7b7e\u540d\u4e3a\u7a7a error. Treating broad PaymentWebhook filter failure as sidecar per user authorization."
+          "summary": "Verified WeChatPay CN callback exact failing test also fails on clean origin/main c87d9bc11f4e1cf90e60c06660b472e8afeb10a0 with the same 400 / 签名异常: 微信签名为空 error. Treating broad PaymentWebhook filter failure as sidecar per user authorization."
         },
         {
           "at": "2026-05-24T07:55:33.131Z",
@@ -23032,7 +23032,7 @@
           "continue_train_decision": "continue_pr7"
         }
       ],
-      "next_task": "DEPLOY-READINESS\uff5cDeploy CAREER 1046 growth foundation fixes"
+      "next_task": "DEPLOY-READINESS｜Deploy CAREER 1046 growth foundation fixes"
     },
     "IQ-NORM-01": {
       "id": "IQ-NORM-01",
@@ -25207,7 +25207,7 @@
       },
       "forbidden_claim_scan": {
         "status": "pass",
-        "summary": "Imported PACK-08 assets scan found 0 forbidden user claims; 1 allowed boundary hit for negated near-tie \u201c\u63a8\u7ffb\u201d boundary."
+        "summary": "Imported PACK-08 assets scan found 0 forbidden user claims; 1 allowed boundary hit for negated near-tie “推翻” boundary."
       },
       "frontend_fallback_scan": {
         "status": "pass",
@@ -40798,7 +40798,7 @@
           "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap_canary_adapter.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-career-choice.zh-CN.importer-adapter.json --locale=zh-CN --dry-run --json",
           "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap_canary_adapter.sqlite php backend/artisan articles:import-editorial-package --file=docs/seo/canary-packages/mbti-vs-holland-code-career-choice.en.importer-adapter.json --locale=en --dry-run --json"
         ],
-        "notes": "English adapter passed with ok=true/action=will_create/would_write=true. Chinese adapter failed with evergreen_definition_required, evergreen_method_required, and claim_boundary_forbidden_phrase for the sentence containing \u4e00\u5b9a\u9002\u5408. Dry-run table counts stayed zero for articles, article_translation_revisions, article_seo_meta, and article_editorial_package_imports."
+        "notes": "English adapter passed with ok=true/action=will_create/would_write=true. Chinese adapter failed with evergreen_definition_required, evergreen_method_required, and claim_boundary_forbidden_phrase for the sentence containing 一定适合. Dry-run table counts stayed zero for articles, article_translation_revisions, article_seo_meta, and article_editorial_package_imports."
       },
       "local": {
         "status": "passed",
@@ -41407,7 +41407,7 @@
         "commands": [
           "ssh \"$API_SSH_ALIAS\" 'cd /var/www/fap-api/current/backend && php artisan tinker --execute=\"...\"'"
         ],
-        "notes": "English has 0 claim warnings. Chinese has 2 boundary_context=true warnings for boundary/disclaimer sentences: \u533b\u5b66\u8bca\u65ad and \u4e00\u5b9a\u9002\u5408. These are acceptable for editorial review but may require explicit acknowledgement in a later controlled publish preflight. Publish remains forbidden."
+        "notes": "English has 0 claim warnings. Chinese has 2 boundary_context=true warnings for boundary/disclaimer sentences: 医学诊断 and 一定适合. These are acceptable for editorial review but may require explicit acknowledgement in a later controlled publish preflight. Publish remains forbidden."
       },
       "cta_review": {
         "status": "passed",
@@ -42062,7 +42062,7 @@
         "commands": [
           "Chrome Google Search Console sitemap page submission for https://fermatmind.com/sitemap.xml"
         ],
-        "notes": "GSC displayed '\u5df2\u6210\u529f\u63d0\u4ea4\u7ad9\u70b9\u5730\u56fe'. After a read-only refresh, the submitted sitemap table showed https://fermatmind.com/sitemap.xml, type \u7ad9\u70b9\u5730\u56fe, date 2026\u5e746\u67083\u65e5, status \u6210\u529f, discovered pages 2,272, discovered videos 0. No URL Inspection request indexing or individual URL submission was performed."
+        "notes": "GSC displayed '已成功提交站点地图'. After a read-only refresh, the submitted sitemap table showed https://fermatmind.com/sitemap.xml, type 站点地图, date 2026年6月3日, status 成功, discovered pages 2,272, discovered videos 0. No URL Inspection request indexing or individual URL submission was performed."
       },
       "public_sitemap_cross_check": {
         "status": "passed",
@@ -42142,7 +42142,7 @@
         "at": "2026-06-03T07:20:22Z",
         "from": "executing",
         "to": "gsc_sitemap_submitted_report_created_local_checks_pending",
-        "note": "Submitted only https://fermatmind.com/sitemap.xml in GSC. Final visible GSC table state after refresh was \u6210\u529f with 2,272 discovered pages. Created docs-only result report. No individual URL request indexing, Baidu, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
+        "note": "Submitted only https://fermatmind.com/sitemap.xml in GSC. Final visible GSC table state after refresh was 成功 with 2,272 discovered pages. Created docs-only result report. No individual URL request indexing, Baidu, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
       },
       {
         "at": "2026-06-03T07:24:09Z",
@@ -42253,7 +42253,7 @@
         "commands": [
           "Chrome visible Baidu Search Resource Platform page check after human operator completed verification/submission"
         ],
-        "notes": "After human operator action, the visible Baidu dialog showed '\u5b8c\u6210 / \u94fe\u63a5\u63d0\u4ea4\u6210\u529f / \u786e\u5b9a' for input value fermatmind.com/zh/articles/mbti-vs-holland-career-choice. English URL submission, Baidu API token usage, IndexNow, Search Channel writes, CMS mutation, publish, runtime edit, and deploy were not performed."
+        "notes": "After human operator action, the visible Baidu dialog showed '完成 / 链接提交成功 / 确定' for input value fermatmind.com/zh/articles/mbti-vs-holland-career-choice. English URL submission, Baidu API token usage, IndexNow, Search Channel writes, CMS mutation, publish, runtime edit, and deploy were not performed."
       }
     },
     "failure_reason": null,
@@ -42315,7 +42315,7 @@
         "at": "2026-06-03T11:27:42Z",
         "from": "merged_baidu_security_verification_blocked",
         "to": "merged_then_baidu_zh_submission_confirmed_by_follow_up",
-        "note": "Human operator completed Baidu verification/submission after #1870 merged. Codex rechecked the logged-in Baidu page and observed visible success dialog '\u5b8c\u6210 / \u94fe\u63a5\u63d0\u4ea4\u6210\u529f / \u786e\u5b9a' for the zh-CN canary URL."
+        "note": "Human operator completed Baidu verification/submission after #1870 merged. Codex rechecked the logged-in Baidu page and observed visible success dialog '完成 / 链接提交成功 / 确定' for the zh-CN canary URL."
       }
     ],
     "sidecars": [
@@ -42367,7 +42367,7 @@
         "commands": [
           "Chrome visible Baidu Search Resource Platform page check after human operator completed verification/submission"
         ],
-        "notes": "Visible Baidu dialog showed '\u5b8c\u6210 / \u94fe\u63a5\u63d0\u4ea4\u6210\u529f / \u786e\u5b9a' and the visible input value was fermatmind.com/zh/articles/mbti-vs-holland-career-choice."
+        "notes": "Visible Baidu dialog showed '完成 / 链接提交成功 / 确定' and the visible input value was fermatmind.com/zh/articles/mbti-vs-holland-career-choice."
       },
       "report": {
         "status": "created",
@@ -42440,7 +42440,7 @@
         "at": "2026-06-03T11:27:42Z",
         "from": "executing",
         "to": "baidu_zh_success_confirmed_report_created_local_checks_pending",
-        "note": "Recorded visible Baidu success dialog '\u5b8c\u6210 / \u94fe\u63a5\u63d0\u4ea4\u6210\u529f / \u786e\u5b9a' after human operator completed verification/submission. No English URL submission, Baidu API token usage, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
+        "note": "Recorded visible Baidu success dialog '完成 / 链接提交成功 / 确定' after human operator completed verification/submission. No English URL submission, Baidu API token usage, IndexNow, Search Channel write, CMS mutation, publish, runtime edit, or deploy was performed."
       },
       {
         "at": "2026-06-03T11:27:42Z",
@@ -42524,7 +42524,7 @@
         "commands": [
           "Chrome read-only Google Search Console sitemap page check"
         ],
-        "notes": "GSC property sc-domain:fermatmind.com shows https://fermatmind.com/sitemap.xml status \u6210\u529f, submitted/read dates 2026\u5e746\u67083\u65e5, discovered pages 2,272, discovered videos 0. No URL Inspection request indexing was performed."
+        "notes": "GSC property sc-domain:fermatmind.com shows https://fermatmind.com/sitemap.xml status 成功, submitted/read dates 2026年6月3日, discovered pages 2,272, discovered videos 0. No URL Inspection request indexing was performed."
       },
       "baidu_readonly": {
         "status": "passed_with_no_public_index_yet",
@@ -42532,7 +42532,7 @@
           "Chrome read-only Baidu Search Resource Platform link submission page check",
           "Chrome read-only public Baidu search query site:fermatmind.com/zh/articles/mbti-vs-holland-career-choice"
         ],
-        "notes": "Baidu manual zh-CN submission was confirmed by the prior confirmation report. The link submission page does not show a durable submitted-history state on fresh visit. Public Baidu search returned \u62b1\u6b49\uff0c\u672a\u627e\u5230\u76f8\u5173\u7ed3\u679c, so indexing/organic discovery is not yet visible."
+        "notes": "Baidu manual zh-CN submission was confirmed by the prior confirmation report. The link submission page does not show a durable submitted-history state on fresh visit. Public Baidu search returned 抱歉，未找到相关结果, so indexing/organic discovery is not yet visible."
       },
       "report": {
         "status": "created",
@@ -44902,7 +44902,7 @@
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
     "external_asset_paths": [
-      "/Users/rainie/Desktop/\u8d39\u9a6c\u8d44\u6599\u6587\u4ef6/fermatmind-help-service-content-drafts-01.zip",
+      "/Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
       "/Users/rainie/Desktop/fermatmind-help-service-content-drafts-01"
     ],
     "planned_outputs": {
@@ -45193,11 +45193,11 @@
       "policy_owner_answers": {
         "status": "recorded",
         "answers": {
-          "refund_exclusions": "\u975e\u201c\u8d39\u9a6c\u6d4b\u8bd5\u201d\u539f\u56e0",
-          "refund_handling_time": "\u4e09\u4e2a\u5de5\u4f5c\u65e5",
-          "data_deletion_handling_time": "\u4e24\u5e74",
-          "retained_data_exceptions_after_deletion": "\u65e0",
-          "privacy_analytics_wording_confirmation": "\u6b63\u786e"
+          "refund_exclusions": "非“费马测试”原因",
+          "refund_handling_time": "三个工作日",
+          "data_deletion_handling_time": "两年",
+          "retained_data_exceptions_after_deletion": "无",
+          "privacy_analytics_wording_confirmation": "正确"
         }
       },
       "scope_preflight": {
@@ -45208,7 +45208,7 @@
         "status": "pass",
         "commands": [
           {
-            "command": "shasum -a 256 /Users/rainie/Desktop/\u8d39\u9a6c\u8d44\u6599\u6587\u4ef6/fermatmind-help-service-content-drafts-01.zip",
+            "command": "shasum -a 256 /Users/rainie/Desktop/费马资料文件/fermatmind-help-service-content-drafts-01.zip",
             "status": "pass"
           },
           {
@@ -45671,11 +45671,11 @@
       "policy_revision_apply": {
         "status": "applied_local",
         "applied_policy_answers": {
-          "refund_exclusions": "\u975e\u201c\u8d39\u9a6c\u6d4b\u8bd5\u201d\u539f\u56e0",
-          "refund_handling_time": "\u4e09\u4e2a\u5de5\u4f5c\u65e5",
-          "data_deletion_handling_time": "\u4e24\u5e74",
-          "retained_data_exceptions_after_deletion": "\u65e0",
-          "privacy_analytics_wording_confirmation": "\u6b63\u786e"
+          "refund_exclusions": "非“费马测试”原因",
+          "refund_handling_time": "三个工作日",
+          "data_deletion_handling_time": "两年",
+          "retained_data_exceptions_after_deletion": "无",
+          "privacy_analytics_wording_confirmation": "正确"
         },
         "support_contact": "support@fermatmind.com",
         "policy_version": "help_service_policy.v1",
@@ -48019,7 +48019,7 @@
       "raw_proof_copied_to_private_local_storage": true,
       "raw_receipt_proof_copied_to_private_local_storage": true,
       "record_code": "FM-GIVING-2026-06-001",
-      "recipient_name": "\u8054\u5408\u56fd\u513f\u7ae5\u57fa\u91d1\u4f1a\uff08UNICEF\uff09",
+      "recipient_name": "联合国儿童基金会（UNICEF）",
       "recipient_official_url": "https://www.unicef.cn/",
       "amount_minor": 7500,
       "currency": "CNY",
@@ -50115,6 +50115,177 @@
         "at": "2026-06-08",
         "status": "merged",
         "note": "PR #1990 merged at 2026-06-08T07:19:51Z with merge commit 9ba4edbe11382aeb29f1a9a53393137b5e7a2ae5; origin/main contains the merge commit, remote task branch is deleted, local task branch was deleted, and this worktree was left clean on a detached origin/main-derived closeout branch because local main is owned by another worktree."
+      }
+    ]
+  },
+  "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-publish-preflight-01",
+    "base": "origin/main",
+    "status": "blocked",
+    "train_scope": "window_9_help_service_content",
+    "title": "docs(help): run Help draft publish preflight",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized adding and executing HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01 as read-only publish preflight with no CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund, or payment-provider change."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01 is merged; operator approval was recorded as publish-preflight allowance only, not publish authorization."
+      },
+      "production_cms_read_only": {
+        "status": "pass",
+        "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly_laravel_tinker_summary_without_body_output",
+        "checked_rows": 12,
+        "draft": 12,
+        "non_public": 12,
+        "non_indexable": 12,
+        "unpublished": 12,
+        "support_contact_support_at_fermatmind": 12,
+        "policy_version_help_service_policy_v1": 12,
+        "faq_items_count_4": 12
+      },
+      "private_boundary": {
+        "status": "blocked",
+        "payment_id_phrase_hits": 3,
+        "hit_rows": [
+          {
+            "slug": "help-data-deletion",
+            "locale": "en"
+          },
+          {
+            "slug": "help-payment-refund",
+            "locale": "en"
+          },
+          {
+            "slug": "help-unlock-failure",
+            "locale": "en"
+          }
+        ],
+        "private_result_route_hits": 0,
+        "private_order_route_hits": 0,
+        "transaction_id_hits": 0,
+        "tokenized_url_hits": 0,
+        "raw_order_no_hits": 0
+      },
+      "schema_runtime": {
+        "status": "blocked_runtime_gap",
+        "evidence": "fap-web Help detail route currently emits FAQPage only for /help/faq from visible markdown extraction and does not prove CMS faq_items/schema_enabled authority for these service topics."
+      },
+      "publish_runtime": {
+        "status": "blocked_runtime_gap",
+        "evidence": "content-pages:publish-controlled exists but only allows brand, charter, foundation, careers, and policies in en; no bounded controlled publish runtime allows exactly the 12 Help service rows."
+      },
+      "public_routes": {
+        "status": "pass_for_unpublished_drafts",
+        "help_draft_routes_404": 12,
+        "support_routes_200": 2,
+        "privacy_terms_routes_200": 4,
+        "sitemap_llms_help_service_slug_hits": 0
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && php artisan list --no-ansi | rg \"content-pages\"",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": "Publish preflight blocked: three English Help draft rows contain the payment_id phrase pattern; fap-web FAQ schema runtime does not yet consume CMS faq_items/schema_enabled for these service topics; existing content-pages:publish-controlled runtime does not allow the 12 Help service keys or zh-CN.",
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "NO_GO_FOR_PUBLISH_EXECUTE",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md",
+      "preflight_status": "blocked",
+      "draft_count_checked": 12,
+      "package_hash_checked": true,
+      "publish_authorization_prompt_allowed": false,
+      "publish_allowed": false,
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01",
+        "status": "required_before_publish_preflight_rerun",
+        "note": "Remove blocked payment_id phrase hits from local/import/CMS drafts without changing policy meaning."
+      },
+      {
+        "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+        "status": "required_before_publish_execute",
+        "note": "Make Help detail runtime consume CMS faq_items/schema_enabled while preserving visible FAQ and JSON-LD parity."
+      },
+      {
+        "id": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01",
+        "status": "required_before_publish_execute",
+        "note": "Add a bounded fail-closed controlled publish path for exactly the 12 approved Help service ContentPage rows."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01",
+        "status": "required_after_repairs",
+        "note": "Rerun read-only publish preflight after blocker repairs and before any exact publish authorization prompt."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User authorized adding and executing HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01 with read-only publish preflight scope."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "blocked",
+        "note": "Read-only preflight completed and blocked publish execution on content boundary, schema runtime, and controlled publish runtime gaps. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund, or payment-provider change occurred."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "JSON, YAML, artisan list, and path-limited diff checks passed. Unrelated dirty file backend/docs/seo/foundation-daily-giving-technical-entrypoint.md was not staged."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "committed",
+        "note": "Created local commit a6a6a2c183318a21e607c030f469d750d17f2e97 for read-only publish preflight blocker artifact."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "commit_sha_reconciled",
+        "note": "Reconciled ledger commit_sha to amended commit 1b98ee968269492798c1fd974ceba7539e8eb82c."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "commit_sha_pending_pr_head",
+        "note": "Commit SHA is left null inside the commit to avoid self-referential amend churn; PR head and merge closeout will provide immutable SHA evidence."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22304,6 +22304,47 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01
 
+  - id: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-OPERATOR-APPROVAL-R2-01
+    branch: codex/help-content-draft-publish-preflight-01
+    title: "docs(help): run Help draft publish preflight"
+    train_scope: window_9_help_service_content
+    status: blocked
+    scope:
+      - Run a read-only publish preflight for the 12 Help ContentPage CMS drafts.
+      - Confirm draft row count, canonical public paths, support contact, policy fields, FAQ structure, schema readiness, robots/sitemap/llms behavior, and private URL/private ID boundaries.
+      - Record publish blockers and next remediation tasks; do not mutate CMS rows, publish, deploy, submit search URLs, or access private URLs.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json
+      - backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, or change payment-provider behavior.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && php artisan list --no-ansi | rg "content-pages"
+      - git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added the `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01` PR-train manifest/state entry.
- Added a generated read-only publish preflight artifact for the 12 Help service ContentPage CMS drafts.
- Added a human-readable operations report with publish blockers and sidecar tasks.

## Why
Operator approval R2 allows publish preflight, but not publish execution. This PR records the read-only preflight result before any exact publish authorization prompt.

## Preflight result
`NO-GO_FOR_PUBLISH_EXECUTE`

Publish execute remains blocked because:
- Three English Help draft rows contain the blocked `payment_id` phrase pattern.
- The fap-web Help FAQ schema runtime does not yet prove CMS `faq_items` / `schema_enabled` authority for these service topics.
- The existing `content-pages:publish-controlled` runtime does not allow the 12 Help service keys or `zh-CN`.

## Validation commands
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && php artisan list --no-ansi | rg "content-pages"`
- `git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No publish or publish authorization prompt.
- No deploy.
- No search submission.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token read.
- No payment/refund action or payment-provider behavior change.

## Repository rule impact
Help service content remains CMS/backend-authoritative. This PR adds only read-only preflight documentation and PR-train metadata; it does not add frontend fallback content or publishable runtime content.
