### PR TITLE
SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -36,7 +36,10 @@ class SitemapGenerator
         'software-developers',
     ];
 
-    private string $urlPrefix;
+    private const SCALE_FRONTEND_LOCALE_SEGMENTS = [
+        'en' => 'en',
+        'zh-CN' => 'zh',
+    ];
 
     public function __construct(
         private readonly ArticleSeoService $articleSeoService,
@@ -48,14 +51,7 @@ class SitemapGenerator
         private readonly ScaleRegistry $scaleRegistry,
         private readonly CareerDatasetPublicationMetadataService $datasetPublicationMetadataService,
         private readonly CareerDirectoryAuthorityService $careerDirectoryAuthorityService,
-    ) {
-        $configuredPrefix = trim((string) config('services.seo.tests_url_prefix', ''));
-        if ($configuredPrefix === '') {
-            $configuredPrefix = rtrim((string) config('app.frontend_url', config('app.url', 'http://localhost')), '/').'/tests/';
-        }
-
-        $this->urlPrefix = rtrim($configuredPrefix, '/').'/';
-    }
+    ) {}
 
     public function generate(): array
     {
@@ -93,10 +89,8 @@ class SitemapGenerator
 
     public function generateUrls(): array
     {
-        $locale = (string) config('app.locale', 'en');
-
         $urls = array_merge(
-            $this->getScaleUrls($locale),
+            $this->getScaleUrls(),
             $this->getArticleUrls(),
             $this->getCareerJobUrls(),
             $this->getCareerGuideUrls(),
@@ -123,8 +117,13 @@ class SitemapGenerator
         return $this->getDirectoryAuthorityCareerJobDetailUrls();
     }
 
-    private function getScaleUrls(string $locale): array
+    private function getScaleUrls(): array
     {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
         $rows = $this->scaleRegistry->listActivePublic(0);
 
         $slugDates = [];
@@ -144,22 +143,19 @@ class SitemapGenerator
 
             $updatedAt = $this->parseUpdatedAt($row['updated_at'] ?? null);
 
-            $slugs = $this->collectSlugs($row['primary_slug'] ?? null, $row['slugs_json'] ?? null);
-            foreach ($slugs as $slug) {
-                $slug = trim((string) $slug);
-                if ($slug === '') {
-                    continue;
-                }
+            $slug = trim((string) ($row['primary_slug'] ?? ''));
+            if ($slug === '') {
+                continue;
+            }
 
-                if (! array_key_exists($slug, $slugDates)) {
-                    $slugDates[$slug] = $updatedAt;
+            if (! array_key_exists($slug, $slugDates)) {
+                $slugDates[$slug] = $updatedAt;
 
-                    continue;
-                }
+                continue;
+            }
 
-                if ($updatedAt && (! $slugDates[$slug] || $updatedAt->gt($slugDates[$slug]))) {
-                    $slugDates[$slug] = $updatedAt;
-                }
+            if ($updatedAt && (! $slugDates[$slug] || $updatedAt->gt($slugDates[$slug]))) {
+                $slugDates[$slug] = $updatedAt;
             }
         }
 
@@ -168,12 +164,14 @@ class SitemapGenerator
 
         $urls = [];
         foreach ($slugList as $slug) {
-            $urls[] = [
-                'loc' => $this->urlPrefix.rawurlencode($slug),
-                'lastmod' => $this->formatLastmod($slugDates[$slug] ?? null),
-                'slug' => $slug,
-                'updated_at' => ($slugDates[$slug] ?? null)?->toDateTimeString(),
-            ];
+            foreach (self::SCALE_FRONTEND_LOCALE_SEGMENTS as $segment) {
+                $urls[] = [
+                    'loc' => $baseUrl.'/'.$segment.'/tests/'.rawurlencode($slug),
+                    'lastmod' => $this->formatLastmod($slugDates[$slug] ?? null),
+                    'slug' => 'tests:'.$segment.':'.$slug,
+                    'updated_at' => ($slugDates[$slug] ?? null)?->toDateTimeString(),
+                ];
+            }
         }
 
         return $urls;
@@ -859,39 +857,6 @@ class SitemapGenerator
 
         return trim((string) $page->content_md) !== ''
             || trim((string) $page->content_html) !== '';
-    }
-
-    private function collectSlugs($primarySlug, $slugsJson): array
-    {
-        $slugs = [];
-
-        if ($primarySlug !== null) {
-            $slugs[] = (string) $primarySlug;
-        }
-
-        foreach ($this->decodeSlugsJson($slugsJson) as $slug) {
-            $slugs[] = $slug;
-        }
-
-        return $slugs;
-    }
-
-    private function decodeSlugsJson($slugsJson): array
-    {
-        if (is_array($slugsJson)) {
-            return $slugsJson;
-        }
-
-        if (! is_string($slugsJson) || trim($slugsJson) === '') {
-            return [];
-        }
-
-        $decoded = json_decode($slugsJson, true);
-        if (! is_array($decoded)) {
-            return [];
-        }
-
-        return $decoded;
     }
 
     private function parseUpdatedAt($updatedAt): ?Carbon

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -29,7 +29,7 @@ class SitemapGeneratorTest extends TestCase
 
     public function test_generate_includes_dataset_urls_and_only_public_global_scales(): void
     {
-        config(['services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/']);
+        config(['app.frontend_url' => 'https://fermatmind.com']);
 
         $now = now();
         // Isolate this test from migration-seeded default scales.
@@ -100,18 +100,29 @@ class SitemapGeneratorTest extends TestCase
         $slugList = (array) ($payload['slug_list'] ?? []);
         sort($slugList, SORT_STRING);
 
-        $this->assertSame(['career-dataset-hub', 'career-dataset-method', 'public-global', 'public-global-alt'], $slugList);
+        $this->assertSame([
+            'career-dataset-hub',
+            'career-dataset-method',
+            'tests:en:public-global',
+            'tests:zh:public-global',
+        ], $slugList);
 
         $xml = (string) ($payload['xml'] ?? '');
-        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/').'/';
         $this->assertStringContainsString('https://www.fermatmind.com/datasets/occupations', $xml);
         $this->assertStringContainsString('https://www.fermatmind.com/datasets/occupations/method', $xml);
-        $this->assertStringContainsString($prefix.'public-global', $xml);
-        $this->assertStringContainsString($prefix.'public-global-alt', $xml);
-        $this->assertStringNotContainsString($prefix.'private-global', $xml);
-        $this->assertStringNotContainsString($prefix.'private-global-alt', $xml);
-        $this->assertStringNotContainsString($prefix.'tenant-public', $xml);
-        $this->assertStringNotContainsString($prefix.'tenant-public-alt', $xml);
+        $this->assertStringContainsString('https://fermatmind.com/en/tests/public-global', $xml);
+        $this->assertStringContainsString('https://fermatmind.com/zh/tests/public-global', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/tests/public-global', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/en/tests/public-global-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/public-global-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/en/tests/private-global', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/private-global', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/en/tests/private-global-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/private-global-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/en/tests/tenant-public', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/tenant-public', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/en/tests/tenant-public-alt', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/tenant-public-alt', $xml);
     }
 
     public function test_generate_includes_only_indexable_global_article_urls_with_locale_aware_paths(): void

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -30,7 +30,6 @@ class SitemapXmlTest extends TestCase
     {
         config([
             'services.seo.public_sitemap_authority' => 'backend',
-            'services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/',
         ]);
         config(['app.frontend_url' => 'https://staging.fermatmind.com']);
 
@@ -478,13 +477,19 @@ class SitemapXmlTest extends TestCase
         $response->assertHeaderMissing('Set-Cookie');
 
         $body = (string) $response->getContent();
-        $prefix = rtrim((string) config('services.seo.tests_url_prefix'), '/').'/';
-        $this->assertStringContainsString('<loc>'.$prefix.'alpha</loc>', $body);
-        $this->assertStringContainsString('<loc>'.$prefix.'beta</loc>', $body);
-        $this->assertStringContainsString('<loc>'.$prefix.'gamma</loc>', $body);
-        $this->assertStringContainsString('<loc>'.$prefix.'delta</loc>', $body);
-        $this->assertStringNotContainsString('<loc>'.$prefix.'hidden</loc>', $body);
-        $this->assertStringNotContainsString('<loc>'.$prefix.'hidden-alt</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/tests/alpha</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/tests/alpha</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/tests/gamma</loc>', $body);
+        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/tests/gamma</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/tests/alpha</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/tests/beta</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/tests/beta</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/tests/delta</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/tests/delta</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/tests/hidden</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/tests/hidden</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/tests/hidden-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/tests/hidden-alt</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/personality</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/personality/intj-a</loc>', $body);
@@ -526,7 +531,8 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<priority>0.7</priority>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-30</lastmod>', $body);
         $this->assertStringContainsString('<lastmod>2026-01-31</lastmod>', $body);
-        $this->assertSame(1, substr_count($body, '<loc>'.$prefix.'alpha</loc>'));
+        $this->assertSame(1, substr_count($body, '<loc>https://staging.fermatmind.com/en/tests/alpha</loc>'));
+        $this->assertSame(1, substr_count($body, '<loc>https://staging.fermatmind.com/zh/tests/alpha</loc>'));
 
         $entries = $this->sitemapEntries($body);
         $this->assertSame(
@@ -561,11 +567,11 @@ class SitemapXmlTest extends TestCase
         $this->get('/sitemap.xml')->assertNotFound();
     }
 
-    public function test_sitemap_xml_defaults_tests_urls_to_frontend_host_when_prefix_is_not_explicitly_configured(): void
+    public function test_sitemap_xml_exports_localized_canonical_tests_urls_on_frontend_host(): void
     {
         config([
             'services.seo.public_sitemap_authority' => 'backend',
-            'services.seo.tests_url_prefix' => '',
+            'services.seo.tests_url_prefix' => 'https://legacy.fermatmind.com/tests/',
             'app.url' => 'https://api.fermatmind.com',
             'app.frontend_url' => 'https://fermatmind.com',
         ]);
@@ -592,17 +598,20 @@ class SitemapXmlTest extends TestCase
 
         $body = (string) $this->get('/sitemap.xml')->getContent();
 
-        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/host-check</loc>', $body);
-        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/host-check-alt</loc>', $body);
-        $this->assertStringNotContainsString('<loc>https://api.fermatmind.com/tests/host-check</loc>', $body);
-        $this->assertStringNotContainsString('<loc>https://api.fermatmind.com/tests/host-check-alt</loc>', $body);
+        $this->assertStringContainsString('<loc>https://fermatmind.com/en/tests/host-check</loc>', $body);
+        $this->assertStringContainsString('<loc>https://fermatmind.com/zh/tests/host-check</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/tests/host-check</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/en/tests/host-check-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/zh/tests/host-check-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://api.fermatmind.com/en/tests/host-check</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://legacy.fermatmind.com/tests/host-check</loc>', $body);
     }
 
     public function test_sitemap_xml_reads_public_tests_from_v2_registry_when_legacy_registry_is_empty(): void
     {
         config([
             'services.seo.public_sitemap_authority' => 'backend',
-            'services.seo.tests_url_prefix' => 'https://fermatmind.com/tests/',
+            'app.frontend_url' => 'https://fermatmind.com',
         ]);
 
         DB::table('scales_registry')->delete();
@@ -661,10 +670,15 @@ class SitemapXmlTest extends TestCase
 
         $body = (string) $this->get('/sitemap.xml')->getContent();
 
-        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/v2-public</loc>', $body);
-        $this->assertStringContainsString('<loc>https://fermatmind.com/tests/v2-public-alt</loc>', $body);
-        $this->assertStringNotContainsString('<loc>https://fermatmind.com/tests/v2-noindex</loc>', $body);
-        $this->assertStringNotContainsString('<loc>https://fermatmind.com/tests/v2-noindex-alt</loc>', $body);
+        $this->assertStringContainsString('<loc>https://fermatmind.com/en/tests/v2-public</loc>', $body);
+        $this->assertStringContainsString('<loc>https://fermatmind.com/zh/tests/v2-public</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/tests/v2-public</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/en/tests/v2-public-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/zh/tests/v2-public-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/en/tests/v2-noindex</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/zh/tests/v2-noindex</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/en/tests/v2-noindex-alt</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://fermatmind.com/zh/tests/v2-noindex-alt</loc>', $body);
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T17:00:04Z",
+  "updated_at": "2026-06-08T17:05:28Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51356,7 +51356,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-sitemap-diff-02",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "github_checks_passed_ready_to_merge",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs",
     "depends_on": [],
@@ -51398,9 +51398,22 @@
         "evidence": "PHP lint passed for SitemapGenerator and focused SEO sitemap tests. Focused PHPUnit passed with 17 warnings and 406 assertions. Scoped Pint --test passed. JSON/YAML parse passed. Path-limited git diff --check passed."
       },
       "github": {
-        "status": "pending",
-        "head_sha": "a759bc0bb752f80d4425937ba0e98d39f5da7493",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/2008"
+        "status": "pass",
+        "head_sha": "7b1aba66f084a2cba6bd2e798e5823b979c0656f",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2008",
+        "failure_reason": null
       }
     },
     "failure_reason": null,
@@ -51433,6 +51446,11 @@
         "at": "2026-06-09",
         "status": "github_checks_pending",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2008 from head a759bc0bb752f80d4425937ba0e98d39f5da7493; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_passed_ready_to_merge",
+        "note": "GitHub checks passed for PR #2008 head 7b1aba66f084a2cba6bd2e798e5823b979c0656f: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T16:52:18Z",
+  "updated_at": "2026-06-08T16:56:08Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51399,7 +51399,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "33ebf1b1de68997f9ed65a8a10b6f1f4a5a5a0cd",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -51418,6 +51418,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed",
         "note": "Scale sitemap source now emits localized canonical primary_slug URLs only; focused sitemap tests, Pint, JSON/YAML parse, and scope diff checks passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed",
+        "note": "Created scoped implementation commit 33ebf1b1de68997f9ed65a8a10b6f1f4a5a5a0cd."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T14:48:00Z",
+  "updated_at": "2026-06-08T16:52:18Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51349,6 +51349,75 @@
         "at": "2026-06-08",
         "status": "github_checks_passed_pending_external_merge",
         "note": "GitHub checks passed for PR #2007 head fa36572b3540ce0175ad2afde845db82d056d766: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      }
+    ]
+  },
+  "SEO-SITEMAP-DIFF-02": {
+    "repo": "fap-api",
+    "branch": "codex/seo-sitemap-diff-02",
+    "base": "origin/main",
+    "status": "in_progress",
+    "train_scope": "sitemap_diff_parity",
+    "title": "SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided SEO-SITEMAP-DIFF-02 fap-api goal, scope, expected diff resolution, and authorized docs/codex metadata updates as part of the sitemap diff PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "Started from fap-api origin/main at ac2af02543c6956b5bce8d03a65a2aa7969c98a4 after the previous backend sitemap stability merge was present on main; fap-web SEO-SITEMAP-DIFF-01 PR #1082 was merged before this branch started."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/app/Services/SEO/SitemapGenerator.php, focused SEO sitemap tests, and docs/codex PR-train metadata.",
+        "allowed_paths": [
+          "backend/app/Services/SEO/SitemapGenerator.php",
+          "backend/tests/Feature/SEO/SitemapGeneratorTest.php",
+          "backend/tests/Feature/SEO/SitemapXmlTest.php",
+          "backend/tests/Feature/SEO/SitemapSourceApiTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/SEO/SitemapGenerator.php",
+          "php -l backend/tests/Feature/SEO/SitemapGeneratorTest.php",
+          "php -l backend/tests/Feature/SEO/SitemapXmlTest.php",
+          "php -l backend/tests/Feature/SEO/SitemapSourceApiTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/app/Services/SEO/SitemapGenerator.php backend/tests/Feature/SEO/SitemapGeneratorTest.php backend/tests/Feature/SEO/SitemapXmlTest.php backend/tests/Feature/SEO/SitemapSourceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "evidence": "PHP lint passed for SitemapGenerator and focused SEO sitemap tests. Focused PHPUnit passed with 17 warnings and 406 assertions. Scoped Pint --test passed. JSON/YAML parse passed. Path-limited git diff --check passed."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "expected_backend_only_root_test_aliases_resolved": 136,
+      "expected_live_only_localized_test_urls_resolved": 16
+    },
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Created isolated fap-api worktree from latest origin/main and started SEO-SITEMAP-DIFF-02 with only the authorized scale sitemap-source scope."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "Scale sitemap source now emits localized canonical primary_slug URLs only; focused sitemap tests, Pint, JSON/YAML parse, and scope diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T16:56:08Z",
+  "updated_at": "2026-06-08T17:00:04Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51356,7 +51356,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-sitemap-diff-02",
     "base": "origin/main",
-    "status": "in_progress",
+    "status": "github_checks_pending",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs",
     "depends_on": [],
@@ -51396,11 +51396,16 @@
           "git diff --cached --check"
         ],
         "evidence": "PHP lint passed for SitemapGenerator and focused SEO sitemap tests. Focused PHPUnit passed with 17 warnings and 406 assertions. Scoped Pint --test passed. JSON/YAML parse passed. Path-limited git diff --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": "a759bc0bb752f80d4425937ba0e98d39f5da7493",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2008"
       }
     },
     "failure_reason": null,
     "commit_sha": "33ebf1b1de68997f9ed65a8a10b6f1f4a5a5a0cd",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2008",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -51423,6 +51428,11 @@
         "at": "2026-06-09",
         "status": "committed",
         "note": "Created scoped implementation commit 33ebf1b1de68997f9ed65a8a10b6f1f4a5a5a0cd."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_pending",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2008 from head a759bc0bb752f80d4425937ba0e98d39f5da7493; GitHub checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23647,3 +23647,51 @@ prs:
     content_rewrite_allowed: false
     content_authority: backend
     next_task: SEO-SITEMAP-STABILITY-03 in fap-web after this PR is merged
+
+  - id: SEO-SITEMAP-DIFF-02
+    repo: fap-api
+    depends_on: []
+    branch: codex/seo-sitemap-diff-02
+    title: "SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs"
+    train_scope: sitemap_diff_parity
+    status: in_progress
+    scope:
+      - Change backend scale sitemap-source generation from root /tests/* aliases to frontend localized canonical /en/tests/* and /zh/tests/* URLs.
+      - Emit only scales_registry primary_slug values for public global indexable tests; keep slugs_json aliases out of the sitemap source.
+      - Preserve existing backend sitemap filtering for private, inactive, tenant, noindex, and view-policy excluded scales.
+    allowed_paths:
+      - backend/app/Services/SEO/SitemapGenerator.php
+      - backend/tests/Feature/SEO/SitemapGeneratorTest.php
+      - backend/tests/Feature/SEO/SitemapXmlTest.php
+      - backend/tests/Feature/SEO/SitemapSourceApiTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change frontend sitemap behavior, article/topic/career/content-page sitemap enumeration, cache fallback behavior, CMS content, deploy state, or search URL submissions.
+      - Reintroduce root /tests/* aliases, private result/order/share/pay/payment/history/take URLs, or frontend editorial fallback content.
+    validation:
+      - php -l backend/app/Services/SEO/SitemapGenerator.php
+      - php -l backend/tests/Feature/SEO/SitemapGeneratorTest.php
+      - php -l backend/tests/Feature/SEO/SitemapXmlTest.php
+      - php -l backend/tests/Feature/SEO/SitemapSourceApiTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/app/Services/SEO/SitemapGenerator.php backend/tests/Feature/SEO/SitemapGeneratorTest.php backend/tests/Feature/SEO/SitemapXmlTest.php backend/tests/Feature/SEO/SitemapSourceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_rewrite_allowed: false
+    content_authority: backend
+    expected_diff_resolution:
+      backend_only_root_test_aliases: 136
+      live_only_localized_test_urls: 16
+    next_task: SEO-SITEMAP-DIFF-03 in fap-api after this PR is merged


### PR DESCRIPTION
## What changed
- Changed backend scale sitemap generation to emit frontend localized canonical test URLs: `/en/tests/{primary_slug}` and `/zh/tests/{primary_slug}`.
- Stopped exporting `slugs_json` aliases and root `/tests/*` scale URLs from the backend sitemap source.
- Updated focused sitemap generator/XML tests and docs/codex PR-train metadata for SEO-SITEMAP-DIFF-02.

## Why
- PR01 diff evidence showed backend-only root test aliases and live-only localized test URLs. This PR aligns the backend source with the live canonical test URL shape without touching non-scale sitemap differences.

## Validation
- `php -l backend/app/Services/SEO/SitemapGenerator.php`
- `php -l backend/tests/Feature/SEO/SitemapGeneratorTest.php`
- `php -l backend/tests/Feature/SEO/SitemapXmlTest.php`
- `php -l backend/tests/Feature/SEO/SitemapSourceApiTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/app/Services/SEO/SitemapGenerator.php backend/tests/Feature/SEO/SitemapGeneratorTest.php backend/tests/Feature/SEO/SitemapXmlTest.php backend/tests/Feature/SEO/SitemapSourceApiTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Non-scale static/index sitemap differences are deferred to SEO-SITEMAP-DIFF-03.
- Final live parity gate and no-unknown/no-private assertions are deferred to SEO-SITEMAP-DIFF-04.
- No frontend behavior, CMS content, deployment, or search submission changes are included.

## Repository rule impact
- SEO enumeration remains backend-authoritative for backend sitemap source generation. This PR narrows scale sitemap source output to public global canonical `scales_registry.primary_slug` URLs and does not introduce frontend editorial fallback content.