### PR TITLE
SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily

### DIFF
--- a/backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\SeoConversionDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+
+final class RefreshSeoConversionDailyCommand extends Command
+{
+    protected $signature = 'analytics:refresh-seo-conversion-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview aggregation without writing rows}';
+
+    protected $description = 'Refresh the SEO conversion funnel daily read model grouped by safe URL/article/test/session dimensions.';
+
+    public function __construct(
+        private readonly SeoConversionDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->subDays(6)->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value >= 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+        $result = $this->builder->refresh($from, $to, $orgIds, $dryRun);
+
+        $this->line('from='.$result['from']);
+        $this->line('to='.$result['to']);
+        $this->line('org_scope='.(empty($result['org_scope']) ? '*' : implode(',', $result['org_scope'])));
+        $this->line('dry_run='.(($result['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('attempted_rows='.(string) ($result['attempted_rows'] ?? 0));
+        $this->line('skipped_rows='.(string) ($result['skipped_rows'] ?? 0));
+        $this->line('deleted_rows='.(string) ($result['deleted_rows'] ?? 0));
+        $this->line('upserted_rows='.(string) ($result['upserted_rows'] ?? 0));
+
+        if (($result['attempted_rows'] ?? 0) === 0) {
+            $this->warn('No SEO conversion rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+}

--- a/backend/app/Services/Analytics/SeoConversionDailyBuilder.php
+++ b/backend/app/Services/Analytics/SeoConversionDailyBuilder.php
@@ -1,0 +1,437 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Support\Facades\DB;
+
+final class SeoConversionDailyBuilder
+{
+    private const TABLE = 'analytics_seo_conversion_daily';
+
+    /**
+     * @var array<string, string>
+     */
+    private const EVENT_METRIC_MAP = [
+        'landing_pv' => 'landing_pv_count',
+        'article_to_test_click' => 'article_to_test_click_count',
+        'start_test' => 'start_test_count',
+        'complete_test' => 'complete_test_count',
+        'view_result' => 'view_result_count',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const PRIVATE_PATH_SEGMENTS = [
+        'result',
+        'results',
+        'order',
+        'orders',
+        'share',
+        'shares',
+        'pay',
+        'payment',
+        'payments',
+        'history',
+    ];
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array{rows:list<array<string,mixed>>,attempted_rows:int,org_scope:list<int>,from:string,to:string,skipped_rows:int}
+     */
+    public function build(\DateTimeInterface $from, \DateTimeInterface $to, array $orgIds = []): array
+    {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $rows = [];
+        $skippedRows = 0;
+
+        foreach ($this->loadSeoEventsInRange($fromAt, $toAt, $normalizedOrgIds) as $event) {
+            $eventCode = strtolower(trim((string) ($event->event_code ?? '')));
+            $metric = self::EVENT_METRIC_MAP[$eventCode] ?? null;
+            if ($metric === null) {
+                continue;
+            }
+
+            $day = $this->normalizeDay($event->occurred_at ?? null);
+            if ($day === null) {
+                $skippedRows++;
+
+                continue;
+            }
+
+            $meta = $this->decodeJson($event->meta_json ?? null);
+            $seoConversion = is_array($meta['seo_conversion'] ?? null) ? $meta['seo_conversion'] : [];
+            $dimensions = $this->resolveDimensions($seoConversion, $event);
+            if ($dimensions === null) {
+                $skippedRows++;
+
+                continue;
+            }
+
+            $this->incrementMetric($rows, $day, $dimensions, $metric);
+        }
+
+        $now = now();
+        $finalRows = array_values(array_map(static function (array $row) use ($now): array {
+            $row['created_at'] = $now;
+            $row['updated_at'] = $now;
+            $row['last_refreshed_at'] = $now;
+
+            return $row;
+        }, $rows));
+
+        return [
+            'rows' => $finalRows,
+            'attempted_rows' => count($finalRows),
+            'org_scope' => $normalizedOrgIds,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+            'skipped_rows' => $skippedRows,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return array{rows:list<array<string,mixed>>,attempted_rows:int,deleted_rows:int,upserted_rows:int,org_scope:list<int>,from:string,to:string,dry_run:bool,skipped_rows:int}
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds);
+        $rows = $payload['rows'];
+        $deletedRows = 0;
+        $upsertedRows = 0;
+
+        if (! $dryRun && SchemaBaseline::hasTable(self::TABLE)) {
+            DB::transaction(function () use ($payload, $rows, &$deletedRows, &$upsertedRows): void {
+                $deletedRows = $this->deleteScope($payload['from'], $payload['to'], $payload['org_scope']);
+
+                if ($rows === []) {
+                    return;
+                }
+
+                DB::table(self::TABLE)->upsert(
+                    $rows,
+                    [
+                        'day',
+                        'org_id',
+                        'url_hash',
+                        'lang',
+                        'page_type',
+                        'source_url_hash',
+                        'source_article_hash',
+                        'target_test_hash',
+                        'scale_id',
+                        'form_id',
+                        'session_id_hash',
+                        'referrer_host_hash',
+                    ],
+                    [
+                        'url',
+                        'source_url',
+                        'source_article',
+                        'target_test',
+                        'referrer_host',
+                        'landing_pv_count',
+                        'article_to_test_click_count',
+                        'start_test_count',
+                        'complete_test_count',
+                        'view_result_count',
+                        'last_refreshed_at',
+                        'updated_at',
+                    ]
+                );
+
+                $upsertedRows = count($rows);
+            });
+        }
+
+        return $payload + [
+            'deleted_rows' => $deletedRows,
+            'upserted_rows' => $upsertedRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<object>
+     */
+    private function loadSeoEventsInRange(CarbonImmutable $from, CarbonImmutable $to, array $orgIds): array
+    {
+        if (! SchemaBaseline::hasTable('events')) {
+            return [];
+        }
+
+        $eventCodes = array_keys(self::EVENT_METRIC_MAP);
+        $placeholders = implode(',', array_fill(0, count($eventCodes), '?'));
+
+        $query = DB::table('events')
+            ->whereBetween('occurred_at', [$from, $to])
+            ->whereRaw('lower(event_code) in ('.$placeholders.')', $eventCodes)
+            ->select(['id', 'org_id', 'event_code', 'session_id', 'meta_json', 'occurred_at', 'locale']);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        return $query->get()->all();
+    }
+
+    /**
+     * @param  array<string,mixed>  $seoConversion
+     * @return array<string,mixed>|null
+     */
+    private function resolveDimensions(array $seoConversion, object $event): ?array
+    {
+        $url = $this->normalizePublicUrl($seoConversion['url'] ?? null);
+        if ($url === null) {
+            return null;
+        }
+
+        $sourceUrl = $this->normalizePublicUrl($seoConversion['source_url'] ?? null, true);
+        $targetTest = $this->normalizePublicUrl($seoConversion['target_test'] ?? null, true);
+        $referrerHost = $this->normalizeReferrerHost($seoConversion['referrer'] ?? null);
+        $sessionId = $this->normalizeDimension($seoConversion['session_id'] ?? $event->session_id ?? null, 160);
+
+        return [
+            'org_id' => max(0, (int) ($event->org_id ?? 0)),
+            'url' => $url,
+            'url_hash' => sha1($url),
+            'lang' => $this->normalizeLang($seoConversion['lang'] ?? $event->locale ?? null),
+            'page_type' => $this->normalizeDimension($seoConversion['page_type'] ?? null, 64),
+            'source_url' => $sourceUrl,
+            'source_url_hash' => $sourceUrl === null ? '' : sha1($sourceUrl),
+            'source_article' => $this->normalizeDimension($seoConversion['source_article'] ?? null, 160),
+            'source_article_hash' => sha1($this->normalizeDimension($seoConversion['source_article'] ?? null, 160)),
+            'target_test' => $targetTest,
+            'target_test_hash' => $targetTest === null ? '' : sha1($targetTest),
+            'scale_id' => $this->normalizeDimension($seoConversion['scale_id'] ?? null, 64),
+            'form_id' => $this->normalizeDimension($seoConversion['form_id'] ?? null, 64),
+            'session_id_hash' => $sessionId === '' ? '' : hash('sha256', $sessionId),
+            'referrer_host' => $referrerHost,
+            'referrer_host_hash' => $referrerHost === '' ? '' : sha1($referrerHost),
+        ];
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $rows
+     * @param  array<string,mixed>  $dimensions
+     */
+    private function incrementMetric(array &$rows, string $day, array $dimensions, string $metric): void
+    {
+        $key = implode('|', [
+            $day,
+            (string) $dimensions['org_id'],
+            $dimensions['url_hash'],
+            $dimensions['lang'],
+            $dimensions['page_type'],
+            $dimensions['source_url_hash'],
+            $dimensions['source_article_hash'],
+            $dimensions['target_test_hash'],
+            $dimensions['scale_id'],
+            $dimensions['form_id'],
+            $dimensions['session_id_hash'],
+            $dimensions['referrer_host_hash'],
+        ]);
+
+        if (! isset($rows[$key])) {
+            $rows[$key] = [
+                'day' => $day,
+                'org_id' => $dimensions['org_id'],
+                'url' => $dimensions['url'],
+                'url_hash' => $dimensions['url_hash'],
+                'lang' => $dimensions['lang'],
+                'page_type' => $dimensions['page_type'],
+                'source_url' => $dimensions['source_url'],
+                'source_url_hash' => $dimensions['source_url_hash'],
+                'source_article' => $dimensions['source_article'],
+                'source_article_hash' => $dimensions['source_article_hash'],
+                'target_test' => $dimensions['target_test'],
+                'target_test_hash' => $dimensions['target_test_hash'],
+                'scale_id' => $dimensions['scale_id'],
+                'form_id' => $dimensions['form_id'],
+                'session_id_hash' => $dimensions['session_id_hash'],
+                'referrer_host' => $dimensions['referrer_host'],
+                'referrer_host_hash' => $dimensions['referrer_host_hash'],
+                'landing_pv_count' => 0,
+                'article_to_test_click_count' => 0,
+                'start_test_count' => 0,
+                'complete_test_count' => 0,
+                'view_result_count' => 0,
+            ];
+        }
+
+        $rows[$key][$metric] = max(0, (int) ($rows[$key][$metric] ?? 0) + 1);
+    }
+
+    private function normalizePublicUrl(mixed $value, bool $allowEmpty = false): ?string
+    {
+        $candidate = $this->normalizeDimension($value, 2048);
+        if ($candidate === '') {
+            return $allowEmpty ? null : null;
+        }
+
+        $parts = @parse_url($candidate);
+        if (! is_array($parts)) {
+            return null;
+        }
+
+        $path = $this->normalizePath($parts['path'] ?? '');
+        if ($path === null || $this->isPrivatePath($path)) {
+            return null;
+        }
+
+        $scheme = strtolower((string) ($parts['scheme'] ?? ''));
+        $host = strtolower((string) ($parts['host'] ?? ''));
+
+        if ($host !== '') {
+            $prefix = in_array($scheme, ['http', 'https'], true) ? $scheme.'://'.$host : 'https://'.$host;
+
+            return $prefix.$path;
+        }
+
+        return $path;
+    }
+
+    private function normalizePath(string $path): ?string
+    {
+        $path = trim($path);
+        if ($path === '') {
+            return '/';
+        }
+
+        if (! str_starts_with($path, '/')) {
+            return null;
+        }
+
+        $path = preg_replace('#/+#', '/', $path) ?: '/';
+        $path = rtrim($path, '/');
+
+        return $path === '' ? '/' : $path;
+    }
+
+    private function isPrivatePath(string $path): bool
+    {
+        $segments = array_values(array_filter(explode('/', strtolower($path)), static fn (string $segment): bool => $segment !== ''));
+        if ($segments === []) {
+            return false;
+        }
+
+        $firstContentSegment = in_array($segments[0], ['en', 'zh', 'zh-cn', 'zh-tw'], true)
+            ? ($segments[1] ?? '')
+            : $segments[0];
+
+        return in_array($firstContentSegment, self::PRIVATE_PATH_SEGMENTS, true);
+    }
+
+    private function normalizeReferrerHost(mixed $value): string
+    {
+        $candidate = $this->normalizeDimension($value, 2048);
+        if ($candidate === '') {
+            return '';
+        }
+
+        $parts = @parse_url($candidate);
+        if (! is_array($parts)) {
+            return '';
+        }
+
+        return $this->normalizeDimension(strtolower((string) ($parts['host'] ?? '')), 160);
+    }
+
+    private function normalizeDay(mixed $value): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        try {
+            return CarbonImmutable::parse($value)->toDateString();
+        } catch (\Throwable) {
+            return null;
+        }
+    }
+
+    private function normalizeLang(mixed $value): string
+    {
+        $lang = strtolower($this->normalizeDimension($value, 16));
+
+        return preg_match('/^[a-z]{2}(?:-[a-z0-9]{2,8})?$/', $lang) === 1 ? $lang : '';
+    }
+
+    private function normalizeDimension(mixed $value, int $maxLength): string
+    {
+        if (! is_scalar($value)) {
+            return '';
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $normalized = preg_replace('/[\x00-\x1F\x7F]+/', '', $normalized) ?? '';
+
+        return mb_substr($normalized, 0, $maxLength);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function decodeJson(mixed $value): array
+    {
+        if (is_array($value)) {
+            return $value;
+        }
+
+        if (! is_string($value) || trim($value) === '') {
+            return [];
+        }
+
+        $decoded = json_decode($value, true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        $normalized = [];
+        foreach ($orgIds as $orgId) {
+            $value = max(0, (int) $orgId);
+            $normalized[$value] = true;
+        }
+
+        return array_keys($normalized);
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     */
+    private function deleteScope(string $from, string $to, array $orgIds): int
+    {
+        if (! SchemaBaseline::hasTable(self::TABLE)) {
+            return 0;
+        }
+
+        $query = DB::table(self::TABLE)->whereBetween('day', [$from, $to]);
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        return $query->delete();
+    }
+}

--- a/backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php
+++ b/backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php
@@ -1,0 +1,74 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        if (Schema::hasTable('analytics_seo_conversion_daily')) {
+            return;
+        }
+
+        Schema::create('analytics_seo_conversion_daily', function (Blueprint $table): void {
+            $table->id();
+            $table->date('day');
+            $table->unsignedBigInteger('org_id')->default(0);
+
+            $table->text('url');
+            $table->char('url_hash', 40);
+            $table->string('lang', 16)->default('');
+            $table->string('page_type', 64)->default('');
+            $table->text('source_url')->nullable();
+            $table->char('source_url_hash', 40)->default('');
+            $table->string('source_article', 160)->default('');
+            $table->char('source_article_hash', 40)->default('');
+            $table->text('target_test')->nullable();
+            $table->char('target_test_hash', 40)->default('');
+            $table->string('scale_id', 64)->default('');
+            $table->string('form_id', 64)->default('');
+            $table->char('session_id_hash', 64)->default('');
+            $table->string('referrer_host', 160)->default('');
+            $table->char('referrer_host_hash', 40)->default('');
+
+            $table->unsignedInteger('landing_pv_count')->default(0);
+            $table->unsignedInteger('article_to_test_click_count')->default(0);
+            $table->unsignedInteger('start_test_count')->default(0);
+            $table->unsignedInteger('complete_test_count')->default(0);
+            $table->unsignedInteger('view_result_count')->default(0);
+
+            $table->timestamp('last_refreshed_at')->nullable();
+            $table->timestamps();
+
+            $table->unique(
+                [
+                    'day',
+                    'org_id',
+                    'url_hash',
+                    'lang',
+                    'page_type',
+                    'source_url_hash',
+                    'source_article_hash',
+                    'target_test_hash',
+                    'scale_id',
+                    'form_id',
+                    'session_id_hash',
+                    'referrer_host_hash',
+                ],
+                'analytics_seo_conv_daily_scope_unique'
+            );
+            $table->index(['day', 'org_id'], 'analytics_seo_conv_daily_day_org_idx');
+            $table->index(['url_hash', 'day'], 'analytics_seo_conv_daily_url_idx');
+            $table->index(['source_article_hash', 'day'], 'analytics_seo_conv_daily_article_idx');
+            $table->index(['target_test_hash', 'day'], 'analytics_seo_conv_daily_test_idx');
+        });
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent data loss in production.
+        // Irreversible operation: schema/data rollback handled via forward fix migrations.
+    }
+};

--- a/backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
@@ -1,0 +1,177 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\SeoConversionDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class SeoConversionDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_refresh_aggregates_canonical_seo_conversion_events_by_safe_dimensions(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-09 10:00:00');
+        $orgId = 17;
+        $sessionId = 'seo_sess_1234567890abcdef';
+        $basePayload = [
+            'url' => 'https://fermatmind.com/en/articles/personality-types?token=secret',
+            'lang' => 'en',
+            'page_type' => 'article',
+            'source_url' => 'https://fermatmind.com/en/articles/personality-types?email=person@example.com',
+            'source_article' => 'personality-types',
+            'target_test' => '/en/tests/mbti-personality-test-16-personality-types?attempt_id=raw_attempt',
+            'scale_id' => 'MBTI',
+            'form_id' => 'mbti_144',
+            'session_id' => $sessionId,
+            'referrer' => 'https://www.google.com/search?q=mbti&email=person@example.com',
+        ];
+
+        foreach (['landing_pv', 'article_to_test_click', 'start_test', 'complete_test', 'view_result'] as $offset => $eventCode) {
+            $this->insertSeoEvent($orgId, $eventCode, $day->addMinutes($offset), $basePayload);
+        }
+
+        $result = app(SeoConversionDailyBuilder::class)->refresh($day, $day, [$orgId], false);
+
+        $this->assertSame(1, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(0, (int) ($result['skipped_rows'] ?? 0));
+
+        $row = DB::table('analytics_seo_conversion_daily')
+            ->where('day', $day->toDateString())
+            ->where('org_id', $orgId)
+            ->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame('https://fermatmind.com/en/articles/personality-types', (string) $row->url);
+        $this->assertSame('https://fermatmind.com/en/articles/personality-types', (string) $row->source_url);
+        $this->assertSame('/en/tests/mbti-personality-test-16-personality-types', (string) $row->target_test);
+        $this->assertSame('personality-types', (string) $row->source_article);
+        $this->assertSame('MBTI', (string) $row->scale_id);
+        $this->assertSame('mbti_144', (string) $row->form_id);
+        $this->assertSame('www.google.com', (string) $row->referrer_host);
+        $this->assertSame(hash('sha256', $sessionId), (string) $row->session_id_hash);
+        $this->assertSame(1, (int) $row->landing_pv_count);
+        $this->assertSame(1, (int) $row->article_to_test_click_count);
+        $this->assertSame(1, (int) $row->start_test_count);
+        $this->assertSame(1, (int) $row->complete_test_count);
+        $this->assertSame(1, (int) $row->view_result_count);
+        $this->assertStringNotContainsString($sessionId, json_encode((array) $row, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('secret', json_encode((array) $row, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('person@example.com', json_encode((array) $row, JSON_THROW_ON_ERROR));
+        $this->assertStringNotContainsString('raw_attempt', json_encode((array) $row, JSON_THROW_ON_ERROR));
+    }
+
+    public function test_article_to_test_click_does_not_increment_start_test(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-09 11:00:00');
+
+        $this->insertSeoEvent(0, 'article_to_test_click', $day, [
+            'url' => 'https://fermatmind.com/en/articles/personality-types',
+            'lang' => 'en',
+            'page_type' => 'article',
+            'source_article' => 'personality-types',
+            'target_test' => '/en/tests/mbti-personality-test-16-personality-types',
+            'scale_id' => 'MBTI',
+            'form_id' => 'mbti_144',
+            'session_id' => 'seo_sess_click_only',
+        ]);
+
+        app(SeoConversionDailyBuilder::class)->refresh($day, $day, [], false);
+
+        $row = DB::table('analytics_seo_conversion_daily')->first();
+
+        $this->assertNotNull($row);
+        $this->assertSame(1, (int) $row->article_to_test_click_count);
+        $this->assertSame(0, (int) $row->start_test_count);
+    }
+
+    public function test_refresh_skips_private_urls_before_daily_storage(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-09 12:00:00');
+
+        $this->insertSeoEvent(0, 'view_result', $day, [
+            'url' => 'https://fermatmind.com/en/results/raw-result-id',
+            'lang' => 'en',
+            'page_type' => 'result',
+            'scale_id' => 'MBTI',
+            'form_id' => 'mbti_144',
+            'session_id' => 'seo_sess_private',
+        ]);
+
+        $result = app(SeoConversionDailyBuilder::class)->refresh($day, $day, [], false);
+
+        $this->assertSame(0, (int) ($result['upserted_rows'] ?? 0));
+        $this->assertSame(1, (int) ($result['skipped_rows'] ?? 0));
+        $this->assertSame(0, DB::table('analytics_seo_conversion_daily')->count());
+    }
+
+    public function test_refresh_command_supports_dry_run_without_writing_rows(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-09 13:00:00');
+
+        $this->insertSeoEvent(0, 'landing_pv', $day, [
+            'url' => 'https://fermatmind.com/en/articles/personality-types',
+            'lang' => 'en',
+            'page_type' => 'article',
+            'source_article' => 'personality-types',
+            'session_id' => 'seo_sess_dry_run',
+        ]);
+
+        $this->artisan('analytics:refresh-seo-conversion-daily', [
+            '--from' => $day->toDateString(),
+            '--to' => $day->toDateString(),
+            '--dry-run' => true,
+        ])
+            ->expectsOutput('attempted_rows=1')
+            ->expectsOutput('upserted_rows=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_seo_conversion_daily')->count());
+    }
+
+    /**
+     * @param  array<string,mixed>  $seoConversion
+     */
+    private function insertSeoEvent(int $orgId, string $eventCode, CarbonImmutable $occurredAt, array $seoConversion): void
+    {
+        $row = [
+            'id' => (string) Str::uuid(),
+            'event_code' => $eventCode,
+            'event_name' => $eventCode,
+            'org_id' => $orgId,
+            'user_id' => null,
+            'anon_id' => 'anon_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 10),
+            'session_id' => (string) ($seoConversion['session_id'] ?? 'seo_sess_fallback'),
+            'request_id' => 'req_'.substr(str_replace('-', '', (string) Str::uuid()), 0, 12),
+            'attempt_id' => null,
+            'meta_json' => json_encode([
+                'seo_conversion' => $seoConversion,
+            ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'occurred_at' => $occurredAt,
+            'share_id' => null,
+            'created_at' => $occurredAt,
+            'updated_at' => $occurredAt,
+            'scale_code' => (string) ($seoConversion['scale_id'] ?? ''),
+            'channel' => 'web',
+            'region' => 'US',
+            'locale' => (string) ($seoConversion['lang'] ?? 'en'),
+        ];
+
+        if (Schema::hasColumn('events', 'scale_code_v2')) {
+            $row['scale_code_v2'] = (string) ($seoConversion['scale_id'] ?? '');
+        }
+
+        if (Schema::hasColumn('events', 'scale_uid')) {
+            $row['scale_uid'] = 'aaaaaaaa-aaaa-4aaa-8aaa-aaaaaaaaaaaa';
+        }
+
+        DB::table('events')->insert($row);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -285,6 +285,17 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_conversion_daily_read_model_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php',
+            'backend/app/Services/Analytics/SeoConversionDailyBuilder.php',
+            'backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_public_healthz_alias_route_addition(): void
     {
         $changed = [
@@ -2827,6 +2838,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoConversionDailyReadModelFile($file)) {
+                continue;
+            }
+
             if ($this->isSeoIntelGscFoundationFile($file)) {
                 continue;
             }
@@ -4907,6 +4922,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isAnalyticsFunnelRefreshCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php';
+    }
+
+    private function isSeoConversionDailyReadModelFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php',
+            'backend/app/Services/Analytics/SeoConversionDailyBuilder.php',
+            'backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php',
+        ], true);
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51766,7 +51766,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "425cb074a59aaa2bc60366d77ee075b1367c127d",
+    "commit_sha": "21b6fc6d2328d95cb09358aa0920e8708d23b1d4",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -51791,7 +51791,7 @@
       {
         "at": "2026-06-09",
         "status": "committed_pending_push",
-        "note": "Created scoped implementation commit 425cb074a59aaa2bc60366d77ee075b1367c127d."
+        "note": "Created scoped implementation commit 21b6fc6d2328d95cb09358aa0920e8708d23b1d4."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51717,7 +51717,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-daily-04",
     "base": "origin/main",
-    "status": "local_checks_passed_after_github_fix",
+    "status": "github_checks_passed_ready_to_merge",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "depends_on": [
@@ -51765,6 +51765,24 @@
           "git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
         ],
         "evidence": "PHP lint passed for the new builder, command, migration, feature test, and BigFive classifier test. Artisan auto-discovers analytics:refresh-seo-conversion-daily. Focused SeoConversionDailyBuilderTest passed 4 tests / 30 assertions. Existing MbtiAttributionEventIngestTest passed 11 tests / 62 assertions. Focused BigFive runtime freeze classifier regression passed after adding the SEO conversion daily read-model exception. Pint --test passed for scoped PHP files. v0.5 SEO route-list remained visible. Migration pretend showed only analytics_seo_conversion_daily DDL. JSON/YAML parse, scope validation, and path-limited git diff --check passed."
+      },
+      "github": {
+        "status": "pass",
+        "head_sha": "b3e9668eb2d05d680fd2abe71cd3640d741fb287",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "failure_reason": null,
+        "evidence": "GitHub checks passed for PR #2011 at head b3e9668eb2d05d680fd2abe71cd3640d741fb287 after adding the BigFive freeze classifier exception for SEO conversion daily read-model files."
       }
     },
     "failure_reason": null,
@@ -51809,6 +51827,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed_after_github_fix",
         "note": "Added a narrow BigFive freeze classifier exception and focused regression for SEO conversion daily read-model files; focused BigFive regression and SeoConversionDailyBuilderTest passed locally."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_passed_ready_to_merge",
+        "note": "GitHub checks passed for PR #2011 at head b3e9668eb2d05d680fd2abe71cd3640d741fb287 and mergeStateStatus is CLEAN."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51475,7 +51475,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-sitemap-diff-03",
     "base": "origin/main",
-    "status": "github_checks_passed_ready_to_merge",
+    "status": "merged",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-03: fix(seo): align non-scale sitemap static and index URLs",
     "depends_on": [
@@ -51542,9 +51542,9 @@
     "failure_reason": null,
     "commit_sha": "c4f13c29810c8d89beaaa880a397d16999962e7b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2009",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-09T03:22:41Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "result": {
       "excluded_backend_only_urls": [
         "dataset hub/method URLs",
@@ -51705,6 +51705,11 @@
         "at": "2026-06-09",
         "status": "github_checks_passed_ready_to_merge",
         "note": "GitHub checks passed for PR #2010 at head 13267cf796b5c9397f106cf196949a4858095fe6 and mergeStateStatus is CLEAN."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "merged",
+        "note": "Reconciled during SEO-CONV-DAILY-04: GitHub PR #2010 is MERGED at 2026-06-09T03:22:41Z with merge commit db2541da0af434fbb27143bdfda9cb04748d2749, origin/main contains the merge commit, and git ls-remote shows codex/seo-conv-ingest-02 is deleted on origin."
       }
     ]
   },
@@ -51712,7 +51717,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-daily-04",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "committed_pending_push",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "depends_on": [
@@ -51725,12 +51730,43 @@
         "evidence": "User explicitly authorized the SEO-CONV PR train and fap-api docs/codex metadata updates on 2026-06-09."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Must wait for SEO-CONV-INGEST-02 and SEO-CONV-RUNTIME-03 to merge before starting."
+        "status": "pass",
+        "evidence": "SEO-CONV-INGEST-02 merged into fap-api main as PR #2010 at 2026-06-09T03:22:41Z with merge commit db2541da0af434fbb27143bdfda9cb04748d2749. SEO-CONV-RUNTIME-03 merged into fap-web main as PR #1085 at 2026-06-09T03:45:35Z with merge commit 84f0d718ac0a322322223b327106cadba803bc87."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to the SEO conversion daily Analytics service, refresh command, migration, focused Analytics feature test, and docs/codex metadata.",
+        "allowed_paths": [
+          "backend/app/Services/Analytics/**",
+          "backend/app/Console/Commands/**",
+          "backend/database/migrations/**",
+          "backend/tests/Feature/Analytics/**",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/Analytics/SeoConversionDailyBuilder.php",
+          "php -l backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php",
+          "php -l backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php",
+          "php -l backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php",
+          "cd backend && php artisan list --raw | rg \"analytics:refresh-seo-conversion-daily|analytics:refresh-mbti-attribution-daily\"",
+          "cd backend && php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi",
+          "cd backend && php artisan test --filter=MbtiAttributionEventIngestTest --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Services/Analytics/SeoConversionDailyBuilder.php app/Console/Commands/RefreshSeoConversionDailyCommand.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php",
+          "cd backend && php artisan route:list --path=api/v0.5/seo --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi | rg \"analytics_seo_conversion_daily|analytics_seo_conv_daily\"",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "evidence": "PHP lint passed for the new builder, command, migration, and feature test. Artisan auto-discovers analytics:refresh-seo-conversion-daily. Focused SeoConversionDailyBuilderTest passed 4 tests / 30 assertions. Existing MbtiAttributionEventIngestTest passed 11 tests / 62 assertions. Pint --test passed for scoped PHP files. v0.5 SEO route-list remained visible. Migration pretend showed only analytics_seo_conversion_daily DDL. JSON/YAML parse, scope validation, and path-limited git diff --check passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "425cb074a59aaa2bc60366d77ee075b1367c127d",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -51741,6 +51777,21 @@
         "at": "2026-06-09",
         "status": "pending_dependency",
         "note": "Initialized future fap-api daily aggregation PR metadata only; implementation intentionally deferred."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Created branch codex/seo-conv-daily-04 from fap-api main after verifying SEO-CONV-INGEST-02 and SEO-CONV-RUNTIME-03 are merged; implementing only daily aggregation read model scope."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "Added analytics_seo_conversion_daily migration, safe daily builder, refresh command, and focused tests; local lint, focused tests, Pint, route-list, migration pretend, metadata parse, scope validation, and diff checks passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed_pending_push",
+        "note": "Created scoped implementation commit 425cb074a59aaa2bc60366d77ee075b1367c127d."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51717,7 +51717,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-daily-04",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "local_checks_passed_after_github_fix",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "depends_on": [
@@ -51741,6 +51741,7 @@
           "backend/app/Console/Commands/**",
           "backend/database/migrations/**",
           "backend/tests/Feature/Analytics/**",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ]
@@ -51755,14 +51756,15 @@
           "cd backend && php artisan list --raw | rg \"analytics:refresh-seo-conversion-daily|analytics:refresh-mbti-attribution-daily\"",
           "cd backend && php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi",
           "cd backend && php artisan test --filter=MbtiAttributionEventIngestTest --no-ansi",
+          "cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_conversion_daily_read_model_changes' --no-ansi",
           "cd backend && ./vendor/bin/pint --test app/Services/Analytics/SeoConversionDailyBuilder.php app/Console/Commands/RefreshSeoConversionDailyCommand.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php",
           "cd backend && php artisan route:list --path=api/v0.5/seo --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi | rg \"analytics_seo_conversion_daily|analytics_seo_conv_daily\"",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
-          "git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+          "git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
         ],
-        "evidence": "PHP lint passed for the new builder, command, migration, and feature test. Artisan auto-discovers analytics:refresh-seo-conversion-daily. Focused SeoConversionDailyBuilderTest passed 4 tests / 30 assertions. Existing MbtiAttributionEventIngestTest passed 11 tests / 62 assertions. Pint --test passed for scoped PHP files. v0.5 SEO route-list remained visible. Migration pretend showed only analytics_seo_conversion_daily DDL. JSON/YAML parse, scope validation, and path-limited git diff --check passed."
+        "evidence": "PHP lint passed for the new builder, command, migration, feature test, and BigFive classifier test. Artisan auto-discovers analytics:refresh-seo-conversion-daily. Focused SeoConversionDailyBuilderTest passed 4 tests / 30 assertions. Existing MbtiAttributionEventIngestTest passed 11 tests / 62 assertions. Focused BigFive runtime freeze classifier regression passed after adding the SEO conversion daily read-model exception. Pint --test passed for scoped PHP files. v0.5 SEO route-list remained visible. Migration pretend showed only analytics_seo_conversion_daily DDL. JSON/YAML parse, scope validation, and path-limited git diff --check passed."
       }
     },
     "failure_reason": null,
@@ -51797,6 +51799,16 @@
         "at": "2026-06-09",
         "status": "github_checks_pending",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2011 from branch codex/seo-conv-daily-04; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_failed_fix_in_progress",
+        "note": "GitHub verify-bigfive failed because the BigFive runtime freeze classifier treated SEO conversion daily command, Analytics service, and migration files as BigFive runtime changes."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed_after_github_fix",
+        "note": "Added a narrow BigFive freeze classifier exception and focused regression for SEO conversion daily read-model files; focused BigFive regression and SeoConversionDailyBuilderTest passed locally."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51717,7 +51717,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-daily-04",
     "base": "origin/main",
-    "status": "committed_pending_push",
+    "status": "github_checks_pending",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily",
     "depends_on": [
@@ -51767,7 +51767,7 @@
     },
     "failure_reason": null,
     "commit_sha": "21b6fc6d2328d95cb09358aa0920e8708d23b1d4",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2011",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -51792,6 +51792,11 @@
         "at": "2026-06-09",
         "status": "committed_pending_push",
         "note": "Created scoped implementation commit 21b6fc6d2328d95cb09358aa0920e8708d23b1d4."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_pending",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2011 from branch codex/seo-conv-daily-04; GitHub checks pending."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23817,6 +23817,7 @@ prs:
       - backend/app/Console/Commands/**
       - backend/database/migrations/**
       - backend/tests/Feature/Analytics/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
@@ -23830,10 +23831,11 @@ prs:
       - php -l backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
       - cd backend && php artisan list --raw | rg "analytics:refresh-seo-conversion-daily"
       - cd backend && php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi
+      - cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_conversion_daily_read_model_changes' --no-ansi
       - cd backend && ./vendor/bin/pint --test app/Services/Analytics/SeoConversionDailyBuilder.php app/Console/Commands/RefreshSeoConversionDailyCommand.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
-      - git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23754,7 +23754,7 @@ prs:
     branch: codex/seo-conv-ingest-02
     title: "SEO-CONV-INGEST-02: feat(analytics): accept canonical SEO conversion funnel ingest"
     train_scope: seo_conversion_tracking
-    status: in_progress
+    status: merged
     scope:
       - Add a backend SEO attribution ingest route that accepts the canonical public SEO funnel events.
       - Accept landing_pv, article_to_test_click, start_test, complete_test, and view_result as distinct event codes.
@@ -23808,7 +23808,7 @@ prs:
     branch: codex/seo-conv-daily-04
     title: "SEO-CONV-DAILY-04: feat(analytics): aggregate SEO conversion funnel daily"
     train_scope: seo_conversion_tracking
-    status: pending_dependency
+    status: in_progress
     scope:
       - Aggregate canonical SEO conversion events into a safe daily read model by URL, article, test, and session dimensions.
       - Support landing_pv, article_to_test_click, start_test, complete_test, and view_result counts without mixing article_to_test_click into start_test.
@@ -23819,6 +23819,22 @@ prs:
       - backend/tests/Feature/Analytics/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
+    do_not:
+      - Add Ops/CMS dashboard views, frontend runtime tracking, ingest routes, production writes, deploys, CMS mutations, or public URL submissions in this PR.
+      - Store raw session_id, raw order identifiers, raw result identifiers, raw attempt identifiers, private paths, or sensitive query values in the daily read model.
+      - Reclassify article_to_test_click as start_test.
+    validation:
+      - php -l backend/app/Services/Analytics/SeoConversionDailyBuilder.php
+      - php -l backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php
+      - php -l backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php
+      - php -l backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+      - cd backend && php artisan list --raw | rg "analytics:refresh-seo-conversion-daily"
+      - cd backend && php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Services/Analytics/SeoConversionDailyBuilder.php app/Console/Commands/RefreshSeoConversionDailyCommand.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false
     database_mutation: true


### PR DESCRIPTION
## What changed
- Added `analytics_seo_conversion_daily` as the safe daily read model for canonical SEO conversion events.
- Added `SeoConversionDailyBuilder` to aggregate `landing_pv`, `article_to_test_click`, `start_test`, `complete_test`, and `view_result` by URL, article, test, and hashed session dimensions.
- Added `analytics:refresh-seo-conversion-daily` with `--from`, `--to`, `--org`, and `--dry-run` support.
- Added focused feature coverage for safe URL/query cleaning, raw session hashing, private path skipping, and `article_to_test_click != start_test`.
- Reconciled SEO-CONV-INGEST-02 metadata as merged to unblock this dependent PR.

## Why
SEO conversion tracking needs a backend daily read model before Ops/CMS can expose acceptance views. This PR keeps the public funnel distinct and safe: raw session IDs are not stored, sensitive query values are stripped, private route families are skipped, and click-through events are not counted as starts.

## Validation
- `php -l backend/app/Services/Analytics/SeoConversionDailyBuilder.php`
- `php -l backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php`
- `php -l backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php`
- `php -l backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php`
- `cd backend && php artisan list --raw | rg "analytics:refresh-seo-conversion-daily|analytics:refresh-mbti-attribution-daily"`
- `cd backend && php artisan test --filter=SeoConversionDailyBuilderTest --no-ansi`
- `cd backend && php artisan test --filter=MbtiAttributionEventIngestTest --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/Analytics/SeoConversionDailyBuilder.php app/Console/Commands/RefreshSeoConversionDailyCommand.php tests/Feature/Analytics/SeoConversionDailyBuilderTest.php`
- `cd backend && php artisan route:list --path=api/v0.5/seo --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-ansi | rg "analytics_seo_conversion_daily|analytics_seo_conv_daily"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/app/Services/Analytics/SeoConversionDailyBuilder.php backend/app/Console/Commands/RefreshSeoConversionDailyCommand.php backend/database/migrations/2026_06_09_000100_create_analytics_seo_conversion_daily_table.php backend/tests/Feature/Analytics/SeoConversionDailyBuilderTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- Ops/CMS read views and APIs remain deferred to `SEO-CONV-OPS-05`.
- Frontend runtime tracking remains in `SEO-CONV-RUNTIME-03`; this PR does not change frontend behavior.
- No production refresh, deploy, CMS mutation, or URL/search submission is included.

## Repository rule impact
Backend analytics remains the authority for the SEO conversion daily read model. This PR adds a backend migration/read-model builder only; it does not move content authority, public sitemap authority, or CMS-backed editorial behavior into frontend code.
