### PR TITLE
CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity

### DIFF
--- a/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+++ b/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
@@ -1,0 +1,461 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Career\CareerCliArtifactPathGuard;
+use Illuminate\Console\Command;
+use Illuminate\Http\Client\Pool;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Arr;
+use Illuminate\Support\Facades\Http;
+use RuntimeException;
+use Symfony\Component\Console\Output\OutputInterface;
+use Throwable;
+
+final class CareerAuditZhDisplayParity extends Command
+{
+    private const VALIDATOR_VERSION = 'career_zh_display_parity_audit_v0.1';
+
+    private const DEFAULT_API_BASE = 'https://api.fermatmind.com/api/v0.5/career/jobs';
+
+    private const DEFAULT_SITE_BASE = 'https://fermatmind.com';
+
+    protected $signature = 'career:audit-zh-display-parity
+        {--api-base= : Public career job API base URL}
+        {--site-base= : Public site base URL for sample URLs}
+        {--slugs= : Optional comma-separated slugs; omitted scans EN/ZH public job indexes}
+        {--timeout=15 : HTTP timeout in seconds}
+        {--batch-size=40 : Max slugs per concurrent detail batch}
+        {--sample-limit=20 : Max sample rows per summary bucket}
+        {--json : Emit JSON report}
+        {--output= : Optional report output path}';
+
+    protected $description = 'Read-only EN/ZH public career job display parity audit.';
+
+    public function handle(): int
+    {
+        try {
+            $apiBase = $this->baseUrl((string) ($this->option('api-base') ?: self::DEFAULT_API_BASE));
+            $siteBase = $this->baseUrl((string) ($this->option('site-base') ?: self::DEFAULT_SITE_BASE));
+            $timeout = max(1, (int) $this->option('timeout'));
+            $batchSize = max(1, min(100, (int) $this->option('batch-size')));
+            $sampleLimit = max(1, (int) $this->option('sample-limit'));
+            $explicitSlugs = $this->csvOption('slugs');
+
+            $index = $explicitSlugs === []
+                ? $this->indexSlugs($apiBase, $timeout)
+                : [
+                    'en' => $explicitSlugs,
+                    'zh-CN' => $explicitSlugs,
+                    'failures' => [],
+                ];
+
+            $slugs = $explicitSlugs === []
+                ? $this->sortedUnique(array_merge($index['en'], $index['zh-CN']))
+                : $explicitSlugs;
+
+            $items = $this->auditSlugs($apiBase, $siteBase, $slugs, $timeout, $batchSize);
+
+            $summary = $this->summary($items, $index, $sampleLimit);
+            $report = [
+                'validator_version' => self::VALIDATOR_VERSION,
+                'decision' => ($summary['api_failure_count'] ?? 0) === 0 ? 'pass' : 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'cms_mutation' => false,
+                'sitemap_changed' => false,
+                'llms_changed' => false,
+                'index_strategy_changed' => false,
+                'api_base' => $apiBase,
+                'site_base' => $siteBase,
+                'scan_scope' => $explicitSlugs === [] ? 'public_index_union' : 'explicit_slugs',
+                'summary' => $summary,
+                'items' => $items,
+                'next_prs' => [
+                    'CAREER-ZH-DISPLAY-PARITY-02' => 'Use reviewed Chinese CMS/workbook display fields through validate/import manifest flow; do not copy English content.',
+                    'CAREER-ZH-DISPLAY-PARITY-03' => 'Add per-slug/per-locale detail cache forget/warm for imported zh-CN display assets.',
+                    'CAREER-ZH-DISPLAY-PARITY-04' => 'Run controlled publish/live parity gate without changing sitemap/llms/index strategy unless separately authorized.',
+                ],
+            ];
+
+            return $this->finish($report);
+        } catch (Throwable $throwable) {
+            return $this->finish([
+                'validator_version' => self::VALIDATOR_VERSION,
+                'decision' => 'blocked',
+                'read_only' => true,
+                'writes_database' => false,
+                'cms_mutation' => false,
+                'sitemap_changed' => false,
+                'llms_changed' => false,
+                'index_strategy_changed' => false,
+                'errors' => [$throwable->getMessage()],
+            ]);
+        }
+    }
+
+    /**
+     * @return array{en: list<string>, zh-CN: list<string>, failures: list<array<string, mixed>>}
+     */
+    private function indexSlugs(string $apiBase, int $timeout): array
+    {
+        $en = $this->fetchJson($apiBase, ['locale' => 'en'], $timeout);
+        $zh = $this->fetchJson($apiBase, ['locale' => 'zh-CN'], $timeout);
+
+        return [
+            'en' => $this->slugsFromIndex($en['json']),
+            'zh-CN' => $this->slugsFromIndex($zh['json']),
+            'failures' => array_values(array_filter([
+                $en['ok'] ? null : ['locale' => 'en', 'status' => $en['status'], 'url' => $en['url']],
+                $zh['ok'] ? null : ['locale' => 'zh-CN', 'status' => $zh['status'], 'url' => $zh['url']],
+            ])),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return list<array<string, mixed>>
+     */
+    private function auditSlugs(string $apiBase, string $siteBase, array $slugs, int $timeout, int $batchSize): array
+    {
+        $items = [];
+        foreach (array_chunk($slugs, $batchSize) as $chunk) {
+            /** @var array<string, Response> $responses */
+            $responses = Http::pool(function (Pool $pool) use ($apiBase, $chunk, $timeout): array {
+                $requests = [];
+                foreach ($chunk as $slug) {
+                    $requests[$slug.'|en'] = $pool->as($slug.'|en')
+                        ->timeout($timeout)
+                        ->acceptJson()
+                        ->get($apiBase.'/'.$slug, ['locale' => 'en']);
+                    $requests[$slug.'|zh-CN'] = $pool->as($slug.'|zh-CN')
+                        ->timeout($timeout)
+                        ->acceptJson()
+                        ->get($apiBase.'/'.$slug, ['locale' => 'zh-CN']);
+                }
+
+                return $requests;
+            });
+
+            foreach ($chunk as $slug) {
+                $items[] = $this->auditSlugFromResponses(
+                    $siteBase,
+                    $slug,
+                    $this->responseResult($responses[$slug.'|en'] ?? null, $this->urlWithQuery($apiBase.'/'.$slug, ['locale' => 'en'])),
+                    $this->responseResult($responses[$slug.'|zh-CN'] ?? null, $this->urlWithQuery($apiBase.'/'.$slug, ['locale' => 'zh-CN'])),
+                );
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function auditSlugFromResponses(string $siteBase, string $slug, array $en, array $zh): array
+    {
+        $enKeys = $this->displayContentKeys($en['json']);
+        $zhKeys = $this->displayContentKeys($zh['json']);
+        $enOnly = array_values(array_diff($enKeys, $zhKeys));
+        $zhOnly = array_values(array_diff($zhKeys, $enKeys));
+        $gateReasons = $this->zhGateReasons($zh['json'], $enOnly, $en, $zh);
+
+        return [
+            'slug' => $slug,
+            'status' => [
+                'en' => $en['status'],
+                'zh-CN' => $zh['status'],
+            ],
+            'sample_urls' => [
+                'en' => $siteBase.'/en/career/jobs/'.$slug,
+                'zh' => $siteBase.'/zh/career/jobs/'.$slug,
+                'api_en' => $en['url'],
+                'api_zh' => $zh['url'],
+            ],
+            'module_counts' => [
+                'en' => count($enKeys),
+                'zh-CN' => count($zhKeys),
+                'en_only' => count($enOnly),
+                'zh_only' => count($zhOnly),
+            ],
+            'missing_modules' => [
+                'en_only' => $enOnly,
+                'zh_only' => $zhOnly,
+            ],
+            'zh_gate_reasons' => $gateReasons,
+            'classification' => $this->classification($en, $zh, $enOnly, $zhOnly),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $index
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function summary(array $items, array $index, int $sampleLimit): array
+    {
+        $classifications = [];
+        foreach ($items as $item) {
+            $classification = (string) ($item['classification'] ?? 'unknown');
+            $classifications[$classification] = ($classifications[$classification] ?? 0) + 1;
+        }
+
+        $sampleByClassification = [];
+        foreach ($items as $item) {
+            $classification = (string) ($item['classification'] ?? 'unknown');
+            $sampleByClassification[$classification] ??= [];
+            if (count($sampleByClassification[$classification]) < $sampleLimit) {
+                $sampleByClassification[$classification][] = [
+                    'slug' => $item['slug'],
+                    'sample_urls' => $item['sample_urls'],
+                    'module_counts' => $item['module_counts'],
+                    'zh_gate_reasons' => $item['zh_gate_reasons'],
+                ];
+            }
+        }
+
+        $indexEn = $index['en'] ?? [];
+        $indexZh = $index['zh-CN'] ?? [];
+
+        return [
+            'total_slugs' => count($items),
+            'en_index_count' => count($indexEn),
+            'zh_index_count' => count($indexZh),
+            'index_en_only_count' => count(array_diff($indexEn, $indexZh)),
+            'index_zh_only_count' => count(array_diff($indexZh, $indexEn)),
+            'same_module_set' => $classifications['same_module_set'] ?? 0,
+            'en_has_modules_zh_missing' => $classifications['en_has_modules_zh_missing'] ?? 0,
+            'zh_has_modules_en_missing' => $classifications['zh_has_modules_en_missing'] ?? 0,
+            'en_200_zh_not_200' => $classifications['en_200_zh_not_200'] ?? 0,
+            'zh_200_en_not_200' => $classifications['zh_200_en_not_200'] ?? 0,
+            'both_missing_or_failed' => $classifications['both_missing_or_failed'] ?? 0,
+            'api_failure_count' => count((array) ($index['failures'] ?? []))
+                + ($classifications['en_200_zh_not_200'] ?? 0)
+                + ($classifications['zh_200_en_not_200'] ?? 0)
+                + ($classifications['both_missing_or_failed'] ?? 0),
+            'classification_counts' => $classifications,
+            'index_failures' => $index['failures'] ?? [],
+            'samples' => $sampleByClassification,
+        ];
+    }
+
+    /**
+     * @param  array{ok: bool, status: int|null}  $en
+     * @param  array{ok: bool, status: int|null}  $zh
+     * @param  list<string>  $enOnly
+     * @param  list<string>  $zhOnly
+     */
+    private function classification(array $en, array $zh, array $enOnly, array $zhOnly): string
+    {
+        if (($en['ok'] ?? false) && ! ($zh['ok'] ?? false)) {
+            return 'en_200_zh_not_200';
+        }
+
+        if (($zh['ok'] ?? false) && ! ($en['ok'] ?? false)) {
+            return 'zh_200_en_not_200';
+        }
+
+        if (! ($en['ok'] ?? false) && ! ($zh['ok'] ?? false)) {
+            return 'both_missing_or_failed';
+        }
+
+        if ($enOnly !== []) {
+            return 'en_has_modules_zh_missing';
+        }
+
+        if ($zhOnly !== []) {
+            return 'zh_has_modules_en_missing';
+        }
+
+        return 'same_module_set';
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     * @return list<string>
+     */
+    private function displayContentKeys(?array $payload): array
+    {
+        $content = Arr::get($payload ?? [], 'display_surface_v1.page.content');
+        if (! is_array($content)) {
+            return [];
+        }
+
+        $keys = array_values(array_filter(array_keys($content), static fn ($key): bool => is_string($key) && $key !== ''));
+        sort($keys);
+
+        return $keys;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     * @param  list<string>  $enOnly
+     * @param  array{ok: bool, status: int|null}  $en
+     * @param  array{ok: bool, status: int|null}  $zh
+     * @return list<string>
+     */
+    private function zhGateReasons(?array $payload, array $enOnly, array $en, array $zh): array
+    {
+        $reasons = [];
+        if (! ($zh['ok'] ?? false)) {
+            $reasons[] = 'zh_detail_http_'.$this->statusLabel($zh['status'] ?? null);
+        }
+        if (! ($en['ok'] ?? false)) {
+            $reasons[] = 'en_detail_http_'.$this->statusLabel($en['status'] ?? null);
+        }
+        if ($enOnly !== []) {
+            $reasons[] = 'zh_missing_en_display_modules';
+        }
+
+        foreach ((array) Arr::get($payload ?? [], 'warnings.red_flags', []) as $flag) {
+            $reasons[] = 'red_flag:'.$flag;
+        }
+        foreach ((array) Arr::get($payload ?? [], 'warnings.amber_flags', []) as $flag) {
+            $reasons[] = 'amber_flag:'.$flag;
+        }
+        foreach ((array) Arr::get($payload ?? [], 'warnings.blocked_claims', []) as $flag) {
+            $reasons[] = 'blocked_claim:'.$flag;
+        }
+
+        $integrityState = Arr::get($payload ?? [], 'integrity_summary.integrity_state');
+        if (is_string($integrityState) && $integrityState !== '') {
+            $reasons[] = 'integrity_state:'.$integrityState;
+        }
+        foreach ((array) Arr::get($payload ?? [], 'integrity_summary.critical_missing_fields', []) as $field) {
+            $reasons[] = 'critical_missing_field:'.$field;
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    /**
+     * @return array{ok: bool, status: int|null, json: array<string, mixed>|null, url: string}
+     */
+    private function fetchJson(string $url, array $query, int $timeout): array
+    {
+        $response = Http::timeout($timeout)->acceptJson()->get($url, $query);
+        $fullUrl = $this->urlWithQuery($url, $query);
+
+        return $this->responseResult($response, $fullUrl);
+    }
+
+    /**
+     * @return array{ok: bool, status: int|null, json: array<string, mixed>|null, url: string}
+     */
+    private function responseResult(?Response $response, string $fullUrl): array
+    {
+        return [
+            'ok' => $response?->successful() === true,
+            'status' => $response?->status(),
+            'json' => $response?->successful() === true ? $this->safeJson($response) : null,
+            'url' => $fullUrl,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>|null
+     */
+    private function safeJson(Response $response): ?array
+    {
+        $json = $response->json();
+
+        return is_array($json) ? $json : null;
+    }
+
+    /**
+     * @param  array<string, mixed>|null  $payload
+     * @return list<string>
+     */
+    private function slugsFromIndex(?array $payload): array
+    {
+        $items = Arr::get($payload ?? [], 'items', []);
+        if (! is_array($items)) {
+            return [];
+        }
+
+        $slugs = [];
+        foreach ($items as $item) {
+            $slug = Arr::get($item, 'identity.canonical_slug');
+            if (is_string($slug) && trim($slug) !== '') {
+                $slugs[] = strtolower(trim($slug));
+            }
+        }
+
+        return $this->sortedUnique($slugs);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function csvOption(string $name): array
+    {
+        $value = trim((string) $this->option($name));
+        if ($value === '') {
+            return [];
+        }
+
+        return $this->sortedUnique(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            explode(',', $value),
+        ));
+    }
+
+    /**
+     * @param  list<string>  $values
+     * @return list<string>
+     */
+    private function sortedUnique(array $values): array
+    {
+        $values = array_values(array_unique(array_filter($values, static fn (string $value): bool => $value !== '')));
+        sort($values);
+
+        return $values;
+    }
+
+    private function baseUrl(string $url): string
+    {
+        $url = rtrim(trim($url), '/');
+        if ($url === '' || filter_var($url, FILTER_VALIDATE_URL) === false) {
+            throw new RuntimeException('Expected a valid URL.');
+        }
+
+        return $url;
+    }
+
+    private function statusLabel(?int $status): string
+    {
+        return $status === null ? 'unknown' : (string) $status;
+    }
+
+    private function urlWithQuery(string $url, array $query): string
+    {
+        return $url.'?'.http_build_query($query);
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     */
+    private function finish(array $report): int
+    {
+        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        if (! is_string($json)) {
+            throw new RuntimeException('Unable to encode zh display parity report.');
+        }
+
+        CareerCliArtifactPathGuard::writeTextOutput($this->option('output'), $json.PHP_EOL);
+
+        if ((bool) $this->option('json')) {
+            $this->output->write($json.PHP_EOL, false, OutputInterface::OUTPUT_RAW);
+        } else {
+            $this->line('validator_version='.(string) ($report['validator_version'] ?? self::VALIDATOR_VERSION));
+            $this->line('decision='.(string) ($report['decision'] ?? 'blocked'));
+            $this->line('total_slugs='.(string) Arr::get($report, 'summary.total_slugs', 0));
+            $this->line('en_has_modules_zh_missing='.(string) Arr::get($report, 'summary.en_has_modules_zh_missing', 0));
+        }
+
+        return ($report['decision'] ?? 'blocked') === 'pass' ? self::SUCCESS : self::FAILURE;
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -19,6 +19,7 @@ use App\Console\Commands\CareerAlignSelectedOnetCrosswalks;
 use App\Console\Commands\CareerApplyOccupationDirectoryReviewDecisions;
 use App\Console\Commands\CareerAuditCanonicalEligibility;
 use App\Console\Commands\CareerAuditDetailReady1048Candidates;
+use App\Console\Commands\CareerAuditZhDisplayParity;
 use App\Console\Commands\CareerCloseoutCanonicalProgressiveCohort;
 use App\Console\Commands\CareerCompileAuthorityWave;
 use App\Console\Commands\CareerCompileRecommendationSubjects;
@@ -217,6 +218,7 @@ class Kernel extends ConsoleKernel
         CareerApplyOccupationDirectoryReviewDecisions::class,
         CareerAuditCanonicalEligibility::class,
         CareerAuditDetailReady1048Candidates::class,
+        CareerAuditZhDisplayParity::class,
         CareerCloseoutCanonicalProgressiveCohort::class,
         CareerAlignActorsAuthorityOccupation::class,
         CareerAlignCareerAuthorityBatch::class,

--- a/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
@@ -1,0 +1,184 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\File;
+use Illuminate\Support\Facades\Http;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class CareerAuditZhDisplayParityCommandTest extends TestCase
+{
+    #[Test]
+    public function it_outputs_read_only_zh_display_parity_report(): void
+    {
+        Http::fake([
+            'https://api.example.test/api/v0.5/career/jobs?locale=en' => Http::response($this->indexPayload([
+                'same-slug',
+                'zh-missing-modules',
+                'zh-extra-modules',
+                'zh-404-slug',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs?locale=zh-CN' => Http::response($this->indexPayload([
+                'same-slug',
+                'zh-missing-modules',
+                'zh-extra-modules',
+                'en-404-slug',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/same-slug?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'source_card',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/same-slug?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'source_card',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/zh-missing-modules?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'source_card',
+                'responsibilities_block',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/zh-missing-modules?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ], amberFlags: ['runtime_published_shell'], criticalMissingFields: ['compiled_recommendation_snapshot']), 200),
+            'https://api.example.test/api/v0.5/career/jobs/zh-extra-modules?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/zh-extra-modules?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'zh_only_module',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/zh-404-slug?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/zh-404-slug?locale=zh-CN' => Http::response(['message' => 'Not found'], 404),
+            'https://api.example.test/api/v0.5/career/jobs/en-404-slug?locale=en' => Http::response(['message' => 'Not found'], 404),
+            'https://api.example.test/api/v0.5/career/jobs/en-404-slug?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ]), 200),
+        ]);
+
+        $output = sys_get_temp_dir().'/career-zh-display-parity-test.json';
+        @unlink($output);
+
+        $exitCode = Artisan::call('career:audit-zh-display-parity', [
+            '--api-base' => 'https://api.example.test/api/v0.5/career/jobs',
+            '--site-base' => 'https://www.example.test',
+            '--json' => true,
+            '--output' => $output,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+        $written = json_decode((string) File::get($output), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode, Artisan::output());
+        $this->assertSame('blocked', $report['decision']);
+        $this->assertTrue($report['read_only']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertFalse($report['sitemap_changed']);
+        $this->assertFalse($report['llms_changed']);
+        $this->assertFalse($report['index_strategy_changed']);
+        $this->assertSame(5, $report['summary']['total_slugs']);
+        $this->assertSame(1, $report['summary']['same_module_set']);
+        $this->assertSame(1, $report['summary']['en_has_modules_zh_missing']);
+        $this->assertSame(1, $report['summary']['zh_has_modules_en_missing']);
+        $this->assertSame(1, $report['summary']['en_200_zh_not_200']);
+        $this->assertSame(1, $report['summary']['zh_200_en_not_200']);
+        $this->assertSame(2, $report['summary']['api_failure_count']);
+        $this->assertSame($report['summary'], $written['summary']);
+
+        $missing = collect($report['items'])->firstWhere('slug', 'zh-missing-modules');
+        $this->assertSame('en_has_modules_zh_missing', $missing['classification']);
+        $this->assertContains('responsibilities_block', $missing['missing_modules']['en_only']);
+        $this->assertContains('source_card', $missing['missing_modules']['en_only']);
+        $this->assertContains('zh_missing_en_display_modules', $missing['zh_gate_reasons']);
+        $this->assertContains('amber_flag:runtime_published_shell', $missing['zh_gate_reasons']);
+        $this->assertContains('critical_missing_field:compiled_recommendation_snapshot', $missing['zh_gate_reasons']);
+        $this->assertSame('https://www.example.test/zh/career/jobs/zh-missing-modules', $missing['sample_urls']['zh']);
+    }
+
+    #[Test]
+    public function it_can_scan_explicit_slugs_without_public_index(): void
+    {
+        Http::fake([
+            'https://api.example.test/api/v0.5/career/jobs/one-slug?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/one-slug?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ]), 200),
+        ]);
+
+        $exitCode = Artisan::call('career:audit-zh-display-parity', [
+            '--api-base' => 'https://api.example.test/api/v0.5/career/jobs',
+            '--slugs' => 'one-slug',
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('explicit_slugs', $report['scan_scope']);
+        $this->assertSame(1, $report['summary']['total_slugs']);
+        $this->assertSame(1, $report['summary']['same_module_set']);
+
+        Http::assertNotSent(static fn ($request): bool => str_ends_with($request->url(), '/career/jobs?locale=en'));
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     * @return array<string, mixed>
+     */
+    private function indexPayload(array $slugs): array
+    {
+        return [
+            'bundle_kind' => 'career_job_index',
+            'items' => array_map(static fn (string $slug): array => [
+                'identity' => [
+                    'canonical_slug' => $slug,
+                ],
+            ], $slugs),
+        ];
+    }
+
+    /**
+     * @param  list<string>  $contentKeys
+     * @param  list<string>  $amberFlags
+     * @param  list<string>  $criticalMissingFields
+     * @return array<string, mixed>
+     */
+    private function detailPayload(
+        array $contentKeys,
+        array $amberFlags = [],
+        array $criticalMissingFields = [],
+    ): array {
+        return [
+            'bundle_kind' => 'career_job_detail',
+            'warnings' => [
+                'red_flags' => [],
+                'amber_flags' => $amberFlags,
+                'blocked_claims' => [],
+            ],
+            'integrity_summary' => [
+                'integrity_state' => 'display_asset_backed',
+                'critical_missing_fields' => $criticalMissingFields,
+            ],
+            'display_surface_v1' => [
+                'page' => [
+                    'content' => array_fill_keys($contentKeys, ['visible' => true]),
+                ],
+            ],
+        ];
+    }
+}

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52187,7 +52187,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-01-audit",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
     "depends_on": [],
@@ -52229,14 +52229,26 @@
         "evidence": "Path-limited git diff --check and git diff --cached --check passed."
       },
       "github": {
-        "status": "queued_retry_pushed",
+        "status": "pass",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
-        "head_sha": "ee69f6884cbd04109fcd2611b3826c16e62c5276",
-        "evidence": "Initial pull_request CI run 27215327825 remained queued on verify-mbti-legacy while push CI equivalent passed; pushing scoped ledger retry transition to trigger fresh check set."
+        "head_sha": "ef50a4a66477dac4ea03cd822d6c30e1d958058a",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "verify-bigfive",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN",
+        "evidence": "GitHub checks passed for PR #2020 at head ef50a4a66477dac4ea03cd822d6c30e1d958058a and mergeStateStatus is CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "20d543a9f73301c1ef9b94308ee0bb1cda2f257e",
+    "commit_sha": "ef50a4a66477dac4ea03cd822d6c30e1d958058a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -52267,6 +52279,11 @@
         "at": "2026-06-09",
         "status": "github_checks_queued_retry_pushed",
         "note": "Initial pull_request CI run remained queued on verify-mbti-legacy and semgrep sarif non-blocking upload; pushed scoped ledger-only retry transition to trigger a fresh check set."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge state was CLEAN for PR #2020 head ef50a4a66477dac4ea03cd822d6c30e1d958058a."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52229,10 +52229,10 @@
         "evidence": "Path-limited git diff --check and git diff --cached --check passed."
       },
       "github": {
-        "status": "pending",
+        "status": "queued_retry_pushed",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
-        "head_sha": "20d543a9f73301c1ef9b94308ee0bb1cda2f257e",
-        "evidence": "PR #2020 opened; GitHub checks pending."
+        "head_sha": "ee69f6884cbd04109fcd2611b3826c16e62c5276",
+        "evidence": "Initial pull_request CI run 27215327825 remained queued on verify-mbti-legacy while push CI equivalent passed; pushing scoped ledger retry transition to trigger fresh check set."
       }
     },
     "failure_reason": null,
@@ -52262,6 +52262,11 @@
         "at": "2026-06-09",
         "status": "github_checks_pending",
         "note": "Opened https://github.com/fermatmind/fap-api/pull/2020 from branch codex/career-zh-display-parity-01-audit; GitHub checks pending."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_queued_retry_pushed",
+        "note": "Initial pull_request CI run remained queued on verify-mbti-legacy and semgrep sarif non-blocking upload; pushed scoped ledger-only retry transition to trigger a fresh check set."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52187,7 +52187,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-01-audit",
     "base": "origin/main",
-    "status": "committed_pending_push",
+    "status": "github_checks_pending",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
     "depends_on": [],
@@ -52227,11 +52227,17 @@
       "diff_check": {
         "status": "pass",
         "evidence": "Path-limited git diff --check and git diff --cached --check passed."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
+        "head_sha": "20d543a9f73301c1ef9b94308ee0bb1cda2f257e",
+        "evidence": "PR #2020 opened; GitHub checks pending."
       }
     },
     "failure_reason": null,
-    "commit_sha": "c6e5d9505c76edb14dc445238c954e667b7975a0",
-    "pr_url": null,
+    "commit_sha": "20d543a9f73301c1ef9b94308ee0bb1cda2f257e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -52251,6 +52257,11 @@
         "at": "2026-06-09",
         "status": "committed_pending_push",
         "note": "Created scoped implementation commit c6e5d9505c76edb14dc445238c954e667b7975a0."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "github_checks_pending",
+        "note": "Opened https://github.com/fermatmind/fap-api/pull/2020 from branch codex/career-zh-display-parity-01-audit; GitHub checks pending."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-08T17:23:16Z",
+  "updated_at": "2026-06-09T00:00:00Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -52180,6 +52180,182 @@
         "at": "2026-06-09",
         "status": "ready_to_merge",
         "note": "GitHub checks passed and merge state was CLEAN for head a8e300f908c22c94caba1c61becf8c6b1c5f2525."
+      }
+    ]
+  },
+  "CAREER-ZH-DISPLAY-PARITY-01": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-display-parity-01-audit",
+    "base": "origin/main",
+    "status": "committed_pending_push",
+    "train_scope": "career_zh_display_parity",
+    "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-DISPLAY-PARITY-01 through CAREER-ZH-DISPLAY-PARITY-04, including fap-api docs/codex metadata updates, on 2026-06-09."
+      },
+      "scope": {
+        "status": "pending",
+        "evidence": "Initialized from user-provided CAREER-ZH-DISPLAY-PARITY PR train scope."
+      },
+      "php_lint": {
+        "status": "pass",
+        "evidence": "php -l passed for CareerAuditZhDisplayParity.php, Console Kernel, and CareerAuditZhDisplayParityCommandTest.php."
+      },
+      "focused_test": {
+        "status": "pass",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=\":memory:\" php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi passed 2 tests / 27 assertions."
+      },
+      "live_audit": {
+        "status": "pass",
+        "evidence": "cd backend && php artisan career:audit-zh-display-parity --json --output=/private/tmp/career-zh-display-parity-01-live.json passed read-only; total_slugs=1046, en_index_count=1046, zh_index_count=1046, same_module_set=374, en_has_modules_zh_missing=672, api_failure_count=0."
+      },
+      "pint": {
+        "status": "pass",
+        "evidence": "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerAuditZhDisplayParity.php app/Console/Kernel.php tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php passed."
+      },
+      "metadata": {
+        "status": "pass",
+        "evidence": "docs/codex/pr-train-state.json parsed as JSON and docs/codex/pr-train.yaml parsed as YAML via Ruby stdlib."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to CareerAuditZhDisplayParity command, Kernel registration, focused command test, and docs/codex metadata."
+      },
+      "diff_check": {
+        "status": "pass",
+        "evidence": "Path-limited git diff --check and git diff --cached --check passed."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "c6e5d9505c76edb14dc445238c954e667b7975a0",
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "in_progress",
+        "note": "Initialized from explicit CAREER-ZH-DISPLAY-PARITY train authorization and started branch codex/career-zh-display-parity-01-audit from latest fap-api main."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "Read-only zh display parity audit command, focused tests, live public API audit, Pint, metadata parse, scope validation, and diff checks passed. Live report reproduced total_slugs=1046 and en_has_modules_zh_missing=672 with api_failure_count=0."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed_pending_push",
+        "note": "Created scoped implementation commit c6e5d9505c76edb14dc445238c954e667b7975a0."
+      }
+    ]
+  },
+  "CAREER-ZH-DISPLAY-PARITY-02": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-display-parity-02-import-manifest",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_display_parity",
+    "title": "CAREER-ZH-DISPLAY-PARITY-02: feat(career): support zh display import manifests",
+    "depends_on": [
+      "CAREER-ZH-DISPLAY-PARITY-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-DISPLAY-PARITY-01 through CAREER-ZH-DISPLAY-PARITY-04, including fap-api docs/codex metadata updates, on 2026-06-09."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-DISPLAY-PARITY-01 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "pending_dependency",
+        "note": "Future import/validation entry initialized only; implementation deferred until PR01 is merged."
+      }
+    ]
+  },
+  "CAREER-ZH-DISPLAY-PARITY-03": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-display-parity-03-detail-cache",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_display_parity",
+    "title": "CAREER-ZH-DISPLAY-PARITY-03: feat(career): refresh job detail cache per locale",
+    "depends_on": [
+      "CAREER-ZH-DISPLAY-PARITY-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-DISPLAY-PARITY-01 through CAREER-ZH-DISPLAY-PARITY-04, including fap-api docs/codex metadata updates, on 2026-06-09."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-DISPLAY-PARITY-02 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "pending_dependency",
+        "note": "Future per-slug/per-locale detail cache entry initialized only; implementation deferred until PR02 is merged."
+      }
+    ]
+  },
+  "CAREER-ZH-DISPLAY-PARITY-04": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-display-parity-04-live-gate",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_display_parity",
+    "title": "CAREER-ZH-DISPLAY-PARITY-04: chore(career): gate zh display live parity",
+    "depends_on": [
+      "CAREER-ZH-DISPLAY-PARITY-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-DISPLAY-PARITY-01 through CAREER-ZH-DISPLAY-PARITY-04, including fap-api docs/codex metadata updates, on 2026-06-09."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-DISPLAY-PARITY-03 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-09",
+        "status": "pending_dependency",
+        "note": "Future controlled publish/live parity gate entry initialized only; implementation deferred until PR03 is merged."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24012,3 +24012,173 @@ prs:
     url_submission: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: CAREER-ZH-DISPLAY-PARITY-01
+    repo: fap-api
+    branch: codex/career-zh-display-parity-01-audit
+    title: "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity"
+    train_scope: career_zh_display_parity
+    status: in_progress
+    scope:
+      - Add a read-only command that audits EN/ZH public career job display parity from public API payloads.
+      - Output total slugs, EN/ZH index mismatches, missing module classifications, Chinese gate/warning reasons, and sample URLs.
+      - Produce a repeatable report for the current 672 Chinese restricted-shell parity gap without changing career display behavior.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+      - backend/app/Console/Kernel.php
+      - backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Import display assets, copy English content into Chinese fields, mutate CMS/database rows, clear or warm caches, publish career content, deploy, or change sitemap/llms/index strategy in this PR.
+      - Modify fap-web or career frontend rendering.
+    validation:
+      - php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+      - php -l backend/app/Console/Kernel.php
+      - php -l backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi
+      - cd backend && php artisan career:audit-zh-display-parity --json --output=/private/tmp/career-zh-display-parity-01-live.json
+      - python3 -c "import json; p=json.load(open('/private/tmp/career-zh-display-parity-01-live.json')); assert p['read_only'] is True and p['writes_database'] is False; assert p['sitemap_changed'] is False and p['llms_changed'] is False and p['index_strategy_changed'] is False; assert p['summary']['total_slugs'] >= 1; print('career zh display parity live report ok:', p['summary']['total_slugs'], p['summary']['en_has_modules_zh_missing'])"
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerAuditZhDisplayParity.php app/Console/Kernel.php tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check -- backend/app/Console/Commands/CareerAuditZhDisplayParity.php backend/app/Console/Kernel.php backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-DISPLAY-PARITY-02
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-DISPLAY-PARITY-01
+    branch: codex/career-zh-display-parity-02-import-manifest
+    title: "CAREER-ZH-DISPLAY-PARITY-02: feat(career): support zh display import manifests"
+    train_scope: career_zh_display_parity
+    status: pending_dependency
+    scope:
+      - Extend the existing career:validate-display-batch and career:import-selected-display-assets flow to accept the reviewed Chinese display asset manifest for the audited gap.
+      - Require CMS/workbook-reviewed Chinese fields and preserve dry-run/force guarded import semantics.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerValidateDisplayBatch.php
+      - backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+      - backend/app/Console/Kernel.php
+      - backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+      - backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+      - backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Copy English content into Chinese display fields, publish content, mutate sitemap/llms/index strategy, deploy, or modify fap-web.
+    validation:
+      - php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php
+      - php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - php -l backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-DISPLAY-PARITY-03
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-DISPLAY-PARITY-02
+    branch: codex/career-zh-display-parity-03-detail-cache
+    title: "CAREER-ZH-DISPLAY-PARITY-03: feat(career): refresh job detail cache per locale"
+    train_scope: career_zh_display_parity
+    status: pending_dependency
+    scope:
+      - Add per-slug/per-locale career job detail cache forget and warm support for public authority cache.
+      - Ensure reviewed display asset imports clear zh-CN detail cache keys such as career:public-authority:job-detail:v1:{slug}:zh-CN.
+    allowed_paths:
+      - backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+      - backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
+      - backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+      - backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - backend/tests/Unit/Services/Career/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Import content, publish content, alter sitemap/llms/index strategy, deploy, or modify fap-web.
+    validation:
+      - php -l backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+      - php -l backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
+      - php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Services/Career/PublicCareerAuthorityResponseCache.php app/Console/Commands/CareerWarmPublicAuthorityCache.php app/Console/Commands/CareerImportSelectedDisplayAssets.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-DISPLAY-PARITY-04
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-DISPLAY-PARITY-03
+    branch: codex/career-zh-display-parity-04-live-gate
+    title: "CAREER-ZH-DISPLAY-PARITY-04: chore(career): gate zh display live parity"
+    train_scope: career_zh_display_parity
+    status: pending_dependency
+    scope:
+      - Add or run the controlled live parity gate after reviewed Chinese display imports and cache refresh.
+      - Verify the audited 672 Chinese pages are no longer restricted shells and EN/ZH display modules are structurally aligned.
+      - Output final parity report while preserving sitemap/llms/index strategy unless separately authorized.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+      - backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+      - backend/docs/career/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change sitemap, llms.txt, indexability, deploy, or publish without explicit production authorization.
+      - Modify fap-web.
+    validation:
+      - php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi
+      - cd backend && php artisan career:audit-zh-display-parity --json --output=/private/tmp/career-zh-display-parity-04-live.json
+      - python3 -m json.tool /private/tmp/career-zh-display-parity-04-live.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added `career:audit-zh-display-parity`, a read-only public API audit command for EN/ZH career job display parity.
- Registered the command in the console kernel.
- Added focused HTTP-faked coverage for same-module, zh-missing-module, zh-extra-module, EN-only failure, and ZH-only failure classifications.
- Registered the CAREER-ZH-DISPLAY-PARITY PR train metadata for PR01-PR04 in root `docs/codex`.

## Why
The current production symptom is not a route availability issue: EN/ZH indexes both expose the same 1046 slugs, but 672 Chinese job details are missing display modules present in English. This PR turns that observation into a repeatable audit report with per-slug missing modules, Chinese gate/warning reasons, and sample URLs.

## Validation commands
- `php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php`
- `php -l backend/app/Console/Kernel.php`
- `php -l backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi`
- `cd backend && php artisan career:audit-zh-display-parity --json --output=/private/tmp/career-zh-display-parity-01-live.json`
- `python3 -c "import json; p=json.load(open('/private/tmp/career-zh-display-parity-01-live.json')); assert p['read_only'] is True and p['writes_database'] is False; assert p['sitemap_changed'] is False and p['llms_changed'] is False and p['index_strategy_changed'] is False; assert p['summary']['total_slugs'] >= 1; print('career zh display parity live report ok:', p['summary']['total_slugs'], p['summary']['en_has_modules_zh_missing'])"`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerAuditZhDisplayParity.php app/Console/Kernel.php tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check -- backend/app/Console/Commands/CareerAuditZhDisplayParity.php backend/app/Console/Kernel.php backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

Live read-only audit result:
- `total_slugs=1046`
- `en_index_count=1046`
- `zh_index_count=1046`
- `same_module_set=374`
- `en_has_modules_zh_missing=672`
- `zh_has_modules_en_missing=0`
- `en_200_zh_not_200=0`
- `zh_200_en_not_200=0`
- `api_failure_count=0`

## Intentionally deferred
- No display asset import or CMS/database mutation. That is CAREER-ZH-DISPLAY-PARITY-02.
- No cache forget/warm behavior. That is CAREER-ZH-DISPLAY-PARITY-03.
- No controlled publish, deploy, sitemap/llms/index strategy change, or final live parity gate. That is CAREER-ZH-DISPLAY-PARITY-04 or separate explicit production authorization.

Repository rule impact: career job content and display semantics remain backend-authoritative. This PR adds read-only audit tooling only and does not introduce frontend fallback content or runtime rendering authority.
