### PR TITLE
SEO-SITEMAP-DIFF-03: fix(seo): align non-scale sitemap static and index URLs

### DIFF
--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -94,10 +94,10 @@ class SitemapGenerator
             $this->getArticleUrls(),
             $this->getCareerJobUrls(),
             $this->getCareerGuideUrls(),
-            $this->getCareerDatasetUrls(),
             $this->getPersonalityUrls(),
             $this->getTopicUrls(),
-            $this->getContentPageUrls()
+            $this->getContentPageUrls(),
+            $this->getStaticIndexUrls()
         );
 
         $urls = collect($urls)
@@ -309,42 +309,7 @@ class SitemapGenerator
 
     private function getCareerJobUrls(): array
     {
-        return array_merge(
-            $this->getCareerJobListUrls(),
-            $this->getCareerJobDetailUrls()
-        );
-    }
-
-    private function getCareerDatasetUrls(): array
-    {
-        $publication = $this->datasetPublicationMetadataService->build()->toArray();
-        $distribution = (array) ($publication['distribution'] ?? []);
-
-        $hubUrl = trim((string) ($distribution['documentation_url'] ?? ''));
-        $methodUrl = trim((string) ($distribution['methodology_url'] ?? ''));
-
-        $updatedAt = now('UTC');
-        $entries = [];
-
-        if ($hubUrl !== '') {
-            $entries[] = [
-                'loc' => $hubUrl,
-                'lastmod' => $updatedAt->toAtomString(),
-                'slug' => 'career-dataset-hub',
-                'updated_at' => $updatedAt->toDateTimeString(),
-            ];
-        }
-
-        if ($methodUrl !== '') {
-            $entries[] = [
-                'loc' => $methodUrl,
-                'lastmod' => $updatedAt->toAtomString(),
-                'slug' => 'career-dataset-method',
-                'updated_at' => $updatedAt->toDateTimeString(),
-            ];
-        }
-
-        return $entries;
+        return $this->getCareerJobDetailUrls();
     }
 
     private function getCareerJobListUrls(): array
@@ -785,6 +750,10 @@ class SitemapGenerator
                 continue;
             }
 
+            if ((string) $row->kind === ContentPage::KIND_HELP) {
+                continue;
+            }
+
             $path = $this->contentPageCanonicalPath($row);
             if ($path === null) {
                 continue;
@@ -804,6 +773,45 @@ class SitemapGenerator
         }
 
         return $urls;
+    }
+
+    private function getStaticIndexUrls(): array
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        if ($baseUrl === '') {
+            return [];
+        }
+
+        $updatedAt = now('UTC');
+        $paths = [
+            '/',
+            '/en',
+            '/en/business',
+            '/en/career',
+            '/en/career/guides',
+            '/en/career/recommendations',
+            '/en/career/tests',
+            '/en/support',
+            '/en/tests',
+            '/en/tests/category/career',
+            '/en/tests/category/personality',
+            '/zh/business',
+            '/zh/career',
+            '/zh/career/guides',
+            '/zh/career/recommendations',
+            '/zh/career/tests',
+            '/zh/support',
+            '/zh/tests',
+            '/zh/tests/category/career',
+            '/zh/tests/category/personality',
+        ];
+
+        return array_map(static fn (string $path): array => [
+            'loc' => $baseUrl.$path,
+            'lastmod' => $updatedAt->toAtomString(),
+            'slug' => 'static-index:'.($path === '/' ? 'root' : trim(str_replace('/', ':', $path), ':')),
+            'updated_at' => $updatedAt->toDateTimeString(),
+        ], $paths);
     }
 
     private function contentPageCanonicalPath(ContentPage $page): ?string

--- a/backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php
+++ b/backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php
@@ -12,7 +12,7 @@ final class CareerDatasetSitemapDiscoverabilityTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_backend_sitemap_generator_includes_dataset_hub_and_method_urls(): void
+    public function test_backend_sitemap_generator_excludes_dataset_hub_and_method_urls(): void
     {
         config([
             'app.frontend_url' => 'https://www.fermatmind.com',
@@ -21,7 +21,7 @@ final class CareerDatasetSitemapDiscoverabilityTest extends TestCase
         $payload = app(SitemapGenerator::class)->generate();
         $xml = (string) ($payload['xml'] ?? '');
 
-        $this->assertStringContainsString('https://www.fermatmind.com/datasets/occupations', $xml);
-        $this->assertStringContainsString('https://www.fermatmind.com/datasets/occupations/method', $xml);
+        $this->assertStringNotContainsString('https://www.fermatmind.com/datasets/occupations', $xml);
+        $this->assertStringNotContainsString('https://www.fermatmind.com/datasets/occupations/method', $xml);
     }
 }

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -7,6 +7,7 @@ use App\Models\ArticleTranslationRevision;
 use App\Models\CareerGuide;
 use App\Models\CareerJob;
 use App\Models\CareerJobSeoMeta;
+use App\Models\ContentPage;
 use App\Models\PersonalityProfile;
 use App\Models\PersonalityProfileSeoMeta;
 use App\Models\PersonalityProfileVariant;
@@ -27,7 +28,7 @@ class SitemapGeneratorTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_generate_includes_dataset_urls_and_only_public_global_scales(): void
+    public function test_generate_excludes_dataset_urls_and_includes_only_public_global_scales(): void
     {
         config(['app.frontend_url' => 'https://fermatmind.com']);
 
@@ -100,16 +101,14 @@ class SitemapGeneratorTest extends TestCase
         $slugList = (array) ($payload['slug_list'] ?? []);
         sort($slugList, SORT_STRING);
 
-        $this->assertSame([
-            'career-dataset-hub',
-            'career-dataset-method',
-            'tests:en:public-global',
-            'tests:zh:public-global',
-        ], $slugList);
+        $this->assertContains('tests:en:public-global', $slugList);
+        $this->assertContains('tests:zh:public-global', $slugList);
+        $this->assertNotContains('career-dataset-hub', $slugList);
+        $this->assertNotContains('career-dataset-method', $slugList);
 
         $xml = (string) ($payload['xml'] ?? '');
-        $this->assertStringContainsString('https://www.fermatmind.com/datasets/occupations', $xml);
-        $this->assertStringContainsString('https://www.fermatmind.com/datasets/occupations/method', $xml);
+        $this->assertStringNotContainsString('https://www.fermatmind.com/datasets/occupations', $xml);
+        $this->assertStringNotContainsString('https://www.fermatmind.com/datasets/occupations/method', $xml);
         $this->assertStringContainsString('https://fermatmind.com/en/tests/public-global', $xml);
         $this->assertStringContainsString('https://fermatmind.com/zh/tests/public-global', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/tests/public-global', $xml);
@@ -123,6 +122,58 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/tenant-public', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/en/tests/tenant-public-alt', $xml);
         $this->assertStringNotContainsString('https://fermatmind.com/zh/tests/tenant-public-alt', $xml);
+    }
+
+    public function test_generate_includes_core_static_index_urls_and_excludes_help_pages(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'help-about',
+            'path' => '/help/about',
+            'kind' => ContentPage::KIND_HELP,
+            'locale' => 'en',
+            'title' => 'About help',
+            'content_md' => '# About help',
+            'content_html' => null,
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => Carbon::create(2026, 3, 8, 9, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 3, 8, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 3, 8, 9, 0, 0, 'UTC'),
+        ]);
+
+        $payload = app(SitemapGenerator::class)->generate();
+        $xml = (string) ($payload['xml'] ?? '');
+
+        foreach ([
+            'https://fermatmind.com/',
+            'https://fermatmind.com/en',
+            'https://fermatmind.com/en/business',
+            'https://fermatmind.com/en/career',
+            'https://fermatmind.com/en/career/guides',
+            'https://fermatmind.com/en/career/recommendations',
+            'https://fermatmind.com/en/career/tests',
+            'https://fermatmind.com/en/support',
+            'https://fermatmind.com/en/tests',
+            'https://fermatmind.com/en/tests/category/career',
+            'https://fermatmind.com/en/tests/category/personality',
+            'https://fermatmind.com/zh/business',
+            'https://fermatmind.com/zh/career',
+            'https://fermatmind.com/zh/career/guides',
+            'https://fermatmind.com/zh/career/recommendations',
+            'https://fermatmind.com/zh/career/tests',
+            'https://fermatmind.com/zh/support',
+            'https://fermatmind.com/zh/tests',
+            'https://fermatmind.com/zh/tests/category/career',
+            'https://fermatmind.com/zh/tests/category/personality',
+        ] as $loc) {
+            $this->assertStringContainsString($loc, $xml);
+        }
+
+        $this->assertStringNotContainsString('https://fermatmind.com/en/help/about', $xml);
     }
 
     public function test_generate_includes_only_indexable_global_article_urls_with_locale_aware_paths(): void
@@ -549,9 +600,8 @@ class SitemapGeneratorTest extends TestCase
         $payload = app(SitemapGenerator::class)->generate();
         $xml = (string) ($payload['xml'] ?? '');
 
-        $this->assertStringContainsString('https://staging.fermatmind.com/zh/career/jobs', $xml);
-
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs', $xml);
+        $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/career/jobs', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/en/career/jobs/product-manager', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/career/jobs/product-manager', $xml);
         $this->assertStringNotContainsString('https://staging.fermatmind.com/zh/career/jobs/robots-noindex', $xml);

--- a/backend/tests/Feature/SEO/SitemapSourceApiTest.php
+++ b/backend/tests/Feature/SEO/SitemapSourceApiTest.php
@@ -262,8 +262,32 @@ class SitemapSourceApiTest extends TestCase
         }
 
         $locs = collect($data['items'])->pluck('loc')->all();
+        $this->assertContains('https://fermatmind.com/', $locs);
+        $this->assertContains('https://fermatmind.com/en', $locs);
+        $this->assertContains('https://fermatmind.com/en/business', $locs);
+        $this->assertContains('https://fermatmind.com/en/career', $locs);
+        $this->assertContains('https://fermatmind.com/en/career/guides', $locs);
+        $this->assertContains('https://fermatmind.com/en/career/recommendations', $locs);
+        $this->assertContains('https://fermatmind.com/en/career/tests', $locs);
+        $this->assertContains('https://fermatmind.com/en/support', $locs);
+        $this->assertContains('https://fermatmind.com/en/tests', $locs);
+        $this->assertContains('https://fermatmind.com/en/tests/category/career', $locs);
+        $this->assertContains('https://fermatmind.com/en/tests/category/personality', $locs);
+        $this->assertContains('https://fermatmind.com/zh/business', $locs);
+        $this->assertContains('https://fermatmind.com/zh/career', $locs);
+        $this->assertContains('https://fermatmind.com/zh/career/guides', $locs);
+        $this->assertContains('https://fermatmind.com/zh/career/recommendations', $locs);
+        $this->assertContains('https://fermatmind.com/zh/career/tests', $locs);
+        $this->assertContains('https://fermatmind.com/zh/support', $locs);
+        $this->assertContains('https://fermatmind.com/zh/tests', $locs);
+        $this->assertContains('https://fermatmind.com/zh/tests/category/career', $locs);
+        $this->assertContains('https://fermatmind.com/zh/tests/category/personality', $locs);
         $this->assertContains('https://fermatmind.com/en/career/jobs/civil-engineers', $locs);
         $this->assertContains('https://fermatmind.com/zh/career/jobs/civil-engineers', $locs);
+        $this->assertNotContains('https://fermatmind.com/datasets/occupations', $locs);
+        $this->assertNotContains('https://fermatmind.com/datasets/occupations/method', $locs);
+        $this->assertNotContains('https://fermatmind.com/en/career/jobs', $locs);
+        $this->assertNotContains('https://fermatmind.com/zh/career/jobs', $locs);
     }
 
     public function test_sitemap_source_excludes_forbidden_url_patterns(): void

--- a/backend/tests/Feature/SEO/SitemapXmlTest.php
+++ b/backend/tests/Feature/SEO/SitemapXmlTest.php
@@ -507,8 +507,8 @@ class SitemapXmlTest extends TestCase
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/articles/mbti-basics</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/articles/mbti-basics</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/articles/article-draft</loc>', $body);
-        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs</loc>', $body);
-        $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/jobs</loc>', $body);
+        $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/agricultural-inspectors</loc>', $body);
         $this->assertStringContainsString('<loc>https://staging.fermatmind.com/zh/career/jobs/agricultural-inspectors</loc>', $body);
         $this->assertStringNotContainsString('<loc>https://staging.fermatmind.com/en/career/jobs/product-manager</loc>', $body);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T17:18:04Z",
+  "updated_at": "2026-06-08T17:23:16Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51475,7 +51475,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-sitemap-diff-03",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "github_checks_passed_ready_to_merge",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-03: fix(seo): align non-scale sitemap static and index URLs",
     "depends_on": [
@@ -51521,9 +51521,22 @@
         "evidence": "PHP lint passed for SitemapGenerator and focused SEO sitemap tests. Focused PHPUnit passed with 19 warnings and 600 assertions. Scoped Pint --test passed. JSON/YAML parse passed. Path-limited git diff --check passed."
       },
       "github": {
-        "status": "pending",
-        "head_sha": "d5493b79a1e185920b3d1d0f8c0bc67cdc7a0c4a",
-        "pr_url": "https://github.com/fermatmind/fap-api/pull/2009"
+        "status": "pass",
+        "head_sha": "f775b00cbf94137dfe5c0832942d1afc6658bc4f",
+        "passed_checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2009",
+        "failure_reason": null
       }
     },
     "failure_reason": null,
@@ -51567,6 +51580,11 @@
         "at": "2026-06-09",
         "status": "github_checks_pending",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2009 from head d5493b79a1e185920b3d1d0f8c0bc67cdc7a0c4a; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_passed_ready_to_merge",
+        "note": "GitHub checks passed for PR #2009 head f775b00cbf94137dfe5c0832942d1afc6658bc4f: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T17:11:21Z",
+  "updated_at": "2026-06-08T17:15:12Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51522,7 +51522,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "c4f13c29810c8d89beaaa880a397d16999962e7b",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -51552,6 +51552,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed",
         "note": "Non-scale sitemap source now excludes dataset/help/career-jobs index URLs and includes core public static/index URLs; focused tests, Pint, JSON/YAML parse, and scope diff checks passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed",
+        "note": "Created scoped implementation commit c4f13c29810c8d89beaaa880a397d16999962e7b."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T17:05:28Z",
+  "updated_at": "2026-06-08T17:11:21Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51356,7 +51356,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-sitemap-diff-02",
     "base": "origin/main",
-    "status": "github_checks_passed_ready_to_merge",
+    "status": "merged",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs",
     "depends_on": [],
@@ -51399,7 +51399,7 @@
       },
       "github": {
         "status": "pass",
-        "head_sha": "7b1aba66f084a2cba6bd2e798e5823b979c0656f",
+        "head_sha": "70bce0cbc971fe52f85d49d338bf79b284806862",
         "passed_checks": [
           "hygiene",
           "supply-chain",
@@ -51413,15 +51413,27 @@
         ],
         "merge_state": "CLEAN",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2008",
-        "failure_reason": null
+        "failure_reason": null,
+        "merge_commit": "4693a7628df557bee64d6b4693a9bf5df733a1d9",
+        "merged_at": "2026-06-08T17:03:46Z",
+        "remote_branch_deleted": true,
+        "origin_main_contains_merge_commit": true
+      },
+      "post_merge": {
+        "status": "pass",
+        "merge_commit": "4693a7628df557bee64d6b4693a9bf5df733a1d9",
+        "origin_main_contains_merge_commit": true,
+        "main_synced_to_origin_main": true,
+        "local_cleanup_executed": true,
+        "evidence": "PR #2008 is MERGED on GitHub; origin/main contains merge commit 4693a7628df557bee64d6b4693a9bf5df733a1d9; remote branch codex/seo-sitemap-diff-02 is deleted; local main is synced to origin/main; task worktree and local branch were removed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "33ebf1b1de68997f9ed65a8a10b6f1f4a5a5a0cd",
+    "commit_sha": "70bce0cbc971fe52f85d49d338bf79b284806862",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2008",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-08T17:03:46Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "expected_backend_only_root_test_aliases_resolved": 136,
       "expected_live_only_localized_test_urls_resolved": 16
@@ -51451,6 +51463,95 @@
         "at": "2026-06-09",
         "status": "github_checks_passed_ready_to_merge",
         "note": "GitHub checks passed for PR #2008 head 7b1aba66f084a2cba6bd2e798e5823b979c0656f: hygiene, supply-chain, content-pack-build-validate, Semgrep blocking, Semgrep OSS, semgrep sarif upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "merged",
+        "note": "PR #2008 squash-merged at 2026-06-08T17:03:46Z with merge commit 4693a7628df557bee64d6b4693a9bf5df733a1d9; origin/main contains the merge commit; local main synced; local and remote task branches cleaned up."
+      }
+    ]
+  },
+  "SEO-SITEMAP-DIFF-03": {
+    "repo": "fap-api",
+    "branch": "codex/seo-sitemap-diff-03",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "sitemap_diff_parity",
+    "title": "SEO-SITEMAP-DIFF-03: fix(seo): align non-scale sitemap static and index URLs",
+    "depends_on": [
+      "SEO-SITEMAP-DIFF-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly provided SEO-SITEMAP-DIFF-03 fap-api goal, scope, expected diff resolution, and authorized docs/codex metadata updates as part of the sitemap diff PR train."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "SEO-SITEMAP-DIFF-02 merged as https://github.com/fermatmind/fap-api/pull/2008 at 2026-06-08T17:03:46Z with merge commit 4693a7628df557bee64d6b4693a9bf5df733a1d9 before this branch started."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to backend/app/Services/SEO/SitemapGenerator.php, focused SEO sitemap tests, dataset sitemap regression test, and docs/codex PR-train metadata.",
+        "allowed_paths": [
+          "backend/app/Services/SEO/SitemapGenerator.php",
+          "backend/tests/Feature/SEO/SitemapGeneratorTest.php",
+          "backend/tests/Feature/SEO/SitemapXmlTest.php",
+          "backend/tests/Feature/SEO/SitemapSourceApiTest.php",
+          "backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/SEO/SitemapGenerator.php",
+          "php -l backend/tests/Feature/SEO/SitemapGeneratorTest.php",
+          "php -l backend/tests/Feature/SEO/SitemapXmlTest.php",
+          "php -l backend/tests/Feature/SEO/SitemapSourceApiTest.php",
+          "php -l backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/app/Services/SEO/SitemapGenerator.php backend/tests/Feature/SEO/SitemapGeneratorTest.php backend/tests/Feature/SEO/SitemapXmlTest.php backend/tests/Feature/SEO/SitemapSourceApiTest.php backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json",
+          "git diff --cached --check"
+        ],
+        "evidence": "PHP lint passed for SitemapGenerator and focused SEO sitemap tests. Focused PHPUnit passed with 19 warnings and 600 assertions. Scoped Pint --test passed. JSON/YAML parse passed. Path-limited git diff --check passed."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "result": {
+      "excluded_backend_only_urls": [
+        "dataset hub/method URLs",
+        "help content page URLs",
+        "localized career jobs index URLs"
+      ],
+      "included_static_index_url_groups": [
+        "root/en",
+        "business",
+        "career",
+        "career guides/recommendations/tests",
+        "support",
+        "tests and tests category indexes"
+      ]
+    },
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Created isolated fap-api worktree from latest origin/main after SEO-SITEMAP-DIFF-02 merged and cleaned up."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "Non-scale sitemap source now excludes dataset/help/career-jobs index URLs and includes core public static/index URLs; focused tests, Pint, JSON/YAML parse, and scope diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T17:15:12Z",
+  "updated_at": "2026-06-08T17:18:04Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -51475,7 +51475,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-sitemap-diff-03",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-03: fix(seo): align non-scale sitemap static and index URLs",
     "depends_on": [
@@ -51519,11 +51519,16 @@
           "git diff --cached --check"
         ],
         "evidence": "PHP lint passed for SitemapGenerator and focused SEO sitemap tests. Focused PHPUnit passed with 19 warnings and 600 assertions. Scoped Pint --test passed. JSON/YAML parse passed. Path-limited git diff --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": "d5493b79a1e185920b3d1d0f8c0bc67cdc7a0c4a",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2009"
       }
     },
     "failure_reason": null,
     "commit_sha": "c4f13c29810c8d89beaaa880a397d16999962e7b",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2009",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -51557,6 +51562,11 @@
         "at": "2026-06-09",
         "status": "committed",
         "note": "Created scoped implementation commit c4f13c29810c8d89beaaa880a397d16999962e7b."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_pending",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2009 from head d5493b79a1e185920b3d1d0f8c0bc67cdc7a0c4a; GitHub checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23695,3 +23695,54 @@ prs:
       backend_only_root_test_aliases: 136
       live_only_localized_test_urls: 16
     next_task: SEO-SITEMAP-DIFF-03 in fap-api after this PR is merged
+
+  - id: SEO-SITEMAP-DIFF-03
+    repo: fap-api
+    depends_on:
+      - SEO-SITEMAP-DIFF-02
+    branch: codex/seo-sitemap-diff-03
+    title: "SEO-SITEMAP-DIFF-03: fix(seo): align non-scale sitemap static and index URLs"
+    train_scope: sitemap_diff_parity
+    status: in_progress
+    scope:
+      - Remove backend sitemap-source URLs that frontend authority explicitly excludes or marks noindex: dataset hub/method, help pages, and localized career jobs index pages.
+      - Add backend-authoritative core public static/index URLs needed for sitemap parity, including root/en, business, career, support, tests, test category, and career index surfaces.
+      - Preserve career job detail, article, topic, personality, career guide detail, and scale canonical URL behavior from prior PRs.
+    allowed_paths:
+      - backend/app/Services/SEO/SitemapGenerator.php
+      - backend/tests/Feature/SEO/SitemapGeneratorTest.php
+      - backend/tests/Feature/SEO/SitemapXmlTest.php
+      - backend/tests/Feature/SEO/SitemapSourceApiTest.php
+      - backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change frontend sitemap behavior, scale sitemap URL generation, cache fallback behavior, CMS content, deploy state, or search URL submissions.
+      - Add private result/order/share/pay/payment/history/take URLs, dataset URLs, help URLs, or career jobs index URLs to sitemap source.
+    validation:
+      - php -l backend/app/Services/SEO/SitemapGenerator.php
+      - php -l backend/tests/Feature/SEO/SitemapGeneratorTest.php
+      - php -l backend/tests/Feature/SEO/SitemapXmlTest.php
+      - php -l backend/tests/Feature/SEO/SitemapSourceApiTest.php
+      - php -l backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/app/Services/SEO/SitemapGenerator.php backend/tests/Feature/SEO/SitemapGeneratorTest.php backend/tests/Feature/SEO/SitemapXmlTest.php backend/tests/Feature/SEO/SitemapSourceApiTest.php backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_rewrite_allowed: false
+    content_authority: backend
+    expected_diff_resolution:
+      backend_only_non_scale_excluded_or_noindex_urls: 12
+      live_only_static_index_urls: 15
+    next_task: SEO-SITEMAP-DIFF-04 in fap-web after this PR is merged


### PR DESCRIPTION
## What changed
- Removed backend sitemap-source output for frontend-excluded dataset hub/method URLs.
- Removed backend sitemap-source output for help content pages and localized career jobs index pages.
- Added backend sitemap-source expression for core public static/index URLs: root/en, business, career, career guides/recommendations/tests, support, tests, and tests category indexes.
- Updated focused sitemap generator/XML/source tests plus the dataset sitemap regression test.
- Reconciled SEO-SITEMAP-DIFF-02 ledger state after PR #2008 was squash-merged and cleaned up.

## Why
- PR01 diff evidence showed remaining non-scale backend-only URLs that frontend authority excludes or marks noindex, plus public static/index live URLs missing from backend source.
- This PR keeps the source aligned with frontend public canonical sitemap policy without touching scale URL behavior from SEO-SITEMAP-DIFF-02.

## Validation
- `php -l backend/app/Services/SEO/SitemapGenerator.php`
- `php -l backend/tests/Feature/SEO/SitemapGeneratorTest.php`
- `php -l backend/tests/Feature/SEO/SitemapXmlTest.php`
- `php -l backend/tests/Feature/SEO/SitemapSourceApiTest.php`
- `php -l backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/SEO/SitemapGenerator.php tests/Feature/SEO/SitemapGeneratorTest.php tests/Feature/SEO/SitemapXmlTest.php tests/Feature/SEO/SitemapSourceApiTest.php tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/app/Services/SEO/SitemapGenerator.php backend/tests/Feature/SEO/SitemapGeneratorTest.php backend/tests/Feature/SEO/SitemapXmlTest.php backend/tests/Feature/SEO/SitemapSourceApiTest.php backend/tests/Feature/SEO/CareerDatasetSitemapDiscoverabilityTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Final live parity gate, no unknowns, and private URL assertions are deferred to SEO-SITEMAP-DIFF-04 in fap-web.
- No frontend behavior, CMS content, deployment, or search submission changes are included.

## Repository rule impact
- SEO enumeration remains backend-authoritative for backend sitemap source generation. This PR removes URLs that frontend authority denies/noindexes and adds backend expression for public static/index routes; it does not introduce frontend editorial fallback content.