### PR TITLE
CAREER-ZH-DISPLAY-PARITY-02: feat(career): support zh display import manifests

### DIFF
--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -22,6 +22,8 @@ final class CareerImportSelectedDisplayAssets extends Command
 
     private const VALIDATOR_VERSION = 'career_selected_display_asset_import_v0.1';
 
+    private const ZH_DISPLAY_PARITY_SCOPE = 'career_zh_display_parity_v0.1';
+
     private const SOURCE_SYSTEM_SOC = 'us_soc';
 
     private const SOURCE_SYSTEM_ONET = 'onet_soc_2019';
@@ -131,6 +133,8 @@ final class CareerImportSelectedDisplayAssets extends Command
                 'source_file_basename' => basename($file),
                 'source_file_sha256' => hash_file('sha256', $file) ?: null,
                 'manifest_sha256' => $manifest['manifest_sha256'] ?? null,
+                'manifest_scope' => $manifest['manifest_scope'] ?? null,
+                'manifest_target_locale' => $manifest['manifest_target_locale'] ?? null,
                 'manifest_expected_delta' => $manifest['expected_delta'] ?? null,
                 'requested_slugs' => $slugs,
                 'total_rows' => $workbook['total_rows'],
@@ -283,6 +287,8 @@ final class CareerImportSelectedDisplayAssets extends Command
         $rows = (array) ($decoded['rows'] ?? []);
         $expectedDelta = (array) ($decoded['expected_delta'] ?? []);
         $workbookSha = hash_file('sha256', $workbookPath) ?: null;
+        $manifestScope = trim((string) ($planner['scope'] ?? $decoded['scope'] ?? ''));
+        $targetLocale = trim((string) ($planner['target_locale'] ?? $decoded['target_locale'] ?? ''));
 
         $errors = [];
         if ((string) ($planner['version'] ?? '') !== 'career_full_upload_planner_v0.1') {
@@ -299,6 +305,12 @@ final class CareerImportSelectedDisplayAssets extends Command
         }
         if (! isset($expectedDelta['career_job_display_assets'])) {
             $errors[] = 'Manifest expected_delta.career_job_display_assets is required.';
+        }
+        if ($manifestScope !== '' && $manifestScope !== self::ZH_DISPLAY_PARITY_SCOPE) {
+            $errors[] = 'Manifest planner.scope must be career_zh_display_parity_v0.1 when provided.';
+        }
+        if ($manifestScope === self::ZH_DISPLAY_PARITY_SCOPE && $targetLocale !== 'zh-CN') {
+            $errors[] = 'Manifest planner.target_locale must be zh-CN for career_zh_display_parity_v0.1.';
         }
 
         $candidateSlugs = [];
@@ -330,6 +342,24 @@ final class CareerImportSelectedDisplayAssets extends Command
             if (in_array($status, ['manual_hold', 'duplicate_identity_hold', 'broad_group_hold', 'CN_proxy_hold'], true)) {
                 $errors[] = "Manifest import candidate {$slug} is a held row.";
             }
+            if ($manifestScope === self::ZH_DISPLAY_PARITY_SCOPE) {
+                $localeScope = (array) ($row['locale_scope'] ?? []);
+                if (! in_array('zh-CN', $localeScope, true)) {
+                    $errors[] = "Manifest import candidate {$slug} must include zh-CN in locale_scope.";
+                }
+                if ((string) ($row['target_locale'] ?? '') !== 'zh-CN') {
+                    $errors[] = "Manifest import candidate {$slug} must declare target_locale zh-CN.";
+                }
+                if ((string) ($row['content_authority'] ?? '') !== 'reviewed_workbook') {
+                    $errors[] = "Manifest import candidate {$slug} must declare content_authority reviewed_workbook.";
+                }
+                if ((bool) ($row['reviewed_chinese_fields'] ?? false) !== true) {
+                    $errors[] = "Manifest import candidate {$slug} must have reviewed_chinese_fields true.";
+                }
+                if ((bool) ($row['seo_release_gates_unchanged'] ?? false) !== true) {
+                    $errors[] = "Manifest import candidate {$slug} must keep seo_release_gates_unchanged true.";
+                }
+            }
 
             $candidateSlugs[] = $slug;
         }
@@ -349,6 +379,10 @@ final class CareerImportSelectedDisplayAssets extends Command
             'row_count' => count($rows),
             'upload_candidate_slugs' => $candidateSlugs,
         ];
+        if ($manifestScope === self::ZH_DISPLAY_PARITY_SCOPE) {
+            $manifestPayload['scope'] = $manifestScope;
+            $manifestPayload['target_locale'] = $targetLocale;
+        }
         $computedManifestSha = hash('sha256', json_encode($manifestPayload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '');
         if (($planner['upload_manifest_sha256'] ?? null) !== $computedManifestSha) {
             $errors[] = 'Manifest upload_manifest_sha256 does not match workbook/candidate payload.';
@@ -360,6 +394,8 @@ final class CareerImportSelectedDisplayAssets extends Command
 
         $decoded['manifest_sha256'] = hash_file('sha256', $path) ?: null;
         $decoded['manifest_candidate_slugs'] = $candidateSlugs;
+        $decoded['manifest_scope'] = $manifestScope !== '' ? $manifestScope : null;
+        $decoded['manifest_target_locale'] = $targetLocale !== '' ? $targetLocale : null;
         $decoded['manifest_expected_display_delta'] = (int) ($expectedDelta['career_job_display_assets'] ?? 0);
         $decoded['manifest_baseline_display_assets'] = (int) data_get($planner, 'db_baseline.career_job_display_assets', 0);
 

--- a/backend/app/Console/Commands/CareerValidateDisplayBatch.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayBatch.php
@@ -444,6 +444,8 @@ final class CareerValidateDisplayBatch extends Command
             'personality_fit_present' => $json['en_personality'] !== null && $json['cn_personality'] !== null,
             'caveat_present' => $this->hasText($row, 'EN_Caveat') && $this->hasText($row, 'CN_Caveat'),
             'next_steps_present' => $this->hasText($row, 'EN_Next_Steps') && $this->hasText($row, 'CN_Next_Steps'),
+            'reviewed_chinese_text_present' => $this->reviewedChineseTextPresent($row),
+            'copied_en_to_cn_fields' => $this->copiedEnglishToChineseFields($row),
             'forbidden_public_terms_found' => $this->forbiddenTerms($row),
         ];
     }
@@ -923,6 +925,8 @@ final class CareerValidateDisplayBatch extends Command
             $contentGate['personality_fit_present'],
             $contentGate['caveat_present'],
             $contentGate['next_steps_present'],
+            $contentGate['reviewed_chinese_text_present'],
+            $contentGate['copied_en_to_cn_fields'] === [],
             $contentGate['forbidden_public_terms_found'] === [],
         ]);
         $authorityState = (string) ($authorityGate['authority_state'] ?? $authorityGate['public_API_state'] ?? '');
@@ -1221,6 +1225,8 @@ final class CareerValidateDisplayBatch extends Command
                 static fn (array $row): string => (string) $row['slug'],
                 array_filter($rows, static fn (array $row): bool => (bool) $row['import_eligible']),
             )),
+            'scope' => 'career_zh_display_parity_v0.1',
+            'target_locale' => 'zh-CN',
         ];
 
         return [
@@ -1233,6 +1239,8 @@ final class CareerValidateDisplayBatch extends Command
             ],
             'planner' => [
                 'version' => 'career_full_upload_planner_v0.1',
+                'scope' => 'career_zh_display_parity_v0.1',
+                'target_locale' => 'zh-CN',
                 'generated_at' => now()->toISOString(),
                 'db_baseline' => [
                     'career_job_display_assets' => $this->displayAssetBaselineCount(),
@@ -1267,6 +1275,12 @@ final class CareerValidateDisplayBatch extends Command
             'hold_reason' => $this->fullUploadHoldReason($status),
             'import_eligible' => $importEligible,
             'cohort_id' => $importEligible ? 'full_upload_manifest' : null,
+            'locale_scope' => ['en', 'zh-CN'],
+            'target_locale' => 'zh-CN',
+            'content_authority' => 'reviewed_workbook',
+            'reviewed_chinese_fields' => (bool) data_get($item, 'content_gate.reviewed_chinese_text_present', false)
+                && data_get($item, 'content_gate.copied_en_to_cn_fields', []) === [],
+            'seo_release_gates_unchanged' => true,
             'authority_state' => (string) ($authority['authority_state'] ?? ''),
             'display_surface_ready' => (bool) ($authority['display_surface_ready'] ?? false),
             'scores' => [
@@ -1778,6 +1792,61 @@ final class CareerValidateDisplayBatch extends Command
         sort($found);
 
         return $found;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     */
+    private function reviewedChineseTextPresent(array $row): bool
+    {
+        foreach (array_keys($this->chineseReviewFieldPairs()) as $cnField) {
+            if (! $this->containsHan($this->stringValue($row, $cnField))) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  array<string, string|int>  $row
+     * @return list<string>
+     */
+    private function copiedEnglishToChineseFields(array $row): array
+    {
+        $copied = [];
+        foreach ($this->chineseReviewFieldPairs() as $cnField => $enField) {
+            if ($this->normalizedText($this->stringValue($row, $cnField)) === $this->normalizedText($this->stringValue($row, $enField))) {
+                $copied[] = "{$cnField}:{$enField}";
+            }
+        }
+
+        return $copied;
+    }
+
+    /**
+     * @return array<string, string>
+     */
+    private function chineseReviewFieldPairs(): array
+    {
+        return [
+            'CN_Title' => 'EN_Title',
+            'CN_H1' => 'EN_H1',
+            'CN_Quick_Answer' => 'EN_Quick_Answer',
+            'CN_Definition' => 'EN_Definition',
+            'CN_Caveat' => 'EN_Caveat',
+            'CN_Next_Steps' => 'EN_Next_Steps',
+        ];
+    }
+
+    private function containsHan(string $value): bool
+    {
+        return preg_match('/\p{Han}/u', $value) === 1;
+    }
+
+    private function normalizedText(string $value): string
+    {
+        return strtolower(trim(preg_replace('/\s+/u', ' ', $value) ?? $value));
     }
 
     /**

--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -528,7 +528,7 @@ final class CareerSelectedDisplayAssetMapper
             }
         }
 
-        $this->validateContent($row, $errors);
+        $this->validateContent($row, $errors, $expectedOverride !== null);
         $this->validateSchema($decoded, $errors);
         $this->validateCta($row, $slug, $errors);
         $this->validateSources($decoded['source_refs'] ?? null, $errors);
@@ -776,7 +776,7 @@ final class CareerSelectedDisplayAssetMapper
      * @param  list<string>  $errors
      * @param  array<string, string|int>  $row
      */
-    private function validateContent(array $row, array &$errors): void
+    private function validateContent(array $row, array &$errors, bool $requireReviewedChinese): void
     {
         foreach ([
             'EN_Title',
@@ -793,6 +793,25 @@ final class CareerSelectedDisplayAssetMapper
             'CN_Next_Steps',
         ] as $field) {
             $this->expect($this->stringValue($row, $field) !== '', "{$field} is required.", $errors);
+        }
+
+        if (! $requireReviewedChinese) {
+            return;
+        }
+
+        foreach ([
+            'CN_Title' => 'EN_Title',
+            'CN_H1' => 'EN_H1',
+            'CN_Quick_Answer' => 'EN_Quick_Answer',
+            'CN_Definition' => 'EN_Definition',
+            'CN_Caveat' => 'EN_Caveat',
+            'CN_Next_Steps' => 'EN_Next_Steps',
+        ] as $cnField => $enField) {
+            $cnValue = $this->stringValue($row, $cnField);
+            $enValue = $this->stringValue($row, $enField);
+
+            $this->expect($this->containsHan($cnValue), "{$cnField} must contain reviewed Chinese text.", $errors);
+            $this->expect($this->normalizedText($cnValue) !== $this->normalizedText($enValue), "{$cnField} must not be copied from {$enField}.", $errors);
         }
     }
 
@@ -1066,6 +1085,16 @@ final class CareerSelectedDisplayAssetMapper
         $encoded = json_encode($value, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
 
         return strtolower(is_string($encoded) ? $encoded : '');
+    }
+
+    private function containsHan(string $value): bool
+    {
+        return preg_match('/\p{Han}/u', $value) === 1;
+    }
+
+    private function normalizedText(string $value): string
+    {
+        return strtolower(trim(preg_replace('/\s+/u', ' ', $value) ?? $value));
     }
 
     private function urlCount(mixed $value): int

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -106,6 +106,61 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
+    public function zh_display_parity_manifest_requires_reviewed_chinese_workbook_authority(): void
+    {
+        $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
+        $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        $workbook = $this->writeWorkbook([$row]);
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest(
+                $workbook,
+                [$row],
+                manifestScope: 'career_zh_display_parity_v0.1',
+                targetLocale: 'zh-CN',
+            ),
+        );
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('career_zh_display_parity_v0.1', $report['manifest_scope']);
+        $this->assertSame('zh-CN', $report['manifest_target_locale']);
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
+            $this->writeManifest(
+                $workbook,
+                [$row],
+                manifestScope: 'career_zh_display_parity_v0.1',
+                targetLocale: 'zh-CN',
+                reviewedChineseFields: false,
+            ),
+        );
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('must have reviewed_chinese_fields true', implode(' ', $report['errors']));
+
+        $copied = $row;
+        $copied['CN_Title'] = $copied['EN_Title'];
+        $copied['CN_H1'] = $copied['EN_H1'];
+        $copiedWorkbook = $this->writeWorkbook([$copied]);
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $copiedWorkbook,
+            $this->writeManifest(
+                $copiedWorkbook,
+                [$copied],
+                manifestScope: 'career_zh_display_parity_v0.1',
+                targetLocale: 'zh-CN',
+            ),
+        );
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('CN_Title must contain reviewed Chinese text.', implode(' ', $report['errors']));
+        $this->assertStringContainsString('CN_Title must not be copied from EN_Title.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
     public function plan_manifest_rejects_invalid_or_held_candidates(): void
     {
         $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
@@ -900,7 +955,10 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     public function command_created_selected_asset_is_available_to_display_surface_builder(): void
     {
         $occupation = $this->createAuthorityOccupation('data-scientists', '15-2051', '15-2051.00');
-        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+        $row = $this->row('data-scientists');
+        $row['Primary_CTA_Label'] = '测量我的职业兴趣';
+        $row['CN_Target_Queries'] = $this->encodeJson(['query' => '数据科学家职业']);
+        $workbook = $this->writeWorkbook([$row]);
 
         [$exitCode, $report] = $this->runImport($workbook, 'data-scientists', ['--force' => true]);
 
@@ -952,8 +1010,13 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         int $baselineDisplayAssets = 0,
         ?string $publicResolutionType = 'public_canonical_job',
         string $rowStatus = 'upload_candidate',
+        ?string $manifestScope = null,
+        ?string $targetLocale = null,
+        ?bool $reviewedChineseFields = null,
+        ?string $contentAuthority = null,
+        ?bool $seoReleaseGatesUnchanged = null,
     ): string {
-        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus): array {
+        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus, $manifestScope, $targetLocale, $reviewedChineseFields, $contentAuthority, $seoReleaseGatesUnchanged): array {
             $manifestRow = [
                 'row_number' => $index + 2,
                 'slug' => $row['Slug'],
@@ -966,6 +1029,13 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
 
             if ($publicResolutionType !== null) {
                 $manifestRow['public_resolution_type'] = $publicResolutionType;
+            }
+            if ($manifestScope === 'career_zh_display_parity_v0.1') {
+                $manifestRow['locale_scope'] = ['en', 'zh-CN'];
+                $manifestRow['target_locale'] = $targetLocale ?? 'zh-CN';
+                $manifestRow['content_authority'] = $contentAuthority ?? 'reviewed_workbook';
+                $manifestRow['reviewed_chinese_fields'] = $reviewedChineseFields ?? true;
+                $manifestRow['seo_release_gates_unchanged'] = $seoReleaseGatesUnchanged ?? true;
             }
 
             return $manifestRow;
@@ -982,6 +1052,10 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
             'row_count' => count($manifestRows),
             'upload_candidate_slugs' => $candidateSlugs,
         ];
+        if ($manifestScope === 'career_zh_display_parity_v0.1') {
+            $payload['scope'] = $manifestScope;
+            $payload['target_locale'] = $targetLocale ?? 'zh-CN';
+        }
         $manifest = [
             'workbook' => [
                 'path' => $workbook,
@@ -992,6 +1066,8 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
             ],
             'planner' => [
                 'version' => $plannerVersion,
+                'scope' => $manifestScope,
+                'target_locale' => $targetLocale,
                 'generated_at' => '2026-05-05T00:00:00Z',
                 'db_baseline' => [
                     'career_job_display_assets' => $baselineDisplayAssets,

--- a/backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
@@ -132,10 +132,10 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
         $this->createAuthorityOccupation('ready-upload-slug', '15-2011', '15-2011.00');
 
         $workbook = $this->writeWorkbook([
-            $this->row('existing-display-slug', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
-            $this->row('ready-upload-slug', title: 'Ready Upload', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
+            $this->row('existing-display-slug', cnTitle: '已有展示职业', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
+            $this->row('ready-upload-slug', title: 'Ready Upload', cnTitle: '待上传职业', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
             $this->row('needs-repair-slug', title: 'Needs Repair', soc: '17-1011', onet: '17-1011.00'),
-            $this->row('software-developers', title: 'Software Developers', soc: '15-1252', onet: '15-1252.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
+            $this->row('software-developers', title: 'Software Developers', cnTitle: '软件开发人员', soc: '15-1252', onet: '15-1252.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
         ]);
         $planOutput = $this->tempDir().'/career_full_upload_plan.json';
         $planMarkdown = $this->tempDir().'/career_full_upload_plan.md';
@@ -154,6 +154,8 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
         $this->assertFileExists($planMarkdown);
         $this->assertSame(4, $plan['workbook']['rows']);
         $this->assertCount(4, $plan['rows']);
+        $this->assertSame('career_zh_display_parity_v0.1', $plan['planner']['scope']);
+        $this->assertSame('zh-CN', $plan['planner']['target_locale']);
         $this->assertSame($plan['planner']['upload_manifest_sha256'], $report['full_upload_plan']['planner']['upload_manifest_sha256']);
 
         $rows = collect($plan['rows'])->keyBy('slug');
@@ -161,6 +163,11 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
         $this->assertFalse($rows->get('existing-display-slug')['import_eligible']);
         $this->assertSame('upload_candidate', $rows->get('ready-upload-slug')['status']);
         $this->assertTrue($rows->get('ready-upload-slug')['import_eligible']);
+        $this->assertSame(['en', 'zh-CN'], $rows->get('ready-upload-slug')['locale_scope']);
+        $this->assertSame('zh-CN', $rows->get('ready-upload-slug')['target_locale']);
+        $this->assertSame('reviewed_workbook', $rows->get('ready-upload-slug')['content_authority']);
+        $this->assertTrue($rows->get('ready-upload-slug')['reviewed_chinese_fields']);
+        $this->assertTrue($rows->get('ready-upload-slug')['seo_release_gates_unchanged']);
         $this->assertSame('needs_workbook_repair', $rows->get('needs-repair-slug')['status']);
         $this->assertFalse($rows->get('needs-repair-slug')['import_eligible']);
         $this->assertSame('manual_hold', $rows->get('software-developers')['status']);
@@ -179,10 +186,10 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
         $this->createAuthorityOccupation('ready-upload-slug-two', '15-2011', '15-2011.00');
 
         $first = $this->writeWorkbook([
-            $this->row('ready-upload-slug', title: 'Ready Upload', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
+            $this->row('ready-upload-slug', title: 'Ready Upload', cnTitle: '待上传职业', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
         ]);
         $second = $this->writeWorkbook([
-            $this->row('ready-upload-slug-two', title: 'Ready Upload Two', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
+            $this->row('ready-upload-slug-two', title: 'Ready Upload Two', cnTitle: '第二个待上传职业', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
         ]);
 
         [, $firstReport] = $this->runValidator($first, '');
@@ -441,7 +448,7 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
     private function row(
         string $slug,
         string $title = 'Data scientists',
-        string $cnTitle = 'Data scientists',
+        string $cnTitle = '数据科学家',
         string $soc = '15-2051',
         string $onet = '15-2051.00',
         bool $schemaValid = false,

--- a/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
@@ -57,6 +57,23 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         $this->assertSame(24, $result['summary']['component_order_count']);
     }
 
+    public function test_it_rejects_manifest_rows_that_copy_english_into_core_chinese_fields(): void
+    {
+        $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
+        $row['CN_Title'] = $row['EN_Title'];
+        $row['CN_H1'] = $row['EN_H1'];
+
+        $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow(
+            $row,
+            ['soc' => '15-2011', 'onet' => '15-2011.00'],
+        );
+
+        $errors = implode(' ', $result['errors']);
+        $this->assertStringContainsString('CN_Title must contain reviewed Chinese text.', $errors);
+        $this->assertStringContainsString('CN_Title must not be copied from EN_Title.', $errors);
+        $this->assertStringContainsString('CN_H1 must not be copied from EN_H1.', $errors);
+    }
+
     public function test_it_maps_d5_selected_rows_to_display_asset_payloads(): void
     {
         foreach ($this->d5Rows() as $row) {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52187,7 +52187,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-01-audit",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
     "depends_on": [],
@@ -52245,14 +52245,18 @@
         ],
         "merge_state": "CLEAN",
         "evidence": "GitHub checks passed for PR #2020 at head ef50a4a66477dac4ea03cd822d6c30e1d958058a and mergeStateStatus is CLEAN."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2020 is MERGED; origin/main contains merge commit af382b46070d1455f6b7e2d9fe9af18ba7cb0e55; remote branch codex/career-zh-display-parity-01-audit was pruned; local branch cleanup was complete; post-merge command registration and one-slug read-only audit passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "ef50a4a66477dac4ea03cd822d6c30e1d958058a",
+    "commit_sha": "af382b46070d1455f6b7e2d9fe9af18ba7cb0e55",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2020",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-09T15:28:28Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [],
     "transitions": [
       {
@@ -52284,6 +52288,11 @@
         "at": "2026-06-09",
         "status": "ready_to_merge",
         "note": "GitHub checks passed and merge state was CLEAN for PR #2020 head ef50a4a66477dac4ea03cd822d6c30e1d958058a."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "reconciled_merged",
+        "note": "Reconciled inside CAREER-ZH-DISPLAY-PARITY-02 metadata scope after PR #2020 squash merge. origin/main contains af382b46070d1455f6b7e2d9fe9af18ba7cb0e55 and local/remote task branches are cleaned up."
       }
     ]
   },
@@ -52291,7 +52300,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-02-import-manifest",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-02: feat(career): support zh display import manifests",
     "depends_on": [
@@ -52303,13 +52312,59 @@
         "evidence": "User explicitly authorized adding and executing CAREER-ZH-DISPLAY-PARITY-01 through CAREER-ZH-DISPLAY-PARITY-04, including fap-api docs/codex metadata updates, on 2026-06-09."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-ZH-DISPLAY-PARITY-01 to merge."
+        "status": "pass",
+        "evidence": "CAREER-ZH-DISPLAY-PARITY-01 PR #2020 merged at 2026-06-09T15:28:28Z and origin/main contains merge commit af382b46070d1455f6b7e2d9fe9af18ba7cb0e55."
+      },
+      "implementation": {
+        "status": "pass",
+        "evidence": "Implemented zh display parity manifest scope on validate/import commands and manifest-scoped reviewed Chinese field guard in mapper; no database writes, sitemap, llms, or index strategy changes."
+      },
+      "php_lint": {
+        "status": "pass",
+        "evidence": "php -l passed for CareerImportSelectedDisplayAssets.php, CareerValidateDisplayBatch.php, CareerSelectedDisplayAssetMapper.php, and focused test files."
+      },
+      "focused_tests": {
+        "status": "pass",
+        "evidence": "APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=\":memory:\" php artisan test passed for CareerImportSelectedDisplayAssetsCommandTest.php (28 tests / 4957 assertions), CareerValidateDisplayBatchCommandTest.php (11 tests / 144 assertions), and CareerSelectedDisplayAssetMapperTest.php (13 tests / 2691 assertions)."
+      },
+      "pint": {
+        "status": "pass",
+        "evidence": "cd backend && ./vendor/bin/pint --test passed for scoped command, mapper, and test files."
+      },
+      "metadata": {
+        "status": "pass",
+        "evidence": "docs/codex/pr-train-state.json parsed as JSON; docs/codex/pr-train.yaml parsed as YAML via Ruby stdlib."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to PR02 scoped validate/import/mapper tests plus docs/codex state metadata."
+      },
+      "diff_check": {
+        "status": "pass",
+        "evidence": "Path-limited git diff --check passed for scoped PR02 files and docs/codex metadata."
+      },
+      "github": {
+        "status": "pass",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2021",
+        "head_sha": "cf63925061cefe8be49188f187e0453f9d656d25",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "verify-bigfive",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN",
+        "evidence": "GitHub checks passed for PR #2021 at head cf63925061cefe8be49188f187e0453f9d656d25 and mergeStateStatus is CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "cf63925061cefe8be49188f187e0453f9d656d25",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2021",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -52319,6 +52374,26 @@
         "at": "2026-06-09",
         "status": "pending_dependency",
         "note": "Future import/validation entry initialized only; implementation deferred until PR01 is merged."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "local_checks_passed",
+        "note": "PR02 implementation and local checks passed. Validator full-upload plans now include career_zh_display_parity_v0.1 scope and zh-CN target; import manifests enforce reviewed_workbook zh-CN rows; mapper rejects copied English core Chinese fields for manifest-scoped rows."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "committed_pending_push",
+        "note": "Created scoped implementation commit 83ee19f5fb8b82ba01a94a8e92deff82ad68d159 pending push and PR creation."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2021 for CAREER-ZH-DISPLAY-PARITY-02; waiting for GitHub checks."
+      },
+      {
+        "at": "2026-06-09",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and mergeStateStatus is CLEAN for PR #2021; ready for squash merge."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added `career_zh_display_parity_v0.1` manifest scope support to `career:validate-display-batch` full-upload plans.
- Hardened `career:import-selected-display-assets --manifest` so zh parity manifests must target `zh-CN`, use `reviewed_workbook`, keep SEO release gates unchanged, and mark `reviewed_chinese_fields=true` per candidate row.
- Added manifest-scoped mapper validation that rejects copied EN -> CN core text fields before writing display assets.
- Reconciled `CAREER-ZH-DISPLAY-PARITY-01` merged state in the PR-train ledger and advanced PR02 local-check state.

## Why
This keeps the 672 zh display parity repair path on the existing validated workbook/import pipeline, while blocking accidental English-copy display assets and preserving CMS/workbook authority. It does not perform any import, cache warm, publish, sitemap, llms, or index strategy change.

## Validation commands
- `php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php`
- `php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php`
- `php -l backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php`
- `php -l backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php && php -l backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php && php -l backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Console/Commands/CareerValidateDisplayBatch.php app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check -- backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php backend/app/Console/Commands/CareerValidateDisplayBatch.php backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php docs/codex/pr-train.yaml docs/codex/pr-train-state.json`

## Intentionally deferred
- No real `--force` import for the 672 zh pages.
- No cache forget/warm changes; that remains `CAREER-ZH-DISPLAY-PARITY-03`.
- No live parity gate or production publish; that remains `CAREER-ZH-DISPLAY-PARITY-04`.
- No sitemap, llms, canonical, or indexing behavior changes.

## Repository rule impact
Career job display content remains backend/CMS/workbook authoritative. This PR strengthens the backend import contract only; it does not introduce frontend fallback content or publishable static content.
