### PR TITLE
fix(cms): enforce content page publication gates

### DIFF
--- a/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ContentPagesImportLocalBaseline.php
@@ -194,6 +194,13 @@ final class ContentPagesImportLocalBaseline extends Command
             'reviewer' => $this->nullableString($row['reviewer'] ?? null),
             'faq_items' => $this->normalizeFaqItems($row['faq_items'] ?? $row['faqItems'] ?? []),
             'schema_enabled' => (bool) ($row['schema_enabled'] ?? $row['schemaEnabled'] ?? false),
+            'publish_allowed' => (bool) ($row['publish_allowed'] ?? $row['publishAllowed'] ?? false),
+            'operator_approval_required' => (bool) ($row['operator_approval_required'] ?? $row['operatorApprovalRequired'] ?? true),
+            'operator_approved_at' => $this->nullableString($row['operator_approved_at'] ?? $row['operatorApprovedAt'] ?? null),
+            'claim_gate_status' => $this->normalizeClaimGateStatus($row['claim_gate_status'] ?? $row['claimGateStatus'] ?? null),
+            'forbidden_claims' => $this->normalizeForbiddenClaims($row['forbidden_claims'] ?? $row['forbiddenClaims'] ?? []),
+            'faq_schema_eligible' => (bool) ($row['faq_schema_eligible'] ?? $row['faqSchemaEligible'] ?? false),
+            'schema_eligibility_reviewed_at' => $this->nullableString($row['schema_eligibility_reviewed_at'] ?? $row['schemaEligibilityReviewedAt'] ?? null),
             'status' => $status,
         ];
     }
@@ -285,6 +292,16 @@ final class ContentPagesImportLocalBaseline extends Command
         return $status === ContentPage::STATUS_PUBLISHED ? 'approved' : 'draft';
     }
 
+    private function normalizeClaimGateStatus(mixed $value): string
+    {
+        $normalized = strtolower(trim((string) $value));
+        if (in_array($normalized, ContentPage::CLAIM_GATE_STATUSES, true)) {
+            return $normalized;
+        }
+
+        return 'not_reviewed';
+    }
+
     private function defaultTranslationGroupId(string $slug): string
     {
         return 'content-page-'.preg_replace('/[^a-z0-9]+/', '-', $slug);
@@ -334,6 +351,26 @@ final class ContentPagesImportLocalBaseline extends Command
         }
 
         return $items;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeForbiddenClaims(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $claims = [];
+        foreach ($value as $claim) {
+            $normalized = trim((string) $claim);
+            if ($normalized !== '') {
+                $claims[] = $normalized;
+            }
+        }
+
+        return array_values(array_unique($claims));
     }
 
     /**

--- a/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
+++ b/backend/app/Console/Commands/ReleaseVerifyPublicContent.php
@@ -122,8 +122,7 @@ final class ReleaseVerifyPublicContent extends Command
                 ->where('locale', $row['locale'])
                 ->where('kind', $row['kind'])
                 ->where('path', $row['path'])
-                ->where('status', ContentPage::STATUS_PUBLISHED)
-                ->where('is_public', true)
+                ->publiclyReadable()
                 ->exists();
 
             if (! $exists) {
@@ -134,8 +133,7 @@ final class ReleaseVerifyPublicContent extends Command
         $publishedPublicCount = ContentPage::query()
             ->withoutGlobalScopes()
             ->where('org_id', 0)
-            ->where('status', ContentPage::STATUS_PUBLISHED)
-            ->where('is_public', true)
+            ->publiclyReadable()
             ->count();
 
         return [

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
@@ -35,7 +35,7 @@ final class ContentPageController extends Controller
             ->where('org_id', $validated['org_id'])
             ->where('slug', $this->normalizeSlug($slug))
             ->where('locale', $validated['locale'])
-            ->publishedPublic()
+            ->publiclyReadable()
             ->first();
 
         if (! $page instanceof ContentPage) {
@@ -627,8 +627,8 @@ final class ContentPageController extends Controller
     private function isScienceControlledPage(string $normalizedSlug, string $pageType, bool $scienceReviewRequired): bool
     {
         return $scienceReviewRequired
-            || in_array($pageType, ['science', 'methodology', 'boundary'], true)
-            || in_array($normalizedSlug, ['science', 'method-boundaries', 'item-design-notes', 'reliability-validity', 'data-privacy', 'common-misconceptions'], true);
+            || in_array($pageType, ContentPage::SCIENCE_CONTROLLED_PAGE_TYPES, true)
+            || in_array($normalizedSlug, ContentPage::SCIENCE_CONTROLLED_SLUGS, true);
     }
 
     private function dateString(mixed $value): ?string

--- a/backend/app/Models/ContentPage.php
+++ b/backend/app/Models/ContentPage.php
@@ -59,6 +59,21 @@ final class ContentPage extends Model
         'not_applicable',
     ];
 
+    public const SCIENCE_CONTROLLED_SLUGS = [
+        'science',
+        'method-boundaries',
+        'item-design-notes',
+        'reliability-validity',
+        'data-privacy',
+        'common-misconceptions',
+    ];
+
+    public const SCIENCE_CONTROLLED_PAGE_TYPES = [
+        'science',
+        'methodology',
+        'boundary',
+    ];
+
     public const TRANSLATION_STATUS_SOURCE = 'source';
 
     public const TRANSLATION_STATUS_DRAFT = 'draft';
@@ -189,6 +204,116 @@ final class ContentPage extends Model
         return $query
             ->where('status', self::STATUS_PUBLISHED)
             ->where('is_public', true);
+    }
+
+    public function scopePubliclyReadable($query)
+    {
+        return $query
+            ->publishedPublic()
+            ->where(static function ($publishedAtQuery): void {
+                $publishedAtQuery
+                    ->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->where(static function ($query): void {
+                $query
+                    ->where(static function ($standardPage): void {
+                        $standardPage
+                            ->whereNotIn('slug', self::SCIENCE_CONTROLLED_SLUGS)
+                            ->where(static function ($pageTypeQuery): void {
+                                $pageTypeQuery
+                                    ->whereNull('page_type')
+                                    ->orWhereNotIn('page_type', self::SCIENCE_CONTROLLED_PAGE_TYPES);
+                            })
+                            ->where(static function ($reviewQuery): void {
+                                $reviewQuery
+                                    ->whereNull('science_review_required')
+                                    ->orWhere('science_review_required', false);
+                            });
+                    })
+                    ->orWhere(static function ($controlledPage): void {
+                        $controlledPage
+                            ->where(static function ($scienceQuery): void {
+                                $scienceQuery
+                                    ->whereIn('slug', self::SCIENCE_CONTROLLED_SLUGS)
+                                    ->orWhereIn('page_type', self::SCIENCE_CONTROLLED_PAGE_TYPES)
+                                    ->orWhere('science_review_required', true);
+                            })
+                            ->where('publish_allowed', true)
+                            ->where('review_state', 'approved')
+                            ->where(static function ($legalQuery): void {
+                                $legalQuery
+                                    ->whereNull('legal_review_required')
+                                    ->orWhere('legal_review_required', false);
+                            })
+                            ->where(static function ($scienceReviewQuery): void {
+                                $scienceReviewQuery
+                                    ->whereNull('science_review_required')
+                                    ->orWhere('science_review_required', false);
+                            })
+                            ->where('claim_gate_status', 'passed')
+                            ->where(static function ($claimsQuery): void {
+                                $claimsQuery
+                                    ->whereNull('forbidden_claims')
+                                    ->orWhere('forbidden_claims', '[]')
+                                    ->orWhereJsonLength('forbidden_claims', 0);
+                            })
+                            ->where(static function ($operatorQuery): void {
+                                $operatorQuery
+                                    ->where('operator_approval_required', false)
+                                    ->orWhereNotNull('operator_approved_at');
+                            })
+                            ->where(static function ($schemaQuery): void {
+                                $schemaQuery
+                                    ->where('schema_enabled', false)
+                                    ->orWhere(static function ($schemaReviewQuery): void {
+                                        $schemaReviewQuery
+                                            ->where('faq_schema_eligible', true)
+                                            ->whereNotNull('schema_eligibility_reviewed_at');
+                                    });
+                            });
+                    });
+            });
+    }
+
+    public function scopePubliclyIndexable($query)
+    {
+        return $query
+            ->publiclyReadable()
+            ->where('is_indexable', true);
+    }
+
+    public function isScienceControlledPage(): bool
+    {
+        return in_array((string) $this->slug, self::SCIENCE_CONTROLLED_SLUGS, true)
+            || in_array((string) $this->page_type, self::SCIENCE_CONTROLLED_PAGE_TYPES, true)
+            || (bool) $this->science_review_required;
+    }
+
+    public function passesPublicReadinessGate(): bool
+    {
+        if ((string) $this->status !== self::STATUS_PUBLISHED || ! (bool) $this->is_public) {
+            return false;
+        }
+
+        if ($this->published_at !== null && $this->published_at->isFuture()) {
+            return false;
+        }
+
+        if (! $this->isScienceControlledPage()) {
+            return true;
+        }
+
+        $forbiddenClaims = is_array($this->forbidden_claims) ? array_values($this->forbidden_claims) : [];
+
+        return (bool) $this->publish_allowed
+            && (string) $this->review_state === 'approved'
+            && ! (bool) $this->legal_review_required
+            && ! (bool) $this->science_review_required
+            && (string) $this->claim_gate_status === 'passed'
+            && $forbiddenClaims === []
+            && (! (bool) $this->operator_approval_required || $this->operator_approved_at !== null)
+            && (! (bool) $this->schema_enabled || ((bool) $this->faq_schema_eligible && $this->schema_eligibility_reviewed_at !== null));
     }
 
     public function isSourceContent(): bool

--- a/backend/app/Services/SEO/SitemapGenerator.php
+++ b/backend/app/Services/SEO/SitemapGenerator.php
@@ -732,14 +732,8 @@ class SitemapGenerator
         $rows = ContentPage::query()
             ->withoutGlobalScopes()
             ->where('org_id', 0)
-            ->where('status', ContentPage::STATUS_PUBLISHED)
-            ->where('is_public', true)
-            ->where('is_indexable', true)
+            ->publiclyIndexable()
             ->whereIn('locale', ['en', 'zh-CN'])
-            ->where(static function ($query): void {
-                $query->whereNull('published_at')
-                    ->orWhere('published_at', '<=', now());
-            })
             ->orderBy('locale')
             ->orderBy('slug')
             ->get();

--- a/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
+++ b/backend/app/Services/SeoIntel/Sources/BackendAuthorityUrlTruthSource.php
@@ -80,14 +80,8 @@ final class BackendAuthorityUrlTruthSource implements UrlTruthInventorySource
             $pages = ContentPage::query()
                 ->withoutGlobalScopes()
                 ->where('org_id', 0)
-                ->where('status', ContentPage::STATUS_PUBLISHED)
-                ->where('is_public', true)
-                ->where('is_indexable', true)
+                ->publiclyIndexable()
                 ->whereIn('locale', ['en', 'zh-CN'])
-                ->where(static function ($query): void {
-                    $query->whereNull('published_at')
-                        ->orWhere('published_at', '<=', now());
-                })
                 ->orderBy('locale')
                 ->orderBy('slug')
                 ->get();

--- a/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+++ b/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
@@ -68,6 +68,9 @@ final class ContentPagePublicApiTest extends TestCase
 
         $this->assertSame('policy', (string) $methodBoundaries->kind);
         $this->assertSame('/method-boundaries', (string) $methodBoundaries->path);
+        $this->assertTrue((bool) $methodBoundaries->publish_allowed);
+        $this->assertSame('passed', (string) $methodBoundaries->claim_gate_status);
+        $this->assertNotNull($methodBoundaries->operator_approved_at);
         $this->assertContains('四、医学与高风险场景边界', $methodBoundaries->headings_json ?? []);
     }
 
@@ -128,6 +131,87 @@ final class ContentPagePublicApiTest extends TestCase
         $this->assertStringContainsString('not a medical diagnosis', $enContent);
         $this->assertStringContainsString('do not guarantee school admission, employment', $enContent);
         $this->assertStringContainsString('Data and privacy boundaries', $enContent);
+    }
+
+    public function test_public_api_hides_science_content_pages_until_public_readiness_gate_passes(): void
+    {
+        $sciencePage = ContentPage::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'reliability-validity',
+            'path' => '/reliability-validity',
+            'kind' => ContentPage::KIND_POLICY,
+            'page_type' => 'methodology',
+            'title' => 'Reliability and validity',
+            'summary' => 'Science review page.',
+            'template' => 'policy',
+            'animation_profile' => 'policy',
+            'locale' => 'en',
+            'published_at' => '2026-06-09',
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'content_md' => "## Reliability\n\nDraft science content.",
+            'content_html' => '',
+            'seo_title' => 'Reliability and validity',
+            'meta_description' => 'Science review page.',
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'publish_allowed' => false,
+            'operator_approval_required' => true,
+            'operator_approved_at' => null,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+        ]);
+
+        $this->getJson('/api/v0.5/content-pages/reliability-validity?locale=en&org_id=0')
+            ->assertNotFound()
+            ->assertJsonPath('ok', false);
+
+        $sciencePage->forceFill([
+            'publish_allowed' => true,
+            'operator_approved_at' => '2026-06-09 00:00:00',
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+        ])->save();
+
+        $this->getJson('/api/v0.5/content-pages/reliability-validity?locale=en&org_id=0')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('page.slug', 'reliability-validity')
+            ->assertJsonPath('page.publish_allowed', true)
+            ->assertJsonPath('page.claim_gate_status', 'passed');
+
+        ContentPage::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'brand',
+            'path' => '/brand',
+            'kind' => ContentPage::KIND_COMPANY,
+            'page_type' => 'company',
+            'title' => 'Brand',
+            'summary' => 'Brand page.',
+            'template' => 'brand',
+            'animation_profile' => 'brand',
+            'locale' => 'en',
+            'published_at' => '2026-06-09',
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'content_md' => "## Brand\n\nCompany content.",
+            'content_html' => '',
+            'seo_title' => 'Brand',
+            'meta_description' => 'Brand page.',
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'publish_allowed' => false,
+            'claim_gate_status' => 'not_reviewed',
+        ]);
+
+        $this->getJson('/api/v0.5/content-pages/brand?locale=en&org_id=0')
+            ->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('page.slug', 'brand');
     }
 
     public function test_ops_list_and_update_are_backed_by_content_pages_table(): void

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -176,6 +176,64 @@ class SitemapGeneratorTest extends TestCase
         $this->assertStringNotContainsString('https://fermatmind.com/en/help/about', $xml);
     }
 
+    public function test_generate_excludes_science_content_pages_until_public_readiness_gate_passes(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'item-design-notes',
+            'path' => '/item-design-notes',
+            'kind' => ContentPage::KIND_POLICY,
+            'page_type' => 'methodology',
+            'locale' => 'en',
+            'title' => 'Item design notes',
+            'content_md' => '## Item design notes',
+            'content_html' => null,
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'publish_allowed' => false,
+            'operator_approval_required' => true,
+            'operator_approved_at' => null,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'published_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
+        ]);
+
+        ContentPage::query()->create([
+            'org_id' => 0,
+            'slug' => 'method-boundaries',
+            'path' => '/method-boundaries',
+            'kind' => ContentPage::KIND_POLICY,
+            'page_type' => 'boundary',
+            'locale' => 'en',
+            'title' => 'Method boundaries',
+            'content_md' => '## Method boundaries',
+            'content_html' => null,
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'publish_allowed' => true,
+            'operator_approval_required' => true,
+            'operator_approved_at' => Carbon::create(2026, 6, 9, 8, 0, 0, 'UTC'),
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'published_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
+            'created_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
+            'updated_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
+        ]);
+
+        $xml = (string) (app(SitemapGenerator::class)->generate()['xml'] ?? '');
+
+        $this->assertStringContainsString('https://fermatmind.com/en/method-boundaries', $xml);
+        $this->assertStringNotContainsString('https://fermatmind.com/en/item-design-notes', $xml);
+    }
+
     public function test_generate_includes_only_indexable_global_article_urls_with_locale_aware_paths(): void
     {
         config([

--- a/content_baselines/content_pages/content_pages.en.json
+++ b/content_baselines/content_pages/content_pages.en.json
@@ -177,6 +177,12 @@
     "sourceDoc": "content_pages.en.method_boundaries.baseline",
     "isPublic": true,
     "isIndexable": true,
+    "publishAllowed": true,
+    "operatorApprovalRequired": true,
+    "operatorApprovedAt": "2026-05-08",
+    "claimGateStatus": "passed",
+    "forbiddenClaims": [],
+    "faqSchemaEligible": false,
     "headings": [
       "What FermatMind assessments are",
       "What results can support",

--- a/content_baselines/content_pages/content_pages.zh-CN.json
+++ b/content_baselines/content_pages/content_pages.zh-CN.json
@@ -260,6 +260,12 @@
     "sourceDoc": "content_pages.zh-CN.method_boundaries.baseline",
     "isPublic": true,
     "isIndexable": true,
+    "publishAllowed": true,
+    "operatorApprovalRequired": true,
+    "operatorApprovedAt": "2026-05-08",
+    "claimGateStatus": "passed",
+    "forbiddenClaims": [],
+    "faqSchemaEligible": false,
     "headings": [
       "一、费马测试的测评是什么",
       "二、测评结果能做什么",


### PR DESCRIPTION
## What changed
- Added backend public readiness gates for science/method content pages before public API exposure.
- Reused the same gated scope for sitemap generation, SEO URL truth, and release verification so unsafe rows do not remain indexable.
- Extended local content-page baseline import to preserve publication safety fields such as `publish_allowed`, `operator_approval_required`, `operator_approved_at`, `claim_gate_status`, forbidden claims, and FAQ schema eligibility.
- Marked the existing zh-CN/en `method-boundaries` baseline rows with reviewed/passed publication metadata.
- Added regression coverage for public API 404-before-gate / 200-after-gate behavior and sitemap exclusion before the gate passes.

## Why
PR #1086 fixed frontend-visible rendering bugs, but the durable CMS/API risk remained: a science/method content page could be `published + is_public` and still be publicly exposed before review/approval and claim gates were actually passed. This PR moves that rule into backend authority paths so long-term SEO/CMS operations fail closed.

## Validation
- `php artisan test --filter=ContentPagePublicApiTest` PASS: 7 tests, 262 assertions.
- `php artisan test --filter=SitemapGeneratorTest` PASS: 8 tests, 123 assertions.
- `php artisan test --filter=ContentPagePublicApiTest && php artisan test --filter=SitemapGeneratorTest` PASS.
- `php artisan route:list` PASS: 218 routes.
- `DB_CONNECTION=sqlite DB_DATABASE=/tmp/fap-api-content-page-gate.sqlite php artisan migrate --force` PASS.
- `bash scripts/ci_verify_mbti.sh` PASS.
- `git diff --check` PASS.

Note: raw `php artisan migrate` against the local default `.env` was blocked by local MySQL auth (`SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`). The SQLite migration path and full MBTI CI migration path both passed.

## Intentionally deferred
- No production CMS records are changed by this PR. Operators still need to set real rows to reviewed/approved/passed states in CMS.
- No `landing_surfaces`/`page_blocks` homepage content changes are included.
- No article body/content edits are included; article public content remains governed by existing article publication/revision gates.
- No generic landing surface gate was added, because homepage and module ordering have different authority semantics from science/method content pages.

## Repository rule impact
- This reinforces the existing backend/CMS authority rule for static content pages: public exposure is decided by backend CMS state, not frontend fallback logic.
- Science/method content pages now require explicit backend publication-safety state before public API, sitemap, or URL-truth exposure.
