### PR TITLE
CAREER-ZH-DISPLAY-PARITY-04: chore(career): gate zh display live parity

### DIFF
--- a/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+++ b/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
@@ -29,6 +29,8 @@ final class CareerAuditZhDisplayParity extends Command
         {--timeout=15 : HTTP timeout in seconds}
         {--batch-size=40 : Max slugs per concurrent detail batch}
         {--sample-limit=20 : Max sample rows per summary bucket}
+        {--summary-only : Omit per-slug items from the JSON report}
+        {--assert-live-parity : Exit non-zero when the live parity gate is blocked}
         {--json : Emit JSON report}
         {--output= : Optional report output path}';
 
@@ -43,6 +45,7 @@ final class CareerAuditZhDisplayParity extends Command
             $batchSize = max(1, min(100, (int) $this->option('batch-size')));
             $sampleLimit = max(1, (int) $this->option('sample-limit'));
             $explicitSlugs = $this->csvOption('slugs');
+            $assertLiveParity = (bool) $this->option('assert-live-parity');
 
             $index = $explicitSlugs === []
                 ? $this->indexSlugs($apiBase, $timeout)
@@ -59,9 +62,12 @@ final class CareerAuditZhDisplayParity extends Command
             $items = $this->auditSlugs($apiBase, $siteBase, $slugs, $timeout, $batchSize);
 
             $summary = $this->summary($items, $index, $sampleLimit);
+            $liveGate = $this->liveGate($summary, $items);
             $report = [
                 'validator_version' => self::VALIDATOR_VERSION,
-                'decision' => ($summary['api_failure_count'] ?? 0) === 0 ? 'pass' : 'blocked',
+                'decision' => $assertLiveParity
+                    ? $liveGate['decision']
+                    : (($summary['api_failure_count'] ?? 0) === 0 ? 'pass' : 'blocked'),
                 'read_only' => true,
                 'writes_database' => false,
                 'cms_mutation' => false,
@@ -71,12 +77,12 @@ final class CareerAuditZhDisplayParity extends Command
                 'api_base' => $apiBase,
                 'site_base' => $siteBase,
                 'scan_scope' => $explicitSlugs === [] ? 'public_index_union' : 'explicit_slugs',
+                'assert_live_parity' => $assertLiveParity,
+                'live_gate' => $liveGate,
                 'summary' => $summary,
-                'items' => $items,
+                'items' => (bool) $this->option('summary-only') ? [] : $items,
                 'next_prs' => [
-                    'CAREER-ZH-DISPLAY-PARITY-02' => 'Use reviewed Chinese CMS/workbook display fields through validate/import manifest flow; do not copy English content.',
-                    'CAREER-ZH-DISPLAY-PARITY-03' => 'Add per-slug/per-locale detail cache forget/warm for imported zh-CN display assets.',
-                    'CAREER-ZH-DISPLAY-PARITY-04' => 'Run controlled publish/live parity gate without changing sitemap/llms/index strategy unless separately authorized.',
+                    'controlled_import_required' => 'If live_gate.decision is blocked because zh pages remain restricted shells or structurally mismatched, run only an explicitly approved reviewed-workbook import/publish/cache refresh before asserting live parity.',
                 ],
             ];
 
@@ -239,6 +245,61 @@ final class CareerAuditZhDisplayParity extends Command
             'classification_counts' => $classifications,
             'index_failures' => $index['failures'] ?? [],
             'samples' => $sampleByClassification,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function liveGate(array $summary, array $items): array
+    {
+        $restrictedShellCount = 0;
+        foreach ($items as $item) {
+            $reasons = (array) ($item['zh_gate_reasons'] ?? []);
+            foreach ($reasons as $reason) {
+                $reason = (string) $reason;
+                if (str_contains($reason, 'runtime_published_shell')
+                    || str_contains($reason, 'critical_missing_field:')) {
+                    $restrictedShellCount++;
+
+                    break;
+                }
+            }
+        }
+
+        $blockers = [];
+        if ((int) ($summary['api_failure_count'] ?? 0) > 0) {
+            $blockers[] = 'api_failures_or_http_mismatches';
+        }
+        if ((int) ($summary['index_en_only_count'] ?? 0) > 0 || (int) ($summary['index_zh_only_count'] ?? 0) > 0) {
+            $blockers[] = 'public_index_locale_mismatch';
+        }
+        if ((int) ($summary['en_has_modules_zh_missing'] ?? 0) > 0) {
+            $blockers[] = 'zh_missing_en_display_modules';
+        }
+        if ((int) ($summary['zh_has_modules_en_missing'] ?? 0) > 0) {
+            $blockers[] = 'zh_has_unexpected_extra_modules';
+        }
+        if ($restrictedShellCount > 0) {
+            $blockers[] = 'zh_restricted_shell_or_integrity_gap';
+        }
+
+        return [
+            'decision' => $blockers === [] ? 'pass' : 'blocked',
+            'blockers' => $blockers,
+            'total_slugs' => (int) ($summary['total_slugs'] ?? 0),
+            'same_module_set' => (int) ($summary['same_module_set'] ?? 0),
+            'module_mismatch_count' => (int) ($summary['en_has_modules_zh_missing'] ?? 0)
+                + (int) ($summary['zh_has_modules_en_missing'] ?? 0),
+            'restricted_shell_count' => $restrictedShellCount,
+            'api_failure_count' => (int) ($summary['api_failure_count'] ?? 0),
+            'index_mismatch_count' => (int) ($summary['index_en_only_count'] ?? 0)
+                + (int) ($summary['index_zh_only_count'] ?? 0),
+            'sitemap_changed' => false,
+            'llms_changed' => false,
+            'index_strategy_changed' => false,
         ];
     }
 

--- a/backend/docs/career/generated/career-zh-display-parity-04-live-report.json
+++ b/backend/docs/career/generated/career-zh-display-parity-04-live-report.json
@@ -1,0 +1,1811 @@
+{
+  "validator_version": "career_zh_display_parity_audit_v0.1",
+  "generated_from": "/private/tmp/career-zh-display-parity-04-live.json",
+  "read_only": true,
+  "writes_database": false,
+  "cms_mutation": false,
+  "sitemap_changed": false,
+  "llms_changed": false,
+  "index_strategy_changed": false,
+  "api_base": "https://api.fermatmind.com/api/v0.5/career/jobs",
+  "site_base": "https://fermatmind.com",
+  "scan_scope": "public_index_union",
+  "decision": "pass",
+  "live_gate": {
+    "decision": "blocked",
+    "blockers": [
+      "zh_missing_en_display_modules",
+      "zh_restricted_shell_or_integrity_gap"
+    ],
+    "total_slugs": 1046,
+    "same_module_set": 374,
+    "module_mismatch_count": 672,
+    "restricted_shell_count": 1029,
+    "api_failure_count": 0,
+    "index_mismatch_count": 0,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "index_strategy_changed": false
+  },
+  "summary": {
+    "total_slugs": 1046,
+    "en_index_count": 1046,
+    "zh_index_count": 1046,
+    "index_en_only_count": 0,
+    "index_zh_only_count": 0,
+    "same_module_set": 374,
+    "en_has_modules_zh_missing": 672,
+    "zh_has_modules_en_missing": 0,
+    "en_200_zh_not_200": 0,
+    "zh_200_en_not_200": 0,
+    "both_missing_or_failed": 0,
+    "api_failure_count": 0,
+    "classification_counts": {
+      "same_module_set": 374,
+      "en_has_modules_zh_missing": 672
+    },
+    "index_failures": [
+
+    ],
+    "samples": {
+      "same_module_set": [
+        {
+          "slug": "accountants-and-auditors",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/accountants-and-auditors",
+            "zh": "https://fermatmind.com/zh/career/jobs/accountants-and-auditors",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:fit_score.provisional",
+            "amber_flag:strain_score.restricted",
+            "amber_flag:ai_survival_score.provisional",
+            "critical_missing_field:task_prototype_signature",
+            "critical_missing_field:structural_stability"
+          ]
+        },
+        {
+          "slug": "actors",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/actors",
+            "zh": "https://fermatmind.com/zh/career/jobs/actors",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/actors?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/actors?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 4,
+            "zh-CN": 4,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "aerospace-engineers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/aerospace-engineers",
+            "zh": "https://fermatmind.com/zh/career/jobs/aerospace-engineers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 12,
+            "zh-CN": 12,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:runtime_published_navigation_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "blocked_claim:display_asset_claims_unavailable",
+            "integrity_state:runtime_published_shell",
+            "critical_missing_field:compiled_recommendation_snapshot",
+            "critical_missing_field:display_asset_claims"
+          ]
+        },
+        {
+          "slug": "agricultural-and-food-scientists",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-and-food-scientists",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-and-food-scientists",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-scientists?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-scientists?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 12,
+            "zh-CN": 12,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:runtime_published_navigation_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "blocked_claim:display_asset_claims_unavailable",
+            "integrity_state:runtime_published_shell",
+            "critical_missing_field:compiled_recommendation_snapshot",
+            "critical_missing_field:display_asset_claims"
+          ]
+        },
+        {
+          "slug": "agricultural-workers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-workers",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-workers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-workers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-workers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 12,
+            "zh-CN": 12,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:runtime_published_navigation_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "blocked_claim:display_asset_claims_unavailable",
+            "integrity_state:runtime_published_shell",
+            "critical_missing_field:compiled_recommendation_snapshot",
+            "critical_missing_field:display_asset_claims"
+          ]
+        },
+        {
+          "slug": "animal-scientists",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/animal-scientists",
+            "zh": "https://fermatmind.com/zh/career/jobs/animal-scientists",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-scientists?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-scientists?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "animal-trainers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/animal-trainers",
+            "zh": "https://fermatmind.com/zh/career/jobs/animal-trainers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-trainers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-trainers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "announcers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/announcers",
+            "zh": "https://fermatmind.com/zh/career/jobs/announcers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/announcers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/announcers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 12,
+            "zh-CN": 12,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:runtime_published_navigation_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "blocked_claim:display_asset_claims_unavailable",
+            "integrity_state:runtime_published_shell",
+            "critical_missing_field:compiled_recommendation_snapshot",
+            "critical_missing_field:display_asset_claims"
+          ]
+        },
+        {
+          "slug": "anthropologists-and-archeologists",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/anthropologists-and-archeologists",
+            "zh": "https://fermatmind.com/zh/career/jobs/anthropologists-and-archeologists",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropologists-and-archeologists?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropologists-and-archeologists?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 12,
+            "zh-CN": 12,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:runtime_published_navigation_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "blocked_claim:display_asset_claims_unavailable",
+            "integrity_state:runtime_published_shell",
+            "critical_missing_field:compiled_recommendation_snapshot",
+            "critical_missing_field:display_asset_claims"
+          ]
+        },
+        {
+          "slug": "anthropology-and-archeology-teachers-postsecondary",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/anthropology-and-archeology-teachers-postsecondary",
+            "zh": "https://fermatmind.com/zh/career/jobs/anthropology-and-archeology-teachers-postsecondary",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropology-and-archeology-teachers-postsecondary?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropology-and-archeology-teachers-postsecondary?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "appraisers-and-assessors-of-real-estate",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/appraisers-and-assessors-of-real-estate",
+            "zh": "https://fermatmind.com/zh/career/jobs/appraisers-and-assessors-of-real-estate",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-and-assessors-of-real-estate?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-and-assessors-of-real-estate?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "appraisers-of-personal-and-business-property",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/appraisers-of-personal-and-business-property",
+            "zh": "https://fermatmind.com/zh/career/jobs/appraisers-of-personal-and-business-property",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-of-personal-and-business-property?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-of-personal-and-business-property?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "arbitrators-mediators-and-conciliators",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/arbitrators-mediators-and-conciliators",
+            "zh": "https://fermatmind.com/zh/career/jobs/arbitrators-mediators-and-conciliators",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/arbitrators-mediators-and-conciliators?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/arbitrators-mediators-and-conciliators?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 12,
+            "zh-CN": 12,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:runtime_published_navigation_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "blocked_claim:display_asset_claims_unavailable",
+            "integrity_state:runtime_published_shell",
+            "critical_missing_field:compiled_recommendation_snapshot",
+            "critical_missing_field:display_asset_claims"
+          ]
+        },
+        {
+          "slug": "architects",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/architects",
+            "zh": "https://fermatmind.com/zh/career/jobs/architects",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architects?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architects?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "architects-except-landscape-and-naval",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/architects-except-landscape-and-naval",
+            "zh": "https://fermatmind.com/zh/career/jobs/architects-except-landscape-and-naval",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architects-except-landscape-and-naval?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architects-except-landscape-and-naval?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "architectural-and-civil-drafters",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/architectural-and-civil-drafters",
+            "zh": "https://fermatmind.com/zh/career/jobs/architectural-and-civil-drafters",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-civil-drafters?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-civil-drafters?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "architectural-and-engineering-managers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/architectural-and-engineering-managers",
+            "zh": "https://fermatmind.com/zh/career/jobs/architectural-and-engineering-managers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-engineering-managers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-engineering-managers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "architecture-teachers-postsecondary",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/architecture-teachers-postsecondary",
+            "zh": "https://fermatmind.com/zh/career/jobs/architecture-teachers-postsecondary",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architecture-teachers-postsecondary?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architecture-teachers-postsecondary?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "archivists",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/archivists",
+            "zh": "https://fermatmind.com/zh/career/jobs/archivists",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/archivists?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/archivists?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "area-ethnic-and-cultural-studies-teachers-postsecondary",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary",
+            "zh": "https://fermatmind.com/zh/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 26,
+            "en_only": 0,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        }
+      ],
+      "en_has_modules_zh_missing": [
+        {
+          "slug": "actuaries",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/actuaries",
+            "zh": "https://fermatmind.com/zh/career/jobs/actuaries",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/actuaries?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/actuaries?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "acupuncturists",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/acupuncturists",
+            "zh": "https://fermatmind.com/zh/career/jobs/acupuncturists",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/acupuncturists?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/acupuncturists?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "acute-care-nurses",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/acute-care-nurses",
+            "zh": "https://fermatmind.com/zh/career/jobs/acute-care-nurses",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/acute-care-nurses?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/acute-care-nurses?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "adapted-physical-education-specialists",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/adapted-physical-education-specialists",
+            "zh": "https://fermatmind.com/zh/career/jobs/adapted-physical-education-specialists",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adapted-physical-education-specialists?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adapted-physical-education-specialists?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "adhesive-bonding-machine-operators-and-tenders",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/adhesive-bonding-machine-operators-and-tenders",
+            "zh": "https://fermatmind.com/zh/career/jobs/adhesive-bonding-machine-operators-and-tenders",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adhesive-bonding-machine-operators-and-tenders?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adhesive-bonding-machine-operators-and-tenders?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "administrative-law-judges-adjudicators-and-hearing-officers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers",
+            "zh": "https://fermatmind.com/zh/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "administrative-services-managers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/administrative-services-managers",
+            "zh": "https://fermatmind.com/zh/career/jobs/administrative-services-managers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-services-managers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-services-managers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+            "zh": "https://fermatmind.com/zh/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "adult-literacy-and-ged-teachers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/adult-literacy-and-ged-teachers",
+            "zh": "https://fermatmind.com/zh/career/jobs/adult-literacy-and-ged-teachers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-literacy-and-ged-teachers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-literacy-and-ged-teachers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "advanced-practice-psychiatric-nurses",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/advanced-practice-psychiatric-nurses",
+            "zh": "https://fermatmind.com/zh/career/jobs/advanced-practice-psychiatric-nurses",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advanced-practice-psychiatric-nurses?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advanced-practice-psychiatric-nurses?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "advertising-and-promotions-managers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/advertising-and-promotions-managers",
+            "zh": "https://fermatmind.com/zh/career/jobs/advertising-and-promotions-managers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-and-promotions-managers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-and-promotions-managers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "advertising-promotions-and-marketing-managers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/advertising-promotions-and-marketing-managers",
+            "zh": "https://fermatmind.com/zh/career/jobs/advertising-promotions-and-marketing-managers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-promotions-and-marketing-managers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-promotions-and-marketing-managers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "advertising-sales-agents",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/advertising-sales-agents",
+            "zh": "https://fermatmind.com/zh/career/jobs/advertising-sales-agents",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-sales-agents?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-sales-agents?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "aerospace-engineering-and-operations-technicians",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/aerospace-engineering-and-operations-technicians",
+            "zh": "https://fermatmind.com/zh/career/jobs/aerospace-engineering-and-operations-technicians",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineering-and-operations-technicians?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineering-and-operations-technicians?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "agents-and-business-managers-of-artists-performers-and-athletes",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes",
+            "zh": "https://fermatmind.com/zh/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "agricultural-and-food-science-technicians",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-and-food-science-technicians",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-and-food-science-technicians",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-science-technicians?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-science-technicians?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "agricultural-engineers",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-engineers",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-engineers",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-engineers?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-engineers?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "agricultural-equipment-operators",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-equipment-operators",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-equipment-operators",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-equipment-operators?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-equipment-operators?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "agricultural-inspectors",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-inspectors",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-inspectors",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-inspectors?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-inspectors?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        },
+        {
+          "slug": "agricultural-sciences-teachers-postsecondary",
+          "sample_urls": {
+            "en": "https://fermatmind.com/en/career/jobs/agricultural-sciences-teachers-postsecondary",
+            "zh": "https://fermatmind.com/zh/career/jobs/agricultural-sciences-teachers-postsecondary",
+            "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-sciences-teachers-postsecondary?locale=en",
+            "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-sciences-teachers-postsecondary?locale=zh-CN"
+          },
+          "module_counts": {
+            "en": 26,
+            "zh-CN": 12,
+            "en_only": 14,
+            "zh_only": 0
+          },
+          "zh_gate_reasons": [
+            "zh_missing_en_display_modules",
+            "amber_flag:display_asset_backed_directory_draft_shell",
+            "blocked_claim:compiled_recommendation_claims_unavailable",
+            "integrity_state:display_asset_backed",
+            "critical_missing_field:compiled_recommendation_snapshot"
+          ]
+        }
+      ]
+    }
+  },
+  "samples": {
+    "same_module_set": [
+      {
+        "slug": "accountants-and-auditors",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/accountants-and-auditors",
+          "zh": "https://fermatmind.com/zh/career/jobs/accountants-and-auditors",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:fit_score.provisional",
+          "amber_flag:strain_score.restricted",
+          "amber_flag:ai_survival_score.provisional",
+          "critical_missing_field:task_prototype_signature",
+          "critical_missing_field:structural_stability"
+        ]
+      },
+      {
+        "slug": "actors",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/actors",
+          "zh": "https://fermatmind.com/zh/career/jobs/actors",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/actors?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/actors?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 4,
+          "zh-CN": 4,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "aerospace-engineers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/aerospace-engineers",
+          "zh": "https://fermatmind.com/zh/career/jobs/aerospace-engineers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 12,
+          "zh-CN": 12,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:runtime_published_navigation_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "blocked_claim:display_asset_claims_unavailable",
+          "integrity_state:runtime_published_shell",
+          "critical_missing_field:compiled_recommendation_snapshot",
+          "critical_missing_field:display_asset_claims"
+        ]
+      },
+      {
+        "slug": "agricultural-and-food-scientists",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-and-food-scientists",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-and-food-scientists",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-scientists?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-scientists?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 12,
+          "zh-CN": 12,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:runtime_published_navigation_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "blocked_claim:display_asset_claims_unavailable",
+          "integrity_state:runtime_published_shell",
+          "critical_missing_field:compiled_recommendation_snapshot",
+          "critical_missing_field:display_asset_claims"
+        ]
+      },
+      {
+        "slug": "agricultural-workers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-workers",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-workers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-workers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-workers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 12,
+          "zh-CN": 12,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:runtime_published_navigation_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "blocked_claim:display_asset_claims_unavailable",
+          "integrity_state:runtime_published_shell",
+          "critical_missing_field:compiled_recommendation_snapshot",
+          "critical_missing_field:display_asset_claims"
+        ]
+      },
+      {
+        "slug": "animal-scientists",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/animal-scientists",
+          "zh": "https://fermatmind.com/zh/career/jobs/animal-scientists",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-scientists?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-scientists?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "animal-trainers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/animal-trainers",
+          "zh": "https://fermatmind.com/zh/career/jobs/animal-trainers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-trainers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-trainers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "announcers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/announcers",
+          "zh": "https://fermatmind.com/zh/career/jobs/announcers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/announcers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/announcers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 12,
+          "zh-CN": 12,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:runtime_published_navigation_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "blocked_claim:display_asset_claims_unavailable",
+          "integrity_state:runtime_published_shell",
+          "critical_missing_field:compiled_recommendation_snapshot",
+          "critical_missing_field:display_asset_claims"
+        ]
+      },
+      {
+        "slug": "anthropologists-and-archeologists",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/anthropologists-and-archeologists",
+          "zh": "https://fermatmind.com/zh/career/jobs/anthropologists-and-archeologists",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropologists-and-archeologists?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropologists-and-archeologists?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 12,
+          "zh-CN": 12,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:runtime_published_navigation_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "blocked_claim:display_asset_claims_unavailable",
+          "integrity_state:runtime_published_shell",
+          "critical_missing_field:compiled_recommendation_snapshot",
+          "critical_missing_field:display_asset_claims"
+        ]
+      },
+      {
+        "slug": "anthropology-and-archeology-teachers-postsecondary",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/anthropology-and-archeology-teachers-postsecondary",
+          "zh": "https://fermatmind.com/zh/career/jobs/anthropology-and-archeology-teachers-postsecondary",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropology-and-archeology-teachers-postsecondary?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropology-and-archeology-teachers-postsecondary?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "appraisers-and-assessors-of-real-estate",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/appraisers-and-assessors-of-real-estate",
+          "zh": "https://fermatmind.com/zh/career/jobs/appraisers-and-assessors-of-real-estate",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-and-assessors-of-real-estate?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-and-assessors-of-real-estate?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "appraisers-of-personal-and-business-property",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/appraisers-of-personal-and-business-property",
+          "zh": "https://fermatmind.com/zh/career/jobs/appraisers-of-personal-and-business-property",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-of-personal-and-business-property?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-of-personal-and-business-property?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "arbitrators-mediators-and-conciliators",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/arbitrators-mediators-and-conciliators",
+          "zh": "https://fermatmind.com/zh/career/jobs/arbitrators-mediators-and-conciliators",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/arbitrators-mediators-and-conciliators?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/arbitrators-mediators-and-conciliators?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 12,
+          "zh-CN": 12,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:runtime_published_navigation_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "blocked_claim:display_asset_claims_unavailable",
+          "integrity_state:runtime_published_shell",
+          "critical_missing_field:compiled_recommendation_snapshot",
+          "critical_missing_field:display_asset_claims"
+        ]
+      },
+      {
+        "slug": "architects",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/architects",
+          "zh": "https://fermatmind.com/zh/career/jobs/architects",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architects?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architects?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "architects-except-landscape-and-naval",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/architects-except-landscape-and-naval",
+          "zh": "https://fermatmind.com/zh/career/jobs/architects-except-landscape-and-naval",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architects-except-landscape-and-naval?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architects-except-landscape-and-naval?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "architectural-and-civil-drafters",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/architectural-and-civil-drafters",
+          "zh": "https://fermatmind.com/zh/career/jobs/architectural-and-civil-drafters",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-civil-drafters?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-civil-drafters?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "architectural-and-engineering-managers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/architectural-and-engineering-managers",
+          "zh": "https://fermatmind.com/zh/career/jobs/architectural-and-engineering-managers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-engineering-managers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-engineering-managers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "architecture-teachers-postsecondary",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/architecture-teachers-postsecondary",
+          "zh": "https://fermatmind.com/zh/career/jobs/architecture-teachers-postsecondary",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architecture-teachers-postsecondary?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architecture-teachers-postsecondary?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "archivists",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/archivists",
+          "zh": "https://fermatmind.com/zh/career/jobs/archivists",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/archivists?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/archivists?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "area-ethnic-and-cultural-studies-teachers-postsecondary",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary",
+          "zh": "https://fermatmind.com/zh/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 26,
+          "en_only": 0,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      }
+    ],
+    "en_has_modules_zh_missing": [
+      {
+        "slug": "actuaries",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/actuaries",
+          "zh": "https://fermatmind.com/zh/career/jobs/actuaries",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/actuaries?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/actuaries?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "acupuncturists",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/acupuncturists",
+          "zh": "https://fermatmind.com/zh/career/jobs/acupuncturists",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/acupuncturists?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/acupuncturists?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "acute-care-nurses",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/acute-care-nurses",
+          "zh": "https://fermatmind.com/zh/career/jobs/acute-care-nurses",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/acute-care-nurses?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/acute-care-nurses?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "adapted-physical-education-specialists",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/adapted-physical-education-specialists",
+          "zh": "https://fermatmind.com/zh/career/jobs/adapted-physical-education-specialists",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adapted-physical-education-specialists?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adapted-physical-education-specialists?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "adhesive-bonding-machine-operators-and-tenders",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/adhesive-bonding-machine-operators-and-tenders",
+          "zh": "https://fermatmind.com/zh/career/jobs/adhesive-bonding-machine-operators-and-tenders",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adhesive-bonding-machine-operators-and-tenders?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adhesive-bonding-machine-operators-and-tenders?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "administrative-law-judges-adjudicators-and-hearing-officers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers",
+          "zh": "https://fermatmind.com/zh/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "administrative-services-managers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/administrative-services-managers",
+          "zh": "https://fermatmind.com/zh/career/jobs/administrative-services-managers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-services-managers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-services-managers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+          "zh": "https://fermatmind.com/zh/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "adult-literacy-and-ged-teachers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/adult-literacy-and-ged-teachers",
+          "zh": "https://fermatmind.com/zh/career/jobs/adult-literacy-and-ged-teachers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-literacy-and-ged-teachers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-literacy-and-ged-teachers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "advanced-practice-psychiatric-nurses",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/advanced-practice-psychiatric-nurses",
+          "zh": "https://fermatmind.com/zh/career/jobs/advanced-practice-psychiatric-nurses",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advanced-practice-psychiatric-nurses?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advanced-practice-psychiatric-nurses?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "advertising-and-promotions-managers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/advertising-and-promotions-managers",
+          "zh": "https://fermatmind.com/zh/career/jobs/advertising-and-promotions-managers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-and-promotions-managers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-and-promotions-managers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "advertising-promotions-and-marketing-managers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/advertising-promotions-and-marketing-managers",
+          "zh": "https://fermatmind.com/zh/career/jobs/advertising-promotions-and-marketing-managers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-promotions-and-marketing-managers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-promotions-and-marketing-managers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "advertising-sales-agents",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/advertising-sales-agents",
+          "zh": "https://fermatmind.com/zh/career/jobs/advertising-sales-agents",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-sales-agents?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-sales-agents?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "aerospace-engineering-and-operations-technicians",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/aerospace-engineering-and-operations-technicians",
+          "zh": "https://fermatmind.com/zh/career/jobs/aerospace-engineering-and-operations-technicians",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineering-and-operations-technicians?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineering-and-operations-technicians?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "agents-and-business-managers-of-artists-performers-and-athletes",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes",
+          "zh": "https://fermatmind.com/zh/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "agricultural-and-food-science-technicians",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-and-food-science-technicians",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-and-food-science-technicians",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-science-technicians?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-science-technicians?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "agricultural-engineers",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-engineers",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-engineers",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-engineers?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-engineers?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "agricultural-equipment-operators",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-equipment-operators",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-equipment-operators",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-equipment-operators?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-equipment-operators?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "agricultural-inspectors",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-inspectors",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-inspectors",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-inspectors?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-inspectors?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      },
+      {
+        "slug": "agricultural-sciences-teachers-postsecondary",
+        "sample_urls": {
+          "en": "https://fermatmind.com/en/career/jobs/agricultural-sciences-teachers-postsecondary",
+          "zh": "https://fermatmind.com/zh/career/jobs/agricultural-sciences-teachers-postsecondary",
+          "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-sciences-teachers-postsecondary?locale=en",
+          "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-sciences-teachers-postsecondary?locale=zh-CN"
+        },
+        "module_counts": {
+          "en": 26,
+          "zh-CN": 12,
+          "en_only": 14,
+          "zh_only": 0
+        },
+        "zh_gate_reasons": [
+          "zh_missing_en_display_modules",
+          "amber_flag:display_asset_backed_directory_draft_shell",
+          "blocked_claim:compiled_recommendation_claims_unavailable",
+          "integrity_state:display_asset_backed",
+          "critical_missing_field:compiled_recommendation_snapshot"
+        ]
+      }
+    ]
+  },
+  "items_omitted": true,
+  "external_blocker": "Reviewed zh display import/publish/cache refresh has not yet cleared live parity blockers."
+}

--- a/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
@@ -88,6 +88,11 @@ final class CareerAuditZhDisplayParityCommandTest extends TestCase
         $this->assertFalse($report['sitemap_changed']);
         $this->assertFalse($report['llms_changed']);
         $this->assertFalse($report['index_strategy_changed']);
+        $this->assertSame('blocked', $report['live_gate']['decision']);
+        $this->assertContains('api_failures_or_http_mismatches', $report['live_gate']['blockers']);
+        $this->assertContains('zh_missing_en_display_modules', $report['live_gate']['blockers']);
+        $this->assertContains('zh_restricted_shell_or_integrity_gap', $report['live_gate']['blockers']);
+        $this->assertSame(1, $report['live_gate']['restricted_shell_count']);
         $this->assertSame(5, $report['summary']['total_slugs']);
         $this->assertSame(1, $report['summary']['same_module_set']);
         $this->assertSame(1, $report['summary']['en_has_modules_zh_missing']);
@@ -130,10 +135,58 @@ final class CareerAuditZhDisplayParityCommandTest extends TestCase
 
         $this->assertSame(0, $exitCode, Artisan::output());
         $this->assertSame('explicit_slugs', $report['scan_scope']);
+        $this->assertSame('pass', $report['live_gate']['decision']);
         $this->assertSame(1, $report['summary']['total_slugs']);
         $this->assertSame(1, $report['summary']['same_module_set']);
 
         Http::assertNotSent(static fn ($request): bool => str_ends_with($request->url(), '/career/jobs?locale=en'));
+    }
+
+    #[Test]
+    public function it_can_assert_the_live_parity_gate_without_mutating_content_or_index_strategy(): void
+    {
+        Http::fake([
+            'https://api.example.test/api/v0.5/career/jobs/gated-slug?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'source_card',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/gated-slug?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+            ], amberFlags: ['runtime_published_shell']), 200),
+        ]);
+
+        $exitCode = Artisan::call('career:audit-zh-display-parity', [
+            '--api-base' => 'https://api.example.test/api/v0.5/career/jobs',
+            '--slugs' => 'gated-slug',
+            '--summary-only' => true,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('blocked', $report['live_gate']['decision']);
+        $this->assertSame([], $report['items']);
+        $this->assertFalse($report['live_gate']['sitemap_changed']);
+        $this->assertFalse($report['live_gate']['llms_changed']);
+        $this->assertFalse($report['live_gate']['index_strategy_changed']);
+
+        $exitCode = Artisan::call('career:audit-zh-display-parity', [
+            '--api-base' => 'https://api.example.test/api/v0.5/career/jobs',
+            '--slugs' => 'gated-slug',
+            '--assert-live-parity' => true,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertTrue($report['assert_live_parity']);
+        $this->assertSame('blocked', $report['decision']);
+        $this->assertSame('blocked', $report['live_gate']['decision']);
+        $this->assertContains('zh_missing_en_display_modules', $report['live_gate']['blockers']);
+        $this->assertContains('zh_restricted_shell_or_integrity_gap', $report['live_gate']['blockers']);
     }
 
     /**

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52532,7 +52532,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-04-live-gate",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "github_checks_pending",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-04: chore(career): gate zh display live parity",
     "depends_on": [
@@ -52578,11 +52578,17 @@
       "diff_check": {
         "status": "pass",
         "evidence": "git diff --check passed after implementation; git diff --cached --check will be run after staging."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2023",
+        "head_sha": "d02233d1372b302ee06569d5ddbc03f92983bef7",
+        "evidence": "PR #2023 opened for CAREER-ZH-DISPLAY-PARITY-04; GitHub checks are pending."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "d02233d1372b302ee06569d5ddbc03f92983bef7",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2023",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -52609,6 +52615,11 @@
         "at": "2026-06-09T16:53:13Z",
         "status": "local_checks_passed",
         "note": "Implemented live parity gate/report. Local focused tests and live audit passed; live parity remains blocked only by external reviewed zh content state, recorded as sidecar."
+      },
+      {
+        "at": "2026-06-09T16:58:00Z",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2023 and pushed implementation commit d02233d1372b302ee06569d5ddbc03f92983bef7; waiting for GitHub checks."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -266,9 +266,7 @@
       "repo": "fap-api",
       "branch": "codex/seo-cms-canary-be-01-hreflang-cta-surfaces",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "commit_sha": "dc96157c0c226ed39c2036a27670c092bc54013f",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1852",
       "checks": {
@@ -373,9 +371,7 @@
           "note": "Reconciled before SEO-CMS-CANARY-DRAFT-PATH-01: GitHub PR #1852 is MERGED with merge commit dc96157c0c226ed39c2036a27670c092bc54013f, and origin/main contains that commit."
         }
       ],
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "next_task": "SEO-CMS-CANARY-WEB-01"
     },
     "PR-EQ-PER-01": {
@@ -1541,9 +1537,7 @@
           "git_diff_check": "passed: git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -1569,9 +1563,7 @@
           "git_diff_check": "passed: git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -1788,9 +1780,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -1828,8 +1818,7 @@
       "depends_on": [
         "iq-report-builder-three-dimension-result-schema"
       ],
-      "checks": {
-      },
+      "checks": {},
       "sidecar_issues": [
         {
           "sidecar_id": "IQ-SIDECAR-COMMERCE-DEFERRED-001",
@@ -1916,9 +1905,7 @@
           "evidence": "User explicitly authorized registering AUDIT-1 in docs/codex/pr-train.yaml and docs/codex/pr-train-state.json only."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-2 2786 public-resolution source resolver",
       "merged_at": null,
@@ -1959,9 +1946,7 @@
           "evidence": "AUDIT-1 merged as 0c6dc52e9806242dc73cec405c7f09c05161d19b and origin/main contains the merge commit."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-3 Occupation entity inventory audit",
       "merged_at": null,
@@ -2053,9 +2038,7 @@
           "evidence": "Full MBTI CI chain exited 0 after the test-only allowlist fix; generated compiled artifacts were restored because they are outside AUDIT-3 scope."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-4 Baseline/display metadata inventory audit",
       "merged_at": null,
@@ -2154,12 +2137,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed after AUDIT-4 allowlist fix in unrelated BigFive norm/content tests with SQLSTATE[HY000]: General error: 5 database is locked against /tmp/fap-ci.sqlite.",
             "Scoped AUDIT-4 tests, AUDIT-1/2/3 regressions, pint, git diff --check, and BigFive runtime freeze path gate passed."
@@ -2259,9 +2238,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-6 Runtime projection/truth eligibility audit",
       "merged_at": null,
@@ -2352,9 +2329,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-7 SEO/GEO readiness audit",
       "merged_at": null,
@@ -2449,9 +2424,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-8 Surface readiness audit",
       "merged_at": null,
@@ -2541,9 +2514,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-9 career:audit-canonical-eligibility command integration",
       "merged_at": null,
@@ -2639,9 +2610,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-10 80-cohort readiness plan",
       "merged_at": null,
@@ -2734,9 +2703,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-11 Manifest train generator",
       "merged_at": null,
@@ -2823,9 +2790,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-12 Batch live acceptance v2",
       "merged_at": null,
@@ -2975,9 +2940,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "AUDIT-13 2786 full audit artifact/report",
       "merged_at": null,
@@ -3060,9 +3023,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "next_pr": "End of 2786 eligibility audit PR train",
       "merged_at": null,
@@ -3127,9 +3088,7 @@
       "merged_at": "2026-05-12T16:55:20Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-RT-03": {
       "repo": "fap-api",
@@ -3209,9 +3168,7 @@
         "Personality type related articles remain deferred because no stable Personality related article authority was identified for INFJ-A/INFJ-T pages.",
         "Test detail related articles remain deferred because the existing related_test_slug contract is a fixed three-article test page slot and changing it would widen PR-RT-03 scope."
       ],
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "merge_sha": "44621613e5255a76631138d641da218e2993e343"
     },
     "CMD-FIX-1": {
@@ -3240,9 +3197,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-AH-04": {
       "repo": "fap-api",
@@ -3373,9 +3328,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "CTX-CONSUME-1": {
       "repo": "fap-api",
@@ -3428,9 +3381,7 @@
       "merged_at": "2026-05-13T12:11:29Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "CTX-EXPORT-1": {
       "repo": "fap-api",
@@ -3484,9 +3435,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-SURFACE-CONTEXT-1": {
       "repo": "fap-api",
@@ -3541,9 +3490,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-SEO-GEO-1": {
       "repo": "fap-api",
@@ -3648,9 +3595,7 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
+          "affected_slugs": [],
           "affected_locales": [
             "en",
             "zh"
@@ -3764,9 +3709,7 @@
       "merged_at": "2026-05-13T10:31:09Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-TITLE-1": {
       "repo": "fap-api",
@@ -3872,9 +3815,7 @@
       "merged_at": "2026-05-13T10:49:47Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-RUNTIME-1": {
       "repo": "fap-api",
@@ -3979,9 +3920,7 @@
       "merged_at": "2026-05-13T11:08:33Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-INDEX-1": {
       "repo": "fap-api",
@@ -4081,9 +4020,7 @@
       "merged_at": "2026-05-13T11:37:01Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-ENTITY-1": {
       "repo": "fap-api",
@@ -4136,9 +4073,7 @@
       "merged_at": "2026-05-13T11:53:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-CANDIDATE-1": {
       "repo": "fap-api",
@@ -4191,18 +4126,14 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-00": {
       "repo": "fap-api",
       "branch": "codex/riasec-personalization-00-train-registration",
       "title": "docs(codex): register RIASEC personalization train",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "scope_type": "train_registration_only",
       "allowed_paths": [
         "docs/codex/pr-train.yaml",
@@ -4224,9 +4155,7 @@
       "merged_at": "2026-05-13T07:06:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-01": {
       "repo": "fap-api",
@@ -4279,9 +4208,7 @@
       "merged_at": "2026-05-13T07:35:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-02": {
       "repo": "fap-api",
@@ -4330,9 +4257,7 @@
       "merged_at": "2026-05-13T07:53:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-03": {
       "repo": "fap-api",
@@ -4377,9 +4302,7 @@
       "merged_at": "2026-05-13T08:16:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-04": {
       "repo": "fap-api",
@@ -4426,9 +4349,7 @@
       "merged_at": "2026-05-13T08:33:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-05": {
       "repo": "fap-api",
@@ -4473,9 +4394,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-06": {
       "repo": "fap-web",
@@ -4495,15 +4414,12 @@
       ],
       "commit_sha": "bb01c378674b28857b98ddbdf3d657144ef3b83e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1423",
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": "2026-05-22T10:38:13Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-PERSONALIZATION-07": {
       "repo": "fap-web",
@@ -4526,15 +4442,12 @@
       ],
       "commit_sha": "7740b1b09ce6dddb693ac5dbcf8a1d027b0db08b",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1440",
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-RT-04": {
       "repo": "fap-api",
@@ -4614,9 +4527,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "post_merge_runbook_required": true
     },
     "RIASEC-DEEP-COPY-01": {
@@ -4684,9 +4595,7 @@
       "merged_at": "2026-05-13T11:31:25Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-DEEP-COPY-02": {
       "repo": "fap-api",
@@ -4750,9 +4659,7 @@
       "merged_at": "2026-05-13T12:05:30Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "RIASEC-DEEP-COPY-03": {
       "repo": "fap-api",
@@ -5228,9 +5135,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-INDEX-ENTITY-POLICY-2": {
       "repo": "fap-api",
@@ -5287,9 +5192,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-INDEX-STATE-MINIMUM-APPLY-PLAN-2": {
       "repo": "fap-api",
@@ -5345,9 +5248,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-READINESS-COMMAND-1": {
       "repo": "fap-api",
@@ -5400,9 +5301,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-MANIFEST-TRAIN-COMMAND-1": {
       "repo": "fap-api",
@@ -5455,9 +5354,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-READINESS-SELECTION-2": {
       "repo": "fap-api",
@@ -5510,9 +5407,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-CMS-03": {
       "repo": "fap-api",
@@ -5660,9 +5555,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-TARGET-DELTA-1": {
       "repo": "fap-api",
@@ -5716,9 +5609,7 @@
       "merged_at": "2026-05-14T06:05:11Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-RUNTIME-CANDIDATE-PREP-1": {
       "repo": "fap-api",
@@ -5771,9 +5662,7 @@
       "merged_at": "2026-05-14T06:29:28Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-RUNTIME-CANDIDATE-PREP-APPLY-GATE-1": {
       "repo": "fap-api",
@@ -5828,9 +5717,7 @@
       "merged_at": "2026-05-14T07:00:35Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-RUNTIME-ARTIFACT-REFRESH-1": {
       "repo": "fap-api",
@@ -5883,9 +5770,7 @@
       "merged_at": "2026-05-14T07:45:52Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-51-DELTA-ROLLOUT-MANIFEST-1": {
       "repo": "fap-api",
@@ -5938,9 +5823,7 @@
       "merged_at": "2026-05-14T08:07:46Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-DELTA-ROLLOUT-GATE-1": {
       "repo": "fap-api",
@@ -5993,9 +5876,7 @@
       "merged_at": "2026-05-14T08:27:04Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-TOTAL-LIVE-ACCEPTANCE-1": {
       "repo": "fap-api",
@@ -6049,9 +5930,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-RUNTIME-CANDIDATE-ARTIFACT-REFRESH-2": {
       "repo": "fap-api",
@@ -6109,9 +5988,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-CMS-04": {
       "repo": "fap-api",
@@ -6196,9 +6073,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-CANDIDATE-AWARE-AUDIT-POLICY-1": {
       "repo": "fap-api",
@@ -6249,9 +6124,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-DELTA-ROLLOUT-APPLY-BATCH-AUTHORITY-1": {
       "repo": "fap-api",
@@ -6331,9 +6204,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-POST-ROLLOUT-RUNTIME-PROJECTION-AUTHORITY-1": {
       "repo": "fap-api",
@@ -6392,9 +6263,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-80-LIVE-SURFACE-AUTHORITY-1": {
       "repo": "fap-api",
@@ -6452,9 +6321,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-PROGRESSIVE-COHORT-TARGET-DELTA-1": {
       "repo": "fap-api",
@@ -6517,12 +6384,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed only Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive audit/command/test/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -6598,12 +6461,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career runtime candidate prep command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -6679,12 +6538,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career runtime artifact refresh command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -6759,12 +6614,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive rollout manifest/gate command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -6840,12 +6691,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive live acceptance command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -6861,12 +6708,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
             "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
@@ -6943,12 +6786,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled') assertions.",
             "Current PR changed only Career progressive closeout command/planner/tests/docs/train metadata paths and does not touch content pack publish/rollback code or compiled content assets.",
@@ -6964,12 +6803,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Unit\\Services\\BigFive\\ResultPageV2\\BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff with backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
             "Current PR does not modify backend/app/Http/Controllers/API/V0_3/MbtiAttributionEventController.php.",
@@ -7045,12 +6880,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at tests/Feature/Content/PacksPublishBig5Test.php:94 asserting File::isDirectory($target.'/compiled').",
             "backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at tests/Feature/Content/PacksRollbackBig5Test.php:97 asserting File::isDirectory($target.'/compiled').",
@@ -7116,9 +6947,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-PROGRESSIVE-READINESS-OCCUPATION-AWARE-SELECTION-1": {
       "repo": "fap-api",
@@ -7176,9 +7005,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-PROGRESSIVE-RUNTIME-CANDIDATE-POOL-SELECTION-1": {
       "repo": "fap-api",
@@ -7235,9 +7062,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-PROGRESSIVE-READINESS-CN-PROXY-EXCLUSION-1": {
       "repo": "fap-api",
@@ -7310,9 +7135,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-RUNTIME-PROJECTION-LOOKUP-LATEST-SELECTION-1": {
       "repo": "fap-api",
@@ -7385,12 +7208,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at compiled directory assertion.",
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertion.",
@@ -7472,9 +7291,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "REPAIR-PROGRESSIVE-READINESS-SOFTWARE-MANUAL-HOLD-EXCLUSION-1": {
       "repo": "fap-api",
@@ -7556,12 +7373,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksPublishBig5Test at the target compiled directory assertion.",
             "bash backend/scripts/ci_verify_mbti.sh failed in Tests\\Feature\\Content\\PacksRollbackBig5Test at the target compiled directory assertion.",
@@ -7652,12 +7465,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed BigFiveResultPageV2CoreBodyPreviewTest::runtime_paths_have_no_uncommitted_diff while reporting CMS test-edge files from the parent worktree, not the current PR files.",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test and Tests\\Feature\\Content\\PacksRollbackBig5Test at compiled directory assertions.",
@@ -7759,12 +7568,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -7857,12 +7662,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -7963,12 +7764,8 @@
           "owner_repo": "fap-api",
           "scope_relation": "external_to_current_pr",
           "introduced_by_current_pr": false,
-          "affected_slugs": [
-
-          ],
-          "affected_locales": [
-
-          ],
+          "affected_slugs": [],
+          "affected_locales": [],
           "evidence": [
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksPublishBig5Test at File::isDirectory($target.'/compiled').",
             "bash backend/scripts/ci_verify_mbti.sh failed Tests\\Feature\\Content\\PacksRollbackBig5Test at File::isDirectory($target.'/compiled').",
@@ -8063,9 +7860,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-CMS-FIX-MASTER": {
       "repo": "fap-api",
@@ -8153,9 +7948,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-GRAPH-01": {
       "repo": "fap-api",
@@ -8255,9 +8048,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "PR-MEDIA-01": {
       "repo": "fap-api",
@@ -8333,9 +8124,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ]
+      "sidecar_issues": []
     },
     "AUDIT-API-IQ-RESULT-SECRECY": {
       "repo": "fap-api",
@@ -8431,9 +8220,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-16T14:10:19+08:00",
@@ -9132,9 +8919,7 @@
       "merged_at": "2026-05-17T00:01:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-16T14:10:19+08:00",
@@ -9288,9 +9073,7 @@
       "merged_at": "2026-05-17T13:21:17Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T08:28:18+08:00",
@@ -9366,9 +9149,7 @@
           "evidence": "PR opened as https://github.com/fermatmind/fap-api/pull/1431; GitHub checks pending at PR creation."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "commit_sha": "39c079a34babf048df02f39bdd9fdda78dc07d9e",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1431"
@@ -9440,9 +9221,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T10:54:07+08:00",
@@ -9709,9 +9488,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T16:20:00+08:00",
@@ -9805,9 +9582,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T22:00:00+08:00",
@@ -10192,9 +9967,7 @@
       "merged_at": "2026-05-17T06:32:14Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T13:54:00+08:00",
@@ -10305,9 +10078,7 @@
       "merged_at": "2026-05-17T09:29:52Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T15:50:00+08:00",
@@ -10436,9 +10207,7 @@
       "merged_at": "2026-05-17T10:11:08Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T17:20:00+08:00",
@@ -10563,9 +10332,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T19:05:00+08:00",
@@ -10670,9 +10437,7 @@
       "merged_at": "2026-05-17T11:40:42Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T11:16:57.277842Z",
@@ -10774,9 +10539,7 @@
       "merged_at": "2026-05-17T12:07:10Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T11:45:00Z",
@@ -10881,9 +10644,7 @@
       "merged_at": "2026-05-17T12:43:41Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T12:20:00Z",
@@ -11001,9 +10762,7 @@
       "merged_at": "2026-05-17T13:39:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T12:56:08Z",
@@ -11226,9 +10985,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-18T02:04:59Z",
@@ -11267,9 +11024,7 @@
       "repo": "fap-api",
       "branch": "codex/publish-api-media-origin-readyness",
       "base": "main",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "status": "merged",
       "train_scope": "publishing_reliability",
       "risk_level": "medium",
@@ -11327,9 +11082,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T13:35:00Z",
@@ -11422,9 +11175,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T13:43:00Z",
@@ -11452,9 +11203,7 @@
       "repo": "fap-api",
       "branch": "codex/storage-release-roots-audit",
       "base": "main",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "status": "pr_open",
       "train_scope": "storage_runtime_hygiene",
       "risk_level": "low",
@@ -11522,9 +11271,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T15:22:58Z",
@@ -11552,9 +11299,7 @@
       "repo": "fap-api",
       "branch": "codex/docs-shell-safety-guard",
       "base": "main",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "status": "pr_open",
       "train_scope": "storage_runtime_hygiene",
       "risk_level": "low",
@@ -11627,9 +11372,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-17T16:01:58Z",
@@ -11747,9 +11490,7 @@
       "merged_at": "2026-05-18T12:08:39Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-18T11:57:22Z",
@@ -11877,9 +11618,7 @@
       "merged_at": "2026-05-18T12:56:16Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-18T12:45:00Z",
@@ -12095,9 +11834,7 @@
           "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null; python3 -c \"import yaml, pathlib; yaml.safe_load(pathlib.Path('docs/codex/pr-train.yaml').read_text())\"; git diff --check; git diff --cached --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -12215,9 +11952,7 @@
           "status": "passed"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -12335,9 +12070,7 @@
           "status": "passed"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -12455,9 +12188,7 @@
           "status": "passed"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -12579,9 +12310,7 @@
           "evidence": "PR #1541 was merged and origin/main contains merge commit 316223c6e9ece53da47bbd7523bb648a2cfb3c85."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -12726,9 +12455,7 @@
           "status": "passed"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -12852,9 +12579,7 @@
           "evidence": "Reconciled CONTENT-OPS-01 as merged/completed only in docs/codex/pr-train-state.json. No runtime, production, env, scheduler, Metabase, external API, crawler log, search submission, Research publish, or pSEO operation was performed."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T01:02:33Z",
@@ -13009,9 +12734,7 @@
       "merged_at": "2026-05-19T14:00:03Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T13:45:00Z",
@@ -13090,9 +12813,7 @@
       "merged_at": "2026-05-19T14:42:31Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T14:05:25Z",
@@ -13200,9 +12921,7 @@
       "merged_at": "2026-05-19T15:37:13Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T15:14:47Z",
@@ -13260,9 +12979,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T15:40:30Z",
@@ -13386,9 +13103,7 @@
       "merged_at": "2026-05-19T20:17:56Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T20:13:48Z",
@@ -13445,9 +13160,7 @@
       "merged_at": "2026-05-19T20:23:32Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T20:18:53Z",
@@ -13504,9 +13217,7 @@
       "merged_at": "2026-05-19T20:27:28Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T20:24:01Z",
@@ -13570,9 +13281,7 @@
       "merged_at": "2026-05-19T20:39:19Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T20:27:55Z",
@@ -13629,9 +13338,7 @@
       "merged_at": null,
       "remote_branch_deleted": null,
       "local_cleanup_executed": null,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T23:05:07Z",
@@ -13672,9 +13379,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-19T23:05:07Z",
@@ -13728,9 +13433,7 @@
       "merged_at": "2026-05-20T00:56:13Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-20T00:40:00Z",
@@ -13803,9 +13506,7 @@
       "merged_at": "2026-05-20T04:00:03Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "history": [
         {
           "at": "2026-05-20T03:35:34Z",
@@ -15003,9 +14704,7 @@
       "status": "merged",
       "state": "merged",
       "title": "docs(seo-intel): add observation governance architecture contract",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "commit_sha": "9d0b26e4ca234354963d9747f0f27438588856bc",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1556",
       "checks": {
@@ -16185,8 +15884,7 @@
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": "Blocked before production write because the official Search Channel Queue command does not support bounded single-URL enqueue.",
       "merged_at": null,
@@ -16239,8 +15937,7 @@
           "git_diff_check": "passed: git diff --check",
           "scope_diff": "passed: changed files remain inside the allowed scope for SEO-GROWTH-MBTI-ACTION-01B-FIX-01"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": null,
       "merged_at": null,
@@ -16297,8 +15994,7 @@
           "yaml_manifest": "passed: yaml.safe_load(docs/codex/pr-train.yaml)",
           "git_diff_check": "passed: git diff --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": "Blocked before production write because the official production Search Channel Queue write gate is closed.",
       "merged_at": null,
@@ -16560,8 +16256,7 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": null,
       "merged_at": null,
@@ -16621,8 +16316,7 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": null,
       "merged_at": "2026-05-23T05:28:44Z",
@@ -16694,8 +16388,7 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": null,
       "merged_at": null,
@@ -16752,8 +16445,7 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": null,
       "merged_at": null,
@@ -16811,8 +16503,7 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": "Production preflight report found active old www Research URL Truth rows. A full three-URL bounded apex write would create duplicate Research canonical clusters because URL Truth upsert keys use canonical_url_hash + locale.",
       "merged_at": null,
@@ -16873,8 +16564,7 @@
           "git_diff_check": "passed: git diff --check",
           "git_diff_cached_check": "passed: git diff --cached --check"
         },
-        "github": {
-        }
+        "github": {}
       },
       "failure_reason": null,
       "merged_at": null,
@@ -17036,9 +16726,7 @@
       "repo": "fap-api",
       "branch": "codex/ops-security-storage-path-safety-01",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "findings": [
         66,
         68,
@@ -17102,9 +16790,7 @@
           "evidence": "PR #1625 required checks passed: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, verify-mbti-v2. mergeStateStatus=CLEAN before squash merge."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T17:10:13Z",
       "remote_branch_deleted": true,
@@ -17204,9 +16890,7 @@
           "evidence": "PR #1626 required checks succeeded before squash merge: hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, verify-mbti-v2."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T17:42:47Z",
       "remote_branch_deleted": true,
@@ -17312,9 +16996,7 @@
           "evidence": "PR #1627 rerun completed with hygiene, semgrep sarif, Semgrep OSS, verify-mbti-legacy, and verify-mbti-v2 all successful before squash merge."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T18:17:31Z",
       "remote_branch_deleted": true,
@@ -17403,9 +17085,7 @@
           "evidence": "GitHub PR #1628 is MERGED at fd0fb1f4c1109d2a806085cd0debcad98f38ab33; remote branch is absent."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T18:54:35Z",
       "remote_branch_deleted": true,
@@ -17455,9 +17135,7 @@
           "evidence": "GitHub PR #1629 is MERGED at 47f18f4f4806f734f08f8677f8d15a36da6c3198; remote branch is absent."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T19:21:05Z",
       "remote_branch_deleted": true,
@@ -17603,9 +17281,7 @@
           "command": "git diff --check"
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T20:23:03Z",
       "remote_branch_deleted": true,
@@ -17676,9 +17352,7 @@
           "evidence": "GitHub PR #1632 is MERGED and origin/main contains merge commit ceef6619d3b28276f76f8e0ce5194c03a2762df2."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T20:44:54Z",
       "remote_branch_deleted": true,
@@ -17753,9 +17427,7 @@
           "evidence": "GitHub PR #1633 is MERGED and origin/main contains merge commit bd4816a8253c1307f3cca47e1479e98959aec3a6; remote task branch is absent."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": "2026-05-23T21:07:40Z",
       "remote_branch_deleted": true,
@@ -18422,9 +18094,7 @@
           "evidence": "PR #1640 checks passed for Semgrep OSS, hygiene, semgrep sarif, verify-mbti-legacy, and verify-mbti-v2 at head bc00a0678dafa449a7e41a39bf176da3419793a7."
         }
       },
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -18461,9 +18131,7 @@
       "repo": "fap-api",
       "branch": "codex/pr-audit-be-01-ci-supply-chain",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1644",
       "checks": {
         "local": {
@@ -18479,9 +18147,7 @@
             "ruby -e JSON state parse",
             "git diff --check"
           ],
-          "failed": [
-
-          ]
+          "failed": []
         },
         "github_required_checks": {
           "status": "passed",
@@ -18494,18 +18160,14 @@
             "semgrep sarif non-blocking upload",
             "Semgrep OSS"
           ],
-          "failed": [
-
-          ]
+          "failed": []
         }
       },
       "failure_reason": null,
       "merged_at": "2026-05-24T07:37:28Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-24T07:16:21.665+00:00",
@@ -18582,9 +18244,7 @@
             "verify-mbti-legacy",
             "verify-mbti-v2"
           ],
-          "failed": [
-
-          ],
+          "failed": [],
           "evidence": "PR #1645 passed required GitHub checks and was squash-merged as 0338122739bbe4fd9645943d4f08372a3881f560."
         },
         "runtime_freeze_ci_fix": {
@@ -18714,9 +18374,7 @@
             "verify-mbti-legacy",
             "verify-mbti-v2"
           ],
-          "failed": [
-
-          ],
+          "failed": [],
           "evidence": "GitHub required checks passed on PR #1648 after adding the scoped runtime-freeze classifier evidence for the attempt_quality retirement migration."
         },
         "github_required_checks": {
@@ -18731,9 +18389,7 @@
             "verify-mbti-legacy",
             "verify-mbti-v2"
           ],
-          "failed": [
-
-          ],
+          "failed": [],
           "evidence": "GitHub PR #1648 is MERGED and origin/main contains merge commit d18c0cc36a84ce50b823c995e4226b188551b0d0."
         }
       },
@@ -18741,9 +18397,7 @@
       "merged_at": "2026-05-24T09:57:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-24T09:26:29.265Z",
@@ -19697,9 +19351,7 @@
       "repo": "fap-api",
       "branch": "codex/seo-growth-mbti-action-01d-scan-00",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "commit_sha": "8208e69422a7487d272df57107a5b5e1cacf6b68",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1661",
       "checks": {
@@ -19773,9 +19425,7 @@
       "repo": "fap-api",
       "branch": "codex/en-parity-00-full-site-inventory",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "commit_sha": "a95de5c9ff047851336ee1f7c35b2255ac8ba683",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1663",
       "checks": {
@@ -20068,9 +19718,7 @@
       "merged_at": "2026-05-25T05:24:17Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T08:30:00+00:00",
@@ -20150,9 +19798,7 @@
       "merged_at": "2026-05-25T05:42:59Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T06:10:00Z",
@@ -20232,9 +19878,7 @@
       "merged_at": "2026-05-25T06:02:20Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T06:50:00Z",
@@ -20310,9 +19954,7 @@
       "merged_at": "2026-05-25T06:05:12Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T05:01:32Z",
@@ -20401,9 +20043,7 @@
       "merged_at": "2026-05-25T07:00:22Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T06:15:55Z",
@@ -20493,9 +20133,7 @@
       "merged_at": "2026-05-25T07:18:00Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T07:10:00Z",
@@ -20569,9 +20207,7 @@
       "merged_at": "2026-05-25T07:30:44Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T07:30:00Z",
@@ -20841,9 +20477,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T06:15:00Z",
@@ -20881,9 +20515,7 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-parity-scan-00",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "commit_sha": "87345d16c4b7b22a23ead480925bb1f4c58d2721",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1679",
       "checks": {
@@ -21021,9 +20653,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-25T12:10:55.823326+00:00",
@@ -21148,9 +20778,7 @@
       "merged_at": "2026-05-25T16:53:34Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "events": [
         {
           "at": "2026-05-26T00:00:00+08:00",
@@ -21247,9 +20875,7 @@
       "merged_at": "2026-05-25T17:35:54Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-ARTICLE-TRANSLATION-BATCH-02",
       "events": [
         {
@@ -21357,9 +20983,7 @@
       "merged_at": "2026-05-25T17:53:52Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-TOPIC-TEST-LANDING-BATCH-03",
       "events": [
         {
@@ -21474,9 +21098,7 @@
       "merged_at": "2026-05-25T18:07:37Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-RESEARCH-CLAIM-REVIEW-BATCH-04",
       "events": [
         {
@@ -21588,9 +21210,7 @@
       "merged_at": "2026-05-25T18:21:07Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-CAREER-CONTENT-BATCH-05",
       "events": [
         {
@@ -21709,9 +21329,7 @@
       "merged_at": "2026-05-25T18:36:38Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-RESULT-REPORT-ASSET-BATCH-06",
       "events": [
         {
@@ -21818,9 +21436,7 @@
       "merged_at": "2026-05-26T00:00:16Z",
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-MEDIA-ALT-VISUAL-REVIEW-BATCH-07",
       "events": [
         {
@@ -21917,9 +21533,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-GLOBAL-UI-I18N-BATCH-08",
       "events": [
         {
@@ -21986,9 +21600,7 @@
       "merged_at": null,
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
-      "sidecar_issues": [
-
-      ],
+      "sidecar_issues": [],
       "next_task": "GLOBAL-EN-ZH-FULL-PARITY-VERIFY-POST-BATCH",
       "events": [
         {
@@ -22695,9 +22307,7 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": true,
       "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01",
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "transitions": [
         {
           "at": "2026-05-28T09:51:44Z",
@@ -22723,9 +22333,7 @@
       "base": "main",
       "title": "CAREER-1046-OPS-READ-MODEL-REPAIR-01 career runtime read model repair",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "checks": {
         "focused_phpunit": {
           "status": "pass",
@@ -22843,9 +22451,7 @@
           "note": "PR #1784 checks passed, squash merged at 530f412f8996b8223a2c6a36dd93fee5d3135584, remote branch deleted, local branch deleted, and post-merge focused test passed."
         }
       ],
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "next_task": "CAREER-1046-OBSERVABILITY-SLO-01",
       "merge_commit_sha": "530f412f8996b8223a2c6a36dd93fee5d3135584"
     },
@@ -22949,9 +22555,7 @@
           "note": "PR #1794 checks passed, squash merged at 1f6694b12db6a4f35c65f2fe5e753243bce01eae, remote branch deleted, local branch deleted, and post-merge focused test passed."
         }
       ],
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "next_task": "PR-HIRING-01",
       "merge_commit_sha": "1f6694b12db6a4f35c65f2fe5e753243bce01eae"
     },
@@ -23055,9 +22659,7 @@
           "note": "PR #1795 checks passed, squash merged at 6b50e9ab5ed00c2bfc0365d0d4ffc48a8696f58e, remote branch deleted, local branch deleted, and post-merge focused test passed."
         }
       ],
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "next_task": "CAREER-1046-INTERNAL-LINKING-AUTHORITY-01",
       "merge_commit_sha": "6b50e9ab5ed00c2bfc0365d0d4ffc48a8696f58e"
     },
@@ -23156,9 +22758,7 @@
           "note": "Reconciled already-merged fap-api PR #1798 before resuming CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01."
         }
       ],
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "next_task": "CAREER-1046-FRONTEND-DISCOVERY-UX-01",
       "merge_sha": "38d0c8a7646d9e8264c62694c60a8445d3623096"
     },
@@ -23198,9 +22798,7 @@
           "note": "Reconciled fap-web PR #939 as merged before resuming dependent fap-api PR6."
         }
       ],
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "next_task": "CAREER-L3-DYNAMIC-SLOT-ARCHITECTURE-01",
       "merge_sha": "7626b901d77a5191a1b9211fd0b9a91c854a6c4f"
     },
@@ -23443,9 +23041,7 @@
       "base": "main",
       "title": "IQ-NORM-01 add IQ norm calibration authority",
       "status": "merged",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "checks": {
         "local": {
           "status": "passed",
@@ -23757,8 +23353,7 @@
       "depends_on": [
         "IQ-NORM-03"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": "2026-05-31T15:48:58Z",
       "remote_branch_deleted": true,
@@ -23796,8 +23391,7 @@
       "depends_on": [
         "IQ-PAID-REPORT-01"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -23893,8 +23487,7 @@
       "depends_on": [
         "IQ-CMS-MEDIA-01"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -24016,8 +23609,7 @@
       "depends_on": [
         "IQ-SEO-RAMP-01"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -24183,8 +23775,7 @@
       "depends_on": [
         "IQ-OBS-01"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "merged_at": null,
       "remote_branch_deleted": false,
@@ -24211,9 +23802,7 @@
       "base": "main",
       "title": "CLINICAL-LAUNCH-01 mental-health launch authority state machine",
       "status": "ci_fix_in_progress",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "checks": {
         "focused_phpunit": {
           "status": "pass",
@@ -24307,8 +23896,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-01"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24321,12 +23909,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-03"
     },
     "CLINICAL-LAUNCH-03": {
@@ -24339,8 +23923,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-02"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24353,12 +23936,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-04"
     },
     "CLINICAL-LAUNCH-04": {
@@ -24371,8 +23950,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-03"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24385,12 +23963,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-05"
     },
     "CLINICAL-LAUNCH-05": {
@@ -24403,8 +23977,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-04"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24417,12 +23990,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-06"
     },
     "CLINICAL-LAUNCH-06": {
@@ -24435,8 +24004,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-05"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24449,12 +24017,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-07"
     },
     "CLINICAL-LAUNCH-07": {
@@ -24467,8 +24031,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-06"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24481,12 +24044,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-08"
     },
     "CLINICAL-LAUNCH-08": {
@@ -24499,8 +24058,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-07"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24513,12 +24071,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-09"
     },
     "CLINICAL-LAUNCH-09": {
@@ -24531,8 +24085,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-08"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24545,12 +24098,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-10"
     },
     "CLINICAL-LAUNCH-10": {
@@ -24563,8 +24112,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-09"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24577,12 +24125,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-11"
     },
     "CLINICAL-LAUNCH-11": {
@@ -24595,8 +24139,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-10"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24609,12 +24152,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-12"
     },
     "CLINICAL-LAUNCH-12": {
@@ -24627,8 +24166,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-11"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24641,12 +24179,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-13"
     },
     "CLINICAL-LAUNCH-13": {
@@ -24659,8 +24193,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-12"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24673,12 +24206,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-14"
     },
     "CLINICAL-LAUNCH-14": {
@@ -24691,8 +24220,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-13"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24705,12 +24233,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-15"
     },
     "CLINICAL-LAUNCH-15": {
@@ -24723,8 +24247,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-14"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24737,12 +24260,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-16"
     },
     "CLINICAL-LAUNCH-16": {
@@ -24755,8 +24274,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-15"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24769,12 +24287,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-17"
     },
     "CLINICAL-LAUNCH-17": {
@@ -24787,8 +24301,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-16"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24801,12 +24314,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-18"
     },
     "CLINICAL-LAUNCH-18": {
@@ -24819,8 +24328,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-17"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24833,12 +24341,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-19"
     },
     "CLINICAL-LAUNCH-19": {
@@ -24851,8 +24355,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-18"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24865,12 +24368,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-LAUNCH-20"
     },
     "CLINICAL-LAUNCH-20": {
@@ -24883,8 +24382,7 @@
       "depends_on": [
         "CLINICAL-LAUNCH-19"
       ],
-      "checks": {
-      },
+      "checks": {},
       "failure_reason": null,
       "commit_sha": null,
       "pr_url": null,
@@ -24897,12 +24395,8 @@
         "github_checks_green": null,
         "post_merge_revalidated": null
       },
-      "transitions": [
-
-      ],
-      "sidecars": [
-
-      ],
+      "transitions": [],
+      "sidecars": [],
       "next_task": "CLINICAL-MH-LAUNCH-TRAIN-CLOSEOUT"
     },
     "ANALYTICS-FUNNEL-REPORT-READY-PROJECTION-MAPPING-02": {
@@ -25004,9 +24498,7 @@
     "merged_at": "2026-05-18T16:21:48Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "metadata": {
       "dependency": "SEO-DASH-PROD-03D-SCAN",
       "production_write_execution": false,
@@ -25141,9 +24633,7 @@
     "branch": "codex/ops-ci-codescan-api-01",
     "base": "main",
     "title": "chore(ci): enable code scanning for fap-api",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "962be45f81044d1eec60088ef34235f8e020032e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1476",
     "checks": {
@@ -25153,8 +24643,7 @@
         "git_diff_check": "passed",
         "scope_validation": "passed"
       },
-      "github": {
-      }
+      "github": {}
     },
     "failure_reason": null,
     "merged_at": null,
@@ -25205,9 +24694,7 @@
     "branch": "codex/ops-ci-codescan-api-02",
     "base": "main",
     "title": "fix(ci): eliminate CiScaleImpact Semgrep findings",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "a194a0bb1d0cf83e130cce205cb9410cb48d725b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1607",
     "checks": {
@@ -25229,9 +24716,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-23T13:40:00+08:00",
@@ -25283,9 +24768,7 @@
     "merged_at": "2026-05-19T04:08:06Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T04:00:51.285Z",
@@ -25336,16 +24819,13 @@
         "git_diff_check": "passed",
         "scope_validation": "passed"
       },
-      "github": {
-      }
+      "github": {}
     },
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T04:10:16.588Z",
@@ -25414,9 +24894,7 @@
     "merged_at": "2026-05-19T15:24:19Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T15:00:00Z",
@@ -25494,9 +24972,7 @@
     "merged_at": "2026-05-19T15:41:57Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T15:00:00Z",
@@ -25578,9 +25054,7 @@
     "merged_at": "2026-05-19T20:45:57Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T20:06:36Z",
@@ -25664,9 +25138,7 @@
     "merged_at": "2026-05-19T21:11:58Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T20:06:36Z",
@@ -25763,9 +25235,7 @@
     "merged_at": "2026-05-19T22:39:08Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T20:06:36Z",
@@ -25864,9 +25334,7 @@
     "merged_at": "2026-05-19T22:55:01Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T22:39:08Z",
@@ -25956,9 +25424,7 @@
     "merged_at": "2026-05-19T23:15:17Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T22:39:08Z",
@@ -26046,9 +25512,7 @@
     "merged_at": "2026-05-19T23:24:32Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T23:15:17Z",
@@ -26133,9 +25597,7 @@
     "merged_at": "2026-05-19T23:40:38Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T23:15:17Z",
@@ -26223,9 +25685,7 @@
     "merged_at": "2026-05-20T00:07:13Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T23:55:28Z",
@@ -26300,9 +25760,7 @@
     "merged_at": "2026-05-20T00:24:00Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-19T23:55:28Z",
@@ -26582,9 +26040,7 @@
     "merged_at": "2026-05-20T01:58:13Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-20T01:44:34Z",
@@ -26675,9 +26131,7 @@
     "merged_at": "2026-05-20T02:44:41Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-20T02:16:00Z",
@@ -27218,9 +26672,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "history": [
       {
         "at": "2026-05-20T11:20:00+08:00",
@@ -29568,9 +29020,7 @@
       "repo": "fap-api",
       "branch": "codex/ops-admin-ui-01-table-toolbar",
       "status": "pr_opened",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "commit_sha": null,
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1750",
       "checks": {
@@ -30435,9 +29885,7 @@
       "repo": "fap-api",
       "branch": "codex/global-en-zh-human-review-import-queue-00",
       "base": "main",
-      "depends_on": [
-
-      ],
+      "depends_on": [],
       "title": "GLOBAL-EN-ZH-HUMAN-REVIEW-IMPORT-QUEUE-00 consolidated review queue",
       "commit_sha": "e934e8a5617ec669f6f326e1177e0c6044f9cb22",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/1699",
@@ -31410,9 +30858,7 @@
       "remote_branch_deleted": false,
       "local_cleanup_executed": false,
       "next_task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_REPAIR-01",
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "transitions": [
         {
           "at": "2026-05-28T18:48:00+08:00",
@@ -31496,9 +30942,7 @@
       "remote_branch_deleted": true,
       "local_cleanup_executed": true,
       "next_task": "RESULT-EMAIL-GATE-POLICY-02",
-      "sidecars": [
-
-      ],
+      "sidecars": [],
       "transitions": [
         {
           "at": "2026-05-29T00:36:09+08:00",
@@ -32379,9 +31823,7 @@
     "merged_at": "2026-05-25T07:03:57Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "events": [
       {
         "at": "2026-05-25T06:55:00Z",
@@ -32459,9 +31901,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "events": [
       {
         "at": "2026-05-25T07:20:00Z",
@@ -32484,9 +31924,7 @@
     "repo": "fap-api",
     "branch": "codex/marketingskills-fermatmind-fit-scan-00",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "2d08bb46555389226adf6dbce80dcc9111e2b82a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1680",
     "checks": {
@@ -32683,9 +32121,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "events": [
       {
         "at": "2026-05-25T21:45:00+08:00",
@@ -34152,9 +33588,7 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ]
+        "outside_scope": []
       },
       "github": {
         "status": "passed",
@@ -34249,9 +33683,7 @@
           "backend/tests/Unit/Domain/Career/Audit/CareerRuntimeCandidatePrepPlannerTest.php",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ]
+        "outside_scope": []
       },
       "github": {
         "status": "passed",
@@ -34372,9 +33804,7 @@
           "backend/tests/Unit/Domain/Career/Audit/CareerRuntimeArtifactRefreshPlannerTest.php",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "diff_checks": [
           "git diff --check",
           "git diff --cached --check"
@@ -34465,9 +33895,7 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ]
+        "outside_scope": []
       },
       "github": {
         "status": "passed",
@@ -34563,9 +33991,7 @@
           "backend/tests/Unit/Domain/Career/Audit/CareerDeltaRolloutManifestPlannerTest.php",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "diff_checks": [
           "git diff --check",
           "git diff --cached --check"
@@ -34648,9 +34074,7 @@
           "backend/tests/Unit/Domain/Career/Audit/CareerProgressiveCohortCloseoutPlannerTest.php",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "diff_checks": [
           "git diff --check",
           "git diff --cached --check"
@@ -34691,9 +34115,7 @@
     "branch": "codex/take-en-question-locale-scan-00",
     "base": "main",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "title": "TAKE-EN-QUESTION-LOCALE-SCAN-00 take flow EN/ZH question locale scan",
     "commit_sha": "75b26a54aa2e66cb892d58e88b526f7848d6ac4c",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1732",
@@ -34722,9 +34144,7 @@
           "docs/codex/pr-train-state.json",
           "docs/codex/pr-train.yaml"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "evidence": "Changed files are confined to read-only scan artifacts, focused test, and PR train metadata."
       },
       "local_validation": {
@@ -34838,9 +34258,7 @@
           "docs/codex/pr-train-state.json",
           "docs/codex/pr-train.yaml"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "evidence": "Final branch diff is confined to MBTI controller projection, MBTI English sidecar pack data, focused test, and PR train metadata; shared QuestionsService is no longer in the branch diff."
       },
       "local_validation": {
@@ -34971,9 +34389,7 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "changed_files": [
           "backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
           "docs/codex/pr-train-state.json",
@@ -35117,9 +34533,7 @@
           "docs/codex/pr-train.yaml",
           "docs/codex/pr-train-state.json"
         ],
-        "outside_scope": [
-
-        ],
+        "outside_scope": [],
         "changed_files": [
           "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/manifest.json",
           "backend/content_packs/ENNEAGRAM/v1-forced-choice-144/compiled/questions.compiled.json",
@@ -35307,9 +34721,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_SOURCE_CONTROLLED_IMPORT-01",
     "merge_commit": "54b47ccc27aa556e5d0596cee72245a66bbb3df3"
   },
@@ -35424,9 +34836,7 @@
     "base": "main",
     "title": "DETAIL_READY_1048_REPLACEMENT_AUTHORITY_INDEX_STATE_CONFLICT-01 replacement index-state runtime projection conflict report",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "05f7dda0b1350e523c02ea38daccbbedd91ce7e4",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1745",
     "checks": [
@@ -35502,9 +34912,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "DETAIL_READY_1048_DELTA_AUTHORITY_REPAIR-01 or 1047 target decision"
   },
   "DETAIL_READY_1047_DELTA_AUTHORITY_REPAIR-01": {
@@ -35514,9 +34922,7 @@
     "base": "main",
     "title": "DETAIL_READY_1047_DELTA_AUTHORITY_REPAIR-01 clean 1047 delta authority manifest",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "e5cbc6816d70383ad33c9da985bd76d6c00c3b73",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1746",
     "checks": [
@@ -35597,9 +35003,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Select one clean replacement or approve 1046/hold decision before apply preflight"
   },
   "DETAIL_READY_1046_DELTA_AUTHORITY_REPAIR-01": {
@@ -35609,9 +35013,7 @@
     "base": "main",
     "title": "DETAIL_READY_1046_DELTA_AUTHORITY_REPAIR-01 clean 1046 delta authority manifest",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "6716bf50c3cd22691d4609434f8a2b12442b2c8a",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1747",
     "checks": [
@@ -35692,9 +35094,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 explicit approval required before any apply"
   },
   "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01": {
@@ -35704,9 +35104,7 @@
     "base": "main",
     "title": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 production preflight for clean 1046 rollout apply",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "67e95aac7a4344a407c5c1b563c4131a27d2d7aa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1748",
     "checks": [
@@ -35792,9 +35190,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "DEPLOY-READINESS | Deploy fap-api PR #1747 before rerunning apply preflight"
   },
   "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01": {
@@ -35804,9 +35200,7 @@
     "base": "main",
     "title": "DETAIL_READY_1046_ROLLOUT_NO_AUDIT_DRY_RUN-01 no-write career rollout dry-run",
     "status": "merged",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "09ec7f599b05d7d555ad186af81633010f5c47f3",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1749",
     "checks": [
@@ -35882,9 +35276,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "DETAIL_READY_1046_ROLLOUT_APPLY_PREFLIGHT-01 rerun production no-write preflight after deploy"
   },
   "CAREER-1046-OPS-SCOPE-RECONCILIATION-01": {
@@ -35894,9 +35286,7 @@
     "base": "main",
     "title": "CAREER-1046-OPS-SCOPE-RECONCILIATION-01 reconcile public 1046 career runtime with CMS/Ops 378 scope",
     "status": "completed",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "e30f96f4e068c2a7b62e1fe67950ffab6b061c72",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1754",
     "checks": [
@@ -36007,9 +35397,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "CAREER-1046-OPS-READ-MODEL-REPAIR-01 explicit approval required before implementation"
   },
   "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01": {
@@ -36019,9 +35407,7 @@
     "base": "main",
     "title": "ANALYTICS-FUNNEL-EVENT-TAXONOMY-01 unify canonical funnel event taxonomy",
     "status": "ci_fix_local_checks_passed",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "265e1dcc58edd5a122627ff0e61594c5e3dbeeab",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1761",
     "checks": [
@@ -36225,9 +35611,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": true
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Phase 3 ContentPacksIndex responsibility shrink requires explicit authorization"
   },
   "ANALYTICS-FUNNEL-OPS-READ-MODEL-REPAIR-01": {
@@ -36370,9 +35754,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-CONTROLLED-REFRESH-PREFLIGHT-01"
   },
   "ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-01": {
@@ -37090,9 +36472,7 @@
     "base": "main",
     "title": "OPS-API-INTERNAL-RESOLVE-PROOF Node1 API access stability proof",
     "status": "pr_opened_with_sidecars",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "93556a55fbcf71aa998566eb4f276218cda48788",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1840",
     "checks": [
@@ -37319,9 +36699,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": "passed"
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "deploy-readiness required after merge"
   },
   "PAYMENT-ALIPAY-SCHEDULER-BOOTSTRAP-02": {
@@ -37433,9 +36811,7 @@
         "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1774 after local validation passed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Run validation, open PR, and after merge perform deploy-readiness plus production scheduler runner verification."
   },
   "OPS-RELEASE-TRAIN-BACKEND-DEPLOY-ADAPTER-01": {
@@ -37561,9 +36937,7 @@
         "summary": "Opened PR https://github.com/fermatmind/fap-api/pull/1770 after local validation passed; no deploy performed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Wait for GitHub checks and Codex final review; do not merge or deploy from this PR."
   },
   "OPS-RELEASE-TRAIN-WORKFLOW-PRODUCTION-ENV-BINDING-01": {
@@ -37682,9 +37056,7 @@
         "summary": "Validated workflow binding change locally without deploy, mode=run, production approval, rollback, or production mutation."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Open PR and keep production deploy disabled; manual GitHub production branch restriction remains required."
   },
   "OPS-RELEASE-TRAIN-CAREER-WARM-CACHE-NONBLOCKING-01": {
@@ -37899,9 +37271,7 @@
       "git_diff_check": "passed",
       "git_diff_cached_check": null
     },
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "BACKEND-DEPLOY-READINESS for ANALYTICS-FUNNEL-REFRESH-DRY-RUN-SQL-FIX-02",
     "reconciliation": [
       {
@@ -38118,9 +37488,7 @@
         "summary": "PR #1777 was squash-merged at 23dd1bc4c55947f0f7eda1d4499f62395fb62d81; origin/main contains the merge commit, remote branch was deleted, and local cleanup completed before starting PAYMENT-ALIPAY-OWNER-MISMATCH-CONTROLLED-REPAIR-04."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Controlled owner-mismatch repair only after explicit future approval."
   },
   "PAYMENT-ALIPAY-OWNER-MISMATCH-CONTROLLED-REPAIR-04": {
@@ -38508,9 +37876,7 @@
         "note": "Ledger closeout: confirmed https://github.com/fermatmind/fap-api/pull/1786 merged at 2026-05-31T07:57:19Z; origin/main contains 9e59c976a71811e76f9a70c64eb6380cf0a25878; task branch cleanup completed or remote branch absent."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "AUDIT-SEC-PAYMENT-INTEGRITY-01",
     "merge_commit": "9e59c976a71811e76f9a70c64eb6380cf0a25878",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1786",
@@ -39036,9 +38402,7 @@
         "note": "Created PR #1804 for docs-only security audit train ledger closeout; waiting for GitHub checks."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": null,
     "github": {
       "status": "checks_pending",
@@ -39357,9 +38721,7 @@
     "base": "main",
     "status": "pr_open_checks_pending",
     "title": "docs(foundation): validate Daily Giving backend runtime",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "322bf0d8f0884c48730fc23c2713710315d19863",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1833",
     "checks": {
@@ -39668,9 +39030,7 @@
     "base": "main",
     "status": "merged",
     "title": "CAREER-DIRECTORY-AUTHORITY-ARTIFACT-API-01 career directory authority artifact API",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "68f2b2dfc0b3b587a53ad85dc52a4b0f4b2eabcf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1830",
     "checks": {
@@ -40405,9 +39765,7 @@
     "base": "main",
     "status": "merged",
     "title": "CAREER-LEGACY-FULL-JOBS-INDEX-CONSUMER-AUDIT-01 legacy full jobs index consumer audit",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "commit_sha": "24288ec8713900f6709cd472b51f2d097ef263af",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/1845",
     "checks": {
@@ -40942,9 +40300,7 @@
         "note": "Ledger reconciled: PR #1850 is merged, origin/main contains merge commit d176ddc4, remote branch is deleted, and post-merge focused test passed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-WEB-EVENT-NAME-ALIGNMENT-02"
   },
   "ANALYTICS-FUNNEL-PURCHASE-REPORT-TRUTH-BRIDGE-03": {
@@ -41030,9 +40386,7 @@
         "note": "Opened https://github.com/fermatmind/fap-api/pull/1851 for GitHub checks and merge review."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "ANALYTICS-FUNNEL-GA4-PUBLIC-EVENT-SMOKE-01"
   },
   "SEO-CMS-CANARY-PREFLIGHT-LEDGER-01": {
@@ -41077,9 +40431,7 @@
         "note": "Registered only to satisfy SEO-CMS-CANARY-DRAFT-PATH-01 dependency bookkeeping in fap-api; fap-web PR #1004 is the owning PR."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CMS-CANARY-DRAFT-PATH-01"
   },
   "SEO-CMS-CANARY-DRAFT-PATH-01": {
@@ -41149,9 +40501,7 @@
         "note": "Reconciled before SEO-CMS-CANARY-DRAFT-VERIFY-01: GitHub PR #1855 is MERGED with merge commit 88efaf9b6e25e1a77b775de2ff07ade65eadbda0, local main equals origin/main, and the task branch cleanup was completed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "Authorized importer dry-run and read-only collision check, or SEO-CMS-CANARY-PREVIEW-01 only if no safe preview alternative exists."
   },
   "SEO-CMS-CANARY-DRAFT-VERIFY-01": {
@@ -41233,9 +40583,7 @@
         "note": "Reconciled before SEO-CONTENT-CANARY-PACKAGE-01: GitHub PR #1856 is MERGED with merge commit 1e75eef2631274554a4776fcc028b2ffb0e82dbc, local main equals origin/main, and the task branch cleanup was completed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CONTENT-P1-08 remains blocked unless this verification returns GO and user separately authorizes draft-only execution."
   },
   "SEO-CONTENT-CANARY-PACKAGE-01": {
@@ -41315,9 +40663,7 @@
         "note": "Reconciled before SEO-CMS-CANARY-IMPORT-DRYRUN-01: GitHub PR #1857 is MERGED with merge commit e7d5f14d55be02bd9f74bb2a9fbdd9ccd0e30be4, local main equals origin/main, and task branch cleanup was completed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CMS-CANARY-IMPORT-DRYRUN-01 should run controlled importer dry-run and collision validation before any draft-only execution."
   },
   "SEO-CMS-CANARY-IMPORT-DRYRUN-01": {
@@ -41409,9 +40755,7 @@
         "note": "Reconciled before SEO-CMS-CANARY-PACKAGE-ADAPTER-01: GitHub PR #1858 is MERGED with merge commit 6b0e6584c6ed9a47b023479130c4332127f79042, local main equals origin/main, and task branch cleanup was completed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CONTENT-P1-08 remains blocked. Next authorization should address package/importer schema mapping and hidden CMS/DB readonly collision verification."
   },
   "SEO-CMS-CANARY-PACKAGE-ADAPTER-01": {
@@ -41501,9 +40845,7 @@
         "note": "Reconciled before SEO-CMS-CANARY-IMPORTER-GATE-01: GitHub PR #1859 is MERGED with merge commit 2c0cf1bf81b3ff751d75112914863850c5bacf15, origin/main contains the merge commit, and the remote task branch is no longer present."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CONTENT-P1-08 remains blocked. Next step is either importer rule/schema mapping for the Chinese package gates or authorized operator readonly hidden collision verification after adapter/importer gates pass."
   },
   "SEO-CMS-CANARY-IMPORTER-GATE-01": {
@@ -41586,9 +40928,7 @@
         "note": "Reconciled before SEO-CMS-CANARY-OPERATOR-COLLISION-01: GitHub PR #1860 is MERGED with merge commit 26f4fec3b7112acff6d3276613b1cd57744350f9, origin/main contains the merge commit, local main equals origin/main, and local/remote task branch cleanup was completed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CMS-CANARY-OPERATOR-COLLISION-01 may proceed only after this PR is merged; SEO-CONTENT-P1-08 remains blocked until hidden CMS/DB collision is operator-verified by readonly path."
   },
   "SEO-CMS-CANARY-OPERATOR-COLLISION-01": {
@@ -41751,9 +41091,7 @@
         "note": "Reconciled before SEO-CONTENT-CANARY-EN-METADATA-01: GitHub PR #1862 is merged with merge commit 52a3efa1657244e61648875e31dd2fe97d1f195b, origin/main/local main are at that SHA, and the local/remote task branches were cleaned up."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CONTENT-CANARY-EN-METADATA-01 may proceed to apply GPT-5.5 Pro approved English SEO metadata replacements; publish remains forbidden."
   },
   "SEO-CONTENT-CANARY-EN-METADATA-01": {
@@ -41840,9 +41178,7 @@
         "note": "Reconciled before SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01: GitHub PR #1863 is merged with merge commit 76b40c07b5eb679e7b593aca2007a77e1e56d4d7, origin/main contains that commit, and the remote task branch is absent. Publish remains forbidden."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-CONTENT-P1-08 draft-only execution has completed; SEO-CONTENT-P1-08-POSTCHECK-ARCHIVE-01 archives the passed postcheck report and keeps publish blocked."
   },
   "SEO-CONTENT-P1-08": {
@@ -42202,8 +41538,7 @@
     ],
     "commit_sha": "11e82c0c7000bc90f2ec550b83d80a9b941465dc",
     "pr_url": null,
-    "checks": {
-    },
+    "checks": {},
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -42245,8 +41580,7 @@
     ],
     "commit_sha": "6547f4e08aebd665da98916dd5787a4a23adfed9",
     "pr_url": null,
-    "checks": {
-    },
+    "checks": {},
     "failure_reason": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -43432,9 +42766,7 @@
         "note": "Ledger reconciliation only: PR #1873 is merged, origin/main contains merge commit 4fa540738eb90b9777cade2da6d3c9d43feb70a5, remote branch is absent, and local cleanup was executed. No runtime files changed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-DASH-API-01 after separate authorization.",
     "merge_commit": "4fa540738eb90b9777cade2da6d3c9d43feb70a5"
   },
@@ -43553,9 +42885,7 @@
         "note": "Reconciled merged ledger for SEO-DASH-API-01 while starting SEO-DASH-MIGRATION-01. PR #1875 merged at cf1488e4aeccee8b6a54686d731e5f1a19ecf279 and branch cleanup was complete."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-DASH-MIGRATION-01 after separate authorization."
   },
   "SEO-DASH-MIGRATION-01": {
@@ -43676,9 +43006,7 @@
         "note": "Ledger reconciliation only: PR #1876 is merged at 09286a347cc8788ac8626c476f386da2086b6e94; branch cleanup and post-merge revalidation were already completed."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-DASH-COLLECTOR-01 after separate production migration readiness/deploy approval",
     "merge_commit_sha": "09286a347cc8788ac8626c476f386da2086b6e94"
   },
@@ -43788,9 +43116,7 @@
         "note": "Ledger reconciliation only: PR #1880 is merged at eddebd8d2392f2416cbb1f00802a6002eed45fdf; origin/main contains the merge commit and local/remote task branch cleanup is complete."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "approval-gated production collector dry-run/no-write smoke after separate authorization",
     "merge_commit_sha": "eddebd8d2392f2416cbb1f00802a6002eed45fdf"
   },
@@ -43899,9 +43225,7 @@
         "note": "Ledger reconciliation only: PR #1882 is merged at 1b88323eb05d579e847d37b0e89ed24464b1924c; origin/main contains the merge commit and local/remote task branch cleanup was complete before SEO-DASH-COLLECTOR-02 started."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "SEO-DASH-COLLECTOR-02 controlled collector runbook or write gate"
   },
   "SEO-DASH-COLLECTOR-02": {
@@ -43996,9 +43320,7 @@
         "note": "Opened PR #1883: https://github.com/fermatmind/fap-api/pull/1883."
       }
     ],
-    "sidecars": [
-
-    ],
+    "sidecars": [],
     "next_task": "approval-gated url_truth_inventory controlled write canary preflight"
   },
   "SEO-ARTICLE-SYSTEM-TRAIN-01": {
@@ -44008,9 +43330,7 @@
     "status": "merged",
     "train_scope": "seo_article_system_window_6",
     "title": "docs(seo): define article system PR train",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "checks": {
       "authorization": {
         "status": "pass",
@@ -47746,9 +47066,7 @@
     "branch": "codex/seo-article-riasec-v2-package-archive-01",
     "status": "merged",
     "title": "docs(seo): archive RIASEC explanation article package v2",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "checks": {
       "authorization": {
         "status": "pass",
@@ -47879,9 +47197,7 @@
       "decision": "GO for reference/source review",
       "content_safe": true,
       "content_blocked": false,
-      "blockers": [
-
-      ],
+      "blockers": [],
       "sidecar_issues": [
         "References remain needs_source_verification and block publish until reviewed.",
         "Career hub links are conditional and must not be activated in CMS body until route eligibility is confirmed.",
@@ -51965,9 +51281,7 @@
     "status": "github_checks_passed_pending_external_merge",
     "train_scope": "sitemap_stability",
     "title": "SEO-SITEMAP-STABILITY-02: fix(seo): make backend sitemap source fail closed with fallback payload",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "checks": {
       "authorization": {
         "status": "pass",
@@ -52045,9 +51359,7 @@
     "status": "merged",
     "train_scope": "sitemap_diff_parity",
     "title": "SEO-SITEMAP-DIFF-02: fix(seo): align scale sitemap source to localized canonical test URLs",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "checks": {
       "authorization": {
         "status": "pass",
@@ -52352,9 +51664,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "transitions": [
       {
         "at": "2026-06-09",
@@ -52481,9 +51791,7 @@
     "merged_at": "2026-06-09T04:18:01Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "transitions": [
       {
         "at": "2026-06-09",
@@ -52611,9 +51919,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "transitions": [
       {
         "at": "2026-06-09",
@@ -52848,9 +52154,7 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "transitions": [
       {
         "at": "2026-06-09",
@@ -52886,9 +52190,7 @@
     "status": "merged",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-01: feat(career): audit zh display parity",
-    "depends_on": [
-
-    ],
+    "depends_on": [],
     "checks": {
       "authorization": {
         "status": "pass",
@@ -52955,9 +52257,7 @@
     "merged_at": "2026-06-09T15:28:28Z",
     "remote_branch_deleted": true,
     "local_cleanup_executed": true,
-    "sidecar_issues": [
-
-    ],
+    "sidecar_issues": [],
     "transitions": [
       {
         "at": "2026-06-09",
@@ -53116,7 +52416,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-03-detail-cache",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-03: feat(career): refresh job detail cache per locale",
     "depends_on": [
@@ -53176,14 +52476,18 @@
         ],
         "merge_state": "MERGEABLE_UNSTABLE_WITH_OLD_CANCELLED_RUNS",
         "evidence": "Current head 669883b5fce3f34e5fa00c787ff730d00d984bd3 required GitHub checks passed. statusCheckRollup also includes cancelled jobs from superseded pull_request run 27220243638 after metadata push; current push run 27220243557 checks passed."
+      },
+      "merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2022 is MERGED, origin/main contains merge commit c0ed3ca7e85b327c5afbf4ae783e1a6f977c8029, the remote task branch was deleted, the isolated local branch was deleted after detaching the worktree, and post-merge focused job-detail cache revalidation passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "8f582fcb3b714a57f4be0e4a840d1f06a5c61302",
+    "commit_sha": "c0ed3ca7e85b327c5afbf4ae783e1a6f977c8029",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2022",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-09T16:37:11Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [
       {
         "id": "external-primary-worktree-dirty-content-baselines-2026-06-09",
@@ -53216,6 +52520,11 @@
         "at": "2026-06-09",
         "status": "ready_to_merge",
         "note": "Required current-head GitHub checks passed for PR #2022; old cancelled jobs from superseded run remain in statusCheckRollup but were not from current head execution."
+      },
+      {
+        "at": "2026-06-09T16:53:13Z",
+        "status": "merged",
+        "note": "Reconciled after GitHub reported PR #2022 merged at 2026-06-09T16:37:11Z and origin/main contained c0ed3ca7e85b327c5afbf4ae783e1a6f977c8029."
       }
     ]
   },
@@ -53223,7 +52532,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-04-live-gate",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-04: chore(career): gate zh display live parity",
     "depends_on": [
@@ -53235,8 +52544,40 @@
         "evidence": "User explicitly authorized adding and executing CAREER-ZH-DISPLAY-PARITY-01 through CAREER-ZH-DISPLAY-PARITY-04, including fap-api docs/codex metadata updates, on 2026-06-09."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-ZH-DISPLAY-PARITY-03 to merge."
+        "status": "pass",
+        "evidence": "CAREER-ZH-DISPLAY-PARITY-03 PR #2022 merged at 2026-06-09T16:37:11Z and origin/main contains merge commit c0ed3ca7e85b327c5afbf4ae783e1a6f977c8029."
+      },
+      "implementation": {
+        "status": "pass",
+        "evidence": "Extended career:audit-zh-display-parity with --summary-only, --assert-live-parity, and a live_gate section that gates API failures, index parity, module parity, and zh restricted-shell/integrity gaps without changing content, sitemap, llms, or index strategy."
+      },
+      "php_lint": {
+        "status": "pass",
+        "evidence": "php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php passed."
+      },
+      "focused_tests": {
+        "status": "pass",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=\":memory:\" php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi passed with 46 assertions. Existing file_get_contents warnings were emitted but exit code was 0."
+      },
+      "live_audit": {
+        "status": "pass_with_external_sidecar",
+        "evidence": "cd backend && php artisan career:audit-zh-display-parity --json --output=/private/tmp/career-zh-display-parity-04-live.json completed successfully; JSON validated. Report decision=pass, live_gate=blocked, total_slugs=1046, same_module_set=374, en_has_modules_zh_missing=672, restricted_shell_count=1029, api_failure_count=0, index_mismatch_count=0, sitemap_changed=false, llms_changed=false, index_strategy_changed=false."
+      },
+      "compact_report": {
+        "status": "pass",
+        "evidence": "backend/docs/career/generated/career-zh-display-parity-04-live-report.json was generated from the successful live audit with summary-only data and validates via python3 -m json.tool."
+      },
+      "metadata": {
+        "status": "pass",
+        "evidence": "docs/codex/pr-train-state.json parsed as JSON via python3 -m json.tool; docs/codex/pr-train.yaml parsed as YAML via Ruby stdlib."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to PR04 scoped audit command, focused audit tests, generated career live report, and docs/codex state metadata."
+      },
+      "diff_check": {
+        "status": "pass",
+        "evidence": "git diff --check passed after implementation; git diff --cached --check will be run after staging."
       }
     },
     "failure_reason": null,
@@ -53246,13 +52587,28 @@
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
     "sidecar_issues": [
-
+      {
+        "id": "career-zh-live-gate-blocked-content-state-2026-06-09",
+        "status": "external_content_state_blocker",
+        "evidence": "Live gate is blocked because reviewed zh display content state is still incomplete: 672 slugs have English display modules missing from zh and 1029 zh pages still expose restricted shell or integrity gap reasons. API availability and index parity are stable (1046/1046 index count, no API failures, no en/zh-only index mismatch). This PR only adds the gate/report and does not import, publish, deploy, or mutate sitemap/llms/index strategy.",
+        "next_action": "Run separately approved reviewed Chinese display asset import/publish and per-slug cache refresh, then rerun career:audit-zh-display-parity --assert-live-parity."
+      },
+      {
+        "id": "external-primary-worktree-dirty-content-baselines-2026-06-09",
+        "status": "external_unrelated",
+        "evidence": "Primary fap-api checkout has unrelated modified content_baselines/content_pages JSON files; current PR04 is isolated in /private/tmp/fap-api-career-zh-display-parity-04 and does not touch those files."
+      }
     ],
     "transitions": [
       {
         "at": "2026-06-09",
         "status": "pending_dependency",
         "note": "Future controlled publish/live parity gate entry initialized only; implementation deferred until PR03 is merged."
+      },
+      {
+        "at": "2026-06-09T16:53:13Z",
+        "status": "local_checks_passed",
+        "note": "Implemented live parity gate/report. Local focused tests and live audit passed; live parity remains blocked only by external reviewed zh content state, recorded as sidecar."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52532,7 +52532,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-display-parity-04-live-gate",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_display_parity",
     "title": "CAREER-ZH-DISPLAY-PARITY-04: chore(career): gate zh display live parity",
     "depends_on": [
@@ -52580,14 +52580,26 @@
         "evidence": "git diff --check passed after implementation; git diff --cached --check will be run after staging."
       },
       "github": {
-        "status": "pending",
+        "status": "pass",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2023",
-        "head_sha": "d02233d1372b302ee06569d5ddbc03f92983bef7",
-        "evidence": "PR #2023 opened for CAREER-ZH-DISPLAY-PARITY-04; GitHub checks are pending."
+        "head_sha": "da07e91896d688efbbe5f20461433197db6972aa",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "verify-bigfive",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN",
+        "evidence": "GitHub checks passed for head da07e91896d688efbbe5f20461433197db6972aa and gh pr view reported mergeStateStatus=CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "d02233d1372b302ee06569d5ddbc03f92983bef7",
+    "commit_sha": "da07e91896d688efbbe5f20461433197db6972aa",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2023",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -52620,6 +52632,11 @@
         "at": "2026-06-09T16:58:00Z",
         "status": "github_checks_pending",
         "note": "Opened PR #2023 and pushed implementation commit d02233d1372b302ee06569d5ddbc03f92983bef7; waiting for GitHub checks."
+      },
+      {
+        "at": "2026-06-09T17:02:20Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and PR #2023 reported mergeStateStatus=CLEAN for head da07e91896d688efbbe5f20461433197db6972aa."
       }
     ]
   }


### PR DESCRIPTION
## What changed
- Added a live parity gate to `career:audit-zh-display-parity` with `--assert-live-parity` and `--summary-only`.
- Added compact generated evidence at `backend/docs/career/generated/career-zh-display-parity-04-live-report.json`.
- Extended focused command tests for the non-mutating gate path and assertion failure mode.
- Reconciled PR03 merge state in the PR-train ledger and recorded PR04 sidecar evidence.

## Why
This turns the zh/en career display mismatch into a repeatable gate: API/index availability, module parity, restricted-shell/integrity gaps, and explicit sitemap/llms/index non-mutation are visible in one report.

## Validation
- `php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerAuditZhDisplayParity.php tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php`
- `cd backend && php artisan career:audit-zh-display-parity --json --output=/private/tmp/career-zh-display-parity-04-live.json`
- `python3 -m json.tool /private/tmp/career-zh-display-parity-04-live.json >/dev/null`
- `python3 -m json.tool backend/docs/career/generated/career-zh-display-parity-04-live-report.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- `git diff --cached --check`

## Live gate evidence
- total slugs: 1046
- en index count: 1046
- zh index count: 1046
- same module set: 374
- en modules missing from zh: 672
- restricted shell / integrity gaps: 1029
- API failures: 0
- index mismatches: 0
- sitemap/llms/index strategy changed: false

## Intentionally deferred
- No import, publish, deploy, sitemap, llms, or indexability changes.
- The live parity gate is currently blocked by external reviewed zh content state. The next operational step is a separately approved reviewed Chinese display asset import/publish/cache refresh, then rerun `career:audit-zh-display-parity --assert-live-parity`.
