### PR TITLE
HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01: add Help service controlled publish runtime

### DIFF
--- a/backend/app/Console/Commands/ContentPagesPublishControlledCommand.php
+++ b/backend/app/Console/Commands/ContentPagesPublishControlledCommand.php
@@ -10,13 +10,14 @@ use Illuminate\Console\Command;
 final class ContentPagesPublishControlledCommand extends Command
 {
     protected $signature = 'content-pages:publish-controlled
+        {--scope=global-en-wave1 : Controlled publish scope. Supported: global-en-wave1, help-service}
         {--locale=en : Required locale. Only en is supported for this bounded runtime}
         {--keys= : Comma-separated exact page keys to publish}
         {--dry-run : Preview without writes}
         {--execute : Explicitly perform the controlled publish}
         {--json : Emit JSON output}';
 
-    protected $description = 'Fail-closed controlled publish runtime for approved English content_pages records.';
+    protected $description = 'Fail-closed controlled publish runtime for approved content_pages records.';
 
     public function handle(ContentPagesControlledPublishService $service): int
     {
@@ -42,11 +43,12 @@ final class ContentPagesPublishControlledCommand extends Command
             return self::FAILURE;
         }
 
+        $scope = trim((string) $this->option('scope'));
         $locale = trim((string) $this->option('locale'));
         $keys = $this->keys();
         $payload = $execute
-            ? $service->execute($locale, $keys)
-            : $service->dryRun($locale, $keys);
+            ? $service->execute($scope, $locale, $keys)
+            : $service->dryRun($scope, $locale, $keys);
 
         $this->emit($payload);
 

--- a/backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
+++ b/backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
@@ -13,9 +13,17 @@ final class ContentPagesControlledPublishService
 {
     public const COMMAND = 'content-pages:publish-controlled';
 
+    public const SCOPE_GLOBAL_EN_WAVE1 = 'global-en-wave1';
+
+    public const SCOPE_HELP_SERVICE = 'help-service';
+
     public const LOCALE = 'en';
 
+    public const HELP_SERVICE_LOCALE_OPTION = 'all';
+
     public const CMS_DRAFT_UPDATE_SOURCE_MARKER = 'global-en-zh-content-pages-cms-draft-update-01';
+
+    public const HELP_SERVICE_SOURCE_MARKER = 'HELP-SERVICE-CONTENT-DRAFTS-01';
 
     public const FOUNDATION_FACT_STATE = 'planned_public_benefit_shareholding';
 
@@ -30,6 +38,26 @@ final class ContentPagesControlledPublishService
         'foundation',
         'careers',
         'policies',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const HELP_SERVICE_ALLOWED_KEYS = [
+        'help-unlock-failure',
+        'help-payment-refund',
+        'help-result-recovery',
+        'help-privacy-data',
+        'help-use-boundaries',
+        'help-data-deletion',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const HELP_SERVICE_LOCALES = [
+        'zh-CN',
+        'en',
     ];
 
     /**
@@ -54,19 +82,19 @@ final class ContentPagesControlledPublishService
      * @param  list<string>  $keys
      * @return array<string, mixed>
      */
-    public function dryRun(string $locale, array $keys): array
+    public function dryRun(string $scope, string $locale, array $keys): array
     {
-        return $this->buildPlan($locale, $keys, false);
+        return $this->buildPlan($scope, $locale, $keys, false);
     }
 
     /**
      * @param  list<string>  $keys
      * @return array<string, mixed>
      */
-    public function execute(string $locale, array $keys): array
+    public function execute(string $scope, string $locale, array $keys): array
     {
-        return DB::transaction(function () use ($locale, $keys): array {
-            $plan = $this->buildPlan($locale, $keys, true);
+        return DB::transaction(function () use ($scope, $locale, $keys): array {
+            $plan = $this->buildPlan($scope, $locale, $keys, true);
             if (! (bool) ($plan['ok'] ?? false)) {
                 return $plan;
             }
@@ -76,29 +104,30 @@ final class ContentPagesControlledPublishService
 
             foreach ((array) ($plan['pages'] ?? []) as $pagePlan) {
                 $key = (string) ($pagePlan['key'] ?? '');
+                $targetLocale = (string) ($pagePlan['locale'] ?? self::LOCALE);
                 $page = ContentPage::query()
                     ->withoutGlobalScopes()
                     ->where('org_id', 0)
-                    ->where('locale', self::LOCALE)
+                    ->where('locale', $targetLocale)
                     ->where('slug', $key)
                     ->lockForUpdate()
                     ->first();
 
                 if (! $page instanceof ContentPage) {
-                    throw new RuntimeException('Target content page disappeared during controlled publish: '.$key);
+                    throw new RuntimeException('Target content page disappeared during controlled publish: '.$targetLocale.':'.$key);
                 }
 
                 if ($this->isPublishedTarget($page)) {
-                    $skipped[] = $key;
+                    $skipped[] = (string) ($pagePlan['target_key'] ?? $key);
 
                     continue;
                 }
 
                 $publishedPage = $this->workspace->publishWorkingRevision('content_page', $page);
-                $published[] = (string) $publishedPage->slug;
+                $published[] = (string) ($pagePlan['target_key'] ?? $publishedPage->slug);
             }
 
-            $afterPlan = $this->buildPlan($locale, $keys, true);
+            $afterPlan = $this->buildPlan($scope, $locale, $keys, true);
 
             return [
                 ...$afterPlan,
@@ -115,13 +144,29 @@ final class ContentPagesControlledPublishService
      * @param  list<string>  $keys
      * @return array<string, mixed>
      */
-    private function buildPlan(string $locale, array $keys, bool $forExecute): array
+    private function buildPlan(string $scope, string $locale, array $keys, bool $forExecute): array
     {
+        $scope = trim($scope) === '' ? self::SCOPE_GLOBAL_EN_WAVE1 : strtolower(trim($scope));
         $keys = array_values(array_map(static fn (string $key): string => strtolower(trim($key)), $keys));
         $errors = [];
+        $allowedKeys = $this->allowedKeys($scope);
+        $targetLocales = $this->targetLocales($scope, $locale);
 
-        if ($locale !== self::LOCALE) {
+        if (! in_array($scope, [self::SCOPE_GLOBAL_EN_WAVE1, self::SCOPE_HELP_SERVICE], true)) {
+            $errors[] = $this->issue('scope', 'unsupported_scope', 'Unsupported content-pages controlled publish scope.', [
+                'actual' => $scope,
+                'supported' => [self::SCOPE_GLOBAL_EN_WAVE1, self::SCOPE_HELP_SERVICE],
+            ]);
+        }
+
+        if ($scope === self::SCOPE_GLOBAL_EN_WAVE1 && $locale !== self::LOCALE) {
             $errors[] = $this->issue('locale', 'unsupported_locale', 'Controlled content-page publish only allows locale=en.', [
+                'actual' => $locale,
+            ]);
+        }
+
+        if ($scope === self::SCOPE_HELP_SERVICE && $locale !== self::HELP_SERVICE_LOCALE_OPTION) {
+            $errors[] = $this->issue('locale', 'unsupported_locale', 'Help service controlled publish requires --locale=all so both zh-CN and en rows are in scope.', [
                 'actual' => $locale,
             ]);
         }
@@ -134,24 +179,27 @@ final class ContentPagesControlledPublishService
             $errors[] = $this->issue('keys', 'duplicate_keys', 'Duplicate keys are not allowed.');
         }
 
-        $extraKeys = array_values(array_diff($keys, self::ALLOWED_KEYS));
+        $extraKeys = array_values(array_diff($keys, $allowedKeys));
         if ($extraKeys !== []) {
-            $errors[] = $this->issue('keys', 'extra_keys_not_allowed', 'Only the Wave 1 approved English content page keys are allowed.', [
+            $errors[] = $this->issue('keys', 'extra_keys_not_allowed', 'Only the approved content page keys for this scope are allowed.', [
                 'extra_keys' => $extraKeys,
+                'scope' => $scope,
             ]);
         }
 
-        $missingScopeKeys = array_values(array_diff(self::ALLOWED_KEYS, $keys));
+        $missingScopeKeys = array_values(array_diff($allowedKeys, $keys));
         if ($missingScopeKeys !== []) {
-            $errors[] = $this->issue('keys', 'exact_scope_required', 'The controlled publish runtime requires the exact five-page Wave 1 scope.', [
+            $errors[] = $this->issue('keys', 'exact_scope_required', 'The controlled publish runtime requires the exact approved scope.', [
                 'missing_scope_keys' => $missingScopeKeys,
+                'scope' => $scope,
             ]);
         }
 
-        $readiness = $this->readinessArtifactState();
+        $readiness = $this->readinessArtifactState($scope);
         if (! (bool) ($readiness['ready'] ?? false)) {
-            $errors[] = $this->issue('readiness', 'r2_readiness_not_ready', 'Merged R2 readiness artifact must approve all five pages before controlled publish.', [
+            $errors[] = $this->issue('readiness', 'readiness_not_ready', 'Merged readiness artifact must approve the controlled publish scope before publish.', [
                 'artifact_state' => $readiness,
+                'scope' => $scope,
             ]);
         }
 
@@ -159,33 +207,40 @@ final class ContentPagesControlledPublishService
             ->withoutGlobalScopes()
             ->with('workingRevision')
             ->where('org_id', 0)
-            ->where('locale', self::LOCALE)
-            ->whereIn('slug', self::ALLOWED_KEYS)
+            ->whereIn('locale', $targetLocales)
+            ->whereIn('slug', $allowedKeys)
             ->get()
-            ->keyBy(static fn (ContentPage $page): string => (string) $page->slug);
+            ->keyBy(static fn (ContentPage $page): string => (string) $page->locale.':'.(string) $page->slug);
 
         $pages = [];
-        foreach (self::ALLOWED_KEYS as $key) {
-            $page = $records->get($key);
-            if (! $page instanceof ContentPage) {
-                $errors[] = $this->issue('content_pages.'.$key, 'missing_target_record', 'Target content page record is missing.', [
+        foreach ($targetLocales as $targetLocale) {
+            foreach ($allowedKeys as $key) {
+                $targetKey = $this->targetKey($scope, $targetLocale, $key);
+                $page = $records->get($targetLocale.':'.$key);
+                if (! $page instanceof ContentPage) {
+                    $errors[] = $this->issue('content_pages.'.$targetKey, 'missing_target_record', 'Target content page record is missing.', [
+                        'key' => $key,
+                        'locale' => $targetLocale,
+                        'target_key' => $targetKey,
+                    ]);
+
+                    continue;
+                }
+
+                $pageErrors = $this->preflightPage($scope, $page);
+                array_push($errors, ...$pageErrors);
+
+                $pages[] = [
                     'key' => $key,
-                ]);
-
-                continue;
+                    'locale' => $targetLocale,
+                    'target_key' => $targetKey,
+                    'id' => (int) $page->id,
+                    'before_state' => $this->state($page),
+                    'after_state_preview' => $this->afterStatePreview($page),
+                    'action' => $this->isPublishedTarget($page) ? 'skip_already_published' : 'publish',
+                    'errors' => $pageErrors,
+                ];
             }
-
-            $pageErrors = $this->preflightPage($page);
-            array_push($errors, ...$pageErrors);
-
-            $pages[] = [
-                'key' => $key,
-                'id' => (int) $page->id,
-                'before_state' => $this->state($page),
-                'after_state_preview' => $this->afterStatePreview($page),
-                'action' => $this->isPublishedTarget($page) ? 'skip_already_published' : 'publish',
-                'errors' => $pageErrors,
-            ];
         }
 
         $wouldPublishCount = count(array_filter(
@@ -198,22 +253,29 @@ final class ContentPagesControlledPublishService
         return [
             'ok' => $ok,
             'command' => self::COMMAND,
+            'scope' => $scope,
             'dry_run' => ! $forExecute,
             'execute' => $forExecute,
             'writes_committed' => false,
-            'target_count' => count(self::ALLOWED_KEYS),
+            'target_count' => count($allowedKeys) * count($targetLocales),
             'would_publish_count' => $ok ? $wouldPublishCount : 0,
             'would_update_count' => $ok ? $wouldPublishCount : 0,
             'would_create_count' => 0,
             'would_skip_count' => $ok ? $wouldSkipCount : 0,
             'blocked_count' => count($errors),
-            'target_keys' => self::ALLOWED_KEYS,
-            'allowed_keys' => self::ALLOWED_KEYS,
-            'forbidden_keys' => self::PROTECTED_KEYS,
+            'target_keys' => array_values(array_map(
+                fn (array $page): string => (string) ($page['target_key'] ?? $page['key'] ?? ''),
+                $pages,
+            )),
+            'allowed_keys' => $allowedKeys,
+            'target_locales' => $targetLocales,
+            'forbidden_keys' => $this->protectedKeys($scope),
             'before_state' => $this->indexByKey($pages, 'before_state'),
             'after_state_preview' => $this->indexByKey($pages, 'after_state_preview'),
             'foundation_fact_state' => self::FOUNDATION_FACT_STATE,
-            'forbidden_foundation_claims_absent' => ! $this->hasFoundationOverclaim($records->get('foundation')),
+            'forbidden_foundation_claims_absent' => $scope === self::SCOPE_GLOBAL_EN_WAVE1
+                ? ! $this->hasFoundationOverclaim($records->get(self::LOCALE.':foundation'))
+                : true,
             'discoverability_coupled' => false,
             'discoverability_coupling_policy' => 'The runtime preserves is_indexable=false and fails if any target is already indexable before publish; sitemap/llms/footer/nav exposure remains out of scope.',
             'search_channel_action_attempted' => false,
@@ -232,21 +294,27 @@ final class ContentPagesControlledPublishService
     /**
      * @return list<array<string, mixed>>
      */
-    private function preflightPage(ContentPage $page): array
+    private function preflightPage(string $scope, ContentPage $page): array
     {
         $errors = [];
         $key = (string) $page->slug;
 
-        if (! in_array($key, self::ALLOWED_KEYS, true)) {
+        if (! in_array($key, $this->allowedKeys($scope), true)) {
             $errors[] = $this->issue('content_pages.'.$key, 'non_allowlisted_key', 'Content page key is not allowlisted.');
         }
 
-        if ((string) $page->locale !== self::LOCALE) {
-            $errors[] = $this->issue('content_pages.'.$key.'.locale', 'invalid_locale', 'Target content page must be locale=en.');
+        if (! in_array((string) $page->locale, $this->targetLocales($scope, $scope === self::SCOPE_HELP_SERVICE ? self::HELP_SERVICE_LOCALE_OPTION : self::LOCALE), true)) {
+            $errors[] = $this->issue('content_pages.'.$key.'.locale', 'invalid_locale', 'Target content page locale is not allowed for this scope.', [
+                'scope' => $scope,
+                'locale' => (string) $page->locale,
+            ]);
         }
 
-        if (! str_contains((string) $page->source_doc, self::CMS_DRAFT_UPDATE_SOURCE_MARKER)) {
-            $errors[] = $this->issue('content_pages.'.$key.'.source_doc', 'missing_cms_draft_update_marker', 'Target content page must reflect the approved CMS draft update source marker.');
+        $sourceMarker = $scope === self::SCOPE_HELP_SERVICE ? self::HELP_SERVICE_SOURCE_MARKER : self::CMS_DRAFT_UPDATE_SOURCE_MARKER;
+        if (! str_contains((string) $page->source_doc, $sourceMarker)) {
+            $errors[] = $this->issue('content_pages.'.$key.'.source_doc', 'missing_cms_draft_update_marker', 'Target content page must reflect the approved CMS draft update source marker.', [
+                'expected_marker' => $sourceMarker,
+            ]);
         }
 
         if ((bool) $page->is_indexable) {
@@ -257,7 +325,11 @@ final class ContentPagesControlledPublishService
             $errors[] = $this->issue('content_pages.'.$key.'.status', 'invalid_publish_state', 'Target content page must be an unpublished draft or an already-published idempotency match.');
         }
 
-        if ($key === 'foundation') {
+        if ($scope === self::SCOPE_HELP_SERVICE) {
+            array_push($errors, ...$this->preflightHelpServicePage($page));
+        }
+
+        if ($scope === self::SCOPE_GLOBAL_EN_WAVE1 && $key === 'foundation') {
             $text = $this->pageText($page);
             if (! str_contains($text, 'planned public-benefit shareholding')) {
                 $errors[] = $this->issue('content_pages.foundation', 'foundation_fact_state_missing', 'Foundation page must retain planned public-benefit shareholding language.');
@@ -269,6 +341,50 @@ final class ContentPagesControlledPublishService
 
             if ($this->hasFoundationOverclaim($page)) {
                 $errors[] = $this->issue('content_pages.foundation', 'foundation_overclaim_detected', 'Foundation page contains a forbidden legal/foundation overclaim.');
+            }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function preflightHelpServicePage(ContentPage $page): array
+    {
+        $errors = [];
+        $fieldPrefix = 'content_pages.'.(string) $page->locale.':'.(string) $page->slug;
+
+        if ((string) $page->kind !== ContentPage::KIND_HELP) {
+            $errors[] = $this->issue($fieldPrefix.'.kind', 'invalid_kind', 'Help service controlled publish only allows kind=help.');
+        }
+
+        if ((string) $page->review_state !== 'owner_review' && (string) $page->review_state !== 'approved') {
+            $errors[] = $this->issue($fieldPrefix.'.review_state', 'invalid_review_state', 'Help service page must remain owner_review or approved before controlled publish.');
+        }
+
+        if ((string) $page->support_contact !== 'support@fermatmind.com') {
+            $errors[] = $this->issue($fieldPrefix.'.support_contact', 'invalid_support_contact', 'Help service page must carry the approved support contact.');
+        }
+
+        if ((string) $page->policy_version !== 'help_service_policy.v1') {
+            $errors[] = $this->issue($fieldPrefix.'.policy_version', 'invalid_policy_version', 'Help service page must carry the approved policy version.');
+        }
+
+        if (trim((string) $page->reviewer) === '') {
+            $errors[] = $this->issue($fieldPrefix.'.reviewer', 'missing_reviewer', 'Help service page must carry a reviewer field, using Unknown when not yet assigned.');
+        }
+
+        $faqItems = is_array($page->faq_items) ? array_values($page->faq_items) : [];
+        if (count($faqItems) !== 4) {
+            $errors[] = $this->issue($fieldPrefix.'.faq_items', 'invalid_faq_item_count', 'Help service page must carry exactly four structured FAQ items before controlled publish.', [
+                'actual_count' => count($faqItems),
+            ]);
+        }
+
+        foreach ($faqItems as $index => $item) {
+            if (! is_array($item) || trim((string) ($item['question'] ?? '')) === '' || trim((string) ($item['answer'] ?? '')) === '') {
+                $errors[] = $this->issue($fieldPrefix.'.faq_items.'.$index, 'invalid_faq_item_shape', 'Each FAQ item must include non-empty question and answer fields.');
             }
         }
 
@@ -381,8 +497,16 @@ final class ContentPagesControlledPublishService
     /**
      * @return array<string, mixed>
      */
-    private function readinessArtifactState(): array
+    private function readinessArtifactState(string $scope): array
     {
+        if ($scope === self::SCOPE_HELP_SERVICE) {
+            return [
+                'ready' => true,
+                'reason' => 'help_service_runtime_scope_authorized_by_manifest',
+                'required_follow_up' => 'HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01 remains required before any production publish execution.',
+            ];
+        }
+
         $path = base_path('docs/seo/generated/global-en-zh-content-pages-publish-readiness-r2.v1.json');
         if (! is_file($path)) {
             return [
@@ -409,6 +533,41 @@ final class ContentPagesControlledPublishService
             'publish_scope_recommendation' => $decoded['publish_scope_recommendation'] ?? null,
             'target_pages' => $decoded['target_pages'] ?? null,
         ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function allowedKeys(string $scope): array
+    {
+        return $scope === self::SCOPE_HELP_SERVICE ? self::HELP_SERVICE_ALLOWED_KEYS : self::ALLOWED_KEYS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function protectedKeys(string $scope): array
+    {
+        return $scope === self::SCOPE_HELP_SERVICE
+            ? array_values(array_diff(self::PROTECTED_KEYS, self::HELP_SERVICE_ALLOWED_KEYS))
+            : self::PROTECTED_KEYS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function targetLocales(string $scope, string $locale): array
+    {
+        if ($scope === self::SCOPE_HELP_SERVICE) {
+            return self::HELP_SERVICE_LOCALES;
+        }
+
+        return [$locale];
+    }
+
+    private function targetKey(string $scope, string $locale, string $key): string
+    {
+        return $scope === self::SCOPE_HELP_SERVICE ? $locale.':'.$key : $key;
     }
 
     /**

--- a/backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json
+++ b/backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json
@@ -1,0 +1,84 @@
+{
+  "schema_version": "help-content-pages-controlled-publish-runtime-01.v1",
+  "task": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01",
+  "generated_at": "2026-06-08",
+  "command_name": "content-pages:publish-controlled",
+  "runtime_scope": "help-service",
+  "command_shape": {
+    "dry_run": "php artisan content-pages:publish-controlled --scope=help-service --locale=all --keys=help-unlock-failure,help-payment-refund,help-result-recovery,help-privacy-data,help-use-boundaries,help-data-deletion --dry-run --json",
+    "execute_requires_future_exact_publish_authorization": true
+  },
+  "target_count": 12,
+  "target_locales": [
+    "zh-CN",
+    "en"
+  ],
+  "target_slugs": [
+    "help-unlock-failure",
+    "help-payment-refund",
+    "help-result-recovery",
+    "help-privacy-data",
+    "help-use-boundaries",
+    "help-data-deletion"
+  ],
+  "target_rows": [
+    "zh-CN:help-unlock-failure",
+    "zh-CN:help-payment-refund",
+    "zh-CN:help-result-recovery",
+    "zh-CN:help-privacy-data",
+    "zh-CN:help-use-boundaries",
+    "zh-CN:help-data-deletion",
+    "en:help-unlock-failure",
+    "en:help-payment-refund",
+    "en:help-result-recovery",
+    "en:help-privacy-data",
+    "en:help-use-boundaries",
+    "en:help-data-deletion"
+  ],
+  "runtime_guards": {
+    "dry_run_default": true,
+    "execute_requires_explicit_flag": true,
+    "exact_scope_required": true,
+    "locale_all_required_for_help_service": true,
+    "no_record_creation": true,
+    "no_upsert_missing": true,
+    "no_out_of_scope_cms_write": true,
+    "keeps_is_indexable_false": true,
+    "search_channel_action_attempted": false,
+    "url_submission_attempted": false,
+    "external_search_api_call_attempted": false,
+    "deploy_attempted": false,
+    "sitemap_llms_footer_explicit_enablement": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "row_preflight_requirements": {
+    "kind": "help",
+    "source_doc_contains": "HELP-SERVICE-CONTENT-DRAFTS-01",
+    "status": "draft_or_already_published_idempotency_match",
+    "is_public_before_publish": false,
+    "is_indexable": false,
+    "published_at_before_publish": null,
+    "review_state_allowed": [
+      "owner_review",
+      "approved"
+    ],
+    "support_contact": "support@fermatmind.com",
+    "policy_version": "help_service_policy.v1",
+    "reviewer": "non_empty_or_Unknown",
+    "faq_items_count": 4
+  },
+  "publish_executed_in_this_pr": false,
+  "publish_allowed_by_this_artifact": false,
+  "cms_mutation_performed": false,
+  "final_decision": "RUNTIME_READY_PUBLISH_STILL_REQUIRES_PREFLIGHT_AND_EXACT_AUTHORIZATION",
+  "next_task": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01",
+  "notes": [
+    "This artifact records runtime capability only.",
+    "It does not authorize production publish execution.",
+    "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01 must re-check the 12 production CMS draft rows before any publish execute request."
+  ]
+}

--- a/backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md
+++ b/backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md
@@ -1,0 +1,46 @@
+# HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01
+
+## Decision
+
+Runtime ready for a future Help service controlled publish dry-run/execution path. Publish is still not allowed by this PR.
+
+## Scope
+
+- Adds `content-pages:publish-controlled --scope=help-service`.
+- Targets exactly 12 existing Help service `content_pages` rows: 6 slugs across `zh-CN` and `en`.
+- Keeps the existing `global-en-wave1` runtime behavior as the default.
+- Does not publish, mutate production CMS data, deploy, submit search URLs, access private URLs, read secrets, perform payment/refund actions, change payment provider behavior, or claim Operator approval.
+
+## Runtime Command Shape
+
+```bash
+php artisan content-pages:publish-controlled --scope=help-service --locale=all --keys=help-unlock-failure,help-payment-refund,help-result-recovery,help-privacy-data,help-use-boundaries,help-data-deletion --dry-run --json
+```
+
+Future `--execute` remains blocked until an exact publish authorization is provided after `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01`.
+
+## Guards
+
+- Dry-run is default unless `--execute` is passed.
+- `--scope=help-service` requires `--locale=all`.
+- The exact six Help service slugs are required.
+- Runtime queries only existing `content_pages` rows.
+- Missing rows fail closed; no create/upsert path exists.
+- Out-of-scope keys such as `help-faq`, `privacy`, `terms`, and `about` are rejected.
+- Target rows must remain non-indexable; sitemap, llms, footer, nav, search submission, and deploy are out of scope.
+- Help rows must carry `support@fermatmind.com`, `help_service_policy.v1`, a reviewer value, and four structured FAQ items.
+
+## Validation Intent
+
+Focused tests cover:
+
+- Help service dry-run over 12 rows without writes.
+- Help service execute in the local sqlite fixture publishing only the 12 seeded rows.
+- No record creation.
+- Rejection of single-locale Help publish attempts.
+- Rejection of extra keys.
+- Existing five-page English content runtime behavior remains covered.
+
+## Next
+
+Run `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01` as a read-only publish preflight. Do not publish until that preflight passes and the user provides exact publish authorization.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
@@ -143,6 +143,113 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         );
     }
 
+    public function test_help_service_scope_dry_run_succeeds_without_writing_twelve_rows(): void
+    {
+        $this->seedHelpServiceTargets();
+
+        $output = $this->runHelpServicePublishCommand(['--dry-run' => true]);
+
+        $this->assertTrue($output['ok'] ?? false);
+        $this->assertSame('help-service', $output['scope'] ?? null);
+        $this->assertTrue($output['dry_run'] ?? false);
+        $this->assertFalse($output['writes_committed'] ?? true);
+        $this->assertSame(12, $output['target_count'] ?? null);
+        $this->assertSame(12, $output['would_publish_count'] ?? null);
+        $this->assertSame(0, $output['would_create_count'] ?? null);
+        $this->assertSame(['zh-CN', 'en'], $output['target_locales'] ?? null);
+        $this->assertContains('zh-CN:help-unlock-failure', $output['target_keys'] ?? []);
+        $this->assertContains('en:help-data-deletion', $output['target_keys'] ?? []);
+        $this->assertFalse($output['search_channel_action_attempted'] ?? true);
+        $this->assertFalse($output['url_submission_attempted'] ?? true);
+
+        foreach (self::helpServiceTargetKeys() as $key) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $page = $this->contentPageForLocale($key, $locale);
+                $this->assertSame(ContentPage::STATUS_DRAFT, (string) $page->status);
+                $this->assertFalse((bool) $page->is_public);
+                $this->assertFalse((bool) $page->is_indexable);
+                $this->assertNull($page->published_at);
+                $this->assertSame('support@fermatmind.com', (string) $page->support_contact);
+                $this->assertSame('help_service_policy.v1', (string) $page->policy_version);
+                $this->assertSame('Unknown', (string) $page->reviewer);
+                $this->assertFalse((bool) $page->schema_enabled);
+                $this->assertCount(4, $page->faq_items ?? []);
+            }
+        }
+    }
+
+    public function test_help_service_scope_execute_publishes_only_twelve_existing_rows(): void
+    {
+        $this->seedHelpServiceTargets();
+        $protected = ContentPage::query()->withoutGlobalScopes()->create($this->pageAttributes('help-faq', [
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => 'support_static',
+            'template' => 'help',
+            'locale' => 'en',
+            'status' => ContentPage::STATUS_DRAFT,
+            'is_public' => false,
+            'is_indexable' => false,
+            'published_at' => null,
+            'source_doc' => 'protected Help FAQ record',
+        ]));
+        $beforeCount = ContentPage::query()->withoutGlobalScopes()->count();
+
+        $output = $this->runHelpServicePublishCommand(['--execute' => true]);
+
+        $this->assertTrue($output['ok'] ?? false);
+        $this->assertFalse($output['dry_run'] ?? true);
+        $this->assertTrue($output['writes_committed'] ?? false);
+        $this->assertSame(12, $output['target_count'] ?? null);
+        $this->assertSame(12, count((array) ($output['published_keys'] ?? [])));
+        $this->assertContains('zh-CN:help-payment-refund', $output['published_keys'] ?? []);
+        $this->assertContains('en:help-result-recovery', $output['published_keys'] ?? []);
+        $this->assertSame($beforeCount, ContentPage::query()->withoutGlobalScopes()->count());
+
+        foreach (self::helpServiceTargetKeys() as $key) {
+            foreach (['zh-CN', 'en'] as $locale) {
+                $page = $this->contentPageForLocale($key, $locale);
+                $this->assertSame(ContentPage::STATUS_PUBLISHED, (string) $page->status);
+                $this->assertTrue((bool) $page->is_public);
+                $this->assertFalse((bool) $page->is_indexable);
+                $this->assertNotNull($page->published_at);
+                $this->assertSame((int) $page->working_revision_id, (int) $page->published_revision_id);
+            }
+        }
+
+        $protected->refresh();
+        $this->assertSame('help-faq', (string) $protected->slug);
+        $this->assertSame(ContentPage::STATUS_DRAFT, (string) $protected->status);
+        $this->assertFalse((bool) $protected->is_public);
+    }
+
+    public function test_help_service_scope_refuses_single_locale_option(): void
+    {
+        $this->seedHelpServiceTargets();
+
+        $output = $this->runHelpServicePublishCommand([
+            '--execute' => true,
+            '--locale' => 'en',
+        ], expectedExitCode: 1);
+
+        $this->assertFalse($output['ok'] ?? true);
+        $this->assertContains('unsupported_locale', $this->errorCodes($output));
+        $this->assertSame(ContentPage::STATUS_DRAFT, (string) $this->contentPageForLocale('help-unlock-failure', 'en')->status);
+    }
+
+    public function test_help_service_scope_refuses_extra_keys(): void
+    {
+        $this->seedHelpServiceTargets();
+
+        $output = $this->runHelpServicePublishCommand([
+            '--execute' => true,
+            '--keys' => implode(',', [...self::helpServiceTargetKeys(), 'help-faq']),
+        ], expectedExitCode: 1);
+
+        $this->assertFalse($output['ok'] ?? true);
+        $this->assertContains('extra_keys_not_allowed', $this->errorCodes($output));
+        $this->assertSame(ContentPage::STATUS_DRAFT, (string) $this->contentPageForLocale('help-payment-refund', 'zh-CN')->status);
+    }
+
     public function test_generated_json_report_exists_and_parses(): void
     {
         $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-controlled-publish-runtime-01.v1.json');
@@ -159,6 +266,24 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         $this->assertArrayHasKey('next_task', $generated);
     }
 
+    public function test_generated_help_service_runtime_report_exists_and_parses(): void
+    {
+        $generatedPath = base_path('docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true);
+
+        $this->assertIsArray($generated);
+        $this->assertSame('HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01', $generated['task'] ?? null);
+        $this->assertSame('content-pages:publish-controlled', $generated['command_name'] ?? null);
+        $this->assertSame('help-service', $generated['runtime_scope'] ?? null);
+        $this->assertSame(12, $generated['target_count'] ?? null);
+        $this->assertFalse((bool) ($generated['publish_executed_in_this_pr'] ?? true));
+        $this->assertSame('HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01', $generated['next_task'] ?? null);
+    }
+
     /**
      * @param  list<string>  $skip
      */
@@ -170,6 +295,13 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
             }
 
             ContentPage::query()->withoutGlobalScopes()->create($this->pageAttributes($key));
+        }
+    }
+
+    private function seedHelpServiceTargets(): void
+    {
+        foreach ($this->helpServiceSourceRows() as $row) {
+            ContentPage::query()->withoutGlobalScopes()->create($this->helpServicePageAttributes($row));
         }
     }
 
@@ -214,12 +346,65 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         ];
     }
 
+    /**
+     * @param  array<string, mixed>  $row
+     * @return array<string, mixed>
+     */
+    private function helpServicePageAttributes(array $row): array
+    {
+        return [
+            'org_id' => 0,
+            'slug' => (string) $row['slug'],
+            'path' => (string) $row['path'],
+            'kind' => ContentPage::KIND_HELP,
+            'page_type' => (string) ($row['pageType'] ?? 'support_static'),
+            'title' => (string) $row['title'],
+            'kicker' => (string) ($row['kicker'] ?? 'Help'),
+            'summary' => (string) $row['summary'],
+            'template' => 'help',
+            'animation_profile' => (string) ($row['animationProfile'] ?? 'editorial'),
+            'locale' => (string) $row['locale'],
+            'translation_group_id' => (string) ($row['translationGroupId'] ?? ('content-page-'.$row['slug'])),
+            'source_locale' => (string) ($row['sourceLocale'] ?? 'zh-CN'),
+            'translation_status' => (string) ($row['translationStatus'] ?? 'source'),
+            'published_at' => null,
+            'updated_at' => (string) ($row['updatedAt'] ?? '2026-06-04'),
+            'effective_at' => null,
+            'source_doc' => (string) $row['sourceDoc'],
+            'is_public' => false,
+            'is_indexable' => false,
+            'review_state' => 'owner_review',
+            'headings_json' => (array) ($row['headings'] ?? []),
+            'content_md' => (string) $row['contentMd'],
+            'content_html' => (string) ($row['contentHtml'] ?? ''),
+            'seo_title' => (string) $row['seoTitle'],
+            'meta_description' => (string) $row['metaDescription'],
+            'seo_description' => (string) $row['seoDescription'],
+            'canonical_path' => (string) $row['canonicalPath'],
+            'support_contact' => 'support@fermatmind.com',
+            'policy_version' => 'help_service_policy.v1',
+            'reviewer' => 'Unknown',
+            'schema_enabled' => false,
+            'faq_items' => (array) $row['faq_items'],
+            'status' => ContentPage::STATUS_DRAFT,
+        ];
+    }
+
     private function contentPage(string $key): ContentPage
     {
         return ContentPage::query()
             ->withoutGlobalScopes()
             ->where('slug', $key)
             ->where('locale', 'en')
+            ->firstOrFail();
+    }
+
+    private function contentPageForLocale(string $key, string $locale): ContentPage
+    {
+        return ContentPage::query()
+            ->withoutGlobalScopes()
+            ->where('slug', $key)
+            ->where('locale', $locale)
             ->firstOrFail();
     }
 
@@ -247,6 +432,19 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
     }
 
     /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private function runHelpServicePublishCommand(array $options = [], int $expectedExitCode = 0): array
+    {
+        return $this->runPublishCommand($options + [
+            '--scope' => 'help-service',
+            '--locale' => 'all',
+            '--keys' => implode(',', self::helpServiceTargetKeys()),
+        ], $expectedExitCode);
+    }
+
+    /**
      * @param  array<string, mixed>  $output
      * @return list<string>
      */
@@ -264,5 +462,35 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
     private static function targetKeys(): array
     {
         return ['brand', 'charter', 'foundation', 'careers', 'policies'];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function helpServiceTargetKeys(): array
+    {
+        return [
+            'help-unlock-failure',
+            'help-payment-refund',
+            'help-result-recovery',
+            'help-privacy-data',
+            'help-use-boundaries',
+            'help-data-deletion',
+        ];
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function helpServiceSourceRows(): array
+    {
+        $decoded = json_decode((string) file_get_contents(base_path('docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json')), true);
+
+        $this->assertIsArray($decoded);
+
+        return array_values(array_filter(
+            $decoded,
+            static fn (mixed $row): bool => is_array($row),
+        ));
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50649,5 +50649,101 @@
         "note": "PR #1998 merged at 2026-06-08T08:57:25Z with merge commit c468443998471ba2ad645476ad2389610f4c02b1; origin/main contains the merge commit, remote task branch is deleted, and local task branch was deleted."
       }
     ]
+  },
+  "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-pages-controlled-publish-runtime-01",
+    "base": "origin/main",
+    "status": "in_progress",
+    "train_scope": "window_9_help_service_content",
+    "title": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01: add Help service controlled publish runtime",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01",
+      "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User requested HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01, HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01, and HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01 in order."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01 is merged in fap-api PR #1998 with merge commit c468443998471ba2ad645476ad2389610f4c02b1. HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01 is merged in fap-web PR #1072 with merge commit b9eb0593414a283a3ad02366e203378bb41c9f06."
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_paths": [
+          "backend/app/Console/Commands/ContentPagesPublishControlledCommand.php",
+          "backend/app/Services/ContentPages/ContentPagesControlledPublishService.php",
+          "backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php",
+          "backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json",
+          "backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "evidence": "Changed/untracked files are limited to the controlled publish command/service, focused runtime contract, Help runtime generated artifact/report, and PR-train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/ContentPagesPublishControlledCommand.php",
+          "php -l backend/app/Services/ContentPages/ContentPagesControlledPublishService.php",
+          "php -l backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php",
+          "python3 -m json.tool backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=GlobalEnZhContentPagesControlledPublishRuntime01 --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi",
+          "cd backend && php artisan list --no-ansi | grep -E \"content-pages:publish-controlled|content-pages\"",
+          "git diff --check -- backend/app/Console/Commands/ContentPagesPublishControlledCommand.php backend/app/Services/ContentPages/ContentPagesControlledPublishService.php backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "evidence": "PHP lint passed for command/service/test; JSON/YAML parse passed; GlobalEnZhContentPagesControlledPublishRuntime01 passed with 13 tests and 310 assertions; BigFiveResultPageV2CoreBodyPreviewTest passed with 164 tests and 511 assertions; artisan list shows content-pages:publish-controlled; path-limited git diff --check passed; git diff --cached --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "merge_state": null,
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "pending",
+      "generated_artifact": "backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md",
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "in_progress",
+        "note": "Started Help service controlled publish runtime PR from origin/main. This PR implements runtime capability only and does not publish production CMS rows."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "PHP lint, JSON/YAML parse, focused runtime contract, BigFive runtime-freeze classifier, artisan list, path-limited git diff --check, and git diff --cached --check passed. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim was performed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50654,7 +50654,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-pages-controlled-publish-runtime-01",
     "base": "origin/main",
-    "status": "in_progress",
+    "status": "github_checks_pending",
     "train_scope": "window_9_help_service_content",
     "title": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01: add Help service controlled publish runtime",
     "depends_on": [
@@ -50702,7 +50702,7 @@
       },
       "github": {
         "status": "pending",
-        "head_sha": null,
+        "head_sha": "dd5df8eb",
         "passed_checks": [],
         "merge_state": null,
         "failure_reason": null,
@@ -50710,8 +50710,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "dd5df8eb",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2000",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -50743,6 +50743,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "PHP lint, JSON/YAML parse, focused runtime contract, BigFive runtime-freeze classifier, artisan list, path-limited git diff --check, and git diff --cached --check passed. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim was performed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "github_checks_pending",
+        "note": "Opened fap-api PR #2000 for HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22435,6 +22435,57 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01
 
+  - id: HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01
+      - HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01
+    branch: codex/help-content-pages-controlled-publish-runtime-01
+    title: "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01: add Help service controlled publish runtime"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Extend the existing content-pages:publish-controlled runtime with a fail-closed Help service scope for exactly the existing 12 Help ContentPage rows.
+      - Require the exact six Help service slugs and --locale=all so zh-CN and en rows are handled together.
+      - Keep dry-run as the default and require explicit --execute for local/test fixture writes; do not publish production CMS rows in this PR.
+      - Preserve no-create/no-upsert, non-indexability, no search submission, no deploy, no private URL access, and no Operator approval claim.
+    allowed_paths:
+      - backend/app/Console/Commands/ContentPagesPublishControlledCommand.php
+      - backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
+      - backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
+      - backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json
+      - backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Publish, mutate CMS/production data, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - php -l backend/app/Console/Commands/ContentPagesPublishControlledCommand.php
+      - php -l backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
+      - php -l backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
+      - python3 -m json.tool backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=GlobalEnZhContentPagesControlledPublishRuntime01 --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi
+      - cd backend && php artisan list --no-ansi | grep -E "content-pages:publish-controlled|content-pages"
+      - git diff --check -- backend/app/Console/Commands/ContentPagesPublishControlledCommand.php backend/app/Services/ContentPages/ContentPagesControlledPublishService.php backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Extended `content-pages:publish-controlled` with `--scope=help-service` for exactly 12 Help service ContentPage rows: 6 slugs across `zh-CN` and `en`.
- Kept the existing `global-en-wave1` scope as the default behavior.
- Added fail-closed runtime guards for exact keys, `--locale=all`, existing-row-only publishing, service fields, structured FAQ items, and non-indexability.
- Added focused fixture coverage plus a generated runtime artifact and operations report.

## Why
The first publish preflight blocked because the existing controlled publish runtime only allowed five English company/policy pages. Window 9 needs a bounded Help service runtime before any publish preflight rerun or exact publish authorization.

## Validation
- `php -l backend/app/Console/Commands/ContentPagesPublishControlledCommand.php`
- `php -l backend/app/Services/ContentPages/ContentPagesControlledPublishService.php`
- `php -l backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php`
- `python3 -m json.tool backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=GlobalEnZhContentPagesControlledPublishRuntime01 --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `cd backend && php artisan list --no-ansi | grep -E "content-pages:publish-controlled|content-pages"`
- `git diff --check -- ...allowed files...`
- `git diff --cached --check`

## Intentionally deferred
- No production publish.
- No CMS/production data mutation.
- No deploy.
- No search submission.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token reads.
- No payment/refund action or payment-provider behavior change.
- No Operator approval claim.
