### PR TITLE
HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01: record Help post-publish runtime smoke

### DIFF
--- a/backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json
@@ -1,0 +1,70 @@
+{
+  "task_id": "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01",
+  "generated_at": "2026-06-08",
+  "scope": "Read-only post-publish smoke after Help service controlled publish execution.",
+  "decision": "BLOCKED_RUNTIME_REPAIR_REQUIRED",
+  "publish_execution": {
+    "authorized_command": "content-pages:publish-controlled --scope=help-service --locale=all --keys=help-unlock-failure,help-payment-refund,help-result-recovery,help-privacy-data,help-use-boundaries,help-data-deletion --execute --json",
+    "ok": true,
+    "writes_committed": true,
+    "target_count": 12,
+    "would_create_count": 0,
+    "blocked_count": 0,
+    "observed_action": "idempotent_confirm_already_published",
+    "published_state": {
+      "status": "published",
+      "is_public": true,
+      "is_indexable": false
+    },
+    "safety": {
+      "search_channel_action_attempted": false,
+      "url_submission_attempted": false,
+      "external_search_api_call_attempted": false,
+      "deploy_attempted": false,
+      "sitemap_llms_footer_explicit_enablement": false,
+      "no_record_creation": true,
+      "no_upsert_missing": true,
+      "no_out_of_scope_cms_write": true
+    }
+  },
+  "public_route_smoke": {
+    "apex_domain": "https://fermatmind.com",
+    "www_redirects_to_apex": true,
+    "checked_pages": 12,
+    "http_200_count": 12,
+    "canonical_count_per_page": 1,
+    "private_pattern_hits": 0,
+    "robots_meta_observed": "index, follow",
+    "expected_robots_from_backend": "noindex",
+    "robots_runtime_status": "blocked",
+    "faqpage_hits_per_page": 0,
+    "schema_runtime_status": "blocked"
+  },
+  "sitemap_llms_smoke": {
+    "checked": [
+      "/sitemap.xml",
+      "/llms.txt",
+      "/llms-full.txt"
+    ],
+    "status": "pass",
+    "help_service_slug_hits": 0,
+    "private_pattern_hits": 0
+  },
+  "blocked_reasons": [
+    "Published Help pages expose HTML robots meta index, follow while backend ContentPage rows remain is_indexable=false.",
+    "Published Help pages did not emit FAQPage JSON-LD in the smoke sample."
+  ],
+  "next_tasks": [
+    "HELP-PAGES-NOINDEX-RUNTIME-01",
+    "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-R2-01"
+  ],
+  "forbidden_actions_not_performed": [
+    "deploy",
+    "search submission",
+    "private result/order/share/pay/payment/history URL access",
+    "secret/env/cookie/token read",
+    "payment/refund action",
+    "payment-provider behavior change",
+    "Operator approval claim"
+  ]
+}

--- a/backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md
@@ -1,0 +1,32 @@
+# HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01
+
+Decision: `BLOCKED_RUNTIME_REPAIR_REQUIRED`.
+
+The Help service controlled publish command completed with `ok=true` for the exact 12 Help ContentPage rows. The command reported `writes_committed=true`, `target_count=12`, `would_create_count=0`, `blocked_count=0`, and no search, sitemap, llms, footer, deploy, or out-of-scope CMS write action.
+
+The publish execution was effectively idempotent at observation time: all 12 target rows were already `published`, `is_public=true`, and `is_indexable=false` before this smoke recorded the public route state.
+
+## Public smoke
+
+| Check | Result |
+| --- | --- |
+| Apex Help service pages | 12/12 returned HTTP 200 |
+| `www` behavior | 308 redirect to apex |
+| Canonical | 1 canonical tag per checked page |
+| Private URL pattern hits | 0 |
+| Sitemap Help service slug hits | 0 |
+| `llms.txt` Help service slug hits | 0 |
+| `llms-full.txt` Help service slug hits | 0 |
+
+## Blockers
+
+1. Published Help pages render HTML robots as `index, follow` even though the backend rows are `is_indexable=false`.
+2. Published Help pages did not emit `FAQPage` JSON-LD in the smoke sample.
+
+## Boundary
+
+This PR records the smoke result only. It does not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+
+## Next
+
+Fix the frontend Help page noindex runtime first, then rerun post-publish smoke. FAQ schema runtime remains blocked until the published pages emit schema from backend-authoritative visible FAQ data.

--- a/backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php
+++ b/backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php
@@ -1,0 +1,37 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Cms;
+
+use Tests\TestCase;
+
+final class HelpContentDraftPostPublishSmokeTest extends TestCase
+{
+    public function test_help_content_draft_post_publish_smoke_records_runtime_blockers(): void
+    {
+        $backendPath = (string) getcwd();
+        $artifactPath = $backendPath.'/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json';
+        $reportPath = $backendPath.'/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md';
+
+        $this->assertFileExists($artifactPath);
+        $this->assertFileExists($reportPath);
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true);
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01', $artifact['task_id'] ?? null);
+        $this->assertSame('BLOCKED_RUNTIME_REPAIR_REQUIRED', $artifact['decision'] ?? null);
+        $this->assertTrue((bool) ($artifact['publish_execution']['ok'] ?? false));
+        $this->assertSame(12, $artifact['publish_execution']['target_count'] ?? null);
+        $this->assertSame(0, $artifact['publish_execution']['would_create_count'] ?? null);
+        $this->assertSame(0, $artifact['publish_execution']['blocked_count'] ?? null);
+        $this->assertFalse((bool) ($artifact['publish_execution']['published_state']['is_indexable'] ?? true));
+        $this->assertSame(12, $artifact['public_route_smoke']['http_200_count'] ?? null);
+        $this->assertSame('blocked', $artifact['public_route_smoke']['robots_runtime_status'] ?? null);
+        $this->assertSame('blocked', $artifact['public_route_smoke']['schema_runtime_status'] ?? null);
+        $this->assertSame(0, $artifact['public_route_smoke']['private_pattern_hits'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_smoke']['help_service_slug_hits'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_smoke']['private_pattern_hits'] ?? null);
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51109,5 +51109,152 @@
       }
     ],
     "merge_sha": "8c14006b101e7e22907f62d00543eb4fee418a4d"
+  },
+  "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01": {
+    "id": "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01",
+    "repo": "fap-api",
+    "branch": "codex/help-content-draft-post-publish-smoke-01",
+    "base": "origin/main",
+    "status": "blocked_runtime_repair_required",
+    "train_scope": "window_9_help_service_content",
+    "title": "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01: record Help post-publish runtime smoke",
+    "depends_on": [
+      "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized the Help service controlled publish command and then requested HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01 to record publish success with robots/schema runtime blocked, followed by Help pages noindex runtime repair."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01 is merged in PR #2002 and ledger-closed in PR #2003. R3 decision was GO_FOR_EXACT_PUBLISH_AUTHORIZATION_PROMPT."
+      },
+      "controlled_publish_execute": {
+        "status": "pass",
+        "command_shape": "content-pages:publish-controlled --scope=help-service --locale=all --keys=<six-help-service-slugs> --execute --json",
+        "ok": true,
+        "writes_committed": true,
+        "target_count": 12,
+        "would_create_count": 0,
+        "blocked_count": 0,
+        "observed_action": "idempotent_confirm_already_published",
+        "published_state": {
+          "status": "published",
+          "is_public": true,
+          "is_indexable": false
+        },
+        "search_channel_action_attempted": false,
+        "url_submission_attempted": false,
+        "external_search_api_call_attempted": false,
+        "deploy_attempted": false,
+        "sitemap_llms_footer_explicit_enablement": false,
+        "no_record_creation": true,
+        "no_upsert_missing": true,
+        "no_out_of_scope_cms_write": true
+      },
+      "public_routes": {
+        "status": "blocked",
+        "apex_http_200_count": 12,
+        "www_redirects_to_apex": true,
+        "canonical_count_per_page": 1,
+        "private_pattern_hits": 0,
+        "robots_meta_observed": "index, follow",
+        "expected_robots_from_backend": "noindex because is_indexable=false",
+        "faqpage_hits_per_page": 0,
+        "failure_reason": "Published Help pages render index, follow and no FAQPage JSON-LD while backend rows are is_indexable=false and FAQ schema runtime was expected."
+      },
+      "sitemap_llms": {
+        "status": "pass",
+        "checked": [
+          "/sitemap.xml",
+          "/llms.txt",
+          "/llms-full.txt"
+        ],
+        "help_service_slug_hits": 0,
+        "private_pattern_hits": 0
+      },
+      "scope": {
+        "status": "pass",
+        "allowed_paths": [
+          "backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json",
+          "backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md",
+          "backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ],
+        "evidence": "Changed and untracked paths are limited to the post-publish smoke generated artifact, operations report, focused contract test, and PR-train metadata."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php",
+          "python3 -m json.tool backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPostPublishSmokeTest --no-ansi",
+          "git diff --check -- backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "evidence": "PHP lint passed; JSON/YAML parse passed; focused PHPUnit passed with 1 warning and 16 assertions; path-limited git diff --check passed."
+      },
+      "github": {
+        "status": "pass",
+        "head_sha": "2a4a78cb5b5073a1df380f6ebb73ae6347f17bcf",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "failure_reason": null,
+        "merge_commit": null
+      }
+    },
+    "failure_reason": "Post-publish smoke blocked on frontend runtime: published Help pages render robots index, follow despite backend is_indexable=false, and FAQPage JSON-LD was not emitted in the smoke sample.",
+    "commit_sha": "2a4a78cb5b5073a1df380f6ebb73ae6347f17bcf",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2004",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "decision": "BLOCKED_RUNTIME_REPAIR_REQUIRED",
+      "generated_artifact": "backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json",
+      "operations_report": "backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md",
+      "next_task_recommendation": "HELP-PAGES-NOINDEX-RUNTIME-01"
+    },
+    "transitions": [
+      {
+        "at": "2026-06-08",
+        "status": "initialized",
+        "note": "Initialized post-publish smoke record after authorized controlled publish execution."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "blocked_runtime_repair_required",
+        "note": "Publish command returned ok=true for 12 target rows with is_indexable=false, but public pages rendered index, follow and no FAQPage JSON-LD."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "local_checks_passed",
+        "note": "Local artifact, manifest/state, focused PHPUnit, and scope checks passed. Runtime blocker remains intentionally recorded as the smoke decision."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "committed",
+        "note": "Created scoped commit c7ebbc3d5aeb0c7b54fe4e19ef9f0aff6fb843d7 for post-publish smoke record."
+      },
+      {
+        "at": "2026-06-08",
+        "status": "github_checks_passed_ready_to_merge",
+        "note": "GitHub checks passed for PR #2004; smoke decision remains blocked_runtime_repair_required by design."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -22577,6 +22577,49 @@ prs:
     content_authority: CMS/backend
     next_task: HELP-CONTENT-DRAFT-PUBLISH-EXECUTE-01
 
+  - id: HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01
+    repo: fap-api
+    depends_on:
+      - HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R3-01
+    branch: codex/help-content-draft-post-publish-smoke-01
+    title: "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01: record Help post-publish runtime smoke"
+    train_scope: window_9_help_service_content
+    status: blocked_runtime_repair_required
+    scope:
+      - Record the exact post-publish smoke result after authorized Help service controlled publish execution.
+      - Confirm publish success for the 12 Help service ContentPage rows while preserving the observed frontend robots/schema runtime blockers.
+      - Keep this PR read-only after the already-authorized controlled publish command and do not repair frontend runtime here.
+    allowed_paths:
+      - backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json
+      - backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md
+      - backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+    validation:
+      - php -l backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php
+      - python3 -m json.tool backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPostPublishSmokeTest --no-ansi
+      - git diff --check -- backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    payment_provider_call: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    fap_web_commit_allowed: false
+    frontend_fallback_authority: false
+    content_authority: CMS/backend
+    next_task: HELP-PAGES-NOINDEX-RUNTIME-01
+
   - id: PUBLIC-BENEFIT-ASSET-PACKAGES-ARCHIVE-01
     repo: fap-api
     branch: codex/public-benefit-asset-packages-archive-01


### PR DESCRIPTION
## What changed
- Added the Help post-publish smoke artifact and operations report.
- Added a focused contract test that keeps the smoke result blocked on frontend runtime repair.
- Registered HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-01 in the PR train manifest/state.

## Why
- The authorized controlled publish command returned ok=true for the 12 Help service ContentPage rows.
- Public route smoke found the Help pages now return 200, but robots render index, follow while backend rows remain is_indexable=false.
- FAQPage JSON-LD was also absent in the sampled published pages.

## Validation
- php -l backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php
- python3 -m json.tool backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json >/dev/null
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=HelpContentDraftPostPublishSmokeTest --no-ansi
- git diff --check -- backend/docs/help/generated/help-content-draft-post-publish-smoke-01.v1.json backend/docs/operations/help-content-draft-post-publish-smoke-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
- git diff --cached --check

## Intentionally deferred
- Frontend Help noindex runtime repair.
- Help FAQ schema runtime repair.
- Post-repair smoke R2.

## Repository rule impact
- No runtime or CMS authority change. This PR records backend-authoritative publish state and frontend runtime blockers only.