### PR TITLE
HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01 ops(help): sync repaired Help drafts

### DIFF
--- a/backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json
@@ -1,0 +1,142 @@
+{
+  "schema": "help-content-draft-blocker-cms-sync-01.v1",
+  "task": "HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01",
+  "generated_at": "2026-06-08",
+  "decision": "CMS_DRAFT_BLOCKER_SYNC_COMPLETE_PUBLISH_STILL_BLOCKED",
+  "scope": "Sync the repaired local Help service ContentPage package into the existing 12 Help CMS drafts only.",
+  "authorization": {
+    "source": "user",
+    "allowed": "CMS mutation to sync the already repaired local package into the existing 12 Help CMS draft rows.",
+    "forbidden": [
+      "publish",
+      "deploy",
+      "search submission",
+      "private result/order/share/pay/payment/history URL access",
+      "secret/env/cookie/token value reading",
+      "payment/refund action",
+      "payment-provider behavior change",
+      "Operator approval claim"
+    ]
+  },
+  "source_package": {
+    "content_page_source_path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "content_page_source_sha256": "af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d",
+    "import_package_path": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "import_package_sha256": "15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44",
+    "source_rows": 12,
+    "local_boundary_scan": {
+      "payment_id": 0,
+      "transaction_id": 0,
+      "orders_route": 0,
+      "result_route": 0,
+      "pay_route": 0,
+      "token_param": 0
+    }
+  },
+  "production_execution": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode",
+    "runtime_revision_sha": "8570a335c5cc539507b3dad4d8659fc9c971d759",
+    "temporary_source_dir": "/tmp/fm-help-blocker-cms-sync.3r25GW",
+    "temporary_source_removed": true,
+    "dry_run": {
+      "command": "php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fm-help-blocker-cms-sync.3r25GW --no-ansi",
+      "exit_code": 0,
+      "files_found": 1,
+      "pages_found": 12,
+      "will_create": 0,
+      "will_update": 12,
+      "will_skip": 0
+    },
+    "import": {
+      "command": "php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fm-help-blocker-cms-sync.3r25GW --no-ansi",
+      "exit_code": 0,
+      "files_found": 1,
+      "pages_found": 12,
+      "will_create": 0,
+      "will_update": 12,
+      "will_skip": 0
+    }
+  },
+  "post_sync_cms_state": {
+    "checked_rows": 12,
+    "draft": 12,
+    "non_public": 12,
+    "non_indexable": 12,
+    "unpublished": 12,
+    "owner_review": 12,
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_items_count_4": 12,
+    "pattern_hits": {
+      "payment_id": 0,
+      "transaction_id": 0,
+      "payment_identifier": 0,
+      "private_route": 0,
+      "token_param": 0
+    },
+    "slugs": [
+      "help-data-deletion",
+      "help-payment-refund",
+      "help-privacy-data",
+      "help-result-recovery",
+      "help-unlock-failure",
+      "help-use-boundaries"
+    ],
+    "locales": [
+      "en",
+      "zh-CN"
+    ]
+  },
+  "public_absence_checks": {
+    "method": "Python urllib GET against public canonical routes with one manual 308 redirect follow",
+    "status": "pass",
+    "routes_checked": 12,
+    "expected_final_status": 404,
+    "results": [
+      {"route": "/zh/help/unlock-failure", "status_chain": [308, 404]},
+      {"route": "/en/help/unlock-failure", "status_chain": [308, 404]},
+      {"route": "/zh/help/payment-refund", "status_chain": [308, 404]},
+      {"route": "/en/help/payment-refund", "status_chain": [308, 404]},
+      {"route": "/zh/help/result-recovery", "status_chain": [308, 404]},
+      {"route": "/en/help/result-recovery", "status_chain": [308, 404]},
+      {"route": "/zh/help/privacy-data", "status_chain": [308, 404]},
+      {"route": "/en/help/privacy-data", "status_chain": [308, 404]},
+      {"route": "/zh/help/use-boundaries", "status_chain": [308, 404]},
+      {"route": "/en/help/use-boundaries", "status_chain": [308, 404]},
+      {"route": "/zh/help/data-deletion", "status_chain": [308, 404]},
+      {"route": "/en/help/data-deletion", "status_chain": [308, 404]}
+    ]
+  },
+  "scope_validation": {
+    "cms_mutation_performed": true,
+    "cms_mutation_limited_to_existing_12_help_drafts": true,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "sidecars": [
+    {
+      "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+      "status": "next_runtime_pr",
+      "note": "Frontend schema runtime still needs to consume CMS faq_items/schema_enabled."
+    },
+    {
+      "id": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01",
+      "status": "follow_up_runtime_pr",
+      "note": "Backend still needs a bounded controlled publish runtime for ContentPage Help rows before publish execute."
+    },
+    {
+      "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+      "status": "hard_gate",
+      "note": "Publish remains blocked until schema runtime, controlled publish runtime, publish preflight, and exact publish authorization are complete."
+    }
+  ],
+  "next_task_recommendation": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01"
+}

--- a/backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md
@@ -1,0 +1,89 @@
+# HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01
+
+Date: 2026-06-08
+
+Decision: `CMS_DRAFT_BLOCKER_SYNC_COMPLETE_PUBLISH_STILL_BLOCKED`
+
+## Scope
+
+This PR synced the repaired local Help service source package into the existing 12 Help `ContentPage` CMS drafts.
+
+Allowed CMS mutation was limited to the existing 12 Help draft rows. No publish, deploy, search submission, private result/order/share/pay/payment/history URL access, secret/env/cookie/token read, payment/refund action, payment-provider behavior change, or Operator approval claim was performed.
+
+## Source Evidence
+
+- ContentPage source: `backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json`
+- ContentPage source SHA-256: `af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d`
+- Import package: `backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json`
+- Import package SHA-256: `15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44`
+- Source rows: 12
+
+Local boundary scan returned zero hits for `payment_id`, `transaction_id`, `/orders/`, `/result/`, `/pay/`, and token parameters.
+
+## Production Execution
+
+- Runtime revision: `8570a335c5cc539507b3dad4d8659fc9c971d759`
+- Temporary source dir: `/tmp/fm-help-blocker-cms-sync.3r25GW`
+- Temporary source dir removed: yes
+
+Dry-run command:
+
+```text
+php artisan content-pages:import-local-baseline --dry-run --upsert --status=draft --source-dir=/tmp/fm-help-blocker-cms-sync.3r25GW --no-ansi
+```
+
+Dry-run result:
+
+```text
+files_found=1
+pages_found=12
+will_create=0
+will_update=12
+will_skip=0
+```
+
+Import command:
+
+```text
+php artisan content-pages:import-local-baseline --upsert --status=draft --source-dir=/tmp/fm-help-blocker-cms-sync.3r25GW --no-ansi
+```
+
+Import result:
+
+```text
+files_found=1
+pages_found=12
+will_create=0
+will_update=12
+will_skip=0
+```
+
+## Post-Sync State
+
+Post-sync read-only CMS summary returned:
+
+- checked rows: 12
+- draft: 12
+- non-public: 12
+- non-indexable: 12
+- unpublished: 12
+- owner review: 12
+- `support_contact=support@fermatmind.com`: 12
+- `policy_version=help_service_policy.v1`: 12
+- `reviewer=Unknown`: 12
+- `schema_enabled=false`: 12
+- `faq_items` count 4: 12
+- `payment_id` hits: 0
+- `transaction_id` hits: 0
+- `payment identifier` hits: 0
+- private route hits: 0
+- token parameter hits: 0
+
+Public canonical route absence checks returned `308 -> 404` for all 12 zh/en Help routes, so the draft rows are still not publicly visible.
+
+## Remaining Gates
+
+- `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01`: frontend schema runtime still needs to consume CMS `faq_items` / `schema_enabled`.
+- `HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01`: backend still needs bounded controlled publish runtime for Help `ContentPage` rows.
+- `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01`: rerun publish preflight after both runtime blockers are fixed.
+- Publish remains blocked until exact publish authorization is provided.

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50460,5 +50460,174 @@
         "note": "PR #1995 merged at 2026-06-08T08:24:57Z with merge commit c0bed89cfc47f295f236f786f43228b5c12e17cc; origin/main contains the merge commit, remote task branch is deleted, and the local task branch was deleted after switching this worktree to detached origin/main because local main is owned by another worktree."
       }
     ]
+  },
+  "HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-blocker-cms-sync-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "ops(help): sync repaired Help drafts to CMS",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized CMS mutation to sync the repaired local package into the existing 12 Help CMS draft rows. Publish, deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, and Operator approval claim are forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01 is merged in PR #1995 with merge commit c0bed89cfc47f295f236f786f43228b5c12e17cc; closeout PR #1996 is merged on origin/main."
+      },
+      "source_package": {
+        "status": "pass",
+        "content_page_source_path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+        "content_page_source_sha256": "af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d",
+        "import_package_path": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+        "import_package_sha256": "15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44",
+        "rows": 12,
+        "local_boundary_scan": {
+          "payment_id": 0,
+          "transaction_id": 0,
+          "orders_route": 0,
+          "result_route": 0,
+          "pay_route": 0,
+          "token_param": 0
+        }
+      },
+      "production_cms_sync": {
+        "status": "pass",
+        "connection_method": "ssh_alias_fap-api-prod_batchmode",
+        "runtime_revision_sha": "8570a335c5cc539507b3dad4d8659fc9c971d759",
+        "temporary_source_dir": "/tmp/fm-help-blocker-cms-sync.3r25GW",
+        "temporary_source_removed": true,
+        "dry_run": {
+          "files_found": 1,
+          "pages_found": 12,
+          "will_create": 0,
+          "will_update": 12,
+          "will_skip": 0
+        },
+        "import": {
+          "files_found": 1,
+          "pages_found": 12,
+          "will_create": 0,
+          "will_update": 12,
+          "will_skip": 0
+        }
+      },
+      "post_sync_cms_state": {
+        "status": "pass",
+        "checked_rows": 12,
+        "draft": 12,
+        "non_public": 12,
+        "non_indexable": 12,
+        "unpublished": 12,
+        "owner_review": 12,
+        "support_contact": 12,
+        "policy_version": 12,
+        "reviewer_unknown": 12,
+        "schema_disabled": 12,
+        "faq_items_4": 12,
+        "pattern_hits": {
+          "payment_id": 0,
+          "transaction_id": 0,
+          "payment_identifier": 0,
+          "private_route": 0,
+          "token_param": 0
+        }
+      },
+      "public_absence": {
+        "status": "pass",
+        "routes_checked": 12,
+        "all_final_404": true,
+        "status_chains": "all routes returned 308 -> 404"
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ]
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "merge_state": null,
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "CMS_DRAFT_BLOCKER_SYNC_COMPLETE_PUBLISH_STILL_BLOCKED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md",
+      "next_task_recommendation": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": true,
+      "cms_mutation_limited_to_existing_12_help_drafts": true,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "sidecars": [
+      {
+        "id": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+        "status": "next_runtime_pr",
+        "note": "Frontend schema runtime still needs to consume CMS faq_items/schema_enabled."
+      },
+      {
+        "id": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01",
+        "status": "follow_up_runtime_pr",
+        "note": "Backend still needs a bounded controlled publish runtime for Help ContentPage rows before publish execute."
+      },
+      {
+        "id": "HELP-CONTENT-DRAFT-PUBLISH-BLOCK",
+        "status": "hard_gate",
+        "note": "Publish remains blocked until schema runtime, controlled publish runtime, publish preflight, and exact publish authorization are complete."
+      }
+    ],
+    "next_task": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01",
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "authorized",
+        "note": "User authorized CMS mutation to sync the repaired local package into the existing 12 Help CMS draft rows."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "production_dry_run_passed",
+        "note": "content-pages:import-local-baseline dry-run found 12 pages, will_create=0, will_update=12."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "cms_sync_complete",
+        "note": "Imported with --upsert --status=draft against the scoped 12-row source; post-sync CMS check kept all 12 rows draft, non-public, non-indexable, unpublished, owner_review, and schema_enabled=false, with payment_id/transaction_id/payment identifier hits at 0."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "JSON/YAML validation, HelpContentImportPackageTest, and scoped diff whitespace checks passed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50465,7 +50465,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-blocker-cms-sync-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync repaired Help drafts to CMS",
     "depends_on": [
@@ -50556,17 +50556,27 @@
         ]
       },
       "github": {
-        "status": "pending",
-        "head_sha": null,
-        "passed_checks": [],
-        "merge_state": null,
+        "status": "pass",
+        "head_sha": "02569ee9373326c4cf5dd44ee67e7e89072688f4",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
         "failure_reason": null,
         "merge_commit": null
       }
     },
     "failure_reason": null,
     "commit_sha": null,
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/1998",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -50627,6 +50637,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "JSON/YAML validation, HelpContentImportPackageTest, and scoped diff whitespace checks passed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #1998 head 02569ee9373326c4cf5dd44ee67e7e89072688f4; merge state pending final GitHub confirmation."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22393,6 +22393,48 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01
 
+  - id: HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-PREFLIGHT-BLOCKER-REPAIR-01
+    branch: codex/help-content-draft-blocker-cms-sync-01
+    title: "ops(help): sync repaired Help drafts to CMS"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Sync the repaired local Help service ContentPage source package to the existing 12 Help CMS draft rows only.
+      - Preserve draft, non-public, non-indexable, unpublished, owner_review, support_contact, policy_version, reviewer, faq_items, and schema_enabled safety state.
+      - Verify the payment_id/transaction_id/payment identifier phrase gate remains clear in CMS summary output.
+      - Record that schema runtime and controlled publish runtime remain separate follow-up PRs.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json
+      - backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi
+      - git diff --check -- backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: true
+    database_mutation: true
+    payment_provider_call: false
+    cms_mutation: true
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Synced the repaired local Help service ContentPage source package into the existing 12 production CMS draft rows.
- Recorded the dry-run/import/post-sync evidence in `help-content-draft-blocker-cms-sync-01.v1.json` and the operations report.
- Added the PR-train manifest/state entry for `HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01`.

## Why
`HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-01` was blocked by the payment_id phrase gate in production CMS draft content. The local package repair has already merged; this PR applies that repaired package to the existing CMS drafts while preserving draft-only safety.

## Validation
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentImportPackageTest --no-ansi`
- `git diff --check -- backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json backend/docs/operations/help-content-draft-blocker-cms-sync-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Production/CMS execution evidence
- Dry-run: `files_found=1`, `pages_found=12`, `will_create=0`, `will_update=12`, `will_skip=0`.
- Import: `files_found=1`, `pages_found=12`, `will_create=0`, `will_update=12`, `will_skip=0`.
- Post-sync: 12 draft, 12 non-public, 12 non-indexable, 12 unpublished, 12 owner_review.
- Phrase gate post-sync: `payment_id=0`, `transaction_id=0`, `payment_identifier=0`, private route hits `0`, token param hits `0`.

## Intentionally deferred
- `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01`
- `HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01`
- `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01`
- Publish remains blocked until exact publish authorization is provided.

## Repository Rule Impact
Content authority remains CMS/backend. No frontend fallback content, publish action, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider behavior change, or Operator approval claim was performed.
