### PR TITLE
docs(seo): update Science ContentPage weekly PR progress

### DIFF
--- a/backend/docs/seo/generated/science-contentpage-real-import-command-enablement-01.v1.json
+++ b/backend/docs/seo/generated/science-contentpage-real-import-command-enablement-01.v1.json
@@ -26,7 +26,37 @@
       "/method-boundaries"
     ],
     "cms_mutation_in_this_pr": false,
-    "production_import_executed": false
+    "production_import_executed_after_pr": true
+  },
+  "closeout_2026_06_08": {
+    "parser_blocker_fixed_by_pr": 1983,
+    "production_no_write_dry_run": {
+      "ok": true,
+      "dry_run": true,
+      "writes_committed": 0,
+      "pages_seen": 6,
+      "planned_create_count": 5,
+      "authority_revision_only_count": 1,
+      "blocked_count": 0
+    },
+    "controlled_execute": {
+      "ok": true,
+      "dry_run": false,
+      "writes_committed": 1,
+      "pages_seen": 6,
+      "created_count": 5,
+      "publish_allowed": 0,
+      "discoverability_allowed": 0
+    },
+    "post_execute_idempotency_dry_run": {
+      "ok": true,
+      "dry_run": true,
+      "writes_committed": 0,
+      "planned_create_count": 0,
+      "skipped_existing_count": 5,
+      "authority_revision_only_count": 1
+    },
+    "publication_status": "NO_GO"
   },
   "runtime_guards": [
     "dry-run is default when --execute is absent",
@@ -53,13 +83,14 @@
     "no DailyGiving amplification"
   ],
   "next_task": {
-    "id": "SCIENCE-CONTENTPAGE-CONTROLLED-CMS-DRAFT-IMPORT-01",
+    "id": "SCIENCE-CONTENTPAGE-OPERATOR-PUBLISH-REVIEW-01",
     "requires": [
-      "GitHub checks green for command enablement PR",
-      "operator exact approval phrase",
-      "production no-write command output reviewed",
-      "controlled execution command scoped to non-public drafts"
+      "operator review of five imported drafts",
+      "claim gate review",
+      "science review",
+      "legal review where required",
+      "publish/discoverability gate remains blocked until approvals are recorded"
     ]
   },
-  "final_decision": "GO_FOR_CONTROLLED_CMS_DRAFT_IMPORT_AFTER_MERGE_AND_EXACT_APPROVAL"
+  "final_decision": "CONTROLLED_NON_PUBLIC_DRAFT_IMPORT_COMPLETE_PUBLICATION_NO_GO"
 }

--- a/backend/docs/seo/generated/science-contentpage-weekly-pr-progress-2026-06-08.v1.json
+++ b/backend/docs/seo/generated/science-contentpage-weekly-pr-progress-2026-06-08.v1.json
@@ -1,0 +1,104 @@
+{
+  "schema_version": "science-contentpage-weekly-pr-progress-2026-06-08.v1",
+  "task": "SCIENCE-CONTENTPAGE-WEEKLY-PR-PROGRESS-2026-06-08",
+  "mode": "docs_only_progress_closeout",
+  "decision": "CONDITIONAL_NON_PUBLIC_DRAFT_IMPORT_COMPLETE_PUBLISH_NO_GO",
+  "science_contentpage_status": {
+    "non_public_draft_import_complete": true,
+    "created_draft_count": 5,
+    "existing_authority_revision_only_count": 1,
+    "publish_allowed": false,
+    "discoverability_allowed": false,
+    "sitemap_allowed": false,
+    "llms_allowed": false,
+    "footer_allowed": false,
+    "search_submission_allowed": false
+  },
+  "production_evidence": {
+    "no_write_dry_run": {
+      "ok": true,
+      "dry_run": true,
+      "writes_committed": 0,
+      "pages_seen": 6,
+      "planned_create_count": 5,
+      "authority_revision_only_count": 1,
+      "blocked_count": 0
+    },
+    "controlled_execute": {
+      "ok": true,
+      "dry_run": false,
+      "writes_committed": 1,
+      "pages_seen": 6,
+      "created_count": 5,
+      "publish_allowed": 0,
+      "discoverability_allowed": 0
+    },
+    "post_execute_idempotency_dry_run": {
+      "ok": true,
+      "dry_run": true,
+      "writes_committed": 0,
+      "planned_create_count": 0,
+      "skipped_existing_count": 5,
+      "authority_revision_only_count": 1
+    }
+  },
+  "created_draft_slugs": [
+    "/science",
+    "/item-design-notes",
+    "/reliability-validity",
+    "/data-privacy",
+    "/common-misconceptions"
+  ],
+  "existing_authority_revision_only": [
+    "/method-boundaries"
+  ],
+  "backend_prs": {
+    "merged": [
+      1922,
+      1944,
+      1948,
+      1955,
+      1958,
+      1959,
+      1960,
+      1967,
+      1973,
+      1976,
+      1978,
+      1981,
+      1983
+    ]
+  },
+  "frontend_prs": {
+    "merged": [
+      1060,
+      1062,
+      1064,
+      1065,
+      1066,
+      1068,
+      1069
+    ]
+  },
+  "adjacent_lines": {
+    "help_contentpage": "Recent Help PRs progressed through service-field production verification, policy sync, operator review R2, approval R2, publish preflight, and blocker repair. They do not authorize Science publishing.",
+    "riasec_article": "Recent RIASEC PRs progressed through review, media, locale, publish smoke, and search-submission preflight. They do not authorize Science discoverability.",
+    "dailygiving": "Recent DailyGiving PRs progressed proof handling and summaries while preserving noindex and search-amplification boundaries."
+  },
+  "remaining_no_go": [
+    "public_publish",
+    "sitemap",
+    "llms",
+    "footer",
+    "search_submission",
+    "social_distribution",
+    "faq_schema",
+    "unsupported_claims"
+  ],
+  "next_allowed_work": [
+    "CMS operator review for five imported drafts",
+    "claim/science/legal review closeout",
+    "publish preflight after approvals",
+    "discoverability gate after public eligibility is explicitly approved"
+  ]
+}

--- a/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/README.md
+++ b/backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08/README.md
@@ -1,6 +1,6 @@
 # Science ContentPage GPT-5.5 Pro Review Draft Package
 
-Status: draft-only, no-write, not for publication.
+Status: draft-only package; five package pages have now been imported as non-public CMS draft rows. Not for publication.
 
 This package splits the GPT-5.5 Pro content asset into three lanes:
 
@@ -10,16 +10,26 @@ This package splits the GPT-5.5 Pro content asset into three lanes:
 
 Hard boundaries:
 
-- No CMS mutation.
-- No database import.
-- No real import command enablement.
+- Package creation PR: no CMS mutation, no database import, and no real import command enablement.
+- Later controlled import: five non-public draft rows were created only after production no-write dry-run, command enablement, parser blocker repair, and exact operator approval phrase.
 - No publish.
 - No sitemap, llms, footer, search submission, or distribution.
 - `/method-boundaries` remains an existing-authority revision proposal, not a new ContentPage record.
+
+Imported non-public draft rows:
+
+- `/science`
+- `/item-design-notes`
+- `/reliability-validity`
+- `/data-privacy`
+- `/common-misconceptions`
+
+All imported rows remain `status=draft`, `is_public=false`, `is_indexable=false`, `publish_allowed=false`, `schema_enabled=false`, and `faq_schema_eligible=false`.
 
 Dry-run command:
 
 ```bash
 cd backend && php artisan content-pages:science-draft-dry-run --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08
 cd backend && php artisan content-pages:science-pre-import-qa --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08
+cd backend && php artisan content-pages:science-import-drafts --package=../backend/docs/seo/import-packages/science-contentpage-gpt55-review-draft-2026-06-08
 ```

--- a/backend/docs/seo/science-contentpage-cms-field-mapping-01.md
+++ b/backend/docs/seo/science-contentpage-cms-field-mapping-01.md
@@ -5,17 +5,40 @@ Updated: 2026-06-08
 Mode: backend/CMS field mapping planning, docs-only
 Branch: `codex/science-contentpage-field-mapping-01`
 
-This report plans how six science/trust/methodology draft pages should map into the current `ContentPage` model before any draft import. It does not implement code, migrations, CMS writes, imports, publication, route creation, sitemap/llms/schema/footer/header changes, or deployment.
+This report plans how six science/trust/methodology draft pages should map into the current `ContentPage` model and records the later controlled non-public draft import closeout. The original field-mapping PR did not implement code, migrations, CMS writes, imports, publication, route creation, sitemap/llms/schema/footer/header changes, or deployment. Later PRs and operator-approved runtime execution imported five non-public draft rows only.
 
 ## Decision
 
-**CONDITIONAL, pre-publication line complete.** The Science ContentPage line has completed the backend/importer safety path and the frontend exposure gates needed before any real content import can be proposed. The line is **not** complete as a publication or distribution task: no CMS write, database import, public publish, sitemap/llms inclusion, search submission, deployment, or social amplification has been authorized or performed.
+**CONDITIONAL, non-public draft import complete.** The Science ContentPage line has completed the backend/importer safety path, frontend exposure gates, production no-write dry-run, and the operator-approved controlled CMS draft import for five new non-public rows. The line is **not** complete as a publication or distribution task: no public publish, sitemap/llms inclusion, footer exposure, search submission, or social amplification has been authorized or performed.
 
 Current practical meaning:
 - Non-public package validation is supported through backend dry-run commands.
 - Operator review readiness is supported through first-class ContentPage review and publish-safety fields.
-- Real import remains locked behind a separate operator approval plus a separate import-command PR.
+- Controlled non-public draft import has run once in production after exact operator approval.
 - Frontend route wrappers and discoverability gates exist, but draft routes stay non-public/non-indexable and are not eligible for footer, sitemap, or llms exposure until later gates pass.
+
+## 0.1 2026-06-08 production import closeout
+
+The later production closeout changed only the draft-storage status, not publication status.
+
+| Check | Result |
+|---|---|
+| Production parser blocker | Fixed by fap-api #1983, which removed the Science package parser's Symfony YAML runtime dependency. |
+| Production no-write dry-run before execute | `ok=1`, `dry_run=1`, `writes_committed=0`, `pages_seen=6`, `planned_create_count=5`, `authority_revision_only_count=1`, `blocked_count=0`. |
+| Controlled execute | Ran `content-pages:science-import-drafts --execute` with the exact approval phrase `SCIENCE_CONTENTPAGE_NON_PUBLIC_DRAFT_IMPORT_APPROVED`. |
+| Controlled execute output | `ok=1`, `dry_run=0`, `writes_committed=1`, `pages_seen=6`, `created_count=5`, `publish_allowed=0`, `discoverability_allowed=0`. |
+| Idempotency dry-run after execute | `ok=1`, `dry_run=1`, `writes_committed=0`, `planned_create_count=0`, `skipped_existing_count=5`, `authority_revision_only_count=1`. |
+| Created draft slugs | `/science`, `/item-design-notes`, `/reliability-validity`, `/data-privacy`, `/common-misconceptions`. |
+| Existing authority skipped | `/method-boundaries` remained existing-authority revision-only and was not created or overwritten. |
+| Post-import exposure QA | Five created rows were `status=draft`, `is_public=false`, `is_indexable=false`, `publish_allowed=false`, `schema_enabled=false`, `faq_schema_eligible=false`, `operator_approval_required=true`, `claim_gate_status=not_reviewed`. |
+| Public discoverability QA | Public sitemap and `llms.txt` checks found no created draft URLs. |
+
+Current remaining blockers:
+- CMS operator review is still required for publication.
+- Claim gate remains `not_reviewed`.
+- Science/legal review remains required where flagged.
+- FAQ schema remains disabled until visible FAQ review and schema eligibility approval.
+- Sitemap, llms, footer, search submission, and public distribution remain **NO-GO**.
 
 ## 0. 2026-06-08 line completion review
 
@@ -30,16 +53,22 @@ This update reconciles the earlier planning report against the merged cross-repo
 | Backend authority reconciliation | fap-api #1958 | Complete | Treated `/method-boundaries` as existing authority/revision-only, not a new record. |
 | Backend publish safety fields | fap-api #1959 | Complete | Promoted `publish_allowed`, operator approval, claim gate, forbidden claims, and FAQ schema eligibility into first-class ContentPage fields. |
 | Backend real-import lock | fap-api #1960 | Complete | Locked real import as dry-run-only and explicitly required separate operator approval plus a separate import-command PR. |
+| Backend package split | fap-api #1973 | Complete | Packaged the GPT-5.5 Pro draft into review audit, six page candidates, and operator review artifacts. |
+| Backend route governance | fap-api #1976 | Complete | Confirmed `/reliability-validity` as the selected public canonical draft route candidate. |
+| Backend production no-write dry-run | fap-api #1978 | Complete | Recorded production no-write dry-run gate and kept writes blocked. |
+| Backend real import command | fap-api #1981 | Complete | Added `content-pages:science-import-drafts` with exact approval phrase and draft-only write guard. |
+| Backend production parser blocker | fap-api #1983 | Complete | Removed missing production Symfony YAML runtime dependency from Science package parsing. |
 | Frontend method-boundary reconciliation | fap-web #1060 | Complete | Reconciled method-boundaries route authority from the frontend planning side. |
 | Frontend guarded route wrappers | fap-web #1062 | Complete | Added guarded root route wrappers for the Science ContentPage slugs; empty CMS remains safe/noindex. |
 | Frontend claim gate | fap-web #1064 | Complete | Added claim-boundary checks for Science ContentPage content. |
 | Frontend FAQ schema gate | fap-web #1065 | Complete | Enforced visible-FAQ-only schema eligibility. |
 | Frontend discoverability gates | fap-web #1066 and #1068 | Complete | Kept draft Science ContentPages out of footer/sitemap/llms and preserved only existing authority routes. |
+| Frontend sitemap source convergence | fap-web #1069 | Complete | Converged static sitemap generation to backend source; Science drafts remain excluded by gate state. |
 
 Line status summary:
-- **Completed:** schema mapping, dry-run validation, operator review readiness, pre-import QA, authority reconciliation, publish-safety fields, real-import lock, guarded routes, claim/FAQ/discoverability tests.
-- **Not completed by design:** real CMS import, draft row creation, publication, public indexability, footer expansion, sitemap/llms inclusion, search submission, deployment, or content distribution.
-- **Next allowed phase:** a separately authorized real-import implementation or production dry-run may be scoped only after operator approval and package/content review evidence exist.
+- **Completed:** schema mapping, dry-run validation, operator review readiness, pre-import QA, authority reconciliation, publish-safety fields, real-import lock, guarded routes, claim/FAQ/discoverability tests, production no-write dry-run, controlled non-public draft import, and post-import exposure QA.
+- **Not completed by design:** publication, public indexability, footer expansion, sitemap/llms inclusion, search submission, or content distribution.
+- **Next allowed phase:** CMS operator review and claim/science/legal review for the imported drafts. Any publish or discoverability PR must remain blocked until those approvals are recorded.
 
 ## 1. Current ContentPage field map
 

--- a/backend/docs/seo/science-contentpage-real-import-command-enablement-01.md
+++ b/backend/docs/seo/science-contentpage-real-import-command-enablement-01.md
@@ -5,6 +5,34 @@ GO for controlled CMS draft import after this PR is merged, GitHub checks are gr
 
 NO-GO for production import, publish, sitemap, llms, footer, search submission, or social distribution inside this PR.
 
+## 2026-06-08 Closeout Update
+
+The command enablement PR was later followed by:
+
+- fap-api #1983, which removed the production parser dependency blocker.
+- A production no-write dry-run that passed with `writes_committed=0`.
+- A controlled production execute using the exact approval phrase `SCIENCE_CONTENTPAGE_NON_PUBLIC_DRAFT_IMPORT_APPROVED`.
+- A post-execute idempotency dry-run that skipped the five existing rows without creating duplicates.
+
+Controlled import result:
+
+```text
+ok=1
+mode=execute
+dry_run=0
+writes_committed=1
+pages_seen=6
+planned_create_count=5
+skipped_existing_count=0
+authority_revision_only_count=1
+blocked_count=0
+created_count=5
+publish_allowed=0
+discoverability_allowed=0
+```
+
+This closeout means controlled non-public draft import is now complete. It does **not** change the publish/discoverability decision: public publish, sitemap, llms, footer, search submission, and social distribution remain NO-GO.
+
 ## Command
 `content-pages:science-import-drafts`
 
@@ -38,7 +66,7 @@ cd backend && php artisan content-pages:science-import-drafts --package=../backe
 - Private routes: blocked by prior pre-import QA gate.
 
 ## Deferred
-- Controlled CMS draft import.
-- Post-import QA.
+- CMS operator publication review.
+- Claim/science/legal review closeout.
 - Publish/discoverability gate.
-- Production no-write shell evidence.
+- Any public publish or search/distribution action.

--- a/backend/docs/seo/science-contentpage-weekly-pr-progress-2026-06-08.md
+++ b/backend/docs/seo/science-contentpage-weekly-pr-progress-2026-06-08.md
@@ -1,0 +1,131 @@
+# Science ContentPage Weekly PR Progress
+
+Date: 2026-06-08
+Mode: docs-only progress closeout
+
+## Decision
+
+**Science ContentPage non-public draft import is complete. Publish and discoverability remain NO-GO.**
+
+The recent PR train moved the six-page Science package from planning and route authority scans into backend-safe CMS draft storage. Five pages now exist as non-public, non-indexable CMS drafts. `/method-boundaries` remains an existing-authority page and was not created or overwritten.
+
+## Backend PR Progress
+
+| PR | Status | Progress meaning |
+|---|---|---|
+| fap-api #1922 | Merged | Planned the ContentPage field mapping and draft-only constraints. |
+| fap-api #1944 | Merged | Added Science ContentPage dry-run validation with no writes. |
+| fap-api #1948 | Merged | Added operator review readiness gate. |
+| fap-api #1955 | Merged | Added pre-import QA gate for claims, routes, FAQ, private URLs, and exposure defaults. |
+| fap-api #1958 | Merged | Reconciled `/method-boundaries` as existing-authority revision-only. |
+| fap-api #1959 | Merged | Added first-class publish/operator/claim/schema safety fields. |
+| fap-api #1960 | Merged | Locked pre-real-import contract as dry-run-only until a later approved command. |
+| fap-api #1967 | Merged | Summarized Science line status before real import enablement. |
+| fap-api #1973 | Merged | Packaged the GPT-5.5 Pro review draft into review audit, six page candidates, and operator review artifacts. |
+| fap-api #1976 | Merged | Confirmed Science reliability route governance and canonical route selection. |
+| fap-api #1978 | Merged | Recorded production no-write dry-run gate. |
+| fap-api #1981 | Merged | Enabled controlled non-public draft import command with exact approval phrase. |
+| fap-api #1983 | Merged | Fixed production parser blocker by removing the missing Symfony YAML runtime dependency. |
+
+## Frontend PR Progress
+
+| PR | Status | Progress meaning |
+|---|---|---|
+| fap-web #1060 | Merged | Reconciled method-boundaries authority from the frontend side. |
+| fap-web #1062 | Merged | Added guarded root route wrappers for Science ContentPage slugs. |
+| fap-web #1064 | Merged | Added Science claim boundary gate. |
+| fap-web #1065 | Merged | Added visible-FAQ-only schema gate. |
+| fap-web #1066 | Merged | Added Science discoverability gate tests. |
+| fap-web #1068 | Merged | Kept Science drafts out of footer, sitemap, and llms until eligibility gates pass. |
+| fap-web #1069 | Merged | Converged static sitemap generation to backend source; Science drafts remain excluded by backend state. |
+
+## Production Closeout Evidence
+
+Production no-write dry-run after deploy:
+
+```text
+ok=1
+mode=dry_run
+dry_run=1
+writes_committed=0
+pages_seen=6
+planned_create_count=5
+skipped_existing_count=0
+authority_revision_only_count=1
+blocked_count=0
+created_count=0
+publish_allowed=0
+discoverability_allowed=0
+```
+
+Controlled execute after exact approval phrase:
+
+```text
+ok=1
+mode=execute
+dry_run=0
+writes_committed=1
+pages_seen=6
+planned_create_count=5
+skipped_existing_count=0
+authority_revision_only_count=1
+blocked_count=0
+created_count=5
+publish_allowed=0
+discoverability_allowed=0
+```
+
+Idempotency dry-run after execute:
+
+```text
+ok=1
+mode=dry_run
+dry_run=1
+writes_committed=0
+pages_seen=6
+planned_create_count=0
+skipped_existing_count=5
+authority_revision_only_count=1
+blocked_count=0
+created_count=0
+publish_allowed=0
+discoverability_allowed=0
+```
+
+## Imported Draft Rows
+
+| Slug | Status | Public | Indexable | Publish allowed | Claim gate | Schema |
+|---|---|---:|---:|---:|---|---|
+| `/science` | draft | false | false | false | not_reviewed | disabled |
+| `/item-design-notes` | draft | false | false | false | not_reviewed | disabled |
+| `/reliability-validity` | draft | false | false | false | not_reviewed | disabled |
+| `/data-privacy` | draft | false | false | false | not_reviewed | disabled |
+| `/common-misconceptions` | draft | false | false | false | not_reviewed | disabled |
+
+`/method-boundaries` was skipped as existing-authority revision-only.
+
+## Adjacent PR Lines
+
+| Line | Recent PRs | Status |
+|---|---|---|
+| Help ContentPage service fields and draft review | fap-api #1947, #1956, #1962, #1966, #1975, #1984, #1985-#1995 | Progressed through service-field production verification, policy sync, operator review R2, approval R2, and publish preflight blocker repair. This is adjacent but not a Science publish gate. |
+| RIASEC article/CMS media line | fap-api #1937, #1943, #1949, #1957, #1961, #1965, #1968, #1971, #1974, #1977, #1980; fap-web #1070, #1071 | Progressed through review, media, locale, publish smoke, and search-submission preflight. This does not authorize Science discoverability. |
+| DailyGiving proof/foundation line | fap-api #1941, #1950, #1969, #1992; fap-web #1059, #1063, #1067 | Progressed proof handling and line summaries while preserving noindex/search-amplification boundaries. This remains separate from Science ContentPage. |
+
+## Remaining NO-GO Gates
+
+- No public publish.
+- No sitemap inclusion.
+- No llms inclusion.
+- No footer exposure.
+- No search submission.
+- No social distribution.
+- No FAQ schema until visible FAQ/schema eligibility review is approved.
+- No publish until operator, claim, science, and legal review decisions are recorded.
+
+## Next Allowed Work
+
+1. CMS operator review for the five imported drafts.
+2. Claim/science/legal review closeout for each draft.
+3. Publish preflight only after approvals.
+4. Discoverability gate only after publish eligibility is true and public exposure is explicitly approved.


### PR DESCRIPTION
## What changed
- Added a Science ContentPage weekly PR progress closeout covering the recent backend/frontend PR train.
- Updated the field-mapping, real-import command, package README, and generated evidence to reflect the current production state: five non-public draft rows imported; `/method-boundaries` remains existing-authority revision-only.
- Preserved the publish/discoverability boundary: no publish, sitemap, llms, footer, search submission, or distribution approval.

## Why
- The earlier docs still described controlled import as deferred. Production dry-run and exact-phrase controlled import have now completed, so the technical docs needed to distinguish current draft-storage completion from still-blocked publication.

## Validation
- `php -r 'foreach (["backend/docs/seo/generated/science-contentpage-real-import-command-enablement-01.v1.json", "backend/docs/seo/generated/science-contentpage-weekly-pr-progress-2026-06-08.v1.json"] as $f) { json_decode(file_get_contents($f), true, 512, JSON_THROW_ON_ERROR); echo $f, " OK\\n"; }'`\n- `git diff --cached --check`\n\n## Intentionally deferred\n- No code changes.\n- No CMS mutation.\n- No import command execution.\n- No publish, sitemap, llms, footer, search submission, or social distribution.