### PR TITLE
HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-R2-01: record Help noindex pass and schema blocker

### DIFF
--- a/backend/docs/help/generated/help-content-draft-post-publish-smoke-r2-01.v1.json
+++ b/backend/docs/help/generated/help-content-draft-post-publish-smoke-r2-01.v1.json
@@ -1,0 +1,179 @@
+{
+  "schema_version": "help-content-draft-post-publish-smoke-r2-01.v1",
+  "generated_at": "2026-06-08",
+  "task": {
+    "id": "HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-R2-01",
+    "type": "read_only_post_publish_smoke_rerun",
+    "scope": "window_9_help_service_content"
+  },
+  "authorization": {
+    "source": "user_requested_scoped_post_publish_smoke_r2",
+    "cms_mutation_allowed": false,
+    "publish_allowed": false,
+    "deploy_allowed": false,
+    "search_submission_allowed": false,
+    "private_url_access_allowed": false,
+    "secret_env_cookie_token_read_allowed": false,
+    "payment_or_refund_allowed": false,
+    "payment_provider_change_allowed": false,
+    "operator_approval_claim_allowed": false,
+    "pr_train_manifest_state_updated": false
+  },
+  "dependency_evidence": {
+    "help_content_draft_post_publish_smoke_01": {
+      "status": "merged",
+      "repo": "fap-api",
+      "pr": "https://github.com/fermatmind/fap-api/pull/2004",
+      "merge_commit": "ef7aedd9b0b60960131cdba71ea5b1140a958f1a",
+      "recorded_decision": "BLOCKED_RUNTIME_REPAIR_REQUIRED"
+    },
+    "help_pages_noindex_runtime_repair": {
+      "status": "merged_and_deployed",
+      "repo": "fap-web",
+      "pr": "https://github.com/fermatmind/fap-web/pull/1075",
+      "merge_commit": "7b095a67dea4d633eafad5e5116d3510b25ace87",
+      "production_frontend_sha": "7b095a67dea4d633eafad5e5116d3510b25ace87"
+    }
+  },
+  "public_route_smoke": {
+    "base_url": "https://fermatmind.com",
+    "checked_pages": 12,
+    "http_200_count": 12,
+    "robots_noindex_count": 12,
+    "robots_index_follow_count": 0,
+    "canonical_count_failures": [],
+    "faqpage_total_hits": 0,
+    "private_tokenized_pattern_hits": 0,
+    "checked_routes": [
+      {
+        "path": "/en/help/unlock-failure",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/en/help/payment-refund",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/en/help/result-recovery",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/en/help/privacy-data",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/en/help/use-boundaries",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/en/help/data-deletion",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/zh/help/unlock-failure",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/zh/help/payment-refund",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/zh/help/result-recovery",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/zh/help/privacy-data",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/zh/help/use-boundaries",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      },
+      {
+        "path": "/zh/help/data-deletion",
+        "status": 200,
+        "robots": "noindex, nofollow, noarchive, nocache",
+        "canonical_count": 1,
+        "faqpage_hits": 0,
+        "private_tokenized_pattern_hits": 0
+      }
+    ]
+  },
+  "sitemap_llms_smoke": {
+    "checked": [
+      "/sitemap.xml",
+      "/llms.txt",
+      "/llms-full.txt"
+    ],
+    "status": "pass",
+    "all_status_200": true,
+    "help_service_slug_hits": 0,
+    "private_tokenized_pattern_hits": 0
+  },
+  "decision": {
+    "status": "PARTIAL_GO_SCHEMA_RUNTIME_BLOCKED",
+    "publish_state": "published_public_noindex",
+    "robots_runtime_status": "pass",
+    "schema_runtime_status": "blocked",
+    "blocking_reasons": [
+      "Published Help pages now render noindex robots correctly after the deployed fap-web noindex runtime repair.",
+      "Published Help pages still emit zero FAQPage JSON-LD hits across the 12-page smoke sample."
+    ],
+    "next_task_recommendation": "HELP-SERVICE-FAQ-SCHEMA-RUNTIME-R2-01"
+  },
+  "scope_validation": {
+    "cms_mutation_performed": false,
+    "publish_performed": false,
+    "deploy_performed": false,
+    "search_submission_performed": false,
+    "private_url_access_performed": false,
+    "secret_env_cookie_token_read": false,
+    "payment_or_refund_performed": false,
+    "payment_provider_changed": false,
+    "operator_approval_claimed": false
+  }
+}

--- a/backend/docs/operations/help-content-draft-post-publish-smoke-r2-2026-06-08.md
+++ b/backend/docs/operations/help-content-draft-post-publish-smoke-r2-2026-06-08.md
@@ -1,0 +1,37 @@
+# HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-R2-01
+
+Decision: `PARTIAL_GO_SCHEMA_RUNTIME_BLOCKED`.
+
+This is a read-only post-publish smoke rerun after the frontend Help noindex runtime repair was merged and deployed. It does not mutate CMS rows, publish, deploy, submit search URLs, access private result/order/share/pay/payment/history URLs, read secrets/env/cookies/tokens, run payment/refund flows, change payment-provider behavior, or claim Operator approval.
+
+## Public Help route smoke
+
+| Check | Result |
+| --- | --- |
+| Help service pages checked | 12 |
+| HTTP 200 pages | 12/12 |
+| Robots noindex pages | 12/12 |
+| Robots `index, follow` pages | 0/12 |
+| Canonical tag failures | 0 |
+| Tokenized private URL pattern hits | 0 |
+| `FAQPage` JSON-LD hits | 0 |
+
+## Machine-readable exposure smoke
+
+| Resource | Status |
+| --- | --- |
+| `/sitemap.xml` | 200 |
+| `/llms.txt` | 200 |
+| `/llms-full.txt` | 200 |
+| Help service slug hits | 0 |
+| Tokenized private URL pattern hits | 0 |
+
+## Outcome
+
+The Help pages are published, public, reachable, and now correctly non-indexable at runtime. The original robots blocker is resolved.
+
+The FAQ schema blocker remains open because the public smoke still found zero `FAQPage` JSON-LD hits across the 12 Help pages. This PR records the blocker only; it does not repair schema runtime.
+
+## Next
+
+Proceed with `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-R2-01` only if the next scope is to repair or rewire backend-authoritative Help FAQ schema output. Keep it separate from publish, CMS mutation, deploy, search submission, and private URL access unless separately authorized.

--- a/backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeR2Test.php
+++ b/backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeR2Test.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Cms;
+
+use Tests\TestCase;
+
+final class HelpContentDraftPostPublishSmokeR2Test extends TestCase
+{
+    public function test_help_content_draft_post_publish_smoke_r2_records_noindex_pass_and_schema_blocker(): void
+    {
+        $backendPath = (string) getcwd();
+        $artifactPath = $backendPath.'/docs/help/generated/help-content-draft-post-publish-smoke-r2-01.v1.json';
+        $reportPath = $backendPath.'/docs/operations/help-content-draft-post-publish-smoke-r2-2026-06-08.md';
+
+        $this->assertFileExists($artifactPath);
+        $this->assertFileExists($reportPath);
+
+        $artifact = json_decode((string) file_get_contents($artifactPath), true);
+
+        $this->assertIsArray($artifact);
+        $this->assertSame('HELP-CONTENT-DRAFT-POST-PUBLISH-SMOKE-R2-01', $artifact['task']['id'] ?? null);
+        $this->assertSame('PARTIAL_GO_SCHEMA_RUNTIME_BLOCKED', $artifact['decision']['status'] ?? null);
+        $this->assertSame('pass', $artifact['decision']['robots_runtime_status'] ?? null);
+        $this->assertSame('blocked', $artifact['decision']['schema_runtime_status'] ?? null);
+        $this->assertSame(12, $artifact['public_route_smoke']['checked_pages'] ?? null);
+        $this->assertSame(12, $artifact['public_route_smoke']['http_200_count'] ?? null);
+        $this->assertSame(12, $artifact['public_route_smoke']['robots_noindex_count'] ?? null);
+        $this->assertSame(0, $artifact['public_route_smoke']['robots_index_follow_count'] ?? null);
+        $this->assertSame(0, $artifact['public_route_smoke']['faqpage_total_hits'] ?? null);
+        $this->assertSame(0, $artifact['public_route_smoke']['private_tokenized_pattern_hits'] ?? null);
+        $this->assertSame([], $artifact['public_route_smoke']['canonical_count_failures'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_smoke']['help_service_slug_hits'] ?? null);
+        $this->assertSame(0, $artifact['sitemap_llms_smoke']['private_tokenized_pattern_hits'] ?? null);
+        $this->assertFalse((bool) ($artifact['scope_validation']['cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($artifact['scope_validation']['publish_performed'] ?? true));
+        $this->assertFalse((bool) ($artifact['scope_validation']['deploy_performed'] ?? true));
+        $this->assertSame('HELP-SERVICE-FAQ-SCHEMA-RUNTIME-R2-01', $artifact['decision']['next_task_recommendation'] ?? null);
+    }
+}


### PR DESCRIPTION
## What changed
- Added a read-only R2 post-publish smoke artifact for the 12 Help service pages.
- Added an operations report recording that Help robots now pass as noindex after the frontend deploy.
- Added a focused contract test for the R2 artifact decision.

## Why
The first post-publish smoke recorded publish success but robots/schema runtime blockers. After the Help noindex runtime repair was deployed, this PR records the current production state: robots is fixed, FAQPage schema remains blocked.

## Validation
- Public HTTP smoke for 12 Help canonical pages, `/sitemap.xml`, `/llms.txt`, and `/llms-full.txt`
- `php -l backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeR2Test.php`
- `python3 -m json.tool backend/docs/help/generated/help-content-draft-post-publish-smoke-r2-01.v1.json >/dev/null`
- `APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE='':memory:'' php artisan test --filter=HelpContentDraftPostPublishSmokeR2Test --no-ansi`
- `git diff --check -- backend/docs/help/generated/help-content-draft-post-publish-smoke-r2-01.v1.json backend/docs/operations/help-content-draft-post-publish-smoke-r2-2026-06-08.md backend/tests/Feature/Cms/HelpContentDraftPostPublishSmokeR2Test.php`
- `git diff --cached --check`

## Intentionally deferred
- `HELP-SERVICE-FAQ-SCHEMA-RUNTIME-R2-01` remains the next scoped task because public Help pages still emit zero FAQPage JSON-LD hits.
- No CMS mutation, publish, deploy, search submission, private URL access, secret/env/cookie/token read, payment/refund action, payment-provider change, or Operator approval claim.

## Repository rule impact
No content authority change. Help content and FAQ authority remain backend/CMS-owned; this PR records production smoke evidence only.