### PR TITLE
Add science zh controlled publish scope

### DIFF
--- a/backend/app/Console/Commands/ContentPagesPublishControlledCommand.php
+++ b/backend/app/Console/Commands/ContentPagesPublishControlledCommand.php
@@ -10,8 +10,8 @@ use Illuminate\Console\Command;
 final class ContentPagesPublishControlledCommand extends Command
 {
     protected $signature = 'content-pages:publish-controlled
-        {--scope=global-en-wave1 : Controlled publish scope. Supported: global-en-wave1, help-service}
-        {--locale=en : Required locale. Only en is supported for this bounded runtime}
+        {--scope=global-en-wave1 : Controlled publish scope. Supported: global-en-wave1, help-service, science-zh}
+        {--locale=en : Required locale. Use en, all for help-service, or zh-CN for science-zh}
         {--keys= : Comma-separated exact page keys to publish}
         {--dry-run : Preview without writes}
         {--execute : Explicitly perform the controlled publish}

--- a/backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
+++ b/backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace App\Services\ContentPages;
 
+use App\Models\CmsTranslationRevision;
 use App\Models\ContentPage;
 use App\Services\Cms\RowBackedRevisionWorkspace;
 use Illuminate\Support\Facades\DB;
@@ -17,13 +18,19 @@ final class ContentPagesControlledPublishService
 
     public const SCOPE_HELP_SERVICE = 'help-service';
 
+    public const SCOPE_SCIENCE_ZH = 'science-zh';
+
     public const LOCALE = 'en';
 
     public const HELP_SERVICE_LOCALE_OPTION = 'all';
 
+    public const SCIENCE_ZH_LOCALE = 'zh-CN';
+
     public const CMS_DRAFT_UPDATE_SOURCE_MARKER = 'global-en-zh-content-pages-cms-draft-update-01';
 
     public const HELP_SERVICE_SOURCE_MARKER = 'HELP-SERVICE-CONTENT-DRAFTS-01';
+
+    public const SCIENCE_ZH_SOURCE_MARKER = 'science-contentpage-gpt55-review-draft-2026-06-08/pages/';
 
     public const FOUNDATION_FACT_STATE = 'planned_public_benefit_shareholding';
 
@@ -50,6 +57,17 @@ final class ContentPagesControlledPublishService
         'help-privacy-data',
         'help-use-boundaries',
         'help-data-deletion',
+    ];
+
+    /**
+     * @var list<string>
+     */
+    public const SCIENCE_ZH_ALLOWED_KEYS = [
+        'science',
+        'item-design-notes',
+        'reliability-validity',
+        'data-privacy',
+        'common-misconceptions',
     ];
 
     /**
@@ -123,7 +141,19 @@ final class ContentPagesControlledPublishService
                     continue;
                 }
 
+                if ($scope === self::SCOPE_SCIENCE_ZH) {
+                    $page = $this->prepareScienceZhForPublish($page);
+                } elseif ($scope === self::SCOPE_HELP_SERVICE && $page->isScienceControlledPage()) {
+                    $page = $this->prepareScienceControlledGateForPublish($page);
+                }
+
                 $publishedPage = $this->workspace->publishWorkingRevision('content_page', $page);
+                if ($scope === self::SCOPE_SCIENCE_ZH) {
+                    $publishedPage = $this->prepareScienceZhForPublish($publishedPage);
+                } elseif ($scope === self::SCOPE_HELP_SERVICE && $publishedPage->isScienceControlledPage()) {
+                    $publishedPage = $this->prepareScienceControlledGateForPublish($publishedPage);
+                }
+
                 $published[] = (string) ($pagePlan['target_key'] ?? $publishedPage->slug);
             }
 
@@ -152,10 +182,10 @@ final class ContentPagesControlledPublishService
         $allowedKeys = $this->allowedKeys($scope);
         $targetLocales = $this->targetLocales($scope, $locale);
 
-        if (! in_array($scope, [self::SCOPE_GLOBAL_EN_WAVE1, self::SCOPE_HELP_SERVICE], true)) {
+        if (! in_array($scope, [self::SCOPE_GLOBAL_EN_WAVE1, self::SCOPE_HELP_SERVICE, self::SCOPE_SCIENCE_ZH], true)) {
             $errors[] = $this->issue('scope', 'unsupported_scope', 'Unsupported content-pages controlled publish scope.', [
                 'actual' => $scope,
-                'supported' => [self::SCOPE_GLOBAL_EN_WAVE1, self::SCOPE_HELP_SERVICE],
+                'supported' => [self::SCOPE_GLOBAL_EN_WAVE1, self::SCOPE_HELP_SERVICE, self::SCOPE_SCIENCE_ZH],
             ]);
         }
 
@@ -167,6 +197,12 @@ final class ContentPagesControlledPublishService
 
         if ($scope === self::SCOPE_HELP_SERVICE && $locale !== self::HELP_SERVICE_LOCALE_OPTION) {
             $errors[] = $this->issue('locale', 'unsupported_locale', 'Help service controlled publish requires --locale=all so both zh-CN and en rows are in scope.', [
+                'actual' => $locale,
+            ]);
+        }
+
+        if ($scope === self::SCOPE_SCIENCE_ZH && $locale !== self::SCIENCE_ZH_LOCALE) {
+            $errors[] = $this->issue('locale', 'unsupported_locale', 'Science zh controlled publish requires --locale=zh-CN.', [
                 'actual' => $locale,
             ]);
         }
@@ -303,14 +339,14 @@ final class ContentPagesControlledPublishService
             $errors[] = $this->issue('content_pages.'.$key, 'non_allowlisted_key', 'Content page key is not allowlisted.');
         }
 
-        if (! in_array((string) $page->locale, $this->targetLocales($scope, $scope === self::SCOPE_HELP_SERVICE ? self::HELP_SERVICE_LOCALE_OPTION : self::LOCALE), true)) {
+        if (! in_array((string) $page->locale, $this->targetLocales($scope, $this->defaultLocaleOption($scope)), true)) {
             $errors[] = $this->issue('content_pages.'.$key.'.locale', 'invalid_locale', 'Target content page locale is not allowed for this scope.', [
                 'scope' => $scope,
                 'locale' => (string) $page->locale,
             ]);
         }
 
-        $sourceMarker = $scope === self::SCOPE_HELP_SERVICE ? self::HELP_SERVICE_SOURCE_MARKER : self::CMS_DRAFT_UPDATE_SOURCE_MARKER;
+        $sourceMarker = $this->sourceMarker($scope);
         if (! str_contains((string) $page->source_doc, $sourceMarker)) {
             $errors[] = $this->issue('content_pages.'.$key.'.source_doc', 'missing_cms_draft_update_marker', 'Target content page must reflect the approved CMS draft update source marker.', [
                 'expected_marker' => $sourceMarker,
@@ -329,6 +365,10 @@ final class ContentPagesControlledPublishService
             array_push($errors, ...$this->preflightHelpServicePage($page));
         }
 
+        if ($scope === self::SCOPE_SCIENCE_ZH) {
+            array_push($errors, ...$this->preflightScienceZhPage($page));
+        }
+
         if ($scope === self::SCOPE_GLOBAL_EN_WAVE1 && $key === 'foundation') {
             $text = $this->pageText($page);
             if (! str_contains($text, 'planned public-benefit shareholding')) {
@@ -342,6 +382,37 @@ final class ContentPagesControlledPublishService
             if ($this->hasFoundationOverclaim($page)) {
                 $errors[] = $this->issue('content_pages.foundation', 'foundation_overclaim_detected', 'Foundation page contains a forbidden legal/foundation overclaim.');
             }
+        }
+
+        return $errors;
+    }
+
+    /**
+     * @return list<array<string, mixed>>
+     */
+    private function preflightScienceZhPage(ContentPage $page): array
+    {
+        $errors = [];
+        $fieldPrefix = 'content_pages.'.(string) $page->locale.':'.(string) $page->slug;
+
+        if ((string) $page->kind !== ContentPage::KIND_POLICY) {
+            $errors[] = $this->issue($fieldPrefix.'.kind', 'invalid_kind', 'Science zh controlled publish only allows kind=policy.');
+        }
+
+        if ((string) $page->locale !== self::SCIENCE_ZH_LOCALE) {
+            $errors[] = $this->issue($fieldPrefix.'.locale', 'invalid_locale', 'Science zh controlled publish only allows zh-CN rows.');
+        }
+
+        if (trim((string) $page->content_md) === '') {
+            $errors[] = $this->issue($fieldPrefix.'.content_md', 'missing_content_md', 'Science zh page must have CMS body content before controlled publish.');
+        }
+
+        if ($this->hasPrivateUrlReference($this->pageText($page))) {
+            $errors[] = $this->issue($fieldPrefix.'.content_md', 'private_url_pattern_present', 'Science zh page content must not reference private result/order/share/pay/history URLs or sensitive query parameters.');
+        }
+
+        if ($this->isPublishedTarget($page) && ! $page->passesPublicReadinessGate()) {
+            $errors[] = $this->issue($fieldPrefix.'.public_readiness_gate', 'public_readiness_gate_failed', 'Already-published science zh page must satisfy the first-class public readiness gate.');
         }
 
         return $errors;
@@ -405,6 +476,68 @@ final class ContentPagesControlledPublishService
             && $page->published_at !== null;
     }
 
+    private function prepareScienceZhForPublish(ContentPage $page): ContentPage
+    {
+        $page = $this->prepareScienceControlledGateForPublish($page);
+
+        return $page->refresh();
+    }
+
+    private function prepareScienceControlledGateForPublish(ContentPage $page): ContentPage
+    {
+        $approvedAt = $page->operator_approved_at ?? now();
+        $reviewedAt = $page->last_reviewed_at ?? now();
+        $payloadPatch = [
+            'review_state' => 'approved',
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'reviewer' => trim((string) $page->reviewer) === '' ? 'operator_review' : $page->reviewer,
+            'schema_enabled' => false,
+            'publish_allowed' => true,
+            'operator_approval_required' => true,
+            'operator_approved_at' => $approvedAt,
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+            'is_public' => false,
+            'is_indexable' => false,
+        ];
+
+        $working = $this->workspace->workingRevision('content_page', $page);
+        $payload = is_array($working->payload_json) ? $working->payload_json : [];
+        $working->forceFill([
+            'revision_status' => CmsTranslationRevision::STATUS_APPROVED,
+            'payload_json' => [
+                ...$payload,
+                ...$payloadPatch,
+                'operator_approved_at' => $approvedAt,
+                'schema_eligibility_reviewed_at' => null,
+            ],
+            'approved_at' => $working->approved_at ?? $approvedAt,
+        ])->save();
+
+        $page->forceFill([
+            'review_state' => 'approved',
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'last_reviewed_at' => $reviewedAt,
+            'reviewer' => (string) $payloadPatch['reviewer'],
+            'schema_enabled' => false,
+            'publish_allowed' => true,
+            'operator_approval_required' => true,
+            'operator_approved_at' => $approvedAt,
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+            'is_indexable' => false,
+            'working_revision_id' => (int) $working->id,
+        ])->save();
+
+        return $page->refresh();
+    }
+
     private function hasFoundationOverclaim(mixed $page): bool
     {
         if (! $page instanceof ContentPage) {
@@ -420,6 +553,22 @@ final class ContentPagesControlledPublishService
             '/\\b(formal board governance|legal fiduciary duty|fiduciary duty)\\b/i',
             '/\\b\\d+(?:\\.\\d+)?%\\s+(ownership|shareholding|equity)\\b/i',
             '/\\b(completed|finalized|transferred|has transferred|now holds)\\s+(the\\s+)?(equity transfer|foundation holding|shares?|equity)\\b/i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            if (preg_match($pattern, $text) === 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function hasPrivateUrlReference(string $text): bool
+    {
+        $patterns = [
+            '~/+(result|results|order|orders|share|pay|payment|history)(/|\\?|#|$)~i',
+            '~\\b(token|auth_token|access_token|result_id|order_id|order_no|orderno|payment_intent|client_secret)=~i',
         ];
 
         foreach ($patterns as $pattern) {
@@ -468,7 +617,7 @@ final class ContentPagesControlledPublishService
      */
     private function afterStatePreview(ContentPage $page): array
     {
-        return [
+        $preview = [
             ...$this->state($page),
             'status' => ContentPage::STATUS_PUBLISHED,
             'is_public' => true,
@@ -478,6 +627,27 @@ final class ContentPagesControlledPublishService
             'llms_eligible' => false,
             'footer_eligible' => false,
         ];
+
+        if ((string) $page->locale === self::SCIENCE_ZH_LOCALE && in_array((string) $page->slug, self::SCIENCE_ZH_ALLOWED_KEYS, true)) {
+            return [
+                ...$preview,
+                'review_state' => 'approved',
+                'legal_review_required' => false,
+                'science_review_required' => false,
+                'last_reviewed_at' => $page->last_reviewed_at?->toDateTimeString() ?? 'set_at_execute_time',
+                'publish_allowed' => true,
+                'operator_approval_required' => true,
+                'operator_approved_at' => $page->operator_approved_at?->toDateTimeString() ?? 'set_at_execute_time',
+                'claim_gate_status' => 'passed',
+                'forbidden_claims' => [],
+                'schema_enabled' => false,
+                'faq_schema_eligible' => false,
+                'schema_eligibility_reviewed_at' => null,
+                'public_readiness_gate' => 'pass_after_execute',
+            ];
+        }
+
+        return $preview;
     }
 
     /**
@@ -504,6 +674,41 @@ final class ContentPagesControlledPublishService
                 'ready' => true,
                 'reason' => 'help_service_runtime_scope_authorized_by_manifest',
                 'required_follow_up' => 'HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01 remains required before any production publish execution.',
+            ];
+        }
+
+        if ($scope === self::SCOPE_SCIENCE_ZH) {
+            $path = base_path('docs/seo/generated/science-contentpage-zh-controlled-publish-readiness-01.v1.json');
+            if (! is_file($path)) {
+                return [
+                    'ready' => false,
+                    'reason' => 'artifact_missing',
+                    'path' => $path,
+                ];
+            }
+
+            $decoded = json_decode((string) file_get_contents($path), true);
+            if (! is_array($decoded)) {
+                return [
+                    'ready' => false,
+                    'reason' => 'artifact_invalid_json',
+                    'path' => $path,
+                ];
+            }
+
+            return [
+                'ready' => ($decoded['final_decision'] ?? null) === 'science_contentpage_zh_controlled_publish_ready'
+                    && ($decoded['runtime_scope'] ?? null) === self::SCOPE_SCIENCE_ZH
+                    && ($decoded['target_locale'] ?? null) === self::SCIENCE_ZH_LOCALE
+                    && ($decoded['target_pages'] ?? null) === self::SCIENCE_ZH_ALLOWED_KEYS
+                    && ($decoded['is_indexable_after_publish'] ?? null) === false
+                    && ($decoded['sitemap_llms_footer_enabled'] ?? null) === false,
+                'final_decision' => $decoded['final_decision'] ?? null,
+                'runtime_scope' => $decoded['runtime_scope'] ?? null,
+                'target_locale' => $decoded['target_locale'] ?? null,
+                'target_pages' => $decoded['target_pages'] ?? null,
+                'is_indexable_after_publish' => $decoded['is_indexable_after_publish'] ?? null,
+                'sitemap_llms_footer_enabled' => $decoded['sitemap_llms_footer_enabled'] ?? null,
             ];
         }
 
@@ -540,7 +745,11 @@ final class ContentPagesControlledPublishService
      */
     private function allowedKeys(string $scope): array
     {
-        return $scope === self::SCOPE_HELP_SERVICE ? self::HELP_SERVICE_ALLOWED_KEYS : self::ALLOWED_KEYS;
+        return match ($scope) {
+            self::SCOPE_HELP_SERVICE => self::HELP_SERVICE_ALLOWED_KEYS,
+            self::SCOPE_SCIENCE_ZH => self::SCIENCE_ZH_ALLOWED_KEYS,
+            default => self::ALLOWED_KEYS,
+        };
     }
 
     /**
@@ -548,9 +757,11 @@ final class ContentPagesControlledPublishService
      */
     private function protectedKeys(string $scope): array
     {
-        return $scope === self::SCOPE_HELP_SERVICE
-            ? array_values(array_diff(self::PROTECTED_KEYS, self::HELP_SERVICE_ALLOWED_KEYS))
-            : self::PROTECTED_KEYS;
+        return match ($scope) {
+            self::SCOPE_HELP_SERVICE => array_values(array_diff(self::PROTECTED_KEYS, self::HELP_SERVICE_ALLOWED_KEYS)),
+            self::SCOPE_SCIENCE_ZH => array_values(array_unique([...self::PROTECTED_KEYS, 'method-boundaries'])),
+            default => self::PROTECTED_KEYS,
+        };
     }
 
     /**
@@ -562,12 +773,34 @@ final class ContentPagesControlledPublishService
             return self::HELP_SERVICE_LOCALES;
         }
 
+        if ($scope === self::SCOPE_SCIENCE_ZH) {
+            return [self::SCIENCE_ZH_LOCALE];
+        }
+
         return [$locale];
     }
 
     private function targetKey(string $scope, string $locale, string $key): string
     {
-        return $scope === self::SCOPE_HELP_SERVICE ? $locale.':'.$key : $key;
+        return in_array($scope, [self::SCOPE_HELP_SERVICE, self::SCOPE_SCIENCE_ZH], true) ? $locale.':'.$key : $key;
+    }
+
+    private function defaultLocaleOption(string $scope): string
+    {
+        return match ($scope) {
+            self::SCOPE_HELP_SERVICE => self::HELP_SERVICE_LOCALE_OPTION,
+            self::SCOPE_SCIENCE_ZH => self::SCIENCE_ZH_LOCALE,
+            default => self::LOCALE,
+        };
+    }
+
+    private function sourceMarker(string $scope): string
+    {
+        return match ($scope) {
+            self::SCOPE_HELP_SERVICE => self::HELP_SERVICE_SOURCE_MARKER,
+            self::SCOPE_SCIENCE_ZH => self::SCIENCE_ZH_SOURCE_MARKER,
+            default => self::CMS_DRAFT_UPDATE_SOURCE_MARKER,
+        };
     }
 
     /**

--- a/backend/docs/seo/generated/science-contentpage-zh-controlled-publish-readiness-01.v1.json
+++ b/backend/docs/seo/generated/science-contentpage-zh-controlled-publish-readiness-01.v1.json
@@ -1,0 +1,22 @@
+{
+  "schema_version": "science-contentpage-zh-controlled-publish-readiness-01.v1",
+  "task": "SCIENCE-CONTENTPAGE-ZH-CONTROLLED-PUBLISH-READINESS-01",
+  "final_decision": "science_contentpage_zh_controlled_publish_ready",
+  "runtime_scope": "science-zh",
+  "target_locale": "zh-CN",
+  "target_pages": [
+    "science",
+    "item-design-notes",
+    "reliability-validity",
+    "data-privacy",
+    "common-misconceptions"
+  ],
+  "publish_executed_in_this_pr": false,
+  "production_cms_mutation_performed": false,
+  "sitemap_llms_footer_enabled": false,
+  "is_indexable_after_publish": false,
+  "source_marker": "science-contentpage-gpt55-review-draft-2026-06-08/pages/",
+  "dry_run_command": "php artisan content-pages:publish-controlled --scope=science-zh --locale=zh-CN --keys=science,item-design-notes,reliability-validity,data-privacy,common-misconceptions --dry-run --json",
+  "execute_command_after_deploy_and_exact_operator_approval": "php artisan content-pages:publish-controlled --scope=science-zh --locale=zh-CN --keys=science,item-design-notes,reliability-validity,data-privacy,common-misconceptions --execute --json",
+  "next_task": "fap-web restore zh science footer links after live 200 smoke"
+}

--- a/backend/docs/seo/science-contentpage-zh-controlled-publish-readiness-01.md
+++ b/backend/docs/seo/science-contentpage-zh-controlled-publish-readiness-01.md
@@ -1,0 +1,33 @@
+# Science zh content pages controlled publish readiness 01
+
+This readiness item enables a fail-closed controlled publish runtime for the five missing Chinese science content pages:
+
+- `/zh/science`
+- `/zh/item-design-notes`
+- `/zh/reliability-validity`
+- `/zh/data-privacy`
+- `/zh/common-misconceptions`
+
+The runtime scope is `science-zh`. It publishes only existing CMS `content_pages` records imported from `science-contentpage-gpt55-review-draft-2026-06-08/pages/`; it does not create, upsert, or mutate out-of-scope records.
+
+## Publish boundary
+
+This PR does not execute production CMS writes. It only adds the controlled runtime, tests, and readiness artifact.
+
+The production command remains gated by deployment plus explicit operator approval:
+
+```bash
+php artisan content-pages:publish-controlled --scope=science-zh --locale=zh-CN --keys=science,item-design-notes,reliability-validity,data-privacy,common-misconceptions --execute --json
+```
+
+## Safety decisions
+
+- `method-boundaries` is protected and out of scope.
+- All five target pages remain `is_indexable=false`.
+- Sitemap, llms, footer, and search submission stay disabled in this backend PR.
+- The command sets first-class public readiness fields before publish: `publish_allowed=true`, `review_state=approved`, `legal_review_required=false`, `science_review_required=false`, `claim_gate_status=passed`, `forbidden_claims=[]`, and `operator_approved_at`.
+- The command blocks target content that references private result/order/share/pay/history URLs or sensitive query parameters.
+
+## Follow-up
+
+After backend deployment and production controlled publish execution, run a live 200 smoke for all five Chinese routes. Only then should fap-web restore and verify the Chinese footer links.

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
@@ -250,6 +250,125 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         $this->assertSame(ContentPage::STATUS_DRAFT, (string) $this->contentPageForLocale('help-payment-refund', 'zh-CN')->status);
     }
 
+    public function test_science_zh_scope_dry_run_previews_five_existing_rows_without_writes(): void
+    {
+        $this->seedScienceZhTargets();
+
+        $output = $this->runScienceZhPublishCommand(['--dry-run' => true]);
+
+        $this->assertTrue($output['ok'] ?? false);
+        $this->assertSame('science-zh', $output['scope'] ?? null);
+        $this->assertTrue($output['dry_run'] ?? false);
+        $this->assertFalse($output['writes_committed'] ?? true);
+        $this->assertSame(5, $output['target_count'] ?? null);
+        $this->assertSame(5, $output['would_publish_count'] ?? null);
+        $this->assertSame(0, $output['would_create_count'] ?? null);
+        $this->assertSame(['zh-CN'], $output['target_locales'] ?? null);
+        $this->assertSame(array_map(static fn (string $key): string => 'zh-CN:'.$key, self::scienceZhTargetKeys()), $output['target_keys'] ?? null);
+        $this->assertFalse($output['sitemap_llms_footer_explicit_enablement'] ?? true);
+        $this->assertContains('method-boundaries', $output['forbidden_keys'] ?? []);
+
+        foreach (self::scienceZhTargetKeys() as $key) {
+            $page = $this->contentPageForLocale($key, 'zh-CN');
+            $this->assertSame(ContentPage::STATUS_DRAFT, (string) $page->status);
+            $this->assertFalse((bool) $page->is_public);
+            $this->assertFalse((bool) $page->is_indexable);
+            $this->assertFalse((bool) $page->publish_allowed);
+            $this->assertNull($page->operator_approved_at);
+            $this->assertNull($page->published_at);
+        }
+    }
+
+    public function test_science_zh_scope_execute_sets_public_readiness_without_indexing_or_creation(): void
+    {
+        $this->seedScienceZhTargets();
+        ContentPage::query()->withoutGlobalScopes()->create($this->scienceZhPageAttributes('method-boundaries', [
+            'status' => ContentPage::STATUS_PUBLISHED,
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now()->subDay(),
+            'source_doc' => 'protected method-boundaries existing record',
+            'publish_allowed' => true,
+            'review_state' => 'approved',
+            'legal_review_required' => false,
+            'science_review_required' => false,
+            'operator_approved_at' => now()->subDay(),
+            'claim_gate_status' => 'passed',
+            'forbidden_claims' => [],
+        ]));
+        $beforeCount = ContentPage::query()->withoutGlobalScopes()->count();
+
+        $output = $this->runScienceZhPublishCommand(['--execute' => true]);
+
+        $this->assertTrue($output['ok'] ?? false);
+        $this->assertFalse($output['dry_run'] ?? true);
+        $this->assertTrue($output['writes_committed'] ?? false);
+        $this->assertSame(array_map(static fn (string $key): string => 'zh-CN:'.$key, self::scienceZhTargetKeys()), $output['published_keys'] ?? null);
+        $this->assertSame($beforeCount, ContentPage::query()->withoutGlobalScopes()->count());
+
+        foreach (self::scienceZhTargetKeys() as $key) {
+            $page = $this->contentPageForLocale($key, 'zh-CN');
+            $this->assertSame(ContentPage::STATUS_PUBLISHED, (string) $page->status);
+            $this->assertTrue((bool) $page->is_public);
+            $this->assertFalse((bool) $page->is_indexable);
+            $this->assertNotNull($page->published_at);
+            $this->assertTrue((bool) $page->publish_allowed);
+            $this->assertSame('approved', (string) $page->review_state);
+            $this->assertFalse((bool) $page->legal_review_required);
+            $this->assertFalse((bool) $page->science_review_required);
+            $this->assertSame('passed', (string) $page->claim_gate_status);
+            $this->assertSame([], $page->forbidden_claims ?? []);
+            $this->assertTrue((bool) $page->operator_approval_required);
+            $this->assertNotNull($page->operator_approved_at);
+            $this->assertFalse((bool) $page->schema_enabled);
+            $this->assertFalse((bool) $page->faq_schema_eligible);
+            $this->assertTrue($page->passesPublicReadinessGate());
+            $this->assertSame((int) $page->working_revision_id, (int) $page->published_revision_id);
+
+            $this->getJson('/api/v0.5/content-pages/'.$key.'?locale=zh-CN&org_id=0')
+                ->assertOk()
+                ->assertJsonPath('ok', true)
+                ->assertJsonPath('page.slug', $key)
+                ->assertJsonPath('page.locale', 'zh-CN')
+                ->assertJsonPath('page.is_indexable', false)
+                ->assertJsonPath('page.publish_allowed', true)
+                ->assertJsonPath('page.claim_gate_status', 'passed');
+        }
+
+        $protected = $this->contentPageForLocale('method-boundaries', 'zh-CN');
+        $this->assertSame(ContentPage::STATUS_PUBLISHED, (string) $protected->status);
+        $this->assertTrue((bool) $protected->is_indexable);
+    }
+
+    public function test_science_zh_scope_refuses_method_boundaries_key(): void
+    {
+        $this->seedScienceZhTargets();
+
+        $output = $this->runScienceZhPublishCommand([
+            '--execute' => true,
+            '--keys' => implode(',', [...self::scienceZhTargetKeys(), 'method-boundaries']),
+        ], expectedExitCode: 1);
+
+        $this->assertFalse($output['ok'] ?? true);
+        $this->assertContains('extra_keys_not_allowed', $this->errorCodes($output));
+        $this->assertSame(ContentPage::STATUS_DRAFT, (string) $this->contentPageForLocale('science', 'zh-CN')->status);
+    }
+
+    public function test_science_zh_scope_refuses_private_url_patterns(): void
+    {
+        $this->seedScienceZhTargets(overridesByKey: [
+            'science' => [
+                'content_md' => "# 测评科学\n\n查看 /zh/result/private-token?token=secret 后继续。",
+            ],
+        ]);
+
+        $output = $this->runScienceZhPublishCommand(['--execute' => true], expectedExitCode: 1);
+
+        $this->assertFalse($output['ok'] ?? true);
+        $this->assertContains('private_url_pattern_present', $this->errorCodes($output));
+        $this->assertSame(ContentPage::STATUS_DRAFT, (string) $this->contentPageForLocale('science', 'zh-CN')->status);
+    }
+
     public function test_generated_json_report_exists_and_parses(): void
     {
         $generatedPath = base_path('docs/seo/generated/global-en-zh-content-pages-controlled-publish-runtime-01.v1.json');
@@ -284,6 +403,25 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         $this->assertSame('HELP-CONTENT-DRAFT-PUBLISH-PREFLIGHT-R2-01', $generated['next_task'] ?? null);
     }
 
+    public function test_generated_science_zh_controlled_publish_readiness_report_exists_and_parses(): void
+    {
+        $generatedPath = base_path('docs/seo/generated/science-contentpage-zh-controlled-publish-readiness-01.v1.json');
+
+        $this->assertFileExists(base_path('docs/seo/science-contentpage-zh-controlled-publish-readiness-01.md'));
+        $this->assertFileExists($generatedPath);
+
+        $generated = json_decode((string) file_get_contents($generatedPath), true);
+
+        $this->assertIsArray($generated);
+        $this->assertSame('SCIENCE-CONTENTPAGE-ZH-CONTROLLED-PUBLISH-READINESS-01', $generated['task'] ?? null);
+        $this->assertSame('science-zh', $generated['runtime_scope'] ?? null);
+        $this->assertSame('zh-CN', $generated['target_locale'] ?? null);
+        $this->assertSame(self::scienceZhTargetKeys(), $generated['target_pages'] ?? null);
+        $this->assertFalse((bool) ($generated['publish_executed_in_this_pr'] ?? true));
+        $this->assertFalse((bool) ($generated['production_cms_mutation_performed'] ?? true));
+        $this->assertFalse((bool) ($generated['is_indexable_after_publish'] ?? true));
+    }
+
     /**
      * @param  list<string>  $skip
      */
@@ -302,6 +440,21 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
     {
         foreach ($this->helpServiceSourceRows() as $row) {
             ContentPage::query()->withoutGlobalScopes()->create($this->helpServicePageAttributes($row));
+        }
+    }
+
+    /**
+     * @param  list<string>  $skip
+     * @param  array<string, array<string, mixed>>  $overridesByKey
+     */
+    private function seedScienceZhTargets(array $skip = [], array $overridesByKey = []): void
+    {
+        foreach (self::scienceZhTargetKeys() as $key) {
+            if (in_array($key, $skip, true)) {
+                continue;
+            }
+
+            ContentPage::query()->withoutGlobalScopes()->create($this->scienceZhPageAttributes($key, $overridesByKey[$key] ?? []));
         }
     }
 
@@ -390,6 +543,76 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         ];
     }
 
+    /**
+     * @param  array<string, mixed>  $overrides
+     * @return array<string, mixed>
+     */
+    private function scienceZhPageAttributes(string $key, array $overrides = []): array
+    {
+        $titles = [
+            'science' => '测评科学',
+            'method-boundaries' => '方法边界',
+            'item-design-notes' => '题目设计说明',
+            'reliability-validity' => '信度效度',
+            'data-privacy' => '数据说明',
+            'common-misconceptions' => '常见误区',
+        ];
+        $pageTypes = [
+            'science' => 'science',
+            'method-boundaries' => 'methodology',
+            'item-design-notes' => 'methodology',
+            'reliability-validity' => 'methodology',
+            'data-privacy' => 'privacy',
+            'common-misconceptions' => 'boundary',
+        ];
+        $title = $titles[$key] ?? $key;
+
+        return $overrides + [
+            'org_id' => 0,
+            'slug' => $key,
+            'path' => '/'.$key,
+            'kind' => ContentPage::KIND_POLICY,
+            'page_type' => $pageTypes[$key] ?? 'methodology',
+            'title' => $title,
+            'kicker' => '测评科学',
+            'summary' => $title.'的中文内容页草稿。',
+            'template' => 'policy',
+            'animation_profile' => 'editorial',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'content-page-'.$key,
+            'source_locale' => 'zh-CN',
+            'translation_status' => ContentPage::TRANSLATION_STATUS_SOURCE,
+            'published_at' => null,
+            'source_doc' => 'science-contentpage-gpt55-review-draft-2026-06-08/pages/'.$key.'.md',
+            'is_public' => false,
+            'is_indexable' => false,
+            'review_state' => 'science_review',
+            'owner' => 'seo_content',
+            'legal_review_required' => true,
+            'science_review_required' => true,
+            'headings_json' => [$title],
+            'content_md' => "# {$title}\n\n这是 {$title} 的中文 CMS 草稿内容，用于受控发布验证。",
+            'content_html' => '',
+            'seo_title' => $title,
+            'meta_description' => $title.'的中文说明。',
+            'seo_description' => $title.'的中文说明。',
+            'canonical_path' => '/'.$key,
+            'support_contact' => null,
+            'policy_version' => null,
+            'reviewer' => 'Unknown',
+            'schema_enabled' => false,
+            'faq_items' => [],
+            'publish_allowed' => false,
+            'operator_approval_required' => true,
+            'operator_approved_at' => null,
+            'claim_gate_status' => 'not_reviewed',
+            'forbidden_claims' => [],
+            'faq_schema_eligible' => false,
+            'schema_eligibility_reviewed_at' => null,
+            'status' => ContentPage::STATUS_DRAFT,
+        ];
+    }
+
     private function contentPage(string $key): ContentPage
     {
         return ContentPage::query()
@@ -445,6 +668,19 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
     }
 
     /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private function runScienceZhPublishCommand(array $options = [], int $expectedExitCode = 0): array
+    {
+        return $this->runPublishCommand($options + [
+            '--scope' => 'science-zh',
+            '--locale' => 'zh-CN',
+            '--keys' => implode(',', self::scienceZhTargetKeys()),
+        ], $expectedExitCode);
+    }
+
+    /**
      * @param  array<string, mixed>  $output
      * @return list<string>
      */
@@ -476,6 +712,20 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
             'help-privacy-data',
             'help-use-boundaries',
             'help-data-deletion',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private static function scienceZhTargetKeys(): array
+    {
+        return [
+            'science',
+            'item-design-notes',
+            'reliability-validity',
+            'data-privacy',
+            'common-misconceptions',
         ];
     }
 


### PR DESCRIPTION
What changed
- Added a fail-closed `science-zh` scope to `content-pages:publish-controlled` for `/zh/science`, `/zh/item-design-notes`, `/zh/reliability-validity`, `/zh/data-privacy`, and `/zh/common-misconceptions`.
- Added readiness docs/artifact for the controlled publish boundary.
- Added feature coverage for dry-run, execute, no-create behavior, protected `method-boundaries`, private URL rejection, public API 200 readiness, and artifact parsing.

Why
- fap-web temporarily hid missing Chinese science footer links. Backend/CMS now needs a controlled publish path so the five Chinese science content pages can become stable public 200s before footer links are restored.

Validation
- `php artisan test tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php`
- `php artisan test tests/Feature/ContentPages/ContentPagePublicApiTest.php --filter 'test_public_api_hides_science_content_pages_until_public_readiness_gate_passes|test_science_content_page_publish_requires_first_class_safety_fields'`\n- `php -r 'foreach (["docs/seo/generated/science-contentpage-zh-controlled-publish-readiness-01.v1.json"] as $f) { json_decode(file_get_contents($f), true); if (json_last_error() !== JSON_ERROR_NONE) { fwrite(STDERR, $f.": ".json_last_error_msg().PHP_EOL); exit(1); } } echo "json ok\\n";'`\n- `git diff --check`\n\nIntentionally deferred\n- No production deploy in this PR.\n- No production CMS publish execution in this PR.\n- No sitemap/llms/footer/search enablement in this PR.\n- fap-web footer restore remains deferred until all five live Chinese routes return 200 after backend deploy and controlled publish execution.\n\nRepository rule impact\n- CMS/backend remains the authority for content pages. This PR adds a controlled backend publish runtime only; it does not add frontend fallback content or static editorial assets.