### PR TITLE
SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
@@ -39,6 +39,11 @@ final class SeoIntelDashboardController
         return $this->respond($this->readService->pagePerformance($this->limit($request)));
     }
 
+    public function conversionFunnel(Request $request): JsonResponse
+    {
+        return $this->respond($this->readService->conversionFunnel($this->safeFilters($request), $this->limit($request)));
+    }
+
     /**
      * @param  array<string, mixed>  $data
      */
@@ -61,5 +66,24 @@ final class SeoIntelDashboardController
         $limit = is_numeric($raw) ? (int) $raw : 25;
 
         return max(1, min($limit, 100));
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function safeFilters(Request $request): array
+    {
+        return $request->only([
+            'group_by',
+            'url',
+            'lang',
+            'page_type',
+            'source_url',
+            'source_article',
+            'target_test',
+            'scale_id',
+            'form_id',
+            'session_id_hash',
+        ]);
     }
 }

--- a/backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php
+++ b/backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php
@@ -1,0 +1,330 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\OpsDashboard;
+
+use App\Support\SchemaBaseline;
+use Illuminate\Support\Facades\DB;
+
+final class SeoConversionFunnelReadService
+{
+    private const TABLE = 'analytics_seo_conversion_daily';
+
+    /**
+     * @var list<string>
+     */
+    private const METRICS = [
+        'landing_pv_count',
+        'article_to_test_click_count',
+        'start_test_count',
+        'complete_test_count',
+        'view_result_count',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    private const PRIVATE_PATH_SEGMENTS = [
+        'result',
+        'results',
+        'order',
+        'orders',
+        'share',
+        'shares',
+        'pay',
+        'payment',
+        'payments',
+        'history',
+    ];
+
+    /**
+     * @return array<string,mixed>
+     */
+    public function read(array $filters = [], int $limit = 25): array
+    {
+        $groupBy = $this->normalizeGroupBy($filters['group_by'] ?? null);
+        $limit = max(1, min($limit, 100));
+
+        if (! SchemaBaseline::hasTable(self::TABLE)) {
+            return $this->emptyPayload($groupBy, ['analytics_seo_conversion_daily_missing']);
+        }
+
+        $groupColumns = $this->groupColumns($groupBy);
+        $query = DB::table(self::TABLE)->select($groupColumns);
+
+        foreach (self::METRICS as $metric) {
+            $query->selectRaw(sprintf('SUM(%s) AS %s', $metric, $metric));
+        }
+
+        $this->applyFilters($query, $filters);
+
+        $query->groupBy($groupColumns)
+            ->orderByDesc('landing_pv_count')
+            ->orderByDesc('start_test_count')
+            ->limit($limit);
+
+        $rows = [];
+        foreach ($query->get() as $row) {
+            $mapped = $this->mapRow($row, $groupBy);
+            if ($mapped === null) {
+                continue;
+            }
+
+            $rows[] = $mapped;
+        }
+
+        return [
+            'source_table' => self::TABLE,
+            'group_by' => $groupBy,
+            'filters' => $this->safeFilters($filters),
+            'privacy' => $this->privacyStatus(),
+            'totals' => $this->totals($rows),
+            'recent_rows' => $rows,
+            'warnings' => [],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function emptyPayload(string $groupBy, array $warnings): array
+    {
+        return [
+            'source_table' => self::TABLE,
+            'group_by' => $groupBy,
+            'filters' => [],
+            'privacy' => $this->privacyStatus(),
+            'totals' => [
+                'landing_pv_count' => 0,
+                'article_to_test_click_count' => 0,
+                'start_test_count' => 0,
+                'complete_test_count' => 0,
+                'view_result_count' => 0,
+            ],
+            'recent_rows' => [],
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @return array<string,string|bool>
+     */
+    private function privacyStatus(): array
+    {
+        return [
+            'raw_session_id_exposed' => false,
+            'session_dimension' => 'sha256_hash_only',
+            'query_policy' => 'query_and_fragment_stripped_before_daily_storage',
+            'private_path_policy' => 'result_order_share_pay_history_excluded',
+            'raw_business_identifier_policy' => 'business_identifiers_rejected_before_daily_storage',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function groupColumns(string $groupBy): array
+    {
+        return match ($groupBy) {
+            'article' => ['source_article', 'lang', 'page_type', 'scale_id', 'form_id'],
+            'test' => ['target_test', 'lang', 'scale_id', 'form_id'],
+            'session' => ['session_id_hash', 'lang', 'source_article', 'target_test', 'scale_id', 'form_id'],
+            default => ['url', 'lang', 'page_type', 'source_article', 'target_test', 'scale_id', 'form_id'],
+        };
+    }
+
+    private function applyFilters(\Illuminate\Database\Query\Builder $query, array $filters): void
+    {
+        foreach ([
+            'lang',
+            'page_type',
+            'source_article',
+            'scale_id',
+            'form_id',
+            'session_id_hash',
+        ] as $field) {
+            $value = $this->normalizeText($filters[$field] ?? null, 160);
+            if ($value !== '') {
+                $query->where($field, $value);
+            }
+        }
+
+        foreach (['url', 'source_url', 'target_test'] as $field) {
+            $value = $this->normalizePublicPathFilter($filters[$field] ?? null);
+            if ($value !== '') {
+                $query->where(function (\Illuminate\Database\Query\Builder $nested) use ($field, $value): void {
+                    $nested->where($field, $value)
+                        ->orWhere($field, 'like', '%'.$value);
+                });
+            }
+        }
+    }
+
+    /**
+     * @return array<string,string>
+     */
+    private function safeFilters(array $filters): array
+    {
+        $safe = [];
+        foreach ([
+            'group_by',
+            'lang',
+            'page_type',
+            'source_article',
+            'scale_id',
+            'form_id',
+            'session_id_hash',
+        ] as $field) {
+            $value = $this->normalizeText($filters[$field] ?? null, 160);
+            if ($value !== '') {
+                $safe[$field] = $value;
+            }
+        }
+
+        foreach (['url', 'source_url', 'target_test'] as $field) {
+            $value = $this->normalizePublicPathFilter($filters[$field] ?? null);
+            if ($value !== '') {
+                $safe[$field] = $value;
+            }
+        }
+
+        return $safe;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function mapRow(object $row, string $groupBy): ?array
+    {
+        $urlPath = $this->safePath($row->url ?? null);
+        $sourcePath = $this->safePath($row->source_url ?? null);
+        $targetPath = $this->safePath($row->target_test ?? null);
+
+        if ($urlPath !== null && $this->isPrivatePath($urlPath)) {
+            return null;
+        }
+
+        $metrics = [];
+        foreach (self::METRICS as $metric) {
+            $metrics[$metric] = (int) ($row->{$metric} ?? 0);
+        }
+
+        return [
+            'group_key' => $this->groupKey($row, $groupBy, $urlPath, $targetPath),
+            'url_path' => $urlPath,
+            'lang' => (string) ($row->lang ?? ''),
+            'page_type' => (string) ($row->page_type ?? ''),
+            'source_url_path' => $sourcePath,
+            'source_article' => (string) ($row->source_article ?? ''),
+            'target_test_path' => $targetPath,
+            'scale_id' => (string) ($row->scale_id ?? ''),
+            'form_id' => (string) ($row->form_id ?? ''),
+            'session_id_hash' => (string) ($row->session_id_hash ?? ''),
+            'referrer_host' => (string) ($row->referrer_host ?? ''),
+            'metrics' => $metrics,
+            'privacy' => [
+                'raw_session_id_exposed' => false,
+                'private_path_excluded' => true,
+                'query_stripped' => true,
+            ],
+        ];
+    }
+
+    private function groupKey(object $row, string $groupBy, ?string $urlPath, ?string $targetPath): string
+    {
+        return match ($groupBy) {
+            'article' => (string) ($row->source_article ?? ''),
+            'test' => $targetPath ?? '',
+            'session' => (string) ($row->session_id_hash ?? ''),
+            default => $urlPath ?? '',
+        };
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $rows
+     * @return array<string,int>
+     */
+    private function totals(array $rows): array
+    {
+        $totals = array_fill_keys(self::METRICS, 0);
+
+        foreach ($rows as $row) {
+            $metrics = is_array($row['metrics'] ?? null) ? $row['metrics'] : [];
+            foreach (self::METRICS as $metric) {
+                $totals[$metric] += (int) ($metrics[$metric] ?? 0);
+            }
+        }
+
+        return $totals;
+    }
+
+    private function normalizeGroupBy(mixed $value): string
+    {
+        $candidate = $this->normalizeText($value, 32);
+
+        return in_array($candidate, ['url', 'article', 'test', 'session'], true) ? $candidate : 'url';
+    }
+
+    private function normalizeText(mixed $value, int $maxLength): string
+    {
+        if (! is_scalar($value)) {
+            return '';
+        }
+
+        $normalized = trim((string) $value);
+        if ($normalized === '') {
+            return '';
+        }
+
+        $normalized = preg_replace('/[\x00-\x1F\x7F]+/', '', $normalized) ?? '';
+
+        return mb_substr($normalized, 0, $maxLength);
+    }
+
+    private function normalizePublicPathFilter(mixed $value): string
+    {
+        $path = $this->safePath($value);
+        if ($path === null || $this->isPrivatePath($path)) {
+            return '';
+        }
+
+        return $path;
+    }
+
+    private function safePath(mixed $value): ?string
+    {
+        if (! is_scalar($value)) {
+            return null;
+        }
+
+        $candidate = trim((string) $value);
+        if ($candidate === '') {
+            return null;
+        }
+
+        $path = parse_url($candidate, PHP_URL_PATH);
+        if (! is_string($path) || $path === '') {
+            return '/';
+        }
+
+        $path = preg_replace('#/+#', '/', $path) ?: '/';
+        $path = rtrim($path, '/');
+
+        return $path === '' ? '/' : $path;
+    }
+
+    private function isPrivatePath(string $path): bool
+    {
+        $segments = array_values(array_filter(explode('/', strtolower($path)), static fn (string $segment): bool => $segment !== ''));
+        if ($segments === []) {
+            return false;
+        }
+
+        $firstContentSegment = in_array($segments[0], ['en', 'zh', 'zh-cn', 'zh-tw'], true)
+            ? ($segments[1] ?? '')
+            : $segments[0];
+
+        return in_array($firstContentSegment, self::PRIVATE_PATH_SEGMENTS, true);
+    }
+}

--- a/backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
+++ b/backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
@@ -176,6 +176,14 @@ final class SeoDashboardApiReadService extends AbstractSeoDashboardReadService
     }
 
     /**
+     * @return array<string, mixed>
+     */
+    public function conversionFunnel(array $filters = [], int $limit = 25): array
+    {
+        return (new SeoConversionFunnelReadService)->read($filters, $limit);
+    }
+
+    /**
      * @param  callable(string): string  $mapper
      * @return list<array{label:string,count:int}>
      */

--- a/backend/docs/contracts/openapi.snapshot.json
+++ b/backend/docs/contracts/openapi.snapshot.json
@@ -3881,6 +3881,31 @@
                 ]
             }
         },
+        "/api/v0.5/ops/seo-intel/conversion-funnel": {
+            "get": {
+                "operationId": "api.v0_5.ops.seo_intel.conversion_funnel",
+                "tags": [
+                    "api:v0.5"
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK"
+                    }
+                },
+                "x-laravel-action": "App\\Http\\Controllers\\API\\V0_5\\Ops\\SeoIntel\\SeoIntelDashboardController@conversionFunnel",
+                "x-laravel-middleware": [
+                    "api",
+                    "App\\Http\\Middleware\\EncryptCookies",
+                    "Illuminate\\Cookie\\Middleware\\AddQueuedCookiesToResponse",
+                    "Illuminate\\Session\\Middleware\\StartSession",
+                    "App\\Http\\Middleware\\SetOpsRequestContext",
+                    "App\\Http\\Middleware\\AdminAuth",
+                    "App\\Http\\Middleware\\ResolveOrgContext",
+                    "App\\Http\\Middleware\\EnsureSeoIntelReadAuthorized"
+                ],
+                "x-laravel-name": "api.v0_5.ops.seo_intel.conversion_funnel"
+            }
+        },
         "/api/v0.5/ops/seo-intel/issues": {
             "get": {
                 "operationId": "api.v0_5.ops.seo_intel.issues",

--- a/backend/routes/api.php
+++ b/backend/routes/api.php
@@ -552,6 +552,8 @@ Route::prefix('v0.5')->group(function () {
                 ->name('api.v0_5.ops.seo_intel.trends');
             Route::get('/page-performance', [SeoIntelDashboardController::class, 'pagePerformance'])
                 ->name('api.v0_5.ops.seo_intel.page_performance');
+            Route::get('/conversion-funnel', [SeoIntelDashboardController::class, 'conversionFunnel'])
+                ->name('api.v0_5.ops.seo_intel.conversion_funnel');
         });
 
     Route::middleware([

--- a/backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Models\AdminUser;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoConversionFunnelOpsReadoutTest extends TestCase
+{
+    use RefreshDatabase;
+
+    #[Test]
+    public function seo_intel_read_admin_can_query_conversion_funnel_by_url_article_test_and_session(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_SEO_INTEL_READ]);
+
+        $this->insertDailyRow([
+            'url' => 'https://fermatmind.com/en/articles/personality-types',
+            'url_hash' => sha1('https://fermatmind.com/en/articles/personality-types'),
+            'source_url' => 'https://fermatmind.com/en/articles/personality-types',
+            'source_url_hash' => sha1('https://fermatmind.com/en/articles/personality-types'),
+            'source_article' => 'personality-types',
+            'source_article_hash' => sha1('personality-types'),
+            'target_test' => '/en/tests/mbti-personality-test-16-personality-types',
+            'target_test_hash' => sha1('/en/tests/mbti-personality-test-16-personality-types'),
+            'session_id_hash' => hash('sha256', 'seo_sess_abc123'),
+            'landing_pv_count' => 3,
+            'article_to_test_click_count' => 2,
+            'start_test_count' => 1,
+            'complete_test_count' => 1,
+            'view_result_count' => 1,
+        ]);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/ops/seo-intel/conversion-funnel?group_by=url')
+            ->assertOk()
+            ->assertJsonPath('meta.contract_version', 'seo-dash-api-01.v1')
+            ->assertJsonPath('data.group_by', 'url')
+            ->assertJsonPath('data.recent_rows.0.group_key', '/en/articles/personality-types')
+            ->assertJsonPath('data.recent_rows.0.metrics.landing_pv_count', 3)
+            ->assertJsonPath('data.recent_rows.0.metrics.article_to_test_click_count', 2)
+            ->assertJsonPath('data.recent_rows.0.metrics.start_test_count', 1)
+            ->assertJsonPath('data.recent_rows.0.metrics.complete_test_count', 1)
+            ->assertJsonPath('data.recent_rows.0.metrics.view_result_count', 1)
+            ->assertJsonPath('data.privacy.raw_session_id_exposed', false);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/ops/seo-intel/conversion-funnel?group_by=article&source_article=personality-types')
+            ->assertOk()
+            ->assertJsonPath('data.group_by', 'article')
+            ->assertJsonPath('data.recent_rows.0.group_key', 'personality-types')
+            ->assertJsonPath('data.recent_rows.0.metrics.article_to_test_click_count', 2)
+            ->assertJsonPath('data.recent_rows.0.metrics.start_test_count', 1);
+
+        $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/ops/seo-intel/conversion-funnel?group_by=test&target_test=/en/tests/mbti-personality-test-16-personality-types')
+            ->assertOk()
+            ->assertJsonPath('data.group_by', 'test')
+            ->assertJsonPath('data.recent_rows.0.group_key', '/en/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonPath('data.recent_rows.0.metrics.complete_test_count', 1);
+
+        $sessionResponse = $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/ops/seo-intel/conversion-funnel?group_by=session')
+            ->assertOk()
+            ->assertJsonPath('data.group_by', 'session')
+            ->assertJsonPath('data.recent_rows.0.group_key', hash('sha256', 'seo_sess_abc123'));
+
+        $json = $sessionResponse->getContent();
+        $this->assertStringNotContainsString('seo_sess_abc123', $json);
+    }
+
+    #[Test]
+    public function conversion_funnel_readout_does_not_expose_private_paths_or_sensitive_queries(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_OPS_READ]);
+
+        $this->insertDailyRow([
+            'url' => 'https://fermatmind.com/en/articles/personality-types?token=secret',
+            'url_hash' => sha1('https://fermatmind.com/en/articles/personality-types'),
+            'source_url' => 'https://fermatmind.com/en/articles/personality-types?email=person@example.com',
+            'source_url_hash' => sha1('https://fermatmind.com/en/articles/personality-types'),
+            'source_article' => 'personality-types',
+            'source_article_hash' => sha1('personality-types'),
+            'target_test' => '/en/tests/mbti-personality-test-16-personality-types?attempt_id=raw_attempt',
+            'target_test_hash' => sha1('/en/tests/mbti-personality-test-16-personality-types'),
+            'session_id_hash' => hash('sha256', 'seo_sess_safe'),
+            'landing_pv_count' => 1,
+        ]);
+        $this->insertDailyRow([
+            'url' => 'https://fermatmind.com/en/results/raw-result-id',
+            'url_hash' => sha1('https://fermatmind.com/en/results/raw-result-id'),
+            'source_article' => 'private-leak',
+            'source_article_hash' => sha1('private-leak'),
+            'session_id_hash' => hash('sha256', 'seo_sess_private'),
+            'view_result_count' => 9,
+        ]);
+
+        $response = $this->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->getJson('/api/v0.5/ops/seo-intel/conversion-funnel?group_by=url')
+            ->assertOk()
+            ->assertJsonPath('data.recent_rows.0.url_path', '/en/articles/personality-types')
+            ->assertJsonPath('data.recent_rows.0.target_test_path', '/en/tests/mbti-personality-test-16-personality-types')
+            ->assertJsonPath('data.totals.view_result_count', 0)
+            ->assertJsonPath('data.privacy.private_path_policy', 'result_order_share_pay_history_excluded');
+
+        $json = $response->getContent();
+        foreach ([
+            'secret',
+            'person@example.com',
+            'raw_attempt',
+            'raw-result-id',
+            '/en/results',
+            'private-leak',
+        ] as $forbidden) {
+            $this->assertStringNotContainsString($forbidden, $json);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     */
+    private function insertDailyRow(array $overrides): void
+    {
+        DB::table('analytics_seo_conversion_daily')->insert(array_merge([
+            'day' => '2026-06-09',
+            'org_id' => 0,
+            'url' => 'https://fermatmind.com/en/articles/personality-types',
+            'url_hash' => sha1('https://fermatmind.com/en/articles/personality-types'),
+            'lang' => 'en',
+            'page_type' => 'article',
+            'source_url' => null,
+            'source_url_hash' => '',
+            'source_article' => '',
+            'source_article_hash' => '',
+            'target_test' => null,
+            'target_test_hash' => '',
+            'scale_id' => 'MBTI',
+            'form_id' => 'mbti_144',
+            'session_id_hash' => '',
+            'referrer_host' => 'www.google.com',
+            'referrer_host_hash' => sha1('www.google.com'),
+            'landing_pv_count' => 0,
+            'article_to_test_click_count' => 0,
+            'start_test_count' => 0,
+            'complete_test_count' => 0,
+            'view_result_count' => 0,
+            'last_refreshed_at' => '2026-06-09 00:00:00',
+            'created_at' => '2026-06-09 00:00:00',
+            'updated_at' => '2026-06-09 00:00:00',
+        ], $overrides));
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'seo_'.Str::lower(Str::random(6)),
+            'email' => 'seo_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'role_'.Str::lower(Str::random(8)),
+            'description' => null,
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['description' => null],
+            );
+
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1061,6 +1061,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_conversion_ops_read_model_file(): void
+    {
+        $changed = [
+            'backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_content_overview_ops_ui_file(): void
     {
         $changed = [
@@ -3938,6 +3947,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Services/SeoIntel/OpsDashboard/SeoSearchChannelQueueReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/SeoUrlTruthReadService.php',
             'backend/app/Services/SeoIntel/OpsDashboard/CareerRuntimeReadModelService.php',
+            'backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php',
         ], true);
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51844,7 +51844,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-ops-05",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "committed_pending_push",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "depends_on": [
@@ -51887,7 +51887,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "23c33d019115b08731e13c220311524722dd0c61",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -51908,6 +51908,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed",
         "note": "Added read-only Ops SEO Intel conversion funnel endpoint backed by analytics_seo_conversion_daily; focused route/auth/privacy/readout tests passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed_pending_push",
+        "note": "Created scoped implementation commit 23c33d019115b08731e13c220311524722dd0c61."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51844,7 +51844,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-ops-05",
     "base": "origin/main",
-    "status": "local_checks_passed_after_github_fix",
+    "status": "github_checks_passed_ready_to_merge",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "depends_on": [
@@ -51893,6 +51893,24 @@
           "git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/contracts/openapi.snapshot.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
         ],
         "evidence": "PHP lint passed for route, controller, read services, focused feature test, and BigFive classifier test. Route-list shows GET /api/v0.5/ops/seo-intel/conversion-funnel. SeoConversionFunnelOpsReadoutTest passed 2 tests / 34 assertions. Existing SeoDashApi01ReadOnlyApiContractTest passed 6 tests / 110 assertions. Focused BigFive runtime freeze regression passed with 2 tests / 10 assertions. OpenAPI snapshot is up-to-date after regeneration. Scoped Pint --test passed. JSON/YAML parse and path-limited git diff --check passed."
+      },
+      "github": {
+        "status": "pass",
+        "head_sha": "0ad2b4fa46792527b89bccbc7e443f2d34e69cf7",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "failure_reason": null,
+        "evidence": "GitHub checks passed for PR #2012 at head 0ad2b4fa46792527b89bccbc7e443f2d34e69cf7 after OpenAPI snapshot and BigFive freeze classifier fixes."
       }
     },
     "failure_reason": null,
@@ -51937,6 +51955,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed_after_github_fix",
         "note": "Regenerated OpenAPI snapshot, added narrow SeoConversionFunnelReadService BigFive freeze classifier coverage, and reran scoped local checks successfully."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_passed_ready_to_merge",
+        "note": "GitHub checks passed for PR #2012 at head 0ad2b4fa46792527b89bccbc7e443f2d34e69cf7 and mergeStateStatus is CLEAN."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51844,7 +51844,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-ops-05",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "local_checks_passed_after_github_fix",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "depends_on": [
@@ -51861,12 +51861,14 @@
       },
       "scope": {
         "status": "pass",
-        "evidence": "Changed files are confined to the v0.5 Ops SEO Intel route/controller, SeoIntel Ops read services, focused SeoIntel feature test, and docs/codex metadata.",
+        "evidence": "Changed files are confined to the v0.5 Ops SEO Intel route/controller, SeoIntel Ops read services, focused SeoIntel feature test, OpenAPI snapshot artifact, BigFive freeze classifier regression, and docs/codex metadata.",
         "allowed_paths": [
           "backend/routes/api.php",
           "backend/app/Http/Controllers/API/V0_5/Ops/**",
           "backend/app/Services/SeoIntel/**",
           "backend/tests/Feature/SeoIntel/**",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "backend/docs/contracts/openapi.snapshot.json",
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ]
@@ -51881,9 +51883,16 @@
           "php -l backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php",
           "cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi",
           "cd backend && php artisan test --filter=SeoConversionFunnelOpsReadoutTest --no-ansi",
-          "cd backend && php artisan test --filter=SeoDashApi01ReadOnlyApiContractTest --no-ansi"
+          "cd backend && php artisan test --filter=SeoDashApi01ReadOnlyApiContractTest --no-ansi",
+          "cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_conversion_ops_read_model_file' --no-ansi",
+          "cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "cd backend && bash scripts/export_openapi.sh --check",
+          "python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/contracts/openapi.snapshot.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
         ],
-        "evidence": "PHP lint passed for route, controller, read services, and focused feature test. Route-list shows GET /api/v0.5/ops/seo-intel/conversion-funnel. SeoConversionFunnelOpsReadoutTest passed 2 tests / 34 assertions. Existing SeoDashApi01ReadOnlyApiContractTest passed 6 tests / 110 assertions."
+        "evidence": "PHP lint passed for route, controller, read services, focused feature test, and BigFive classifier test. Route-list shows GET /api/v0.5/ops/seo-intel/conversion-funnel. SeoConversionFunnelOpsReadoutTest passed 2 tests / 34 assertions. Existing SeoDashApi01ReadOnlyApiContractTest passed 6 tests / 110 assertions. Focused BigFive runtime freeze regression passed with 2 tests / 10 assertions. OpenAPI snapshot is up-to-date after regeneration. Scoped Pint --test passed. JSON/YAML parse and path-limited git diff --check passed."
       }
     },
     "failure_reason": null,
@@ -51918,6 +51927,16 @@
         "at": "2026-06-09",
         "status": "github_checks_pending",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2012 from branch codex/seo-conv-ops-05; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_failed_fix_in_progress",
+        "note": "GitHub verify jobs failed because the new Ops route drifted backend/docs/contracts/openapi.snapshot.json and verify-bigfive classified SeoConversionFunnelReadService as a Big Five runtime change; adding scoped contract artifact and classifier coverage."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed_after_github_fix",
+        "note": "Regenerated OpenAPI snapshot, added narrow SeoConversionFunnelReadService BigFive freeze classifier coverage, and reran scoped local checks successfully."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51844,7 +51844,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-ops-05",
     "base": "origin/main",
-    "status": "committed_pending_push",
+    "status": "github_checks_pending",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "depends_on": [
@@ -51888,7 +51888,7 @@
     },
     "failure_reason": null,
     "commit_sha": "23c33d019115b08731e13c220311524722dd0c61",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2012",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -51913,6 +51913,11 @@
         "at": "2026-06-09",
         "status": "committed_pending_push",
         "note": "Created scoped implementation commit 23c33d019115b08731e13c220311524722dd0c61."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_pending",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2012 from branch codex/seo-conv-ops-05; GitHub checks pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51592,7 +51592,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-ingest-02",
     "base": "origin/main",
-    "status": "github_checks_passed_ready_to_merge",
+    "status": "merged",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-INGEST-02: feat(analytics): accept canonical SEO conversion funnel ingest",
     "depends_on": [
@@ -51768,7 +51768,7 @@
       },
       "github": {
         "status": "pass",
-        "head_sha": "b3e9668eb2d05d680fd2abe71cd3640d741fb287",
+        "head_sha": "963dc6eada45f5adbe0653e88bc134490ca11af0",
         "checks": [
           "hygiene",
           "supply-chain",
@@ -51782,15 +51782,15 @@
         ],
         "merge_state": "CLEAN",
         "failure_reason": null,
-        "evidence": "GitHub checks passed for PR #2011 at head b3e9668eb2d05d680fd2abe71cd3640d741fb287 after adding the BigFive freeze classifier exception for SEO conversion daily read-model files."
+        "evidence": "GitHub checks passed for PR #2011 at final head 963dc6eada45f5adbe0653e88bc134490ca11af0 after adding the BigFive freeze classifier exception for SEO conversion daily read-model files."
       }
     },
     "failure_reason": null,
     "commit_sha": "21b6fc6d2328d95cb09358aa0920e8708d23b1d4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2011",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-09T04:18:01Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [],
     "transitions": [
       {
@@ -51832,6 +51832,11 @@
         "at": "2026-06-09",
         "status": "github_checks_passed_ready_to_merge",
         "note": "GitHub checks passed for PR #2011 at head b3e9668eb2d05d680fd2abe71cd3640d741fb287 and mergeStateStatus is CLEAN."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "merged",
+        "note": "Reconciled during SEO-CONV-OPS-05: PR #2011 is MERGED at 2026-06-09T04:18:01Z with merge commit 1cae5d854b22bccde0becf485d93f6cd19a98fc2; origin/main contains the merge commit; remote branch was deleted; local task branch was deleted after squash merge; post-merge SeoConversionDailyBuilderTest and focused BigFive classifier revalidation passed."
       }
     ]
   },
@@ -51839,7 +51844,7 @@
     "repo": "fap-api",
     "branch": "codex/seo-conv-ops-05",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "seo_conversion_tracking",
     "title": "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts",
     "depends_on": [
@@ -51851,8 +51856,34 @@
         "evidence": "User explicitly authorized the SEO-CONV PR train and fap-api docs/codex metadata updates on 2026-06-09."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Must wait for SEO-CONV-DAILY-04 to merge before starting."
+        "status": "pass",
+        "evidence": "SEO-CONV-DAILY-04 merged into fap-api main as PR #2011 at 2026-06-09T04:18:01Z with merge commit 1cae5d854b22bccde0becf485d93f6cd19a98fc2 before this branch started."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to the v0.5 Ops SEO Intel route/controller, SeoIntel Ops read services, focused SeoIntel feature test, and docs/codex metadata.",
+        "allowed_paths": [
+          "backend/routes/api.php",
+          "backend/app/Http/Controllers/API/V0_5/Ops/**",
+          "backend/app/Services/SeoIntel/**",
+          "backend/tests/Feature/SeoIntel/**",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/routes/api.php",
+          "php -l backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php",
+          "php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php",
+          "php -l backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php",
+          "php -l backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php",
+          "cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi",
+          "cd backend && php artisan test --filter=SeoConversionFunnelOpsReadoutTest --no-ansi",
+          "cd backend && php artisan test --filter=SeoDashApi01ReadOnlyApiContractTest --no-ansi"
+        ],
+        "evidence": "PHP lint passed for route, controller, read services, and focused feature test. Route-list shows GET /api/v0.5/ops/seo-intel/conversion-funnel. SeoConversionFunnelOpsReadoutTest passed 2 tests / 34 assertions. Existing SeoDashApi01ReadOnlyApiContractTest passed 6 tests / 110 assertions."
       }
     },
     "failure_reason": null,
@@ -51867,6 +51898,16 @@
         "at": "2026-06-09",
         "status": "pending_dependency",
         "note": "Initialized future fap-api Ops/CMS readout PR metadata only; implementation intentionally deferred."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Created branch codex/seo-conv-ops-05 from latest fap-api main after SEO-CONV-DAILY-04 merged and cleaned up."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "Added read-only Ops SEO Intel conversion funnel endpoint backed by analytics_seo_conversion_daily; focused route/auth/privacy/readout tests passed."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23865,6 +23865,8 @@ prs:
       - backend/app/Http/Controllers/API/V0_5/Ops/**
       - backend/app/Services/SeoIntel/**
       - backend/tests/Feature/SeoIntel/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - backend/docs/contracts/openapi.snapshot.json
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
     do_not:
@@ -23880,10 +23882,13 @@ prs:
       - cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi
       - cd backend && php artisan test --filter=SeoConversionFunnelOpsReadoutTest --no-ansi
       - cd backend && php artisan test --filter=SeoDashApi01ReadOnlyApiContractTest --no-ansi
+      - cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_conversion_ops_read_model_file' --no-ansi
       - cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php
+      - cd backend && bash scripts/export_openapi.sh --check
+      - python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
-      - git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/contracts/openapi.snapshot.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23856,16 +23856,35 @@ prs:
     branch: codex/seo-conv-ops-05
     title: "SEO-CONV-OPS-05: feat(ops): expose SEO conversion funnel readouts"
     train_scope: seo_conversion_tracking
-    status: pending_dependency
+    status: in_progress
     scope:
       - Add Ops/CMS read views or APIs for URL, article, and test-level SEO conversion funnel acceptance checks.
       - Show privacy/cleaning status without exposing raw private identifiers.
     allowed_paths:
+      - backend/routes/api.php
       - backend/app/Http/Controllers/API/V0_5/Ops/**
       - backend/app/Services/SeoIntel/**
       - backend/tests/Feature/SeoIntel/**
       - docs/codex/pr-train.yaml
       - docs/codex/pr-train-state.json
+    do_not:
+      - Add frontend runtime tracking, ingest behavior, daily aggregation migrations/builders, production writes, deploys, CMS mutations, or public URL submissions in this PR.
+      - Expose raw session_id, raw order identifiers, raw result identifiers, raw attempt identifiers, private paths, or sensitive query values in Ops responses.
+      - Reclassify article_to_test_click as start_test.
+    validation:
+      - php -l backend/routes/api.php
+      - php -l backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php
+      - php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php
+      - php -l backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php
+      - php -l backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php
+      - cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi
+      - cd backend && php artisan test --filter=SeoConversionFunnelOpsReadoutTest --no-ansi
+      - cd backend && php artisan test --filter=SeoDashApi01ReadOnlyApiContractTest --no-ansi
+      - cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false
     database_mutation: false


### PR DESCRIPTION
## What changed
- Added a read-only Ops SEO Intel endpoint: `GET /api/v0.5/ops/seo-intel/conversion-funnel`.
- Added `SeoConversionFunnelReadService` to read `analytics_seo_conversion_daily` by `group_by=url|article|test|session`.
- Exposes safe aggregate metrics for `landing_pv`, `article_to_test_click`, `start_test`, `complete_test`, and `view_result`.
- Keeps session visibility hash-only and strips response paths to safe path values without query strings.
- Filters private result/order/share/pay/history paths out of Ops responses.
- Synced the OpenAPI route snapshot for the new private Ops endpoint.
- Added focused auth/readout/privacy contract tests and narrow BigFive freeze classifier coverage for the read-only Ops service.
- Reconciled `SEO-CONV-DAILY-04` as merged in fap-api metadata.

## Why
The SEO conversion train needs an Ops/CMS acceptance view that can answer the required checks by URL, article, and test without exposing raw private identifiers or mixing article CTA clicks into test starts.

## Validation
- `php -l backend/routes/api.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php`
- `php -l backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php`
- `php -l backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php`
- `php -l backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php`
- `php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && php artisan route:list --path=api/v0.5/ops/seo-intel --no-ansi`
- `cd backend && php artisan test --filter=SeoConversionFunnelOpsReadoutTest --no-ansi`
- `cd backend && php artisan test --filter=SeoDashApi01ReadOnlyApiContractTest --no-ansi`
- `cd backend && php artisan test --filter='BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff|BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_seo_conversion_ops_read_model_file' --no-ansi`
- `cd backend && ./vendor/bin/pint --test routes/api.php app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `cd backend && bash scripts/export_openapi.sh --check`
- `python3 -m json.tool backend/docs/contracts/openapi.snapshot.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- `git diff --check -- backend/routes/api.php backend/app/Http/Controllers/API/V0_5/Ops/SeoIntel/SeoIntelDashboardController.php backend/app/Services/SeoIntel/OpsDashboard/SeoDashboardApiReadService.php backend/app/Services/SeoIntel/OpsDashboard/SeoConversionFunnelReadService.php backend/tests/Feature/SeoIntel/SeoConversionFunnelOpsReadoutTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/contracts/openapi.snapshot.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No frontend runtime tracking changes.
- No ingest behavior changes.
- No daily aggregation builder/migration changes.
- No production refresh, deploy, CMS mutation, or URL/search submission.

## Repository rule impact
Backend remains the authority for SEO conversion analytics and Ops readouts. This PR exposes a read-only private Ops API over the backend daily read model; it does not change public content authority, sitemap behavior, or frontend CMS ownership.