### PR TITLE
ARTICLE-H1-04: fix(ops): constrain article editor heading controls

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource.php
@@ -126,7 +126,8 @@ class ArticleResource extends Resource
                                     ->label(__('ops.resources.articles.fields.content_md'))
                                     ->required()
                                     ->columnSpanFull()
-                                    ->helperText(__('ops.resources.articles.helpers.content_md'))
+                                    ->disableToolbarButtons(['heading'])
+                                    ->helperText(__('ops.resources.articles.helpers.content_md_no_h1'))
                                     ->extraFieldWrapperAttributes(['class' => 'ops-article-workspace-field ops-article-workspace-field--editor']),
                                 Forms\Components\TextInput::make('author_name')
                                     ->label(__('ops.resources.articles.fields.author_name'))

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -2289,6 +2289,7 @@ return [
                 'slug' => 'Used in the public article URL. Keep it short, stable, and human-readable.',
                 'excerpt' => 'Short summary saved to the current working revision.',
                 'content_md' => 'This markdown body is saved to the current working revision for editorial review.',
+                'content_md_no_h1' => 'Body headings must start at H2 (`##`). The article title owns the only H1; save and publish validation will reject body H1 markdown or HTML.',
                 'working_revision_status' => 'Advance the current working revision through machine draft, human review, approval, and release readiness.',
                 'author_name' => 'Public byline shown on the article surface when present.',
                 'reviewer_name' => 'Optional public reviewer attribution.',

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -2289,6 +2289,7 @@ return [
                 'slug' => '用于公开文章 URL。请保持简短、稳定、易读。',
                 'excerpt' => '保存到当前工作版本的简短说明。',
                 'content_md' => '该 Markdown 正文会保存到当前工作版本，用于编辑审核。',
+                'content_md_no_h1' => '正文标题必须从 H2（`##`）开始。文章标题是唯一 H1；保存和发布校验会拒绝正文里的 H1 Markdown 或 HTML。',
                 'working_revision_status' => '推动当前工作版本进入机器初稿、人工审校、批准和待发布状态。',
                 'author_name' => '填写后会作为公开文章署名展示。',
                 'reviewer_name' => '可选的公开审阅者署名。',

--- a/backend/tests/Feature/Ops/OpsCmsEditPolishTest.php
+++ b/backend/tests/Feature/Ops/OpsCmsEditPolishTest.php
@@ -59,6 +59,18 @@ final class OpsCmsEditPolishTest extends TestCase
         $this->assertEditPageHasRail(EditLandingSurface::class, $this->createLandingSurface()->getKey(), expectsTranslation: false, expectsRevision: false, expectsSeo: false);
     }
 
+    public function test_article_editor_removes_heading_toolbar_and_explains_body_h1_boundary(): void
+    {
+        Livewire::test(EditArticle::class, ['record' => $this->createArticle()->getKey()])
+            ->assertOk()
+            ->assertSee(__('ops.resources.articles.helpers.content_md_no_h1'));
+
+        $source = (string) file_get_contents(app_path('Filament/Ops/Resources/ArticleResource.php'));
+
+        $this->assertStringContainsString("->disableToolbarButtons(['heading'])", $source);
+        $this->assertStringContainsString("__('ops.resources.articles.helpers.content_md_no_h1')", $source);
+    }
+
     /**
      * @param  class-string<object>  $component
      */

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52103,7 +52103,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-04",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-04: fix(ops): constrain article editor heading controls",
     "depends_on": [
@@ -52116,8 +52116,32 @@
         "evidence": "User explicitly authorized ARTICLE-H1 PR train and fap-api docs/codex metadata updates on 2026-06-09."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "ARTICLE-H1-04 must wait for ARTICLE-H1-02 and ARTICLE-H1-03."
+        "status": "pass",
+        "evidence": "ARTICLE-H1-02 merged in fap-api PR #2014 on 2026-06-09. ARTICLE-H1-03 merged in fap-web PR #1088 on 2026-06-09 with merge commit 9d4bb1c55ebfcb9695cb04069fee520442f1ef0f."
+      },
+      "php_lint": {
+        "status": "pass",
+        "evidence": "php -l backend/app/Filament/Ops/Resources/ArticleResource.php and php -l backend/tests/Feature/Ops/OpsCmsEditPolishTest.php passed."
+      },
+      "focused_ops_test": {
+        "status": "pass",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=OpsCmsEditPolishTest --no-ansi passed 2 tests / 46 assertions."
+      },
+      "pint": {
+        "status": "pass",
+        "evidence": "cd backend && ./vendor/bin/pint --test app/Filament/Ops/Resources/ArticleResource.php tests/Feature/Ops/OpsCmsEditPolishTest.php passed."
+      },
+      "metadata": {
+        "status": "pass",
+        "evidence": "docs/codex/pr-train-state.json parsed as JSON and docs/codex/pr-train.yaml parsed as YAML."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Tracked changed files are within ARTICLE-H1-04 manifest scope; pre-existing untracked backend/docs/seo/import-packages/science-contentpage-en-review-draft-2026-06-09 remains unstaged and isolated."
+      },
+      "diff_check": {
+        "status": "pass",
+        "evidence": "git diff --check -- backend/app/Filament/Ops/Resources/ArticleResource.php backend/lang docs/codex/pr-train.yaml docs/codex/pr-train-state.json and git diff --cached --check passed before staging."
       }
     },
     "failure_reason": null,
@@ -52132,6 +52156,16 @@
         "at": "2026-06-09",
         "status": "pending_dependency",
         "note": "Initialized future CMS/Ops editor UX constraint PR metadata only; implementation intentionally deferred."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Dependencies verified merged; started ARTICLE-H1-04 Ops article editor heading-control implementation from fap-api main."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "ArticleResource lint, OpsCmsEditPolishTest, Pint, metadata parse, scope validation, and diff checks passed."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52103,7 +52103,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-04",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_opened",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-04: fix(ops): constrain article editor heading controls",
     "depends_on": [
@@ -52145,8 +52145,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "f676123e181ac059493157dbd97e2f4ca16742c2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2015",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -52166,6 +52166,11 @@
         "at": "2026-06-09",
         "status": "local_checks_passed",
         "note": "ArticleResource lint, OpsCmsEditPolishTest, Pint, metadata parse, scope validation, and diff checks passed."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "pr_opened",
+        "note": "Opened fap-api PR #2015 for ARTICLE-H1-04."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52103,7 +52103,7 @@
     "repo": "fap-api",
     "branch": "codex/article-h1-04",
     "base": "origin/main",
-    "status": "pr_opened",
+    "status": "ready_to_merge",
     "train_scope": "article_h1_single_dom",
     "title": "ARTICLE-H1-04: fix(ops): constrain article editor heading controls",
     "depends_on": [
@@ -52142,10 +52142,14 @@
       "diff_check": {
         "status": "pass",
         "evidence": "git diff --check -- backend/app/Filament/Ops/Resources/ArticleResource.php backend/lang docs/codex/pr-train.yaml docs/codex/pr-train-state.json and git diff --cached --check passed before staging."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub checks for head a8e300f908c22c94caba1c61becf8c6b1c5f2525 passed: hygiene, supply-chain, content-pack-build-validate, verify-mbti-legacy, verify-mbti-v2, verify-bigfive, Semgrep blocking secrets, semgrep sarif non-blocking upload, and Semgrep OSS."
       }
     },
     "failure_reason": null,
-    "commit_sha": "f676123e181ac059493157dbd97e2f4ca16742c2",
+    "commit_sha": "a8e300f908c22c94caba1c61becf8c6b1c5f2525",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2015",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -52171,6 +52175,11 @@
         "at": "2026-06-09",
         "status": "pr_opened",
         "note": "Opened fap-api PR #2015 for ARTICLE-H1-04."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN for head a8e300f908c22c94caba1c61becf8c6b1c5f2525."
       }
     ]
   }


### PR DESCRIPTION
## What changed
- Removed the `heading` toolbar button from the Ops Article body MarkdownEditor.
- Added English and Chinese helper copy telling operators that article body headings must start at H2 and that the article title owns the only H1.
- Added OpsCmsEditPolishTest coverage for the editor helper and ArticleResource toolbar configuration.
- Updated ARTICLE-H1-04 PR train state.

## Why
ARTICLE-H1-02 keeps backend save/publish validation as authority. This PR adds the CMS/Ops editor UX constraint so operators are guided away from creating body H1 content before validation rejects it.

## Validation commands
- `php -l backend/app/Filament/Ops/Resources/ArticleResource.php`
- `php -l backend/tests/Feature/Ops/OpsCmsEditPolishTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter=OpsCmsEditPolishTest --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Filament/Ops/Resources/ArticleResource.php tests/Feature/Ops/OpsCmsEditPolishTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -c "import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text()); print('yaml ok')"`
- Scope validation: tracked changed files are within ARTICLE-H1-04 manifest scope; pre-existing untracked import-package directory remains unstaged.
- `git diff --check -- backend/app/Filament/Ops/Resources/ArticleResource.php backend/lang docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

## Intentionally deferred
- No frontend article rendering changes.
- No backend validation weakening.
- No CMS content mutation, publication, deploy, search submission, or production write.
