### PR TITLE
ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish

### DIFF
--- a/backend/app/Console/Commands/ArticleImportLocalBaseline.php
+++ b/backend/app/Console/Commands/ArticleImportLocalBaseline.php
@@ -9,6 +9,7 @@ use App\Models\ArticleCategory;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleBodyHeadingGuard;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
@@ -36,6 +37,7 @@ final class ArticleImportLocalBaseline extends Command
     protected $description = 'Import committed article baseline content into Article CMS tables.';
 
     public function handle(
+        ArticleBodyHeadingGuard $articleBodyHeadingGuard,
         ArticleService $articleService,
         ArticlePublishService $articlePublishService,
         ArticleTranslationRevisionWorkspace $translationRevisionWorkspace,
@@ -59,7 +61,7 @@ final class ArticleImportLocalBaseline extends Command
             $selectedArticles = $this->normalizeSelectedArticles((array) $this->option('article'));
 
             $documents = $this->readDocuments($sourceDir, $selectedLocales);
-            $articles = $this->normalizeArticles($documents, $selectedArticles);
+            $articles = $this->normalizeArticles($documents, $selectedArticles, $articleBodyHeadingGuard);
             $summary = $this->importRows(
                 $articles,
                 [
@@ -196,8 +198,11 @@ final class ArticleImportLocalBaseline extends Command
      * @param  array<int, string>  $selectedArticles
      * @return array<int, array<string, mixed>>
      */
-    private function normalizeArticles(array $documents, array $selectedArticles = []): array
-    {
+    private function normalizeArticles(
+        array $documents,
+        array $selectedArticles,
+        ArticleBodyHeadingGuard $articleBodyHeadingGuard,
+    ): array {
         $rows = [];
         $seen = [];
 
@@ -224,7 +229,7 @@ final class ArticleImportLocalBaseline extends Command
                     ));
                 }
 
-                $normalized = $this->normalizeArticleRow($row, $documentLocale, $file, (int) $index);
+                $normalized = $this->normalizeArticleRow($row, $documentLocale, $file, (int) $index, $articleBodyHeadingGuard);
                 if ($selectedArticles !== [] && ! in_array((string) $normalized['slug'], $selectedArticles, true)) {
                     continue;
                 }
@@ -256,6 +261,7 @@ final class ArticleImportLocalBaseline extends Command
         string $documentLocale,
         string $file,
         int $index,
+        ArticleBodyHeadingGuard $articleBodyHeadingGuard,
     ): array {
         $slug = strtolower(trim((string) ($row['slug'] ?? '')));
         if ($slug === '') {
@@ -284,7 +290,7 @@ final class ArticleImportLocalBaseline extends Command
             ));
         }
 
-        $contentMd = trim((string) ($row['content_md'] ?? ''));
+        $contentMd = trim($articleBodyHeadingGuard->downgradeMarkdownH1ToH2((string) ($row['content_md'] ?? '')));
         if ($contentMd === '') {
             throw new RuntimeException(sprintf(
                 'Baseline file %s is missing content_md for slug=%s.',

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -10,6 +10,7 @@ use App\Models\ArticleCategory;
 use App\Models\ArticleTag;
 use App\Models\ArticleTestEdge;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleBodyHeadingGuard;
 use App\Services\Cms\ArticlePublishService;
 use App\Services\Cms\ArticleSeoService;
 use App\Services\Cms\ArticleService;
@@ -29,6 +30,7 @@ class ArticleController extends Controller
     public function __construct(
         private readonly ArticleService $articleService,
         private readonly ArticlePublishService $articlePublishService,
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
         private readonly ArticleSeoService $articleSeoService,
         private readonly AnswerSurfaceContractService $answerSurfaceContractService,
         private readonly LandingSurfaceContractService $landingSurfaceContractService,
@@ -1052,7 +1054,7 @@ class ArticleController extends Controller
             'published_revision_id' => (int) $revision->id,
             'title' => (string) $revision->title,
             'excerpt' => $revision->excerpt,
-            'content_md' => (string) $revision->content_md,
+            'content_md' => $this->articleBodyHeadingGuard->downgradeMarkdownH1ToH2((string) $revision->content_md),
             'content_html' => null,
             'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($article->cover_image_url),
             'cover_image_alt' => $article->cover_image_alt,
@@ -1140,8 +1142,10 @@ class ArticleController extends Controller
             'locale' => (string) $article->locale,
             'title' => (string) $article->title,
             'excerpt' => $article->excerpt,
-            'content_md' => (string) $article->content_md,
-            'content_html' => $article->content_html,
+            'content_md' => $this->articleBodyHeadingGuard->downgradeMarkdownH1ToH2((string) $article->content_md),
+            'content_html' => $article->content_html !== null
+                ? $this->articleBodyHeadingGuard->downgradeHtmlH1ToH2((string) $article->content_html)
+                : null,
             'cover_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($article->cover_image_url),
             'cover_image_alt' => $article->cover_image_alt,
             'cover_image_width' => $article->cover_image_width !== null ? (int) $article->cover_image_width : null,

--- a/backend/app/Services/Cms/ArticleBodyHeadingGuard.php
+++ b/backend/app/Services/Cms/ArticleBodyHeadingGuard.php
@@ -1,0 +1,92 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use InvalidArgumentException;
+
+final class ArticleBodyHeadingGuard
+{
+    public function assertNoBodyH1(?string $contentMd = null, ?string $contentHtml = null): void
+    {
+        $violations = $this->violations($contentMd, $contentHtml);
+        if ($violations === []) {
+            return;
+        }
+
+        throw new InvalidArgumentException(
+            'Article body must not contain h1 headings; use h2 or lower in CMS body content. Violations: '.implode(', ', $violations).'.'
+        );
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function violations(?string $contentMd = null, ?string $contentHtml = null): array
+    {
+        $violations = [];
+
+        if ($this->containsMarkdownH1((string) ($contentMd ?? ''))) {
+            $violations[] = 'content_md';
+        }
+
+        if ($this->containsHtmlH1((string) ($contentHtml ?? ''))) {
+            $violations[] = 'content_html';
+        }
+
+        return $violations;
+    }
+
+    public function containsMarkdownH1(string $markdown): bool
+    {
+        return preg_match('/^(?!\s{4,})\s{0,3}#(?!#)(?:\s+|$)/m', $markdown) === 1
+            || preg_match('/^(?!\s{4,}).+\R\s{0,3}=+\s*$/m', $markdown) === 1;
+    }
+
+    public function containsHtmlH1(string $html): bool
+    {
+        return preg_match('/<\s*h1(?:\s|>|\/)/i', $html) === 1
+            || preg_match('/<\s*\/\s*h1\s*>/i', $html) === 1;
+    }
+
+    public function downgradeMarkdownH1ToH2(string $markdown): string
+    {
+        $lines = preg_split("/(\r\n|\n|\r)/", $markdown, -1, PREG_SPLIT_DELIM_CAPTURE);
+        if ($lines === false || $lines === []) {
+            return $markdown;
+        }
+
+        $output = '';
+        $inFence = false;
+
+        for ($index = 0; $index < count($lines); $index += 2) {
+            $line = (string) ($lines[$index] ?? '');
+            $separator = (string) ($lines[$index + 1] ?? '');
+
+            if (preg_match('/^\s{0,3}(```|~~~)/', $line) === 1) {
+                $inFence = ! $inFence;
+                $output .= $line.$separator;
+
+                continue;
+            }
+
+            if (! $inFence) {
+                if (preg_match('/^(?<indent>\s{0,3})#(?!#)(?<rest>\s+.*|)$/', $line, $matches) === 1) {
+                    $line = (string) $matches['indent'].'##'.(string) $matches['rest'];
+                } elseif (preg_match('/^\s{0,3}=+\s*$/', $line) === 1) {
+                    $line = preg_replace('/=/', '-', $line) ?? $line;
+                }
+            }
+
+            $output .= $line.$separator;
+        }
+
+        return $output;
+    }
+
+    public function downgradeHtmlH1ToH2(string $html): string
+    {
+        return preg_replace('/(<\s*\/?\s*)h1(\b[^>]*>)/i', '$1h2$2', $html) ?? $html;
+    }
+}

--- a/backend/app/Services/Cms/ArticlePublishService.php
+++ b/backend/app/Services/Cms/ArticlePublishService.php
@@ -16,6 +16,7 @@ final class ArticlePublishService
 {
     public function __construct(
         private readonly SeoDiscoverabilityCacheInvalidator $seoDiscoverabilityCacheInvalidator,
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
     ) {}
 
     public function publishArticle(int $articleId, string $source = 'article_publish_service'): Article
@@ -111,6 +112,11 @@ final class ArticlePublishService
         if (trim((string) $article->content_md) === '') {
             throw new InvalidArgumentException('content_md must exist before publish.');
         }
+
+        $this->articleBodyHeadingGuard->assertNoBodyH1(
+            (string) $article->content_md,
+            (string) ($article->content_html ?? '')
+        );
     }
 
     private function resolvePublishableRevision(Article $article): ArticleTranslationRevision
@@ -136,6 +142,8 @@ final class ArticlePublishService
         if (trim((string) $revision->content_md) === '') {
             throw new InvalidArgumentException('revision content_md must exist before publish.');
         }
+
+        $this->articleBodyHeadingGuard->assertNoBodyH1((string) $revision->content_md);
 
         return $revision;
     }

--- a/backend/app/Services/Cms/ArticleService.php
+++ b/backend/app/Services/Cms/ArticleService.php
@@ -16,6 +16,10 @@ use RuntimeException;
 
 final class ArticleService
 {
+    public function __construct(
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
+    ) {}
+
     /**
      * @param  array<int,mixed>  $tags
      */
@@ -38,6 +42,7 @@ final class ArticleService
         if ($normalizedContentMd === '') {
             throw new InvalidArgumentException('content_md is required.');
         }
+        $this->articleBodyHeadingGuard->assertNoBodyH1($normalizedContentMd);
 
         $normalizedOrgId = max(0, $orgId);
         $resolvedSlug = $this->resolveUniqueSlug(
@@ -118,6 +123,10 @@ final class ArticleService
             if ($nextContentMd === '') {
                 throw new InvalidArgumentException('content_md is required.');
             }
+            $this->articleBodyHeadingGuard->assertNoBodyH1(
+                $nextContentMd,
+                array_key_exists('content_html', $fields) ? (string) ($fields['content_html'] ?? '') : (string) ($article->content_html ?? '')
+            );
 
             $slugInput = array_key_exists('slug', $fields)
                 ? (string) ($fields['slug'] ?? '')

--- a/backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
+++ b/backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
@@ -11,6 +11,10 @@ use Illuminate\Support\Facades\DB;
 
 final class ArticleTranslationRevisionWorkspace
 {
+    public function __construct(
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
+    ) {}
+
     /**
      * @return array<string, mixed>
      */
@@ -90,6 +94,7 @@ final class ArticleTranslationRevisionWorkspace
                 'seo_description' => $payload['seo_description'] ?? $revision->seo_description,
                 'created_by' => $revision->created_by ?: $adminUserId,
             ];
+            $this->articleBodyHeadingGuard->assertNoBodyH1((string) $revisionPayload['content_md']);
 
             if ($revisionChanged && ! in_array($revisionStatus, [
                 ArticleTranslationRevision::STATUS_APPROVED,

--- a/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+++ b/backend/app/Services/Cms/ArticleTranslationWorkflowService.php
@@ -22,6 +22,7 @@ final class ArticleTranslationWorkflowService
     public function __construct(
         private readonly ArticleMachineTranslationProvider $provider,
         private readonly ArticleTranslationRevisionWorkspace $workspace,
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
         private readonly AuditLogger $auditLogger,
     ) {}
 
@@ -389,6 +390,11 @@ final class ArticleTranslationWorkflowService
             if ($revision->revision_status !== ArticleTranslationRevision::STATUS_APPROVED) {
                 throw new ArticleTranslationWorkflowException('Only approved translation revisions can be published.', [
                     'working revision is not approved',
+                ]);
+            }
+            if ($this->articleBodyHeadingGuard->violations((string) $revision->content_md) !== []) {
+                throw new ArticleTranslationWorkflowException('Translation publish preflight failed.', [
+                    'article body h1 headings are not allowed',
                 ]);
             }
 

--- a/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
+++ b/backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
@@ -11,6 +11,7 @@ use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTag;
 use App\Models\ArticleTestEdge;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleBodyHeadingGuard;
 use App\Services\Cms\ArticleTranslationRevisionWorkspace;
 use App\Services\Cms\EditorialPackage\Config\EvergreenAnchors;
 use Illuminate\Support\Facades\DB;
@@ -167,6 +168,7 @@ final class EditorialPackageDraftImporter
     public function __construct(
         private readonly ArticleTranslationRevisionWorkspace $revisionWorkspace,
         private readonly EditorialPackageInputNormalizer $inputNormalizer,
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
     ) {}
 
     /**
@@ -378,7 +380,7 @@ final class EditorialPackageDraftImporter
     private function normalize(array $package, ?string $localeOverride): array
     {
         $package = $this->inputNormalizer->normalize($package);
-        $body = (string) ($package['body_markdown'] ?? '');
+        $body = $this->articleBodyHeadingGuard->downgradeMarkdownH1ToH2((string) ($package['body_markdown'] ?? ''));
         $answerSurface = is_array($package['answer_surface_v1'] ?? null) ? $package['answer_surface_v1'] : [];
 
         return [

--- a/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+++ b/backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
@@ -7,6 +7,7 @@ namespace Tests\Feature\CareerCms;
 use App\Models\Article;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleBodyHeadingGuard;
 use App\Services\Cms\ArticleSeoService;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
@@ -111,6 +112,7 @@ final class ArticleBaselineImportTest extends TestCase
             data_get($editorial->cover_image_variants, 'editorial_metadata.cover_image_style_tag')
         );
         $this->assertContains('/zh/tests/mbti-personality-test-16-personality-types', data_get($editorial->cover_image_variants, 'editorial_metadata.internal_links', []));
+        $this->assertImportedArticleBodiesContainNoH1();
 
         $this->assertSixEditorialArticlesConvergeThroughSeoAuthority();
 
@@ -318,6 +320,29 @@ final class ArticleBaselineImportTest extends TestCase
 
         $this->assertLessThanOrEqual(64, mb_strlen((string) $article->translation_group_id));
         $this->assertStringStartsWith('article:', (string) $article->translation_group_id);
+    }
+
+    private function assertImportedArticleBodiesContainNoH1(): void
+    {
+        $guard = app(ArticleBodyHeadingGuard::class);
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->with('publishedRevision')
+            ->get();
+
+        foreach ($articles as $article) {
+            $this->assertFalse(
+                $guard->containsMarkdownH1((string) $article->content_md),
+                sprintf('Article body contains H1 after baseline import: %s/%s', (string) $article->locale, (string) $article->slug)
+            );
+
+            if ($article->publishedRevision instanceof ArticleTranslationRevision) {
+                $this->assertFalse(
+                    $guard->containsMarkdownH1((string) $article->publishedRevision->content_md),
+                    sprintf('Published revision body contains H1 after baseline import: %s/%s', (string) $article->locale, (string) $article->slug)
+                );
+            }
+        }
     }
 
     private function assertSixEditorialArticlesConvergeThroughSeoAuthority(): void

--- a/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
@@ -9,6 +9,7 @@ use App\Models\ArticleCategory;
 use App\Models\ArticleEditorialPackageImport;
 use App\Models\ArticleSeoMeta;
 use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleBodyHeadingGuard;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
 use Tests\TestCase;
@@ -119,6 +120,8 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
             ->where('slug', 'ai-personality-editorial-draft')
             ->where('locale', 'zh-CN')
             ->firstOrFail();
+        $expectedBody = app(ArticleBodyHeadingGuard::class)
+            ->downgradeMarkdownH1ToH2((string) $package['body_markdown']);
 
         $this->assertSame('draft', (string) $article->status);
         $this->assertFalse((bool) $article->is_public);
@@ -126,7 +129,8 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $this->assertNull($article->published_revision_id);
         $this->assertSame('article_mbti_vs_holland_career_choice_v1', (string) $article->translation_group_id);
         $this->assertSame($package['title'], (string) $article->title);
-        $this->assertSame($package['body_markdown'], (string) $article->content_md);
+        $this->assertSame($expectedBody, (string) $article->content_md);
+        $this->assertFalse(app(ArticleBodyHeadingGuard::class)->containsMarkdownH1((string) $article->content_md));
         $this->assertSame($package['cover_image'], (string) $article->cover_image_url);
         $this->assertSame($package['cover_image_alt'], (string) $article->cover_image_alt);
         $this->assertSame($package['category'], (string) $article->category?->name);
@@ -138,7 +142,7 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
 
         $this->assertInstanceOf(ArticleTranslationRevision::class, $article->workingRevision);
         $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, (string) $article->workingRevision->revision_status);
-        $this->assertSame($package['body_markdown'], (string) $article->workingRevision->content_md);
+        $this->assertSame($expectedBody, (string) $article->workingRevision->content_md);
         $this->assertSame($package['seo_title'], (string) $article->workingRevision->seo_title);
         $this->assertSame($package['meta_description'], (string) $article->workingRevision->seo_description);
 
@@ -154,8 +158,8 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $this->assertSame($package['references'], $metadata['references'] ?? []);
         $this->assertSame($package['answer_surface_v1']['quick_answer'], data_get($metadata, 'answer_surface_v1.quick_answer'));
         $this->assertSame('below_intro', $metadata['answer_surface_visibility'] ?? null);
-        $this->assertSame($this->normalizedBodyHash($package['body_markdown']), data_get($metadata, 'validation.body_hash'));
-        $this->assertSame(['1:AI 与人格如何共同影响判断', '2:执行摘要', '2:为什么这不是单纯技术问题', '2:结论'], data_get($metadata, 'validation.heading_sequence'));
+        $this->assertSame($this->normalizedBodyHash($expectedBody), data_get($metadata, 'validation.body_hash'));
+        $this->assertSame(['2:AI 与人格如何共同影响判断', '2:执行摘要', '2:为什么这不是单纯技术问题', '2:结论'], data_get($metadata, 'validation.heading_sequence'));
 
         $this->assertSame($sensitiveCounts, $this->sensitiveTableCounts());
         $importLog = ArticleEditorialPackageImport::query()
@@ -165,13 +169,13 @@ final class ArticleImportEditorialPackageCommandTest extends TestCase
         $this->assertSame(ArticleEditorialPackageImport::STATUS_IMPORTED, (string) $importLog->status);
         $this->assertSame((int) $article->id, (int) $importLog->article_id);
         $this->assertSame('editorial_journal', (string) $importLog->content_track);
-        $this->assertSame($this->normalizedBodyHash($package['body_markdown']), (string) $importLog->body_hash);
+        $this->assertSame($this->normalizedBodyHash($expectedBody), (string) $importLog->body_hash);
         $this->assertSame(2, (int) $importLog->references_count);
         $this->assertSame('complete', data_get($importLog->references_json, 'status'));
         $this->assertSame('complete', data_get($importLog->media_json, 'status'));
         $this->assertSame('complete', data_get($importLog->graph_json, 'status'));
         $this->assertSame('passed', data_get($importLog->claim_result_json, 'status'));
-        $this->assertSame(['1:AI 与人格如何共同影响判断', '2:执行摘要', '2:为什么这不是单纯技术问题', '2:结论'], $importLog->heading_sequence_json);
+        $this->assertSame(['2:AI 与人格如何共同影响判断', '2:执行摘要', '2:为什么这不是单纯技术问题', '2:结论'], $importLog->heading_sequence_json);
         $this->assertStringNotContainsString($package['body_markdown'], json_encode($importLog->toArray(), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
         $this->getJson('/api/v0.5/articles/ai-personality-editorial-draft?locale=zh-CN')
             ->assertNotFound();

--- a/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+++ b/backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
@@ -67,6 +67,27 @@ final class ArticleCmsWriteAuthTest extends TestCase
         ]);
     }
 
+    public function test_cms_article_create_rejects_body_h1(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+
+        $response = $this->withSession(['ops_org_id' => 16])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles', array_merge($this->articlePayload('body-h1-create'), [
+                'content_md' => "# Duplicate article title\n\nBody",
+            ]));
+
+        $response->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_ARGUMENT');
+
+        $this->assertStringContainsString('must not contain h1', (string) $response->json('message'));
+        $this->assertDatabaseMissing('articles', [
+            'slug' => 'body-h1-create',
+            'org_id' => 16,
+        ]);
+    }
+
     public function test_admin_owner_permission_can_write_articles(): void
     {
         $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_OWNER]);
@@ -209,6 +230,69 @@ final class ArticleCmsWriteAuthTest extends TestCase
         $this->assertFalse((bool) $article->is_public);
         $this->assertNull($article->published_at);
         $this->assertNull($article->scheduled_at);
+    }
+
+    public function test_cms_article_update_rejects_markdown_or_html_body_h1(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_WRITE]);
+        $article = Article::query()->create([
+            'org_id' => 32,
+            'slug' => 'body-h1-update-target',
+            'locale' => 'en',
+            'title' => 'Body H1 update target',
+            'content_md' => '## Existing section',
+            'content_html' => '<h2>Existing section</h2>',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        $response = $this->withSession(['ops_org_id' => 32])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/cms/articles/'.$article->id, [
+                'content_md' => "# Duplicate article title\n\nBody",
+                'content_html' => '<h1>Duplicate article title</h1>',
+            ]);
+
+        $response->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_ARGUMENT');
+
+        $this->assertStringContainsString('content_md', (string) $response->json('message'));
+        $this->assertStringContainsString('content_html', (string) $response->json('message'));
+        $this->assertDatabaseHas('articles', [
+            'id' => $article->id,
+            'content_md' => '## Existing section',
+            'content_html' => '<h2>Existing section</h2>',
+        ]);
+    }
+
+    public function test_article_publish_rejects_existing_body_h1(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_RELEASE]);
+        $article = Article::query()->create([
+            'org_id' => 33,
+            'slug' => 'body-h1-publish-target',
+            'locale' => 'en',
+            'title' => 'Body H1 publish target',
+            'content_md' => "# Duplicate article title\n\nBody",
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => true,
+        ]);
+
+        $response = $this->withSession(['ops_org_id' => 33])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->postJson('/api/v0.5/cms/articles/'.$article->id.'/publish');
+
+        $response->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_ARGUMENT');
+
+        $article->refresh();
+        $this->assertSame('draft', (string) $article->status);
+        $this->assertFalse((bool) $article->is_public);
+        $this->assertNull($article->published_revision_id);
     }
 
     public function test_cms_article_create_rejects_foreign_category_and_tags(): void

--- a/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+++ b/backend/tests/Feature/V0_5/ArticlePublicApiTest.php
@@ -277,6 +277,25 @@ final class ArticlePublicApiTest extends TestCase
         $this->assertStringNotContainsString('www.fermatmind.com', (string) $response->getContent());
     }
 
+    public function test_article_detail_downgrades_legacy_published_revision_body_h1(): void
+    {
+        $this->createArticle([
+            'slug' => 'legacy-body-h1-article',
+            'locale' => 'en',
+            'title' => 'Legacy Body H1 Article',
+        ], [
+            'title' => 'Legacy Body H1 Article',
+            'content_md' => "# Legacy duplicate title\n\nBody\n\n## Existing section",
+        ]);
+
+        $response = $this->getJson('/api/v0.5/articles/legacy-body-h1-article?locale=en');
+
+        $response->assertOk()
+            ->assertJsonPath('article.content_md', "## Legacy duplicate title\n\nBody\n\n## Existing section");
+
+        $this->assertStringStartsWith('## Legacy duplicate title', (string) $response->json('article.content_md'));
+    }
+
     public function test_article_detail_projects_cms_cta_slots_and_visible_faq_without_private_targets(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1528,6 +1528,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Cms/ArticleBodyHeadingGuard.php',
+            'backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_publishing_ops_dashboard_changes(): void
     {
         $changed = [
@@ -2807,6 +2817,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleBodyH1GuardFile($file)) {
+                continue;
+            }
+
             if ($this->isArticlePublishingOpsDashboardFile($file)) {
                 continue;
             }
@@ -3635,6 +3649,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Console/Commands/ArticleImportEditorialPackage.php'
             || str_starts_with($file, 'backend/app/Services/Cms/EditorialPackage/');
+    }
+
+    private function isArticleBodyH1GuardFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Cms/ArticleBodyHeadingGuard.php',
+            'backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php',
+        ], true);
     }
 
     private function isArticlePublishingOpsDashboardFile(string $file): bool

--- a/backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php
+++ b/backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php
@@ -1,0 +1,36 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Cms;
+
+use App\Services\Cms\ArticleBodyHeadingGuard;
+use PHPUnit\Framework\TestCase;
+
+final class ArticleBodyHeadingGuardTest extends TestCase
+{
+    public function test_detects_markdown_and_html_body_h1(): void
+    {
+        $guard = new ArticleBodyHeadingGuard;
+
+        $this->assertSame(['content_md'], $guard->violations("# Duplicate title\n\n## Section"));
+        $this->assertSame(['content_html'], $guard->violations('## Section', '<article><h1>Duplicate title</h1></article>'));
+        $this->assertSame([], $guard->violations("## Section\n\nBody", '<article><h2>Section</h2></article>'));
+    }
+
+    public function test_downgrades_legacy_body_h1_without_touching_fenced_markdown(): void
+    {
+        $guard = new ArticleBodyHeadingGuard;
+
+        $markdown = "# Duplicate title\n\n```md\n# Example stays literal\n```\n\n## Existing section";
+
+        $this->assertSame(
+            "## Duplicate title\n\n```md\n# Example stays literal\n```\n\n## Existing section",
+            $guard->downgradeMarkdownH1ToH2($markdown)
+        );
+        $this->assertSame(
+            '<article><h2 class="hero">Duplicate title</h2><h2>Section</h2></article>',
+            $guard->downgradeHtmlH1ToH2('<article><h1 class="hero">Duplicate title</h1><h2>Section</h2></article>')
+        );
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51967,7 +51967,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-02",
     "base": "origin/main",
-    "status": "committed_pending_push",
+    "status": "github_checks_pending",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish",
     "depends_on": [
@@ -52025,13 +52025,14 @@
       },
       "github": {
         "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2014",
         "checks": [],
         "failure_reason": null
       }
     },
     "failure_reason": null,
     "commit_sha": "0f18583d13a2498637cd650ed871d2cef8b37538",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2014",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -52056,6 +52057,11 @@
         "at": "2026-06-09",
         "status": "committed_pending_push",
         "note": "Created scoped implementation commit 0f18583d13a2498637cd650ed871d2cef8b37538."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_pending",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2014 from branch codex/article-h1-02; GitHub checks pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51962,5 +51962,132 @@
         "note": "GitHub checks passed for PR #2012 at head 0ad2b4fa46792527b89bccbc7e443f2d34e69cf7 and mergeStateStatus is CLEAN."
       }
     ]
+  },
+  "ARTICLE-H1-02": {
+    "repo": "fap-api",
+    "branch": "codex/article-h1-02",
+    "base": "origin/main",
+    "status": "in_progress",
+    "train_scope": "article_h1_single_dom",
+    "title": "ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish",
+    "depends_on": [
+      "ARTICLE-H1-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized ARTICLE-H1 PR train and fap-api docs/codex metadata updates on 2026-06-09."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "ARTICLE-H1-01 merged into fap-web main as PR #1087 at 2026-06-09T05:36:13Z with merge commit da2d4e124de958bdd6256c8ec9d85b3eae6bdfe6 before this branch started."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Planned files are confined to article CMS/API save, publish, translation publish, payload projection, focused tests, optional BigFive freeze classifier coverage, and docs/codex metadata.",
+        "allowed_paths": [
+          "backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php",
+          "backend/app/Services/Cms/ArticleBodyHeadingGuard.php",
+          "backend/app/Services/Cms/ArticleService.php",
+          "backend/app/Services/Cms/ArticlePublishService.php",
+          "backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php",
+          "backend/app/Services/Cms/ArticleTranslationWorkflowService.php",
+          "backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php",
+          "backend/tests/Feature/V0_5/ArticlePublicApiTest.php",
+          "backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php",
+          "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
+          "docs/codex/pr-train.yaml",
+          "docs/codex/pr-train-state.json"
+        ]
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Services/Cms/ArticleBodyHeadingGuard.php",
+          "php -l backend/app/Services/Cms/ArticleService.php",
+          "php -l backend/app/Services/Cms/ArticlePublishService.php",
+          "php -l backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php",
+          "php -l backend/app/Services/Cms/ArticleTranslationWorkflowService.php",
+          "php -l backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php",
+          "php -l backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php",
+          "php -l backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php",
+          "php -l backend/tests/Feature/V0_5/ArticlePublicApiTest.php",
+          "cd backend && php artisan route:list --path=api/v0.5/cms/articles --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter=test_article_detail_downgrades_legacy_published_revision_body_h1 --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
+          "git diff --check -- backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php backend/app/Services/Cms/ArticleBodyHeadingGuard.php backend/app/Services/Cms/ArticleService.php backend/app/Services/Cms/ArticlePublishService.php backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php backend/app/Services/Cms/ArticleTranslationWorkflowService.php backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php backend/tests/Feature/V0_5/ArticlePublicApiTest.php backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+        ],
+        "evidence": "PHP lint, route-list, focused H1 feature/unit tests, focused BigFive runtime path diff, Pint --test, JSON/YAML parse, and path-limited git diff --check passed. Full ArticlePublicApiTest file was not used as a required check because its unchanged sitemap-source cache expectation is recorded as an external sidecar issue."
+      },
+      "github": {
+        "status": "pending",
+        "checks": [],
+        "failure_reason": null
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [
+      {
+        "status": "external_existing",
+        "issue": "ArticlePublicApiTest::test_sitemap_source_uses_public_readable_and_indexable_article_gate currently expects /api/v0.5/seo/sitemap-source to generate fresh payload after Cache::flush(), but SitemapSourceController::index reads only fresh/stale cache or fallback. This was observed while running the full ArticlePublicApiTest file and is outside ARTICLE-H1-02 scope."
+      }
+    ],
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Initialized from explicit ARTICLE-H1 PR train authorization and started branch codex/article-h1-02 from latest fap-api main."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "Added article body H1 guard across CMS save, working revision save, article publish, translation publish, and API payload downgrade; focused local checks passed."
+      }
+    ]
+  },
+  "ARTICLE-H1-04": {
+    "repo": "fap-api",
+    "branch": "codex/article-h1-04",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "article_h1_single_dom",
+    "title": "ARTICLE-H1-04: fix(ops): constrain article editor heading controls",
+    "depends_on": [
+      "ARTICLE-H1-02",
+      "ARTICLE-H1-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized ARTICLE-H1 PR train and fap-api docs/codex metadata updates on 2026-06-09."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "ARTICLE-H1-04 must wait for ARTICLE-H1-02 and ARTICLE-H1-03."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "pending_dependency",
+        "note": "Initialized future CMS/Ops editor UX constraint PR metadata only; implementation intentionally deferred."
+      }
+    ]
   }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51967,7 +51967,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-02",
     "base": "origin/main",
-    "status": "local_checks_passed_after_github_fix",
+    "status": "ready_to_merge",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish",
     "depends_on": [
@@ -52035,10 +52035,23 @@
         "evidence": "PHP lint, route-list, focused H1 feature/unit tests, baseline/editorial importer regressions, the CareerRecommendationPublicApiTest CI failure reproduction, focused BigFive runtime path diff/classifier regression, Pint --test, JSON/YAML parse, and path-limited git diff --check passed. Full ArticlePublicApiTest file was not used as a required check because its unchanged sitemap-source cache expectation is recorded as an external sidecar issue."
       },
       "github": {
-        "status": "failed_fix_pushed",
+        "status": "pass",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2014",
-        "checks": [],
-        "failure_reason": "GitHub verify-mbti-legacy, verify-mbti-v2, and verify-bigfive failed because article baseline/editorial package import paths hit the new body H1 guard and BigFive runtime-freeze needed a narrow CMS H1 guard exception. The fix normalizes importer body H1 to H2, adds importer regressions, and adds a scoped BigFive classifier regression."
+        "head_sha": "203b9851e275d1d8e4a3e5fb4153ffe976c49b04",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS",
+          "verify-bigfive",
+          "verify-mbti-legacy",
+          "verify-mbti-v2"
+        ],
+        "merge_state": "CLEAN",
+        "failure_reason": null,
+        "evidence": "GitHub checks passed for PR #2014 at head 203b9851e275d1d8e4a3e5fb4153ffe976c49b04 after importer normalization and BigFive classifier fixes."
       }
     },
     "failure_reason": null,
@@ -52078,6 +52091,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed_after_github_fix",
         "note": "Fixed GitHub verify failures by normalizing article baseline/editorial package importer body H1 to H2 and adding focused importer plus BigFive classifier regressions; local checks passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2014 at head 203b9851e275d1d8e4a3e5fb4153ffe976c49b04 and mergeStateStatus is CLEAN."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51967,7 +51967,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-02",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "local_checks_passed_after_github_fix",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish",
     "depends_on": [
@@ -51987,13 +51987,17 @@
         "evidence": "Planned files are confined to article CMS/API save, publish, translation publish, payload projection, focused tests, optional BigFive freeze classifier coverage, and docs/codex metadata.",
         "allowed_paths": [
           "backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php",
+          "backend/app/Console/Commands/ArticleImportLocalBaseline.php",
           "backend/app/Services/Cms/ArticleBodyHeadingGuard.php",
           "backend/app/Services/Cms/ArticleService.php",
           "backend/app/Services/Cms/ArticlePublishService.php",
           "backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php",
           "backend/app/Services/Cms/ArticleTranslationWorkflowService.php",
+          "backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php",
           "backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php",
           "backend/tests/Feature/V0_5/ArticlePublicApiTest.php",
+          "backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php",
+          "backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php",
           "backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php",
           "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train.yaml",
@@ -52008,26 +52012,33 @@
           "php -l backend/app/Services/Cms/ArticlePublishService.php",
           "php -l backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php",
           "php -l backend/app/Services/Cms/ArticleTranslationWorkflowService.php",
+          "php -l backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php",
+          "php -l backend/app/Console/Commands/ArticleImportLocalBaseline.php",
           "php -l backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php",
           "php -l backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php",
           "php -l backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php",
           "php -l backend/tests/Feature/V0_5/ArticlePublicApiTest.php",
+          "php -l backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php",
+          "php -l backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php",
           "cd backend && php artisan route:list --path=api/v0.5/cms/articles --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php --no-ansi",
           "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter=test_article_detail_downgrades_legacy_published_revision_body_h1 --no-ansi",
-          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff' --no-ansi",
-          "cd backend && ./vendor/bin/pint --test app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --filter=test_import_creates_and_updates_published_public_articles_for_mbti_minimum_set --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --filter=test_import_creates_non_public_cms_draft_with_exact_body_metadata_and_answer_surface_boundary --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php --filter=test_imported_local_baselines_make_representative_32_type_routes_non_empty --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes' --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
           "python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')\"",
-          "git diff --check -- backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php backend/app/Services/Cms/ArticleBodyHeadingGuard.php backend/app/Services/Cms/ArticleService.php backend/app/Services/Cms/ArticlePublishService.php backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php backend/app/Services/Cms/ArticleTranslationWorkflowService.php backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php backend/tests/Feature/V0_5/ArticlePublicApiTest.php backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
+          "git diff --check -- backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php backend/app/Console/Commands/ArticleImportLocalBaseline.php backend/app/Services/Cms/ArticleBodyHeadingGuard.php backend/app/Services/Cms/ArticleService.php backend/app/Services/Cms/ArticlePublishService.php backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php backend/app/Services/Cms/ArticleTranslationWorkflowService.php backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php backend/tests/Feature/V0_5/ArticlePublicApiTest.php backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json"
         ],
-        "evidence": "PHP lint, route-list, focused H1 feature/unit tests, focused BigFive runtime path diff, Pint --test, JSON/YAML parse, and path-limited git diff --check passed. Full ArticlePublicApiTest file was not used as a required check because its unchanged sitemap-source cache expectation is recorded as an external sidecar issue."
+        "evidence": "PHP lint, route-list, focused H1 feature/unit tests, baseline/editorial importer regressions, the CareerRecommendationPublicApiTest CI failure reproduction, focused BigFive runtime path diff/classifier regression, Pint --test, JSON/YAML parse, and path-limited git diff --check passed. Full ArticlePublicApiTest file was not used as a required check because its unchanged sitemap-source cache expectation is recorded as an external sidecar issue."
       },
       "github": {
-        "status": "pending",
+        "status": "failed_fix_pushed",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2014",
         "checks": [],
-        "failure_reason": null
+        "failure_reason": "GitHub verify-mbti-legacy, verify-mbti-v2, and verify-bigfive failed because article baseline/editorial package import paths hit the new body H1 guard and BigFive runtime-freeze needed a narrow CMS H1 guard exception. The fix normalizes importer body H1 to H2, adds importer regressions, and adds a scoped BigFive classifier regression."
       }
     },
     "failure_reason": null,
@@ -52062,6 +52073,11 @@
         "at": "2026-06-09",
         "status": "github_checks_pending",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2014 from branch codex/article-h1-02; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed_after_github_fix",
+        "note": "Fixed GitHub verify failures by normalizing article baseline/editorial package importer body H1 to H2 and adding focused importer plus BigFive classifier regressions; local checks passed."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -51967,7 +51967,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-02",
     "base": "origin/main",
-    "status": "in_progress",
+    "status": "committed_pending_push",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish",
     "depends_on": [
@@ -52030,7 +52030,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "0f18583d13a2498637cd650ed871d2cef8b37538",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -52051,6 +52051,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed",
         "note": "Added article body H1 guard across CMS save, working revision save, article publish, translation publish, and API payload downgrade; focused local checks passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed_pending_push",
+        "note": "Created scoped implementation commit 0f18583d13a2498637cd650ed871d2cef8b37538."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23849,6 +23849,106 @@ prs:
     content_authority: backend
     next_task: SEO-CONV-OPS-05 in fap-api after this PR is merged
 
+  - id: ARTICLE-H1-02
+    repo: fap-api
+    depends_on:
+      - ARTICLE-H1-01
+    branch: codex/article-h1-02
+    title: "ARTICLE-H1-02: fix(cms): reject article body h1 at save and publish"
+    train_scope: article_h1_single_dom
+    status: in_progress
+    scope:
+      - Add backend/CMS authority guard so article body content cannot be saved or published with H1 headings.
+      - Keep article title as the only public H1 authority while downgrading legacy published body H1 content in API payloads.
+      - Cover CMS create/update, working revision save, generic article publish, translation publish, and public payload projection.
+    allowed_paths:
+      - backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+      - backend/app/Services/Cms/ArticleBodyHeadingGuard.php
+      - backend/app/Services/Cms/ArticleService.php
+      - backend/app/Services/Cms/ArticlePublishService.php
+      - backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
+      - backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+      - backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+      - backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+      - backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend article rendering, live audit scripts, CMS editor toolbar UX, routes, migrations, production content, deploys, or publish live CMS content in this PR.
+      - Rewrite existing article body content in storage.
+      - Add frontend/static editorial fallback content.
+    validation:
+      - php -l backend/app/Services/Cms/ArticleBodyHeadingGuard.php
+      - php -l backend/app/Services/Cms/ArticleService.php
+      - php -l backend/app/Services/Cms/ArticlePublishService.php
+      - php -l backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
+      - php -l backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+      - php -l backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+      - php -l backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php
+      - php -l backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
+      - php -l backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+      - cd backend && php artisan route:list --path=api/v0.5/cms/articles --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter=test_article_detail_downgrades_legacy_published_revision_body_h1 --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php backend/app/Services/Cms/ArticleBodyHeadingGuard.php backend/app/Services/Cms/ArticleService.php backend/app/Services/Cms/ArticlePublishService.php backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php backend/app/Services/Cms/ArticleTranslationWorkflowService.php backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php backend/tests/Feature/V0_5/ArticlePublicApiTest.php backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+    next_task: ARTICLE-H1-03 in fap-web after this PR is merged
+
+  - id: ARTICLE-H1-04
+    repo: fap-api
+    depends_on:
+      - ARTICLE-H1-02
+      - ARTICLE-H1-03
+    branch: codex/article-h1-04
+    title: "ARTICLE-H1-04: fix(ops): constrain article editor heading controls"
+    train_scope: article_h1_single_dom
+    status: pending_dependency
+    scope:
+      - Add CMS/Ops editor experience constraints so article body editors guide operators away from H1.
+      - Keep backend validation from ARTICLE-H1-02 as the authority and add focused editor UX coverage where supported.
+    allowed_paths:
+      - backend/app/Filament/Ops/Resources/ArticleResource.php
+      - backend/lang/**
+      - backend/tests/Feature/Ops/**
+      - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify frontend article rendering, live audit scripts, routes, migrations, production content, deploys, or publish live CMS content in this PR.
+      - Weaken ARTICLE-H1-02 backend validation.
+    validation:
+      - php -l backend/app/Filament/Ops/Resources/ArticleResource.php
+      - cd backend && php artisan test --filter=OpsCmsEditPolishTest --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Filament/Ops/Resources/ArticleResource.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
+      - git diff --check -- backend/app/Filament/Ops/Resources/ArticleResource.php backend/lang docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
   - id: SEO-CONV-OPS-05
     repo: fap-api
     depends_on:

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -23863,13 +23863,17 @@ prs:
       - Cover CMS create/update, working revision save, generic article publish, translation publish, and public payload projection.
     allowed_paths:
       - backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+      - backend/app/Console/Commands/ArticleImportLocalBaseline.php
       - backend/app/Services/Cms/ArticleBodyHeadingGuard.php
       - backend/app/Services/Cms/ArticleService.php
       - backend/app/Services/Cms/ArticlePublishService.php
       - backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
       - backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+      - backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
       - backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
       - backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+      - backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
       - backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php
       - backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
       - docs/codex/pr-train.yaml
@@ -23884,17 +23888,25 @@ prs:
       - php -l backend/app/Services/Cms/ArticlePublishService.php
       - php -l backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
       - php -l backend/app/Services/Cms/ArticleTranslationWorkflowService.php
+      - php -l backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
       - php -l backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+      - php -l backend/app/Console/Commands/ArticleImportLocalBaseline.php
       - php -l backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php
       - php -l backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php
       - php -l backend/tests/Feature/V0_5/ArticlePublicApiTest.php
+      - php -l backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php
+      - php -l backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
       - cd backend && php artisan route:list --path=api/v0.5/cms/articles --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php --no-ansi
       - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter=test_article_detail_downgrades_legacy_published_revision_body_h1 --no-ansi
-      - cd backend && ./vendor/bin/pint --test app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --filter=test_import_creates_and_updates_published_public_articles_for_mbti_minimum_set --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --filter=test_import_creates_non_public_cms_draft_with_exact_body_metadata_and_answer_surface_boundary --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php --filter=test_imported_local_baselines_make_representative_32_type_routes_non_empty --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes' --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
       - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
       - python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"
-      - git diff --check -- backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php backend/app/Services/Cms/ArticleBodyHeadingGuard.php backend/app/Services/Cms/ArticleService.php backend/app/Services/Cms/ArticlePublishService.php backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php backend/app/Services/Cms/ArticleTranslationWorkflowService.php backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php backend/tests/Feature/V0_5/ArticlePublicApiTest.php backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --check -- backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php backend/app/Console/Commands/ArticleImportLocalBaseline.php backend/app/Services/Cms/ArticleBodyHeadingGuard.php backend/app/Services/Cms/ArticleService.php backend/app/Services/Cms/ArticlePublishService.php backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php backend/app/Services/Cms/ArticleTranslationWorkflowService.php backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php backend/tests/Feature/V0_5/ArticleCmsWriteAuthTest.php backend/tests/Feature/V0_5/ArticlePublicApiTest.php backend/tests/Feature/CareerCms/ArticleBaselineImportTest.php backend/tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php backend/tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
       - git diff --cached --check
     merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
     production_write_execution: false


### PR DESCRIPTION
## What changed
- Added an ArticleBodyHeadingGuard service that rejects article body H1 content on CMS create/update, revision workspace save, publish, and translation publish paths.
- Normalized imported baseline/editorial package article bodies by downgrading Markdown/HTML H1 headings to H2 before persistence and publish.
- Downgraded legacy published article API body H1 output to H2 without rewriting existing database content.
- Added focused regressions for CMS write rejection, public API legacy downgrade, importer normalization, and runtime freeze classifier coverage.

## Why
Article detail pages need one final DOM H1 long-term. The frontend now has a renderer-level fallback from ARTICLE-H1-01; this backend PR prevents CMS and importer sources from introducing body-level H1 content again.

## Validation commands
- php -l backend/app/Services/Cms/ArticleBodyHeadingGuard.php
- php -l backend/app/Services/Cms/ArticleService.php
- php -l backend/app/Services/Cms/ArticlePublishService.php
- php -l backend/app/Services/Cms/ArticleTranslationRevisionWorkspace.php
- php -l backend/app/Services/Cms/ArticleTranslationWorkflowService.php
- php -l backend/app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php
- php -l backend/app/Console/Commands/ArticleImportLocalBaseline.php
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/ArticlePublicApiTest.php --filter=test_article_detail_downgrades_legacy_published_revision_body_h1 --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/CareerCms/ArticleBaselineImportTest.php --filter=test_import_creates_and_updates_published_public_articles_for_mbti_minimum_set --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php --filter=test_import_creates_non_public_cms_draft_with_exact_body_metadata_and_answer_surface_boundary --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/CareerRecommendationPublicApiTest.php --filter=test_imported_local_baselines_make_representative_32_type_routes_non_empty --no-ansi
- cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='test_runtime_paths_have_no_uncommitted_diff|test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes' --no-ansi
- cd backend && ./vendor/bin/pint --test app/Console/Commands/ArticleImportLocalBaseline.php app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/ArticleService.php app/Services/Cms/ArticlePublishService.php app/Services/Cms/ArticleTranslationRevisionWorkspace.php app/Services/Cms/ArticleTranslationWorkflowService.php app/Services/Cms/EditorialPackage/EditorialPackageDraftImporter.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php tests/Unit/Services/Cms/ArticleBodyHeadingGuardTest.php tests/Feature/V0_5/ArticleCmsWriteAuthTest.php tests/Feature/V0_5/ArticlePublicApiTest.php tests/Feature/CareerCms/ArticleBaselineImportTest.php tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
- python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
- python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"

## Intentionally deferred
- Live 20-article DOM audit and article_h1_audit_report.md remain in ARTICLE-H1-03.
- CMS editor toolbar/publish UX restrictions remain in ARTICLE-H1-04.
- Existing sitemap-source cache fallback test mismatch is recorded as an external sidecar issue and not changed in this article H1 scope.