### PR TITLE
Harden ContentPage publish gates

### DIFF
--- a/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php
+++ b/backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php
@@ -7,6 +7,7 @@ namespace App\Filament\Ops\Resources\ContentPageResource\Pages;
 use App\Filament\Ops\Resources\ContentPageResource;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Models\ContentPage;
+use App\Services\Cms\ContentPagePublishGate;
 use App\Services\Cms\RowBackedRevisionWorkspace;
 use Filament\Actions;
 use Filament\Resources\Pages\EditRecord;
@@ -207,50 +208,31 @@ class EditContentPage extends EditRecord
      */
     private function validatePublishSafety(ContentPage $record, array $data, string $status, string $reviewState): void
     {
-        $isPublic = (bool) ($data['is_public'] ?? false);
-        $pageType = (string) ($data['page_type'] ?? $record->page_type);
-        $slug = (string) $record->slug;
-        $scienceReviewRequired = (bool) ($data['science_review_required'] ?? false);
-
-        if ($status !== ContentPage::STATUS_PUBLISHED || ! $isPublic || ! $this->isScienceControlledPage($slug, $pageType, $scienceReviewRequired)) {
-            return;
-        }
-
-        $errors = [];
-        if (! (bool) ($data['publish_allowed'] ?? false)) {
-            $errors['publish_allowed'][] = 'publish_allowed must be true before publishing a Science ContentPage.';
-        }
-        if ((bool) ($data['operator_approval_required'] ?? true) && ($data['operator_approved_at'] ?? null) === null) {
-            $errors['operator_approved_at'][] = 'operator_approved_at is required while operator_approval_required is true.';
-        }
-        if ($reviewState !== 'approved') {
-            $errors['review_state'][] = 'review_state must be approved before publishing a Science ContentPage.';
-        }
-        if ((bool) ($data['legal_review_required'] ?? false)) {
-            $errors['legal_review_required'][] = 'legal_review_required must be resolved before publishing a Science ContentPage.';
-        }
-        if ($scienceReviewRequired) {
-            $errors['science_review_required'][] = 'science_review_required must be resolved before publishing a Science ContentPage.';
-        }
-        if ((string) ($data['claim_gate_status'] ?? 'not_reviewed') !== 'passed') {
-            $errors['claim_gate_status'][] = 'claim_gate_status must be passed before publishing a Science ContentPage.';
-        }
-        if (array_values(array_filter((array) ($data['forbidden_claims'] ?? []))) !== []) {
-            $errors['forbidden_claims'][] = 'forbidden_claims must be empty before publishing a Science ContentPage.';
-        }
-        if ((bool) ($data['schema_enabled'] ?? false) && (! (bool) ($data['faq_schema_eligible'] ?? false) || ($data['schema_eligibility_reviewed_at'] ?? null) === null)) {
-            $errors['faq_schema_eligible'][] = 'faq_schema_eligible and schema_eligibility_reviewed_at are required when schema_enabled is true.';
-        }
+        $errors = app(ContentPagePublishGate::class)->errorsForState([
+            'slug' => (string) $record->slug,
+            'page_type' => (string) ($data['page_type'] ?? $record->page_type),
+            'locale' => (string) ($data['locale'] ?? $record->locale),
+            'status' => $status,
+            'is_public' => (bool) ($data['is_public'] ?? false),
+            'is_indexable' => (bool) ($data['is_indexable'] ?? false),
+            'review_state' => $reviewState,
+            'legal_review_required' => (bool) ($data['legal_review_required'] ?? false),
+            'science_review_required' => (bool) ($data['science_review_required'] ?? false),
+            'schema_enabled' => (bool) ($data['schema_enabled'] ?? false),
+            'publish_allowed' => (bool) ($data['publish_allowed'] ?? false),
+            'operator_approval_required' => (bool) ($data['operator_approval_required'] ?? true),
+            'operator_approved_at' => $data['operator_approved_at'] ?? null,
+            'claim_gate_status' => (string) ($data['claim_gate_status'] ?? 'not_reviewed'),
+            'forbidden_claims' => array_values((array) ($data['forbidden_claims'] ?? [])),
+            'faq_schema_eligible' => (bool) ($data['faq_schema_eligible'] ?? false),
+            'schema_eligibility_reviewed_at' => $data['schema_eligibility_reviewed_at'] ?? null,
+            'seo_title' => $data['seo_title'] ?? null,
+            'meta_description' => $data['meta_description'] ?? null,
+            'seo_description' => $data['seo_description'] ?? null,
+        ]);
 
         if ($errors !== []) {
             throw ValidationException::withMessages($errors);
         }
-    }
-
-    private function isScienceControlledPage(string $slug, string $pageType, bool $scienceReviewRequired): bool
-    {
-        return $scienceReviewRequired
-            || in_array($pageType, ['science', 'methodology', 'boundary'], true)
-            || in_array($slug, ['science', 'method-boundaries', 'item-design-notes', 'reliability-validity', 'data-privacy', 'common-misconceptions'], true);
     }
 }

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers\API\V0_5\Cms;
 use App\Filament\Ops\Support\ContentReleaseAudit;
 use App\Http\Controllers\Controller;
 use App\Models\ContentPage;
+use App\Services\Cms\ContentPagePublishGate;
 use App\Services\Cms\RowBackedRevisionWorkspace;
 use App\Services\Cms\SiblingTranslationWorkflowService;
 use Illuminate\Http\JsonResponse;
@@ -18,6 +19,7 @@ final class ContentPageController extends Controller
 {
     public function __construct(
         private readonly RowBackedRevisionWorkspace $workspace,
+        private readonly ContentPagePublishGate $contentPagePublishGate,
     ) {}
 
     /**
@@ -185,23 +187,28 @@ final class ContentPageController extends Controller
         $faqSchemaEligible = (bool) ($validated['faq_schema_eligible'] ?? false);
         $schemaEligibilityReviewedAt = $validated['schema_eligibility_reviewed_at'] ?? null;
 
-        $publishSafetyErrors = $this->publishSafetyErrors(
-            normalizedSlug: $normalizedSlug,
-            pageType: $pageType,
-            status: $status,
-            isPublic: (bool) $validated['is_public'],
-            reviewState: $reviewState,
-            legalReviewRequired: (bool) ($validated['legal_review_required'] ?? false),
-            scienceReviewRequired: (bool) ($validated['science_review_required'] ?? false),
-            schemaEnabled: $schemaEnabled,
-            publishAllowed: $publishAllowed,
-            operatorApprovalRequired: $operatorApprovalRequired,
-            operatorApprovedAt: $operatorApprovedAt,
-            claimGateStatus: $claimGateStatus,
-            forbiddenClaims: $forbiddenClaims,
-            faqSchemaEligible: $faqSchemaEligible,
-            schemaEligibilityReviewedAt: $schemaEligibilityReviewedAt,
-        );
+        $publishSafetyErrors = $this->contentPagePublishGate->errorsForState([
+            'slug' => $normalizedSlug,
+            'page_type' => $pageType,
+            'locale' => (string) $validated['locale'],
+            'status' => $status,
+            'is_public' => (bool) $validated['is_public'],
+            'is_indexable' => (bool) $validated['is_indexable'],
+            'review_state' => $reviewState,
+            'legal_review_required' => (bool) ($validated['legal_review_required'] ?? false),
+            'science_review_required' => (bool) ($validated['science_review_required'] ?? false),
+            'schema_enabled' => $schemaEnabled,
+            'publish_allowed' => $publishAllowed,
+            'operator_approval_required' => $operatorApprovalRequired,
+            'operator_approved_at' => $operatorApprovedAt,
+            'claim_gate_status' => $claimGateStatus,
+            'forbidden_claims' => $forbiddenClaims,
+            'faq_schema_eligible' => $faqSchemaEligible,
+            'schema_eligibility_reviewed_at' => $schemaEligibilityReviewedAt,
+            'seo_title' => $this->nullableString($validated['seo_title'] ?? null),
+            'meta_description' => $this->nullableString($validated['meta_description'] ?? null),
+            'seo_description' => $this->nullableString($validated['seo_description'] ?? null),
+        ]);
         if ($publishSafetyErrors !== []) {
             return response()->json([
                 'ok' => false,
@@ -568,67 +575,6 @@ final class ContentPageController extends Controller
         }
 
         return array_values(array_unique($normalized));
-    }
-
-    /**
-     * @param  list<string>  $forbiddenClaims
-     * @return array<string, list<string>>
-     */
-    private function publishSafetyErrors(
-        string $normalizedSlug,
-        string $pageType,
-        string $status,
-        bool $isPublic,
-        string $reviewState,
-        bool $legalReviewRequired,
-        bool $scienceReviewRequired,
-        bool $schemaEnabled,
-        bool $publishAllowed,
-        bool $operatorApprovalRequired,
-        mixed $operatorApprovedAt,
-        string $claimGateStatus,
-        array $forbiddenClaims,
-        bool $faqSchemaEligible,
-        mixed $schemaEligibilityReviewedAt,
-    ): array {
-        if ($status !== ContentPage::STATUS_PUBLISHED || ! $isPublic || ! $this->isScienceControlledPage($normalizedSlug, $pageType, $scienceReviewRequired)) {
-            return [];
-        }
-
-        $errors = [];
-        if (! $publishAllowed) {
-            $errors['publish_allowed'][] = 'publish_allowed must be true before publishing a Science ContentPage.';
-        }
-        if ($operatorApprovalRequired && $operatorApprovedAt === null) {
-            $errors['operator_approved_at'][] = 'operator_approved_at is required while operator_approval_required is true.';
-        }
-        if ($reviewState !== 'approved') {
-            $errors['review_state'][] = 'review_state must be approved before publishing a Science ContentPage.';
-        }
-        if ($legalReviewRequired) {
-            $errors['legal_review_required'][] = 'legal_review_required must be resolved before publishing a Science ContentPage.';
-        }
-        if ($scienceReviewRequired) {
-            $errors['science_review_required'][] = 'science_review_required must be resolved before publishing a Science ContentPage.';
-        }
-        if ($claimGateStatus !== 'passed') {
-            $errors['claim_gate_status'][] = 'claim_gate_status must be passed before publishing a Science ContentPage.';
-        }
-        if ($forbiddenClaims !== []) {
-            $errors['forbidden_claims'][] = 'forbidden_claims must be empty before publishing a Science ContentPage.';
-        }
-        if ($schemaEnabled && (! $faqSchemaEligible || $schemaEligibilityReviewedAt === null)) {
-            $errors['faq_schema_eligible'][] = 'faq_schema_eligible and schema_eligibility_reviewed_at are required when schema_enabled is true.';
-        }
-
-        return $errors;
-    }
-
-    private function isScienceControlledPage(string $normalizedSlug, string $pageType, bool $scienceReviewRequired): bool
-    {
-        return $scienceReviewRequired
-            || in_array($pageType, ContentPage::SCIENCE_CONTROLLED_PAGE_TYPES, true)
-            || in_array($normalizedSlug, ContentPage::SCIENCE_CONTROLLED_SLUGS, true);
     }
 
     private function dateString(mixed $value): ?string

--- a/backend/app/Models/ContentPage.php
+++ b/backend/app/Models/ContentPage.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Models;
 
 use App\Models\Concerns\HasOrgScope;
+use App\Services\Cms\ContentPagePublishGate;
 use Illuminate\Database\Eloquent\Factories\HasFactory;
 use Illuminate\Database\Eloquent\Model;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -194,6 +195,8 @@ final class ContentPage extends Model
                     ? 'content-page-'.$page->source_content_id
                     : (string) Str::uuid();
             }
+
+            app(ContentPagePublishGate::class)->assertPasses($page);
 
             $page->source_version_hash = $page->computeSourceVersionHash();
         });

--- a/backend/app/Services/Cms/ContentPagePublishGate.php
+++ b/backend/app/Services/Cms/ContentPagePublishGate.php
@@ -1,0 +1,137 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\ContentPage;
+use Illuminate\Validation\ValidationException;
+
+final class ContentPagePublishGate
+{
+    /**
+     * @return array<string, list<string>>
+     */
+    public function errorsFor(ContentPage $page): array
+    {
+        return $this->errorsForState([
+            'slug' => (string) $page->slug,
+            'page_type' => (string) $page->page_type,
+            'locale' => (string) $page->locale,
+            'status' => (string) $page->status,
+            'is_public' => (bool) $page->is_public,
+            'is_indexable' => (bool) $page->is_indexable,
+            'review_state' => (string) $page->review_state,
+            'legal_review_required' => (bool) $page->legal_review_required,
+            'science_review_required' => (bool) $page->science_review_required,
+            'schema_enabled' => (bool) $page->schema_enabled,
+            'publish_allowed' => (bool) $page->publish_allowed,
+            'operator_approval_required' => (bool) $page->operator_approval_required,
+            'operator_approved_at' => $page->operator_approved_at,
+            'claim_gate_status' => (string) ($page->claim_gate_status ?: 'not_reviewed'),
+            'forbidden_claims' => is_array($page->forbidden_claims) ? array_values($page->forbidden_claims) : [],
+            'faq_schema_eligible' => (bool) $page->faq_schema_eligible,
+            'schema_eligibility_reviewed_at' => $page->schema_eligibility_reviewed_at,
+            'seo_title' => $page->seo_title,
+            'seo_description' => $page->seo_description,
+            'meta_description' => $page->meta_description,
+        ]);
+    }
+
+    public function assertPasses(ContentPage $page): void
+    {
+        $errors = $this->errorsFor($page);
+        if ($errors === []) {
+            return;
+        }
+
+        throw ValidationException::withMessages($errors);
+    }
+
+    /**
+     * @param  array<string, mixed>  $state
+     * @return array<string, list<string>>
+     */
+    public function errorsForState(array $state): array
+    {
+        $errors = [];
+        $locale = $this->normalizeLocale((string) ($state['locale'] ?? ''));
+        $isIndexable = (bool) ($state['is_indexable'] ?? false);
+
+        if ($locale === 'en' && $isIndexable) {
+            if (trim((string) ($state['seo_title'] ?? '')) === '') {
+                $errors['seo_title'][] = 'seo_title is required before an English ContentPage can be indexable.';
+            }
+
+            if (
+                trim((string) ($state['meta_description'] ?? '')) === ''
+                && trim((string) ($state['seo_description'] ?? '')) === ''
+            ) {
+                $errors['meta_description'][] = 'meta_description or seo_description is required before an English ContentPage can be indexable.';
+            }
+        }
+
+        $slug = $this->normalizeSlug((string) ($state['slug'] ?? ''));
+        $pageType = (string) ($state['page_type'] ?? '');
+        $scienceReviewRequired = (bool) ($state['science_review_required'] ?? false);
+        $status = (string) ($state['status'] ?? '');
+        $isPublic = (bool) ($state['is_public'] ?? false);
+
+        if (
+            $status !== ContentPage::STATUS_PUBLISHED
+            || ! $isPublic
+            || ! $this->isScienceControlledPage($slug, $pageType, $scienceReviewRequired)
+        ) {
+            return $errors;
+        }
+
+        if (! (bool) ($state['publish_allowed'] ?? false)) {
+            $errors['publish_allowed'][] = 'publish_allowed must be true before publishing a Science ContentPage.';
+        }
+        if ((bool) ($state['operator_approval_required'] ?? true) && ($state['operator_approved_at'] ?? null) === null) {
+            $errors['operator_approved_at'][] = 'operator_approved_at is required while operator_approval_required is true.';
+        }
+        if ((string) ($state['review_state'] ?? '') !== 'approved') {
+            $errors['review_state'][] = 'review_state must be approved before publishing a Science ContentPage.';
+        }
+        if ((bool) ($state['legal_review_required'] ?? false)) {
+            $errors['legal_review_required'][] = 'legal_review_required must be resolved before publishing a Science ContentPage.';
+        }
+        if ($scienceReviewRequired) {
+            $errors['science_review_required'][] = 'science_review_required must be resolved before publishing a Science ContentPage.';
+        }
+        if ((string) ($state['claim_gate_status'] ?? 'not_reviewed') !== 'passed') {
+            $errors['claim_gate_status'][] = 'claim_gate_status must be passed before publishing a Science ContentPage.';
+        }
+        if (array_values(array_filter((array) ($state['forbidden_claims'] ?? []))) !== []) {
+            $errors['forbidden_claims'][] = 'forbidden_claims must be empty before publishing a Science ContentPage.';
+        }
+        if (
+            (bool) ($state['schema_enabled'] ?? false)
+            && (! (bool) ($state['faq_schema_eligible'] ?? false) || ($state['schema_eligibility_reviewed_at'] ?? null) === null)
+        ) {
+            $errors['faq_schema_eligible'][] = 'faq_schema_eligible and schema_eligibility_reviewed_at are required when schema_enabled is true.';
+        }
+
+        return $errors;
+    }
+
+    private function isScienceControlledPage(string $slug, string $pageType, bool $scienceReviewRequired): bool
+    {
+        return $scienceReviewRequired
+            || in_array($pageType, ContentPage::SCIENCE_CONTROLLED_PAGE_TYPES, true)
+            || in_array($slug, ContentPage::SCIENCE_CONTROLLED_SLUGS, true);
+    }
+
+    private function normalizeSlug(string $slug): string
+    {
+        return trim(strtolower($slug));
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = strtolower(str_replace('_', '-', trim($locale)));
+
+        return str_starts_with($normalized, 'zh') ? 'zh-CN' : $normalized;
+    }
+}

--- a/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
+++ b/backend/tests/Feature/ContentPages/ContentPagePublicApiTest.php
@@ -11,6 +11,7 @@ use App\Models\Role;
 use App\Support\Rbac\PermissionNames;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Str;
+use Illuminate\Validation\ValidationException;
 use Tests\TestCase;
 
 final class ContentPagePublicApiTest extends TestCase
@@ -135,7 +136,7 @@ final class ContentPagePublicApiTest extends TestCase
 
     public function test_public_api_hides_science_content_pages_until_public_readiness_gate_passes(): void
     {
-        $sciencePage = ContentPage::query()->withoutGlobalScopes()->create([
+        $sciencePage = ContentPage::withoutEvents(fn (): ContentPage => ContentPage::query()->withoutGlobalScopes()->create([
             'org_id' => 0,
             'slug' => 'reliability-validity',
             'path' => '/reliability-validity',
@@ -162,7 +163,7 @@ final class ContentPagePublicApiTest extends TestCase
             'forbidden_claims' => [],
             'faq_schema_eligible' => false,
             'schema_eligibility_reviewed_at' => null,
-        ]);
+        ]));
 
         $this->getJson('/api/v0.5/content-pages/reliability-validity?locale=en&org_id=0')
             ->assertNotFound()
@@ -212,6 +213,89 @@ final class ContentPagePublicApiTest extends TestCase
             ->assertOk()
             ->assertJsonPath('ok', true)
             ->assertJsonPath('page.slug', 'brand');
+    }
+
+    public function test_english_content_page_cannot_be_indexable_without_seo_title_and_meta_description(): void
+    {
+        $admin = $this->createAdminWithPermissions([
+            PermissionNames::ADMIN_CONTENT_READ,
+            PermissionNames::ADMIN_CONTENT_WRITE,
+        ]);
+
+        $payload = [
+            'title' => 'Science hub',
+            'kicker' => 'Science',
+            'summary' => 'Science content.',
+            'kind' => 'policy',
+            'page_type' => 'science',
+            'template' => 'policy',
+            'animation_profile' => 'policy',
+            'locale' => 'en',
+            'status' => ContentPage::STATUS_DRAFT,
+            'review_state' => 'draft',
+            'published_at' => null,
+            'updated_at' => '2026-06-09',
+            'effective_at' => null,
+            'source_doc' => 'science-contentpage-en-review-draft-2026-06-09',
+            'is_public' => false,
+            'is_indexable' => true,
+            'content_md' => "## Science\n\nDraft content.",
+            'content_html' => '',
+            'seo_title' => '',
+            'meta_description' => '',
+            'seo_description' => '',
+            'canonical_path' => '/science',
+        ];
+
+        $this->withSession(['ops_org_id' => 0])
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->putJson('/api/v0.5/internal/content-pages/science', $payload)
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'CONTENT_PAGE_PUBLISH_GATE_FAILED')
+            ->assertJsonValidationErrors([
+                'seo_title',
+                'meta_description',
+            ]);
+
+        $this->assertDatabaseMissing('content_pages', [
+            'slug' => 'science',
+            'locale' => 'en',
+        ]);
+    }
+
+    public function test_model_level_content_page_gate_blocks_public_science_without_passed_claim_gate(): void
+    {
+        $this->expectException(ValidationException::class);
+
+        ContentPage::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'data-privacy',
+            'path' => '/data-privacy',
+            'kind' => ContentPage::KIND_POLICY,
+            'page_type' => 'science',
+            'title' => 'Data notes',
+            'summary' => 'Data notes.',
+            'template' => 'policy',
+            'animation_profile' => 'policy',
+            'locale' => 'en',
+            'published_at' => '2026-06-09',
+            'is_public' => true,
+            'is_indexable' => true,
+            'review_state' => 'approved',
+            'content_md' => "## Data\n\nContent.",
+            'content_html' => '',
+            'seo_title' => 'Data notes',
+            'meta_description' => 'Data notes.',
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'publish_allowed' => true,
+            'operator_approval_required' => false,
+            'operator_approved_at' => null,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+        ]);
     }
 
     public function test_ops_list_and_update_are_backed_by_content_pages_table(): void

--- a/backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
+++ b/backend/tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
@@ -13,6 +13,7 @@ use App\Services\SEO\SitemapCache;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Carbon;
 use Illuminate\Support\Facades\Cache;
+use InvalidArgumentException;
 use Tests\TestCase;
 
 final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
@@ -46,6 +47,19 @@ final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
         $this->assertDiscoverabilityCachesFlushed();
     }
 
+    public function test_article_publish_rejects_body_h1_before_public_exposure(): void
+    {
+        $article = $this->createArticleWithRevision(
+            ArticleTranslationRevision::STATUS_APPROVED,
+            body: "# Article body\n\nBody text."
+        );
+
+        $this->expectException(InvalidArgumentException::class);
+        $this->expectExceptionMessage('Article body must not contain h1 headings');
+
+        app(ArticlePublishService::class)->publishArticle((int) $article->id, 'test_publish');
+    }
+
     private function seedDiscoverabilityCaches(): void
     {
         $payload = [
@@ -69,7 +83,7 @@ final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
         $this->assertNull(Cache::get(SitemapCache::ETAG_CACHE_KEY));
     }
 
-    private function createArticleWithRevision(string $revisionStatus, bool $published = false): Article
+    private function createArticleWithRevision(string $revisionStatus, bool $published = false, string $body = 'Cache invalidation test body.'): Article
     {
         $category = ArticleCategory::query()->create([
             'org_id' => 0,
@@ -89,7 +103,7 @@ final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
             'locale' => 'en',
             'title' => 'RIASEC cache invalidation test',
             'excerpt' => 'Cache invalidation test excerpt.',
-            'content_md' => 'Cache invalidation test body.',
+            'content_md' => $body,
             'status' => $published ? 'published' : 'draft',
             'is_public' => $published,
             'is_indexable' => true,
@@ -109,7 +123,7 @@ final class ArticlePublishDiscoverabilityCacheInvalidationTest extends TestCase
             'translated_from_version_hash' => (string) $article->source_version_hash,
             'title' => 'RIASEC cache invalidation test',
             'excerpt' => 'Cache invalidation test excerpt.',
-            'content_md' => 'Cache invalidation test body.',
+            'content_md' => $body,
             'seo_title' => 'RIASEC cache invalidation test',
             'seo_description' => 'Cache invalidation test description.',
             'published_at' => $published ? $publishedAt : null,

--- a/backend/tests/Feature/SEO/SitemapGeneratorTest.php
+++ b/backend/tests/Feature/SEO/SitemapGeneratorTest.php
@@ -137,6 +137,8 @@ class SitemapGeneratorTest extends TestCase
             'title' => 'About help',
             'content_md' => '# About help',
             'content_html' => null,
+            'seo_title' => 'About help',
+            'meta_description' => 'About help page.',
             'status' => ContentPage::STATUS_PUBLISHED,
             'is_public' => true,
             'is_indexable' => true,
@@ -180,7 +182,7 @@ class SitemapGeneratorTest extends TestCase
     {
         config(['app.frontend_url' => 'https://fermatmind.com']);
 
-        ContentPage::query()->create([
+        ContentPage::withoutEvents(fn (): ContentPage => ContentPage::query()->create([
             'org_id' => 0,
             'slug' => 'item-design-notes',
             'path' => '/item-design-notes',
@@ -202,7 +204,7 @@ class SitemapGeneratorTest extends TestCase
             'published_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
             'created_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
             'updated_at' => Carbon::create(2026, 6, 8, 9, 0, 0, 'UTC'),
-        ]);
+        ]));
 
         ContentPage::query()->create([
             'org_id' => 0,
@@ -214,6 +216,8 @@ class SitemapGeneratorTest extends TestCase
             'title' => 'Method boundaries',
             'content_md' => '## Method boundaries',
             'content_html' => null,
+            'seo_title' => 'Method boundaries',
+            'meta_description' => 'Method boundaries page.',
             'status' => ContentPage::STATUS_PUBLISHED,
             'is_public' => true,
             'is_indexable' => true,

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -993,6 +993,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php',
             'backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php',
             'backend/app/Models/ContentPage.php',
+            'backend/app/Services/Cms/ContentPagePublishGate.php',
             'backend/app/Services/Cms/ContentPageTranslationAdapter.php',
             'backend/database/migrations/2026_06_08_010000_add_publish_safety_fields_to_content_pages.php',
         ];
@@ -3946,6 +3947,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php',
             'backend/app/Http/Controllers/API/V0_5/Cms/ContentPageController.php',
             'backend/app/Models/ContentPage.php',
+            'backend/app/Services/Cms/ContentPagePublishGate.php',
             'backend/app/Services/Cms/ContentPageTranslationAdapter.php',
             'backend/database/migrations/2026_06_08_010000_add_publish_safety_fields_to_content_pages.php',
         ], true);


### PR DESCRIPTION
## What changed
- Added a shared ContentPage publish gate used by model saving, internal ContentPage API updates, and Filament edits.
- Blocks English ContentPages from becoming indexable without SEO title plus meta/SEO description.
- Keeps Science ContentPages from being saved/published public unless publish/review/operator/claim/schema gates pass.
- Added Article publish regression coverage for body H1 rejection before public exposure.

## Why
These checks move long-term content operations safeguards into backend/CMS authority instead of relying on frontend fallbacks or one-off manual review.

## Validation
- php artisan test tests/Feature/ContentPages/ContentPagePublicApiTest.php tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
- ./vendor/bin/pint --test app/Services/Cms/ContentPagePublishGate.php app/Models/ContentPage.php app/Http/Controllers/API/V0_5/Cms/ContentPageController.php app/Filament/Ops/Resources/ContentPageResource/Pages/EditContentPage.php tests/Feature/ContentPages/ContentPagePublicApiTest.php tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
- php artisan test tests/Feature/Console/ScienceContentPageImportDraftsCommandTest.php tests/Feature/Console/ScienceContentPageDraftDryRunCommandTest.php tests/Feature/ContentPages/ContentPagePublicApiTest.php tests/Feature/SEO/ArticlePublishDiscoverabilityCacheInvalidationTest.php
- git diff --check

## Intentionally deferred
- No production CMS data changes.
- No fap-web sitemap/llms/footer monitoring changes in this PR; that is the next separate PR.