### PR TITLE
docs(codex): close Help blocker CMS sync

### DIFF
--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50465,7 +50465,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-blocker-cms-sync-01",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "ops(help): sync repaired Help drafts to CMS",
     "depends_on": [
@@ -50557,7 +50557,7 @@
       },
       "github": {
         "status": "pass",
-        "head_sha": "02569ee9373326c4cf5dd44ee67e7e89072688f4",
+        "head_sha": "d67b1139b55142e556da87da35f2bec9dc71b562",
         "passed_checks": [
           "hygiene",
           "supply-chain",
@@ -50571,15 +50571,15 @@
         ],
         "merge_state": "CLEAN",
         "failure_reason": null,
-        "merge_commit": null
+        "merge_commit": "c468443998471ba2ad645476ad2389610f4c02b1"
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "c468443998471ba2ad645476ad2389610f4c02b1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1998",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-08T08:57:25Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "decision": "CMS_DRAFT_BLOCKER_SYNC_COMPLETE_PUBLISH_STILL_BLOCKED",
       "generated_artifact": "backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json",
@@ -50642,6 +50642,11 @@
         "at": "2026-06-08",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #1998 head 02569ee9373326c4cf5dd44ee67e7e89072688f4; merge state pending final GitHub confirmation."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged",
+        "note": "PR #1998 merged at 2026-06-08T08:57:25Z with merge commit c468443998471ba2ad645476ad2389610f4c02b1; origin/main contains the merge commit, remote task branch is deleted, and local task branch was deleted."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22400,7 +22400,7 @@ prs:
     branch: codex/help-content-draft-blocker-cms-sync-01
     title: "ops(help): sync repaired Help drafts to CMS"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     scope:
       - Sync the repaired local Help service ContentPage source package to the existing 12 Help CMS draft rows only.
       - Preserve draft, non-public, non-indexable, unpublished, owner_review, support_contact, policy_version, reviewer, faq_items, and schema_enabled safety state.


### PR DESCRIPTION
## What changed
- Marked `HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01` as merged in the PR-train manifest/state.
- Recorded PR #1998 merge commit, merge time, remote branch deletion, and local cleanup facts.

## Why
Closeout bookkeeping after PR #1998 was squash-merged on GitHub.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01`
- `HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01`
- `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01`
