### PR TITLE
HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01: record post-deploy Help publish preflight

### DIFF
--- a/backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json
@@ -1,0 +1,216 @@
+{
+  "schema_version": "help-content-draft-publish-preflight-r3-01.v1",
+  "generated_at": "2026-06-08",
+  "task": {
+    "id": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01",
+    "type": "read_only_post_deploy_publish_preflight",
+    "scope": "window_9_help_service_content"
+  },
+  "authorization": {
+    "source": "user_authorized_manifest_state_and_read_only_r3_preflight",
+    "cms_mutation_allowed": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "search_submission_allowed": false,
+    "private_url_access_allowed": false,
+    "secret_env_cookie_token_read_allowed": false,
+    "payment_or_refund_allowed": false,
+    "payment_provider_change_allowed": false,
+    "operator_approval_claim_allowed": false
+  },
+  "dependency_evidence": {
+    "help_content_draft_blocker_cms_sync": {
+      "status": "merged",
+      "pr": "https://github.com/fermatmind/fap-api/pull/1998",
+      "merge_commit": "c468443998471ba2ad645476ad2389610f4c02b1"
+    },
+    "help_service_faq_schema_runtime": {
+      "status": "merged_and_deployed",
+      "repo": "fap-web",
+      "pr": "https://github.com/fermatmind/fap-web/pull/1072",
+      "merge_commit": "b9eb0593414a283a3ad02366e203378bb41c9f06",
+      "production_frontend_sha": "37299875412c68a39e2a096f1f797800b96ff92e"
+    },
+    "help_content_pages_controlled_publish_runtime": {
+      "status": "merged_and_deployed",
+      "repo": "fap-api",
+      "pr": "https://github.com/fermatmind/fap-api/pull/2000",
+      "merge_commit": "31f0ce4f9f3966719dfc93234b224ce8990871ff",
+      "production_backend_revision_sha": "bf937f67543dc9df656219e195e364d37c8bb63a"
+    },
+    "help_content_draft_publish_preflight_r2": {
+      "status": "merged",
+      "repo": "fap-api",
+      "pr": "https://github.com/fermatmind/fap-api/pull/2001",
+      "merge_commit": "bf937f67543dc9df656219e195e364d37c8bb63a"
+    }
+  },
+  "source_package": {
+    "import_package_path": "backend/docs/help/import-packages/help-service-content-drafts-01.import.v1.json",
+    "import_package_sha256": "15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44",
+    "content_page_source_path": "backend/docs/help/import-packages/content-pages-draft-source/content_pages.help_service_drafts_01.json",
+    "content_page_source_sha256": "af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d",
+    "rows": 12,
+    "slugs": [
+      "help-unlock-failure",
+      "help-payment-refund",
+      "help-result-recovery",
+      "help-privacy-data",
+      "help-use-boundaries",
+      "help-data-deletion"
+    ],
+    "private_boundary_pattern_hits": {
+      "payment_id": 0,
+      "transaction_id": 0,
+      "payment_identifier": 0,
+      "private_route": 0,
+      "token_param": 0
+    }
+  },
+  "cms_draft_evidence": {
+    "source": "HELP-CONTENT-DRAFT-BLOCKER-CMS-SYNC-01 post-sync artifact",
+    "artifact_path": "backend/docs/help/generated/help-content-draft-blocker-cms-sync-01.v1.json",
+    "artifact_sha256": "d017b1a5425656a18d25780a370427dbc368fd760b4e00cc51912007724b63b4",
+    "checked_rows": 12,
+    "draft": 12,
+    "non_public": 12,
+    "non_indexable": 12,
+    "unpublished": 12,
+    "owner_review": 12,
+    "support_contact_support_at_fermatmind": 12,
+    "policy_version_help_service_policy_v1": 12,
+    "reviewer_unknown": 12,
+    "schema_disabled": 12,
+    "faq_items_count_4": 12,
+    "private_boundary_pattern_hits": {
+      "payment_id": 0,
+      "transaction_id": 0,
+      "payment_identifier": 0,
+      "private_route": 0,
+      "token_param": 0
+    }
+  },
+  "production_runtime_checks": {
+    "backend": {
+      "connection_method": "ssh_alias_fap-api-prod_batchmode_readonly_no_env_output",
+      "active_backend_revision_sha": "bf937f67543dc9df656219e195e364d37c8bb63a",
+      "content_pages_publish_controlled_visible": true,
+      "help_service_scope_visible": true,
+      "dry_run_command_shape": "content-pages:publish-controlled --scope=help-service --locale=all --keys=<six-help-service-slugs> --dry-run --json",
+      "dry_run_ok": true,
+      "dry_run": true,
+      "execute": false,
+      "writes_committed": false,
+      "target_count": 12,
+      "would_publish_count": 12,
+      "would_update_count": 12,
+      "would_create_count": 0,
+      "blocked_count": 0,
+      "target_locales": [
+        "zh-CN",
+        "en"
+      ],
+      "pages_count": 12,
+      "actions": [
+        "publish"
+      ],
+      "before_statuses": [
+        "draft"
+      ],
+      "before_public": [
+        false
+      ],
+      "before_indexable": [
+        false
+      ],
+      "after_statuses": [
+        "published"
+      ],
+      "after_public": [
+        true
+      ],
+      "after_indexable": [
+        false
+      ],
+      "error_count": 0,
+      "search_channel_action_attempted": false,
+      "url_submission_attempted": false,
+      "deploy_attempted": false,
+      "discoverability_coupled": false,
+      "sitemap_llms_footer_explicit_enablement": false,
+      "no_record_creation": true,
+      "no_upsert_missing": true,
+      "no_out_of_scope_cms_write": true,
+      "read_secret_env_cookie_token": false
+    },
+    "frontend": {
+      "connection_method": "ssh_alias_web_node1_batchmode_readonly_no_env_output",
+      "active_frontend_sha": "37299875412c68a39e2a096f1f797800b96ff92e",
+      "worktree_status_count": 0,
+      "pm2_process_count": 4,
+      "pm2_statuses": [
+        "online"
+      ],
+      "help_faq_schema_runtime_source": "deployed_sha_contains_fap_web_pr_1072_merge_commit"
+    }
+  },
+  "public_route_checks": {
+    "checked_at": "2026-06-08",
+    "draft_routes_checked": 12,
+    "draft_routes_final_404": 12,
+    "draft_routes_noindex": 12,
+    "draft_routes_jsonld_zero": 12,
+    "draft_routes_faqpage_zero": 12,
+    "support_routes_200": 2,
+    "privacy_terms_routes_200": 4,
+    "help_faq_contact_routes_200": 4,
+    "orders_lookup_routes_200": 2,
+    "orders_lookup_robots": "noindex,nofollow,noarchive,nocache",
+    "public_canonical_routes_checked": 12,
+    "public_canonical_tags_present": 12,
+    "private_url_accessed": false
+  },
+  "sitemap_llms_checks": {
+    "checked_at": "2026-06-08",
+    "resources": [
+      "https://fermatmind.com/sitemap.xml",
+      "https://fermatmind.com/llms.txt",
+      "https://fermatmind.com/llms-full.txt"
+    ],
+    "all_status_200": true,
+    "help_service_slug_hits": 0,
+    "private_pattern_hits": 0,
+    "search_submission_attempted": false
+  },
+  "decision": {
+    "status": "ready_for_exact_publish_authorization",
+    "final_decision": "GO_FOR_EXACT_PUBLISH_AUTHORIZATION_PROMPT",
+    "publish_allowed_in_this_pr": false,
+    "publish_authorization_prompt_allowed": true,
+    "ready_for_exact_publish_authorization": true,
+    "blocking_reasons": [],
+    "required_exact_publish_scope": {
+      "command_shape": "content-pages:publish-controlled --scope=help-service --locale=all --keys=help-unlock-failure,help-payment-refund,help-result-recovery,help-privacy-data,help-use-boundaries,help-data-deletion --execute --json",
+      "target_count": 12,
+      "target_locales": [
+        "zh-CN",
+        "en"
+      ],
+      "keep_indexable_false": true,
+      "search_submission_allowed": false,
+      "sitemap_llms_footer_enablement_allowed": false
+    }
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  },
+  "next_task_recommendation": "HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01"
+}

--- a/backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md
@@ -1,0 +1,58 @@
+# HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01
+
+Status: `ready_for_exact_publish_authorization`
+
+This read-only R3 preflight reran the Window 9 Help service publish checks after the backend and frontend production runtime deploys. It did not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+
+## Decision
+
+`GO_FOR_EXACT_PUBLISH_AUTHORIZATION_PROMPT`
+
+The production runtime now contains the required frontend Help FAQ schema runtime and backend Help service controlled publish runtime. The controlled backend dry-run is clean for exactly the 12 existing Help service draft rows.
+
+## Evidence
+
+| Check | Result |
+| --- | --- |
+| Source import package hash | `15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44` |
+| Draft source hash | `af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d` |
+| CMS sync postcheck artifact | 12 rows draft / non-public / non-indexable / unpublished |
+| Private phrase gate | 0 hits for `payment_id`, `transaction_id`, payment identifier, private route, token |
+| fap-web production SHA | `37299875412c68a39e2a096f1f797800b96ff92e` |
+| fap-api production REVISION | `bf937f67543dc9df656219e195e364d37c8bb63a` |
+| Backend controlled publish runtime | `content-pages:publish-controlled --scope=help-service` visible |
+| Backend controlled publish dry-run | `ok=true`, `target_count=12`, `would_publish_count=12`, `blocked_count=0` |
+| Dry-run write safety | `writes_committed=false`, `would_create_count=0`, `no_upsert_missing=true` |
+| Dry-run discoverability safety | after-preview keeps `is_indexable=false`; no sitemap/llms/footer enablement |
+| Public Help draft routes | 12/12 still 404, no JSON-LD, no FAQPage, `noindex` |
+| `/zh/support` and `/en/support` | 200 |
+| `/zh/privacy`, `/en/privacy`, `/zh/terms`, `/en/terms` | 200 |
+| `/zh/help/faq`, `/en/help/faq`, `/zh/help/contact`, `/en/help/contact` | 200 with canonical tags |
+| `/zh/orders/lookup`, `/en/orders/lookup` | 200 and noindex/nofollow/noarchive/nocache |
+| sitemap / llms / llms-full | 200; no Help service slug hits; no private-pattern hits |
+
+## Publish Boundary
+
+This PR does not authorize or execute publish. It only establishes that an exact publish authorization prompt may now be requested for the next task.
+
+The next task must remain bounded to the controlled backend runtime:
+
+`content-pages:publish-controlled --scope=help-service --locale=all --keys=help-unlock-failure,help-payment-refund,help-result-recovery,help-privacy-data,help-use-boundaries,help-data-deletion --execute --json`
+
+The next task must still forbid deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund actions, payment-provider changes, Operator approval claims, and sitemap/llms/footer enablement.
+
+## Scope Validation
+
+| Boundary | Result |
+| --- | --- |
+| CMS mutation | no |
+| Publish | no |
+| Deploy | no |
+| Search submission | no |
+| Private URL access | no |
+| Secret/env/cookie/token read | no |
+| Payment/refund action | no |
+| Payment provider change | no |
+| Operator approval claim | no |
+
+Next recommendation: `HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01` after exact user authorization.

--- a/backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php
+++ b/backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php
@@ -1,0 +1,77 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Cms;
+
+use Tests\TestCase;
+
+final class HelpContentDraftPublishPreflightR3Test extends TestCase
+{
+    public function test_help_content_draft_publish_preflight_r3_artifact_records_ready_publish_preflight(): void
+    {
+        $backendPath = (string) getcwd();
+        $artifactPath = $backendPath.'/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json';
+
+        $this->assertFileExists($artifactPath);
+        $this->assertFileExists($backendPath.'/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md');
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true);
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('help-content-draft-publish-preflight-r3-01.v1', $artifact['schema_version'] ?? null);
+        $this->assertSame('HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01', $artifact['task']['id'] ?? null);
+        $this->assertSame('ready_for_exact_publish_authorization', $artifact['decision']['status'] ?? null);
+        $this->assertSame('GO_FOR_EXACT_PUBLISH_AUTHORIZATION_PROMPT', $artifact['decision']['final_decision'] ?? null);
+        $this->assertFalse((bool) ($artifact['decision']['publish_allowed_in_this_pr'] ?? true));
+        $this->assertTrue((bool) ($artifact['decision']['publish_authorization_prompt_allowed'] ?? false));
+        $this->assertTrue((bool) ($artifact['decision']['ready_for_exact_publish_authorization'] ?? false));
+        $this->assertSame([], $artifact['decision']['blocking_reasons'] ?? null);
+
+        $this->assertSame(12, $artifact['cms_draft_evidence']['checked_rows'] ?? null);
+        $this->assertSame(0, $artifact['cms_draft_evidence']['private_boundary_pattern_hits']['payment_id'] ?? null);
+        $this->assertSame(0, $artifact['cms_draft_evidence']['private_boundary_pattern_hits']['transaction_id'] ?? null);
+
+        $backendRuntime = $artifact['production_runtime_checks']['backend'] ?? [];
+        $this->assertSame('bf937f67543dc9df656219e195e364d37c8bb63a', $backendRuntime['active_backend_revision_sha'] ?? null);
+        $this->assertTrue((bool) ($backendRuntime['content_pages_publish_controlled_visible'] ?? false));
+        $this->assertTrue((bool) ($backendRuntime['help_service_scope_visible'] ?? false));
+        $this->assertTrue((bool) ($backendRuntime['dry_run_ok'] ?? false));
+        $this->assertTrue((bool) ($backendRuntime['dry_run'] ?? false));
+        $this->assertFalse((bool) ($backendRuntime['execute'] ?? true));
+        $this->assertFalse((bool) ($backendRuntime['writes_committed'] ?? true));
+        $this->assertSame(12, $backendRuntime['target_count'] ?? null);
+        $this->assertSame(12, $backendRuntime['would_publish_count'] ?? null);
+        $this->assertSame(0, $backendRuntime['would_create_count'] ?? null);
+        $this->assertSame(0, $backendRuntime['blocked_count'] ?? null);
+        $this->assertSame(['zh-CN', 'en'], $backendRuntime['target_locales'] ?? null);
+        $this->assertSame([false], $backendRuntime['after_indexable'] ?? null);
+        $this->assertFalse((bool) ($backendRuntime['search_channel_action_attempted'] ?? true));
+        $this->assertFalse((bool) ($backendRuntime['url_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($backendRuntime['deploy_attempted'] ?? true));
+        $this->assertTrue((bool) ($backendRuntime['no_record_creation'] ?? false));
+        $this->assertTrue((bool) ($backendRuntime['no_upsert_missing'] ?? false));
+        $this->assertTrue((bool) ($backendRuntime['no_out_of_scope_cms_write'] ?? false));
+
+        $frontendRuntime = $artifact['production_runtime_checks']['frontend'] ?? [];
+        $this->assertSame('37299875412c68a39e2a096f1f797800b96ff92e', $frontendRuntime['active_frontend_sha'] ?? null);
+        $this->assertSame(4, $frontendRuntime['pm2_process_count'] ?? null);
+        $this->assertSame(['online'], $frontendRuntime['pm2_statuses'] ?? null);
+
+        $this->assertSame(12, $artifact['public_route_checks']['draft_routes_final_404'] ?? null);
+        $this->assertSame(12, $artifact['public_route_checks']['draft_routes_noindex'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_checks']['help_service_slug_hits'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_checks']['private_pattern_hits'] ?? null);
+
+        $scope = $artifact['scope_validation'] ?? [];
+        $this->assertFalse((bool) ($scope['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($scope['publish_performed'] ?? true));
+        $this->assertFalse((bool) ($scope['deploy_performed'] ?? true));
+        $this->assertFalse((bool) ($scope['search_submission_performed'] ?? true));
+        $this->assertFalse((bool) ($scope['private_url_access_performed'] ?? true));
+        $this->assertFalse((bool) ($scope['secret_env_cookie_token_read'] ?? true));
+        $this->assertFalse((bool) ($scope['payment_or_refund_performed'] ?? true));
+        $this->assertFalse((bool) ($scope['payment_provider_changed'] ?? true));
+        $this->assertFalse((bool) ($scope['operator_approval_claimed'] ?? true));
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50654,7 +50654,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-pages-controlled-publish-runtime-01",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01: add Help service controlled publish runtime",
     "depends_on": [
@@ -50701,22 +50701,32 @@
         "evidence": "PHP lint passed for command/service/test; JSON/YAML parse passed; GlobalEnZhContentPagesControlledPublishRuntime01 passed with 13 tests and 310 assertions; BigFiveResultPageV2CoreBodyPreviewTest passed with 164 tests and 511 assertions; artisan list shows content-pages:publish-controlled; path-limited git diff --check passed; git diff --cached --check passed."
       },
       "github": {
-        "status": "pending",
-        "head_sha": "dd5df8eb",
-        "passed_checks": [],
-        "merge_state": null,
+        "status": "pass",
+        "head_sha": "6ffcab4f2f8c7f44e769384202f666f6371dfb15",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "MERGED",
         "failure_reason": null,
-        "merge_commit": null
+        "merge_commit": "31f0ce4f9f3966719dfc93234b224ce8990871ff"
       }
     },
     "failure_reason": null,
-    "commit_sha": "dd5df8eb",
+    "commit_sha": "31f0ce4f9f3966719dfc93234b224ce8990871ff",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2000",
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-06-08T09:48:48Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "result": {
-      "decision": "pending",
+      "decision": "HELP_SERVICE_CONTROLLED_PUBLISH_RUNTIME_MERGED",
       "generated_artifact": "backend/docs/help/generated/help-content-pages-controlled-publish-runtime-01.v1.json",
       "operations_report": "backend/docs/operations/help-content-pages-controlled-publish-runtime-2026-06-08.md",
       "next_task_recommendation": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01"
@@ -50748,6 +50758,11 @@
         "at": "2026-06-08",
         "status": "github_checks_pending",
         "note": "Opened fap-api PR #2000 for HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged_reconciled_in_r3",
+        "note": "GitHub PR #2000 is merged at 2026-06-08T09:48:48Z with merge commit 31f0ce4f9f3966719dfc93234b224ce8990871ff; reconciled as bookkeeping for R3 preflight."
       }
     ]
   },
@@ -50755,7 +50770,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-publish-preflight-r2-01",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "merged",
     "train_scope": "window_9_help_service_content",
     "title": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01: rerun Help publish preflight",
     "depends_on": [
@@ -50833,19 +50848,29 @@
         "evidence": "PHP lint passed for the focused test; JSON/YAML parse passed; HelpContentDraftPublishPreflightR2Test passed with 1 test and 14 assertions; public HTTP checks passed; read-only production revision/artisan list check completed without env/secret output; path-limited git diff --check passed; git diff --cached --check passed."
       },
       "github": {
-        "status": "pending",
-        "head_sha": "114f80b6",
-        "passed_checks": [],
-        "merge_state": null,
+        "status": "pass",
+        "head_sha": "37b8188bf7ef806b65d846104ea0652f7c2e88a5",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "MERGED",
         "failure_reason": null,
-        "merge_commit": null
+        "merge_commit": "bf937f67543dc9df656219e195e364d37c8bb63a"
       }
     },
-    "failure_reason": "Publish preflight R2 remains blocked because production backend active revision does not contain HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01 and production fap-web FAQ schema runtime deployment status is Unknown.",
-    "commit_sha": "114f80b6",
+    "failure_reason": "R2 was blocked at creation time because production runtime was not deployed; GitHub PR #2001 later merged, and R3 now supersedes the runtime-readiness decision after deployment.",
+    "commit_sha": "bf937f67543dc9df656219e195e364d37c8bb63a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2001",
-    "merged_at": null,
-    "remote_branch_deleted": false,
+    "merged_at": "2026-06-08T10:01:19Z",
+    "remote_branch_deleted": true,
     "local_cleanup_executed": false,
     "result": {
       "decision": "NO_GO_FOR_PUBLISH_EXECUTE",
@@ -50882,6 +50907,155 @@
         "at": "2026-06-08",
         "status": "github_checks_pending",
         "note": "Opened fap-api PR #2001 for HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "merged_reconciled_in_r3",
+        "note": "GitHub PR #2001 is merged at 2026-06-08T10:01:19Z with merge commit bf937f67543dc9df656219e195e364d37c8bb63a; R3 rechecks the post-deploy runtime state."
+      }
+    ],
+    "next_task": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01"
+  },
+  "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01": {
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-publish-preflight-r3-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "window_9_help_service_content",
+    "title": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01: record post-deploy Help publish preflight",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User authorized adding and executing HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01 as read-only post-deploy Help publish preflight. CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token reads, payment/refund action, payment-provider change, and Operator approval claim are forbidden."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01 is merged in PR #2001 with merge commit bf937f67543dc9df656219e195e364d37c8bb63a; HELP-CONTENT-PAGES-CONTROLLED-PUBLISH-RUNTIME-01 is merged in PR #2000; fap-web HELP-SERVICE-FAQ-SCHEMA-RUNTIME-01 is merged and deployed in frontend SHA 37299875412c68a39e2a096f1f797800b96ff92e."
+      },
+      "source_package": {
+        "status": "pass",
+        "import_package_sha256": "15843defa1d3925624a49844e0ff15244a6cdff6cbb7c93bd3eac3c7fa5bed44",
+        "content_page_source_sha256": "af59792b896892fa308ccddab0915e72c565e3f696bc10feb0af2c96f6c54d6d",
+        "rows": 12,
+        "private_boundary_pattern_hits": 0
+      },
+      "production_runtime": {
+        "status": "pass",
+        "backend_revision_sha": "bf937f67543dc9df656219e195e364d37c8bb63a",
+        "frontend_sha": "37299875412c68a39e2a096f1f797800b96ff92e",
+        "backend_help_service_scope_visible": true,
+        "frontend_pm2_online_processes": 4
+      },
+      "controlled_publish_dry_run": {
+        "status": "pass",
+        "command_shape": "content-pages:publish-controlled --scope=help-service --locale=all --keys=<six-help-service-slugs> --dry-run --json",
+        "target_count": 12,
+        "would_publish_count": 12,
+        "would_create_count": 0,
+        "blocked_count": 0,
+        "target_locales": [
+          "zh-CN",
+          "en"
+        ],
+        "writes_committed": false,
+        "after_indexable": [
+          false
+        ],
+        "search_channel_action_attempted": false,
+        "url_submission_attempted": false,
+        "deploy_attempted": false
+      },
+      "public_routes": {
+        "status": "pass",
+        "help_draft_routes_404": 12,
+        "help_draft_routes_noindex": 12,
+        "support_routes_200": 2,
+        "privacy_terms_routes_200": 4,
+        "help_faq_contact_routes_200": 4,
+        "orders_lookup_routes_200": 2,
+        "sitemap_llms_help_service_slug_hits": 0,
+        "sitemap_llms_private_pattern_hits": 0
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_paths": [
+          "backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json",
+          "backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md",
+          "backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "evidence": "Changed/untracked files are limited to the R3 preflight artifact, operations report, focused artifact contract, and PR-train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php",
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPublishPreflightR3Test --no-ansi",
+          "public HTTP checks for Help draft routes, support/privacy/terms/help FAQ/help contact/orders lookup, sitemap.xml, llms.txt, llms-full.txt",
+          "read-only production backend and frontend runtime checks without env/secret output",
+          "backend controlled publish dry-run with --scope=help-service --locale=all --keys=<six-help-service-slugs> --dry-run --json",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "evidence": "PHP lint passed; JSON/YAML parse passed; HelpContentDraftPublishPreflightR3Test passed with 1 test and 49 assertions; public HTTP checks passed; read-only production backend/frontend runtime checks passed; help-service controlled publish dry-run passed with target_count=12 and blocked_count=0; path-limited git diff --check and git diff --cached --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": null,
+        "passed_checks": [],
+        "merge_state": null,
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "GO_FOR_EXACT_PUBLISH_AUTHORIZATION_PROMPT",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md",
+      "publish_allowed": false,
+      "publish_authorization_prompt_allowed": true,
+      "next_task_recommendation": "HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01"
+    },
+    "scope_validation": {
+      "cms_mutation_performed": false,
+      "publish_performed": false,
+      "deploy_performed": false,
+      "search_submission_performed": false,
+      "private_url_access_performed": false,
+      "secret_env_cookie_token_read": false,
+      "payment_or_refund_performed": false,
+      "payment_provider_changed": false,
+      "operator_approval_claimed": false,
+      "allowed_paths_only": true
+    },
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "in_progress",
+        "note": "Started read-only post-deploy R3 preflight from origin/main in an isolated fap-api worktree. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim is authorized."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "runtime_preflight_passed_pending_local_checks",
+        "note": "Production backend revision bf937f67543dc9df656219e195e364d37c8bb63a exposes help-service controlled publish and dry-run passes for exactly 12 rows with blocked_count=0; frontend Node1 SHA 37299875412c68a39e2a096f1f797800b96ff92e is online; public draft routes remain 404/noindex and sitemap/llms private scans are clear."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "PHP lint, JSON/YAML parse, focused artifact contract, public HTTP checks, read-only production runtime checks, help-service controlled publish dry-run, and scoped diff whitespace checks passed. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim was performed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50920,7 +50920,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-publish-preflight-r3-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_open_github_checks_pending",
     "train_scope": "window_9_help_service_content",
     "title": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01: record post-deploy Help publish preflight",
     "depends_on": [
@@ -51008,7 +51008,7 @@
       },
       "github": {
         "status": "pending",
-        "head_sha": null,
+        "head_sha": "5d01682bbd442cee1b06cb3a3ab5259ce6904ac4",
         "passed_checks": [],
         "merge_state": null,
         "failure_reason": null,
@@ -51016,8 +51016,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "5d01682bbd442cee1b06cb3a3ab5259ce6904ac4",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2002",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -51056,6 +51056,11 @@
         "at": "2026-06-08",
         "status": "local_checks_passed",
         "note": "PHP lint, JSON/YAML parse, focused artifact contract, public HTTP checks, read-only production runtime checks, help-service controlled publish dry-run, and scoped diff whitespace checks passed. No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment provider change, or Operator approval claim was performed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "pr_open_github_checks_pending",
+        "note": "Opened fap-api PR #2002 for HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01 after local checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -50920,7 +50920,7 @@
     "repo": "fap-api",
     "branch": "codex/help-content-draft-publish-preflight-r3-01",
     "base": "origin/main",
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "window_9_help_service_content",
     "title": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01: record post-deploy Help publish preflight",
     "depends_on": [
@@ -51007,16 +51007,26 @@
         "evidence": "PHP lint passed; JSON/YAML parse passed; HelpContentDraftPublishPreflightR3Test passed with 1 test and 49 assertions; public HTTP checks passed; read-only production backend/frontend runtime checks passed; help-service controlled publish dry-run passed with target_count=12 and blocked_count=0; path-limited git diff --check and git diff --cached --check passed."
       },
       "github": {
-        "status": "pending",
-        "head_sha": "5d01682bbd442cee1b06cb3a3ab5259ce6904ac4",
-        "passed_checks": [],
-        "merge_state": null,
+        "status": "pass",
+        "head_sha": "368d962657225b4bfb8b9a655e2cc70f6244c6d1",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
         "failure_reason": null,
         "merge_commit": null
       }
     },
     "failure_reason": null,
-    "commit_sha": "5d01682bbd442cee1b06cb3a3ab5259ce6904ac4",
+    "commit_sha": "368d962657225b4bfb8b9a655e2cc70f6244c6d1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2002",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -51061,6 +51071,11 @@
         "at": "2026-06-08",
         "status": "pr_open_github_checks_pending",
         "note": "Opened fap-api PR #2002 for HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01 after local checks passed."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2002 and pre-merge scope remains limited to R3 preflight artifact/report/test and docs/codex metadata."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22493,7 +22493,7 @@ prs:
     branch: codex/help-content-draft-publish-preflight-r2-01
     title: "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01: rerun Help publish preflight"
     train_scope: window_9_help_service_content
-    status: in_progress
+    status: merged
     scope:
       - Rerun read-only Help service publish preflight after phrase repair, CMS blocker sync, fap-web FAQ schema runtime merge, and fap-api controlled publish runtime merge.
       - Confirm source packages, CMS post-sync evidence, public route absence, support/privacy/terms routes, sitemap/llms absence, private boundary, and production runtime deployment status.
@@ -22529,7 +22529,53 @@ prs:
     fap_web_commit_allowed: false
     frontend_fallback_authority: false
     content_authority: CMS/backend
-    next_task: HELP-RUNTIME-PROD-DEPLOY-READINESS-01
+    next_task: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01
+
+  - id: HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01
+    branch: codex/help-content-draft-publish-preflight-r3-01
+    title: "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01: record post-deploy Help publish preflight"
+    train_scope: window_9_help_service_content
+    status: in_progress
+    scope:
+      - Record post-deploy Help publish preflight R3 after backend and frontend production runtime are verified.
+      - Confirm fap-web Help FAQ schema runtime, fap-api help-service controlled publish runtime, 12 Help draft dry-run, canonical and robots behavior, sitemap/llms exclusion, and private URL safety.
+      - Preserve publish_allowed=false in this PR and only allow the next exact publish authorization prompt when all R3 gates pass.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json
+      - backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md
+      - backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS/production data, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - php -l backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPublishPreflightR3Test --no-ansi
+      - public HTTP checks for Help draft routes, support/privacy/terms/help FAQ/help contact/orders lookup, sitemap.xml, llms.txt, llms-full.txt
+      - read-only production backend and frontend runtime checks without env/secret output
+      - backend controlled publish dry-run with --scope=help-service --locale=all --keys=<six-help-service-slugs> --dry-run --json
+      - git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01
 
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api


### PR DESCRIPTION
## What changed
- Added the R3 post-deploy Help publish preflight artifact and operations report.
- Added a focused artifact contract for the R3 readiness decision.
- Registered `HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01` in the PR train and reconciled prior Help runtime/preflight merge state.

## Why
- Backend and frontend production runtimes have now been deployed after the R2 blocker.
- R3 records that the Help service controlled publish dry-run is clean for exactly 12 existing Help `ContentPage` draft rows.
- This PR only enables requesting exact publish authorization as a next task; it does not publish.

## Validation
- `php -l backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php`
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPublishPreflightR3Test --no-ansi`
- Public HTTP checks for Help draft routes, support/privacy/terms/help FAQ/help contact/orders lookup, sitemap.xml, llms.txt, llms-full.txt
- Read-only production backend and frontend runtime checks without env/secret output
- Backend controlled publish dry-run with `--scope=help-service --locale=all --keys=<six-help-service-slugs> --dry-run --json`
- `git diff --check -- backend/docs/help/generated/help-content-draft-publish-preflight-r3-01.v1.json backend/docs/operations/help-content-draft-publish-preflight-r3-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPublishPreflightR3Test.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No publish.
- No deploy.
- No search submission.
- No private result/order/share/pay/payment/history URL access.
- No secret/env/cookie/token reads.
- No payment/refund action or payment-provider behavior change.
- No Operator approval claim.

## Repository rule impact
- Content authority remains CMS/backend-owned through `content_pages`.
- No frontend fallback authority, runtime content fallback, sitemap/llms enablement, or publishing behavior is changed by this PR.
