### PR TITLE
Repair existing science zh controlled publish state

### DIFF
--- a/backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
+++ b/backend/app/Services/ContentPages/ContentPagesControlledPublishService.php
@@ -135,7 +135,8 @@ final class ContentPagesControlledPublishService
                     throw new RuntimeException('Target content page disappeared during controlled publish: '.$targetLocale.':'.$key);
                 }
 
-                if ($this->isPublishedTarget($page)) {
+                $action = (string) ($pagePlan['action'] ?? $this->actionForPage($scope, $page));
+                if ($action === 'skip_already_published') {
                     $skipped[] = (string) ($pagePlan['target_key'] ?? $key);
 
                     continue;
@@ -266,6 +267,7 @@ final class ContentPagesControlledPublishService
                 $pageErrors = $this->preflightPage($scope, $page);
                 array_push($errors, ...$pageErrors);
 
+                $action = $this->actionForPage($scope, $page);
                 $pages[] = [
                     'key' => $key,
                     'locale' => $targetLocale,
@@ -273,17 +275,17 @@ final class ContentPagesControlledPublishService
                     'id' => (int) $page->id,
                     'before_state' => $this->state($page),
                     'after_state_preview' => $this->afterStatePreview($page),
-                    'action' => $this->isPublishedTarget($page) ? 'skip_already_published' : 'publish',
+                    'action' => $action,
                     'errors' => $pageErrors,
                 ];
             }
         }
 
-        $wouldPublishCount = count(array_filter(
+        $wouldWriteCount = count(array_filter(
             $pages,
-            static fn (array $page): bool => ($page['action'] ?? null) === 'publish'
+            static fn (array $page): bool => in_array((string) ($page['action'] ?? ''), ['publish', 'repair_existing_published'], true)
         ));
-        $wouldSkipCount = count($pages) - $wouldPublishCount;
+        $wouldSkipCount = count($pages) - $wouldWriteCount;
         $ok = $errors === [];
 
         return [
@@ -294,8 +296,9 @@ final class ContentPagesControlledPublishService
             'execute' => $forExecute,
             'writes_committed' => false,
             'target_count' => count($allowedKeys) * count($targetLocales),
-            'would_publish_count' => $ok ? $wouldPublishCount : 0,
-            'would_update_count' => $ok ? $wouldPublishCount : 0,
+            'would_publish_count' => $ok ? count(array_filter($pages, static fn (array $page): bool => ($page['action'] ?? null) === 'publish')) : 0,
+            'would_update_count' => $ok ? $wouldWriteCount : 0,
+            'would_repair_existing_published_count' => $ok ? count(array_filter($pages, static fn (array $page): bool => ($page['action'] ?? null) === 'repair_existing_published')) : 0,
             'would_create_count' => 0,
             'would_skip_count' => $ok ? $wouldSkipCount : 0,
             'blocked_count' => count($errors),
@@ -313,7 +316,7 @@ final class ContentPagesControlledPublishService
                 ? ! $this->hasFoundationOverclaim($records->get(self::LOCALE.':foundation'))
                 : true,
             'discoverability_coupled' => false,
-            'discoverability_coupling_policy' => 'The runtime preserves is_indexable=false and fails if any target is already indexable before publish; sitemap/llms/footer/nav exposure remains out of scope.',
+            'discoverability_coupling_policy' => 'The runtime preserves is_indexable=false, repairs already-published science-zh targets back to non-indexable, and keeps sitemap/llms/footer/nav exposure out of scope.',
             'search_channel_action_attempted' => false,
             'url_submission_attempted' => false,
             'external_search_api_call_attempted' => false,
@@ -353,7 +356,7 @@ final class ContentPagesControlledPublishService
             ]);
         }
 
-        if ((bool) $page->is_indexable) {
+        if ((bool) $page->is_indexable && ! $this->canRepairPublishedScienceZhPage($scope, $page)) {
             $errors[] = $this->issue('content_pages.'.$key.'.is_indexable', 'discoverability_coupling_risk', 'Controlled publish must not make sitemap/llms eligibility inseparable; target drafts must remain non-indexable.');
         }
 
@@ -411,7 +414,7 @@ final class ContentPagesControlledPublishService
             $errors[] = $this->issue($fieldPrefix.'.content_md', 'private_url_pattern_present', 'Science zh page content must not reference private result/order/share/pay/history URLs or sensitive query parameters.');
         }
 
-        if ($this->isPublishedTarget($page) && ! $page->passesPublicReadinessGate()) {
+        if ($this->isPublishedTarget($page) && ! $this->canRepairPublishedScienceZhPage(self::SCOPE_SCIENCE_ZH, $page) && ! $page->passesPublicReadinessGate()) {
             $errors[] = $this->issue($fieldPrefix.'.public_readiness_gate', 'public_readiness_gate_failed', 'Already-published science zh page must satisfy the first-class public readiness gate.');
         }
 
@@ -474,6 +477,28 @@ final class ContentPagesControlledPublishService
         return (string) $page->status === ContentPage::STATUS_PUBLISHED
             && (bool) $page->is_public
             && $page->published_at !== null;
+    }
+
+    private function actionForPage(string $scope, ContentPage $page): string
+    {
+        if (! $this->isPublishedTarget($page)) {
+            return 'publish';
+        }
+
+        if ($this->canRepairPublishedScienceZhPage($scope, $page)) {
+            return 'repair_existing_published';
+        }
+
+        return 'skip_already_published';
+    }
+
+    private function canRepairPublishedScienceZhPage(string $scope, ContentPage $page): bool
+    {
+        return $scope === self::SCOPE_SCIENCE_ZH
+            && $this->isPublishedTarget($page)
+            && in_array((string) $page->slug, self::SCIENCE_ZH_ALLOWED_KEYS, true)
+            && (string) $page->locale === self::SCIENCE_ZH_LOCALE
+            && ((bool) $page->is_indexable || ! $page->passesPublicReadinessGate());
     }
 
     private function prepareScienceZhForPublish(ContentPage $page): ContentPage
@@ -631,6 +656,7 @@ final class ContentPagesControlledPublishService
         if ((string) $page->locale === self::SCIENCE_ZH_LOCALE && in_array((string) $page->slug, self::SCIENCE_ZH_ALLOWED_KEYS, true)) {
             return [
                 ...$preview,
+                'is_indexable' => false,
                 'review_state' => 'approved',
                 'legal_review_required' => false,
                 'science_review_required' => false,

--- a/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
+++ b/backend/tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php
@@ -340,6 +340,49 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
         $this->assertTrue((bool) $protected->is_indexable);
     }
 
+    public function test_science_zh_scope_repairs_already_published_indexable_rows_without_creation(): void
+    {
+        $this->seedBrokenPublishedScienceZhTargets();
+        $beforeCount = ContentPage::query()->withoutGlobalScopes()->count();
+
+        $dryRun = $this->runScienceZhPublishCommand(['--dry-run' => true]);
+
+        $this->assertTrue($dryRun['ok'] ?? false);
+        $this->assertSame(0, $dryRun['would_publish_count'] ?? null);
+        $this->assertSame(5, $dryRun['would_update_count'] ?? null);
+        $this->assertSame(5, $dryRun['would_repair_existing_published_count'] ?? null);
+        $this->assertSame('repair_existing_published', data_get($dryRun, 'pages.0.action'));
+        $this->assertFalse((bool) data_get($dryRun, 'after_state_preview.science.is_indexable'));
+
+        $output = $this->runScienceZhPublishCommand(['--execute' => true]);
+
+        $this->assertTrue($output['ok'] ?? false);
+        $this->assertTrue($output['writes_committed'] ?? false);
+        $this->assertSame(array_map(static fn (string $key): string => 'zh-CN:'.$key, self::scienceZhTargetKeys()), $output['published_keys'] ?? null);
+        $this->assertSame($beforeCount, ContentPage::query()->withoutGlobalScopes()->count());
+
+        foreach (self::scienceZhTargetKeys() as $key) {
+            $page = $this->contentPageForLocale($key, 'zh-CN');
+            $this->assertSame(ContentPage::STATUS_PUBLISHED, (string) $page->status);
+            $this->assertTrue((bool) $page->is_public);
+            $this->assertFalse((bool) $page->is_indexable);
+            $this->assertSame('approved', (string) $page->review_state);
+            $this->assertFalse((bool) $page->legal_review_required);
+            $this->assertFalse((bool) $page->science_review_required);
+            $this->assertTrue((bool) $page->publish_allowed);
+            $this->assertSame('passed', (string) $page->claim_gate_status);
+            $this->assertSame([], $page->forbidden_claims ?? []);
+            $this->assertNotNull($page->operator_approved_at);
+            $this->assertTrue($page->passesPublicReadinessGate());
+
+            $this->getJson('/api/v0.5/content-pages/'.$key.'?locale=zh-CN&org_id=0')
+                ->assertOk()
+                ->assertJsonPath('ok', true)
+                ->assertJsonPath('page.slug', $key)
+                ->assertJsonPath('page.is_indexable', false);
+        }
+    }
+
     public function test_science_zh_scope_refuses_method_boundaries_key(): void
     {
         $this->seedScienceZhTargets();
@@ -455,6 +498,28 @@ final class GlobalEnZhContentPagesControlledPublishRuntime01Test extends TestCas
             }
 
             ContentPage::query()->withoutGlobalScopes()->create($this->scienceZhPageAttributes($key, $overridesByKey[$key] ?? []));
+        }
+    }
+
+    private function seedBrokenPublishedScienceZhTargets(): void
+    {
+        foreach (self::scienceZhTargetKeys() as $key) {
+            ContentPage::withoutEvents(function () use ($key): void {
+                ContentPage::query()->withoutGlobalScopes()->create($this->scienceZhPageAttributes($key, [
+                    'status' => ContentPage::STATUS_PUBLISHED,
+                    'is_public' => true,
+                    'is_indexable' => true,
+                    'published_at' => now()->subDay(),
+                    'review_state' => 'science_review',
+                    'legal_review_required' => true,
+                    'science_review_required' => true,
+                    'publish_allowed' => false,
+                    'operator_approval_required' => true,
+                    'operator_approved_at' => null,
+                    'claim_gate_status' => 'not_reviewed',
+                    'forbidden_claims' => [],
+                ]));
+            });
         }
     }
 


### PR DESCRIPTION
What changed
- Let the `science-zh` controlled publish scope repair already-published target records that are indexable or fail the science public readiness gate.
- Keep the repair constrained to the five allowlisted zh-CN science content pages.
- Preserve no-create/no-upsert behavior and keep sitemap/llms/footer/search exposure out of scope.
- Added regression coverage for the observed production state: published/public/indexable rows with missing readiness fields.

Why
- Production already has the five target CMS rows in a published/indexable-but-not-publicly-readable state. The previous controlled publish runtime skipped published rows before it could repair them, so the approved production command exited with writes_committed=false.

Validation
- `php artisan test tests/Feature/SeoIntel/GlobalEnZhContentPagesControlledPublishRuntime01Test.php`
- `php artisan test tests/Feature/ContentPages/ContentPagePublicApiTest.php --filter 'test_public_api_hides_science_content_pages_until_public_readiness_gate_passes|test_science_content_page_publish_requires_first_class_safety_fields'`\n- `git diff --check`\n\nIntentionally deferred\n- No production deploy in this PR.\n- No production CMS publish execution in this PR.\n- fap-web footer restoration remains deferred until backend production repair is deployed, executed, and live 200-smoked.\n\nRepository rule impact\n- CMS/backend remains the authority. This PR only repairs the backend controlled publish runtime for existing CMS rows; it does not add frontend content or fallback content.