### PR TITLE
HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01: rerun Help publish preflight

### DIFF
--- a/backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json
@@ -1,0 +1,155 @@
+{
+  "schema_version": "help-content-draft-publish-preflight-r2-01.v1",
+  "generated_at": "2026-06-08",
+  "task": {
+    "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01",
+    "type": "read_only_publish_preflight",
+    "scope": "window_9_help_service_content"
+  },
+  "authorization": {
+    "source": "user_requested_three_pr_sequence",
+    "cms_mutation_allowed": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "search_submission_allowed": false,
+    "private_url_access_allowed": false,
+    "secret_env_cookie_token_read_allowed": false,
+    "payment_or_refund_allowed": false,
+    "payment_provider_change_allowed": false,
+    "operator_approval_claim_allowed": false
+  },
+  "dependency_evidence": {
+    "help_content_draft_blocker_cms_sync": {
+      "status": "merged",
+      "pr": "https://github.com/fermatmind/fap-api/pull/1998",
+      "merge_commit": "c468443998471ba2ad645476ad2389610f4c02b1"
+    },
+    "help_service_faq_schema_runtime": {
+      "status": "merged",
+      "repo": "fap-web",
+      "pr": "https://github.com/fermatmind/fap-web/pull/1072",
+      "merge_commit": "b9eb0593414a283a3ad02366e203378bb41c9f06",
+      "production_deploy_status": "Unknown"
+    },
+    "help_content_pages_controlled_publish_runtime": {
+      "status": "merged",
+      "repo": "fap-api",
+      "pr": "https://github.com/fermatmind/fap-api/pull/2000",
+      "merge_commit": "31f0ce4f9f3966719dfc93234b224ce8990871ff",
+      "production_deploy_status": "not_deployed"
+    }
+  },
+  "source_package": {
+    "import_package_path": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "import_package_sha256": "15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44",
+    "content_page_source_path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "content_page_source_sha256": "af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d",
+    "rows": 12,
+    "slugs": [
+      "help-unlock-failure",
+      "help-payment-refund",
+      "help-result-recovery",
+      "help-privacy-data",
+      "help-use-boundaries",
+      "help-data-deletion"
+    ],
+    "local_private_boundary_scan": {
+      "payment_id": 0,
+      "transaction_id": 0,
+      "payment_identifier": 0,
+      "private_route": 0,
+      "token_param": 0
+    }
+  },
+  "cms_draft_evidence": {
+    "source": "HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01 post-sync artifact",
+    "artifact_path": "backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json",
+    "artifact_sha256": "d017b1a5425656a18d25780a370427dbc368fd760b4e00cc51912007724b63b4",
+    "checked_rows": 12,
+    "draft": 12,
+    "non_public": 12,
+    "non_indexable": 12,
+    "unpublished": 12,
+    "owner_review": 12,
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_items_count_4": 12,
+    "private_boundary_pattern_hits": {
+      "payment_id": 0,
+      "transaction_id": 0,
+      "payment_identifier": 0,
+      "private_route": 0,
+      "token_param": 0
+    }
+  },
+  "public_route_checks": {
+    "checked_at": "2026-06-08",
+    "draft_routes_checked": 12,
+    "draft_routes_final_404": 12,
+    "support_routes_200": 2,
+    "privacy_terms_routes_200": 4,
+    "private_url_accessed": false
+  },
+  "sitemap_llms_checks": {
+    "checked_at": "2026-06-08",
+    "resources": [
+      "https://fermatmind.com/sitemap.xml",
+      "https://fermatmind.com/llms.txt",
+      "https://fermatmind.com/llms-full.txt"
+    ],
+    "all_status_200": true,
+    "help_service_slug_hits": 0,
+    "private_pattern_hits": 0,
+    "search_submission_attempted": false
+  },
+  "source_runtime_checks": {
+    "fap_web_help_faq_schema_runtime_source": {
+      "status": "merged_to_main",
+      "merge_commit": "b9eb0593414a283a3ad02366e203378bb41c9f06",
+      "production_runtime_status": "Unknown"
+    },
+    "fap_api_controlled_publish_runtime_source": {
+      "status": "merged_to_main",
+      "merge_commit": "31f0ce4f9f3966719dfc93234b224ce8990871ff",
+      "artifact_path": "backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json",
+      "artifact_sha256": "b0911983e0f4b1973228c90d0c79ea3569fb266f5621a5ebf08b26050b18c6ee"
+    }
+  },
+  "production_runtime_check": {
+    "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly_no_env_output",
+    "active_backend_revision_sha": "8570a335c5cc539507b3dad4d8659fc9c971d759",
+    "origin_main_sha_at_check": "31f0ce4f9f3966719dfc93234b224ce8990871ff",
+    "commits_behind_origin_main": 7,
+    "contains_help_controlled_publish_runtime_merge": false,
+    "artisan_command_visible": true,
+    "artisan_description_observed": "Fail-closed controlled publish runtime for approved English content_pages records.",
+    "help_service_scope_confirmed_in_production": false,
+    "read_secret_env_cookie_token": false
+  },
+  "decision": {
+    "status": "blocked",
+    "final_decision": "NO_GO_FOR_PUBLISH_EXECUTE",
+    "publish_allowed": false,
+    "publish_authorization_prompt_allowed": false,
+    "ready_for_exact_publish_authorization": false,
+    "blocking_reasons": [
+      "Production backend active revision does not contain HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01.",
+      "Production fap-web Help FAQ schema runtime deployment status is Unknown.",
+      "A post-deploy publish preflight R3 is required before any exact publish authorization prompt."
+    ]
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "next_task_recommendation": "HELP-RUNTIME-PROD-DEPLOY-READINESS-01"
+}

--- a/backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md
@@ -1,0 +1,51 @@
+# HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01
+
+Status: `blocked`
+
+This read-only publish preflight reran the Window 9 Help service checks after the local phrase repair, CMS blocker sync, fap-web FAQ schema runtime PR, and fap-api controlled publish runtime PR. It did not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+
+## Decision
+
+`NO-GO_FOR_PUBLISH_EXECUTE`
+
+Source and main-branch blockers are repaired, but production runtime is not ready for publish execution.
+
+## Evidence
+
+| Check | Result |
+| --- | --- |
+| Source import package hash | `15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44` |
+| Draft source hash | `af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d` |
+| CMS sync postcheck artifact | 12 rows draft / non-public / non-indexable / unpublished |
+| Private phrase gate | 0 hits for `payment_id`, `transaction_id`, payment identifier, private route, token |
+| fap-web FAQ schema runtime source | merged in PR #1072 |
+| fap-api controlled publish runtime source | merged in PR #2000 |
+| Public Help draft routes | 12/12 still 404 |
+| `/zh/support` and `/en/support` | 200 |
+| `/zh/privacy`, `/en/privacy`, `/zh/terms`, `/en/terms` | 200 |
+| sitemap / llms / llms-full | no Help service slug hits; no private-pattern hits |
+| Production backend active revision | `8570a335c5cc539507b3dad4d8659fc9c971d759` |
+| Production backend contains PR #2000 merge | no |
+| Production command description | old English-only controlled publish wording |
+
+## Blockers
+
+1. Production backend does not contain `HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01`.
+2. Production fap-web Help FAQ schema runtime deployment status is `Unknown`.
+3. A post-deploy R3 publish preflight is required before any exact publish authorization prompt.
+
+## Scope Validation
+
+| Boundary | Result |
+| --- | --- |
+| CMS mutation | no |
+| Publish | no |
+| Deploy | no |
+| Search submission | no |
+| Private URL access | no |
+| Secret/env/cookie/token read | no |
+| Payment/refund action | no |
+| Payment provider change | no |
+| Operator approval claim | no |
+
+Next recommendation: `HELP-RUNTIME-PROD-DEPLOY-READINESS-01`, then rerun `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01` after production runtime deployment is verified.

--- a/backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php
+++ b/backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php
@@ -1,0 +1,33 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Cms;
+
+use Tests\TestCase;
+
+final class HelpContentDraftPublishPreflightR2Test extends TestCase
+{
+    public function test_help_content_draft_publish_preflight_r2_artifact_records_blocked_runtime_deploy_state(): void
+    {
+        $artifactPath = base_path('docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json');
+
+        $this->assertFileExists($artifactPath);
+        $this->assertFileExists(base_path('docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md'));
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true);
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('help-content-draft-publish-preflight-r2-01.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01', $artifact['task']['id'] ?? null);
+        $this->assertSame(12, $artifact['cms_draft_evidence']['checked_rows'] ?? null);
+        $this->assertSame(0, $artifact['cms_draft_evidence']['private_boundary_pattern_hits']['payment_id'] ?? null);
+        $this->assertSame(12, $artifact['public_route_checks']['draft_routes_final_404'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_checks']['help_service_slug_hits'] ?? null);
+        $this->assertFalse((bool) ($artifact['production_runtime_check']['contains_help_controlled_publish_runtime_merge'] ?? true));
+        $this->assertSame('blocked', $artifact['decision']['status'] ?? null);
+        $this->assertSame('NO_GO_FOR_PUBLISH_EXECUTE', $artifact['decision']['final_decision'] ?? null);
+        $this->assertFalse((bool) ($artifact['decision']['publish_allowed'] ?? true));
+        $this->assertSame('HELP-RUNTIME-PROD-DEPLOY-READINESS-01', $artifact['next_task_recommendation'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50755,7 +50755,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-publish-preflight-r2-01",
     "base": "origin/main",
-    "status": "in_progress",
+    "status": "github_checks_pending",
     "train_scope": "window_9_help_service_content",
     "title": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01: rerun Help publish preflight",
     "depends_on": [
@@ -50834,7 +50834,7 @@
       },
       "github": {
         "status": "pending",
-        "head_sha": null,
+        "head_sha": "114f80b6",
         "passed_checks": [],
         "merge_state": null,
         "failure_reason": null,
@@ -50842,8 +50842,8 @@
       }
     },
     "failure_reason": "Publish preflight R2 remains blocked because production backend active revision does not contain HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01 and production fap-web FAQ schema runtime deployment status is Unknown.",
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "114f80b6",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2001",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -50877,6 +50877,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "PHP lint, JSON/YAML parse, focused artifact contract, public HTTP checks, read-only production revision/artisan list check, path-limited git diff --check, and git diff --cached --check passed. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim was performed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "github_checks_pending",
+        "note": "Opened fap-api PR #2001 for HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50750,5 +50750,134 @@
         "note": "Opened fap-api PR #2000 for HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01."
       }
     ]
+  },
+  "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-publish-preflight-r2-01",
+    "base": "origin/main",
+    "status": "in_progress",
+    "train_scope": "window_9_help_service_content",
+    "title": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01: rerun Help publish preflight",
+    "depends_on": [
+      "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User requested the three-PR sequence ending with HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01. CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, and Operator approval claim are forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01 is merged in PR #2000 with merge commit 31f0ce4f9f3966719dfc93234b224ce8990871ff. HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01 is merged in fap-web PR #1072."
+      },
+      "source_package": {
+        "status": "pass",
+        "import_package_sha256": "15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44",
+        "content_page_source_sha256": "af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d",
+        "rows": 12,
+        "private_boundary_pattern_hits": 0
+      },
+      "cms_draft_evidence": {
+        "status": "pass_from_prior_post_sync_artifact",
+        "source_artifact": "backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json",
+        "checked_rows": 12,
+        "draft": 12,
+        "non_public": 12,
+        "non_indexable": 12,
+        "unpublished": 12,
+        "support_contact": 12,
+        "policy_version": 12,
+        "faq_items_count_4": 12
+      },
+      "public_routes": {
+        "status": "pass_for_unpublished_drafts",
+        "help_draft_routes_404": 12,
+        "support_routes_200": 2,
+        "privacy_terms_routes_200": 4,
+        "sitemap_llms_help_service_slug_hits": 0,
+        "sitemap_llms_private_pattern_hits": 0
+      },
+      "production_runtime": {
+        "status": "blocked_backend_runtime_not_deployed",
+        "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly_no_env_output",
+        "active_backend_revision_sha": "8570a335c5cc539507b3dad4d8659fc9c971d759",
+        "origin_main_sha_at_check": "31f0ce4f9f3966719dfc93234b224ce8990871ff",
+        "commits_behind_origin_main": 7,
+        "contains_help_controlled_publish_runtime_merge": false,
+        "help_service_scope_confirmed_in_production": false
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_paths": [
+          "backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json",
+          "backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md",
+          "backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "evidence": "Changed/untracked files are limited to the R2 preflight artifact, operations report, focused artifact contract, and PR-train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php",
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPublishPreflightR2Test --no-ansi",
+          "public HTTP checks for Help draft routes, support/privacy/terms, sitemap.xml, llms.txt, llms-full.txt",
+          "ssh -o BatchMode=yes fap-api-prod 'cat /var/www/fap-api/current/REVISION; cd /var/www/fap-api/current/backend && php artisan list --no-ansi | grep -E \"content-pages:publish-controlled|content-pages\"'",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "evidence": "PHP lint passed for the focused test; JSON/YAML parse passed; HelpContentDraftPublishPreflightR2Test passed with 1 test and 14 assertions; public HTTP checks passed; read-only production revision/artisan list check completed without env/secret output; path-limited git diff --check passed; git diff --cached --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "merge_state": null,
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": "Publish preflight R2 remains blocked because production backend active revision does not contain HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01 and production fap-web FAQ schema runtime deployment status is Unknown.",
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "NO_GO_FOR_PUBLISH_EXECUTE",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md",
+      "publish_allowed": false,
+      "publish_authorization_prompt_allowed": false,
+      "next_task_recommendation": "HELP-RUNTIME-PROD-DEPLOY-READINESS-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "blocked_runtime_not_deployed",
+        "note": "R2 preflight completed read-only checks and remains blocked. Source/main blockers are repaired, but production backend active revision is 8570a335c5cc539507b3dad4d8659fc9c971d759 and does not contain PR #2000 merge commit 31f0ce4f9f3966719dfc93234b224ce8990871ff."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "PHP lint, JSON/YAML parse, focused artifact contract, public HTTP checks, read-only production revision/artisan list check, path-limited git diff --check, and git diff --cached --check passed. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim was performed."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22486,6 +22486,51 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01
 
+  - id: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01
+    branch: codex/help-content-draft-publish-preflight-r2-01
+    title: "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01: rerun Help publish preflight"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Rerun read-only Help service publish preflight after phrase repair, CMS blocker sync, fap-web FAQ schema runtime merge, and fap-api controlled publish runtime merge.
+      - Confirm source packages, CMS post-sync evidence, public route absence, support/privacy/terms routes, sitemap/llms absence, private boundary, and production runtime deployment status.
+      - Preserve publish_allowed=false and do not emit an exact publish authorization prompt when production runtime is not ready.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json
+      - backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md
+      - backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS/production data, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - php -l backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPublishPreflightR2Test --no-ansi
+      - public HTTP checks for Help draft routes, support/privacy/terms, sitemap.xml, llms.txt, llms-full.txt
+      - read-only production revision/artisan list check without env/secret output
+      - git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-r2-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-RUNTIME-PROD-DEPLOY-READINESS-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added the read-only R2 Help service publish preflight artifact and operations report.
- Recorded that source/main blockers are repaired but publish remains blocked because production backend is still on revision `8570a335...` and does not contain PR #2000's controlled publish runtime.
- Added a focused artifact contract and PR-train metadata.

## Why
Window 9 needed a publish preflight rerun after phrase repair, CMS sync, fap-web FAQ schema runtime merge, and fap-api controlled publish runtime merge. The rerun must not issue a publish authorization prompt until production runtime is actually ready.

## Validation
- `php -l backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR2Test.php`
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-r2-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPublishPreflightR2Test --no-ansi`
- Public HTTP checks for Help draft routes, support/privacy/terms, sitemap.xml, llms.txt, llms-full.txt
- Read-only production revision/artisan list check without env/secret output
- `git diff --check -- ...allowed files...`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No publish.
- No deploy.
- No search submission.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token reads.
- No payment/refund action or payment-provider behavior change.
- No Operator approval claim.
