### PR TITLE
CAREER-ZH-PARITY-FIX-01: fix(career): compact zh parity workbook readiness

### DIFF
--- a/backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php
+++ b/backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php
@@ -12,6 +12,7 @@ final class CareerFullDisplayWorkbookValidator extends Command
         {--file= : Absolute path to a v4.2 career asset workbook}
         {--slugs= : Optional comma-separated explicit slug allowlist}
         {--json : Emit JSON report}
+        {--summary-only : Omit per-row items and full-upload plan rows from the emitted JSON report}
         {--output= : Optional report output path}
         {--plan-output= : Optional full-upload plan JSON output path for full workbook scans}
         {--plan-md-output= : Optional full-upload plan Markdown summary output path for full workbook scans}
@@ -25,6 +26,7 @@ final class CareerFullDisplayWorkbookValidator extends Command
             '--file' => $this->option('file'),
             '--slugs' => $this->option('slugs'),
             '--json' => (bool) $this->option('json'),
+            '--summary-only' => (bool) $this->option('summary-only'),
             '--output' => $this->option('output'),
             '--plan-output' => $this->option('plan-output'),
             '--plan-md-output' => $this->option('plan-md-output'),

--- a/backend/app/Console/Commands/CareerValidateDisplayBatch.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayBatch.php
@@ -140,6 +140,7 @@ final class CareerValidateDisplayBatch extends Command
         {--file= : Absolute path to a v4.2 career asset workbook}
         {--slugs= : Optional comma-separated explicit slug allowlist; omitted means read-only full workbook scan}
         {--json : Emit JSON report}
+        {--summary-only : Omit per-row items and full-upload plan rows from the emitted JSON report}
         {--output= : Optional report output path}
         {--plan-output= : Optional full-upload plan JSON output path for full workbook scans}
         {--plan-md-output= : Optional full-upload plan Markdown summary output path for full workbook scans}
@@ -1673,7 +1674,11 @@ final class CareerValidateDisplayBatch extends Command
             $report['validated_count'] = count($report['items']);
         }
 
-        $json = json_encode($report, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+        $outputReport = (bool) $this->option('summary-only')
+            ? $this->summaryOnlyReport($report)
+            : $report;
+
+        $json = json_encode($outputReport, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
         if (! is_string($json)) {
             throw new RuntimeException('Unable to encode validation report.');
         }
@@ -1689,15 +1694,58 @@ final class CareerValidateDisplayBatch extends Command
         if ((bool) $this->option('json')) {
             $this->output->write($json.PHP_EOL, false, OutputInterface::OUTPUT_RAW);
         } else {
-            $this->line('validator_version='.$report['validator_version']);
-            $this->line('decision='.$report['decision']);
-            $this->line('validated_count='.$report['validated_count']);
-            if (isset($report['summary'])) {
-                $this->line('summary='.json_encode($report['summary'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+            $this->line('validator_version='.$outputReport['validator_version']);
+            $this->line('decision='.$outputReport['decision']);
+            $this->line('validated_count='.$outputReport['validated_count']);
+            if (isset($outputReport['summary'])) {
+                $this->line('summary='.json_encode($outputReport['summary'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
             }
         }
 
         return $success ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @param  array<string, mixed>  $report
+     * @return array<string, mixed>
+     */
+    private function summaryOnlyReport(array $report): array
+    {
+        $omitted = [
+            'items' => isset($report['items']) && is_array($report['items']) ? count($report['items']) : 0,
+            'full_upload_plan_rows' => is_array(data_get($report, 'full_upload_plan.rows'))
+                ? count(data_get($report, 'full_upload_plan.rows'))
+                : 0,
+        ];
+
+        if (isset($report['items']) && is_array($report['items'])) {
+            $report['items'] = [];
+        }
+
+        if (isset($report['allowlisted_slugs']) && is_array($report['allowlisted_slugs'])) {
+            $report['allowlisted_slug_count'] = count($report['allowlisted_slugs']);
+            $report['allowlisted_slugs'] = [];
+        }
+
+        if (isset($report['recommended_next_batches']) && is_array($report['recommended_next_batches'])) {
+            $report['recommended_next_batch_counts'] = array_map(
+                static fn (mixed $batch): int => is_array($batch) ? count($batch) : 0,
+                $report['recommended_next_batches'],
+            );
+            $report['recommended_next_batches'] = array_map(
+                static fn (mixed $batch): mixed => is_array($batch) ? [] : $batch,
+                $report['recommended_next_batches'],
+            );
+        }
+
+        if (is_array(data_get($report, 'full_upload_plan.rows'))) {
+            data_set($report, 'full_upload_plan.rows', []);
+        }
+
+        $report['report_mode'] = 'summary_only';
+        $report['omitted_counts'] = $omitted;
+
+        return $report;
     }
 
     /**

--- a/backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json
+++ b/backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json
@@ -1,0 +1,86 @@
+{
+  "report_id": "career-zh-parity-fix-01-readiness",
+  "generated_at": "2026-06-11T02:26:01Z",
+  "pr_train_id": "CAREER-ZH-PARITY-FIX-01",
+  "read_only": true,
+  "writes_database": false,
+  "database_mutation": false,
+  "cms_mutation": false,
+  "publish_allowed": false,
+  "deploy_allowed": false,
+  "sitemap_llms_index_strategy_changed": false,
+  "command": "php artisan career:validate-full-display-workbook --json --summary-only --output=/private/tmp/career-zh-parity-fix-01-readiness.json --plan-output=/private/tmp/career-zh-parity-fix-01-plan.json --plan-md-output=/private/tmp/career-zh-parity-fix-01-plan.md",
+  "validator_version": "career_display_batch_validator_v0.2",
+  "source_file_basename": "第九版_d23b_schema_repaired.xlsx",
+  "source_file_sha256": "c30f8743cfd0d8baa14ac931cc7270807425164952f6a44953b5b4ab448778ef",
+  "sheet": "Career_Assets_v4_1",
+  "total_rows": 2786,
+  "column_count": 70,
+  "header_exact_match": true,
+  "decision": "no_go",
+  "report_mode": "summary_only",
+  "validated_count": 2786,
+  "omitted_counts": {
+    "items": 2786,
+    "full_upload_plan_rows": 2786
+  },
+  "allowlisted_slug_count": 2786,
+  "summary": {
+    "allowlisted_count": 2786,
+    "ready_for_second_pilot_validation": 0,
+    "authority_ready_content_blocked": 0,
+    "content_ready_authority_blocked": 0,
+    "blocked_authority_unavailable": 2786,
+    "blocked_docx_fallback": 0,
+    "blocked_api_404": 0
+  },
+  "full_upload_plan": {
+    "planner": {
+      "version": "career_full_upload_planner_v0.1",
+      "scope": "career_zh_display_parity_v0.1",
+      "target_locale": "zh-CN",
+      "generated_at": "2026-06-11T02:25:18.094445Z",
+      "db_baseline": {
+        "career_job_display_assets": null
+      },
+      "upload_manifest_sha256": "93b065ba3e765da94d0745f4709c1798c55d3ec36f69168dc4d6c16e14c0ff46"
+    },
+    "summary": {
+      "already_imported_validated": 0,
+      "upload_candidates": 0,
+      "holds": {
+        "manual_hold": 1,
+        "duplicate_identity_hold": 0,
+        "broad_group_hold": 75,
+        "CN_proxy_hold": 1663,
+        "total": 1739
+      },
+      "needs_workbook_repair": 0,
+      "needs_authority_alignment": 0,
+      "unresolved": 1047,
+      "status_counts": {
+        "already_imported_validated": 0,
+        "upload_candidate": 0,
+        "needs_workbook_repair": 0,
+        "needs_authority_alignment": 0,
+        "duplicate_identity_hold": 0,
+        "broad_group_hold": 75,
+        "CN_proxy_hold": 1663,
+        "manual_hold": 1,
+        "non_importable": 0,
+        "blocked_external_sidecar": 1047
+      }
+    },
+    "rows_omitted_from_readiness_report": 2786,
+    "complete_plan_artifact": "/private/tmp/career-zh-parity-fix-01-plan.json",
+    "complete_plan_rows": 2786
+  },
+  "local_authority_note": "Local validation environment has no career authority DB snapshot, so all 2786 rows are blocked_authority_unavailable locally. This is expected readiness evidence for PR01 and does not import, publish, or mutate production state.",
+  "next_prs": [
+    "CAREER-ZH-PARITY-FIX-02 repair reviewed workbook contract issues",
+    "CAREER-ZH-PARITY-FIX-03 support authority-manifest zh display import",
+    "CAREER-ZH-PARITY-FIX-04 controlled import and zh detail cache refresh",
+    "CAREER-ZH-PARITY-FIX-05 display-asset integrity release policy",
+    "CAREER-ZH-PARITY-FIX-06 final live parity gate"
+  ]
+}

--- a/backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
+++ b/backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
@@ -69,6 +69,32 @@ final class CareerFullDisplayWorkbookValidatorCommandTest extends TestCase
         $this->assertCount(5, $report['strategic_architecture_gap_scan']['gap_matrix']);
     }
 
+    #[Test]
+    public function it_delegates_summary_only_full_workbook_validation(): void
+    {
+        $workbook = $this->writeWorkbook([
+            $this->row('actuaries'),
+            $this->row('data-scientists'),
+        ]);
+
+        $exitCode = Artisan::call('career:validate-full-display-workbook', [
+            '--file' => $workbook,
+            '--json' => true,
+            '--summary-only' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('career:validate-display-batch', $report['command']);
+        $this->assertSame('summary_only', $report['report_mode']);
+        $this->assertSame('full_workbook', $report['scan_scope']);
+        $this->assertSame(2, $report['validated_count']);
+        $this->assertSame(2, $report['omitted_counts']['items']);
+        $this->assertSame([], $report['items']);
+        $this->assertSame([], $report['full_upload_plan']['rows']);
+        $this->assertFalse($report['writes_database']);
+    }
+
     /**
      * @return array<string, string>
      */

--- a/backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
@@ -180,6 +180,44 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_can_emit_summary_only_json_for_large_full_workbook_reports(): void
+    {
+        $this->createAuthorityOccupation('ready-upload-slug', '15-2011', '15-2011.00');
+        $workbook = $this->writeWorkbook([
+            $this->row('ready-upload-slug', title: 'Ready Upload', cnTitle: '待上传职业', soc: '15-2011', onet: '15-2011.00', schemaValid: true, linksStrict: true, ctaAction: 'start_riasec_test'),
+            $this->row('needs-repair-slug', title: 'Needs Repair', soc: '17-1011', onet: '17-1011.00'),
+        ]);
+        $output = $this->tempDir().'/career_validate_summary.json';
+        $planOutput = $this->tempDir().'/career_full_upload_plan.json';
+
+        $exitCode = Artisan::call('career:validate-display-batch', [
+            '--file' => $workbook,
+            '--json' => true,
+            '--summary-only' => true,
+            '--output' => $output,
+            '--plan-output' => $planOutput,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+        $written = json_decode((string) file_get_contents($output), true, flags: JSON_THROW_ON_ERROR);
+        $plan = json_decode((string) file_get_contents($planOutput), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame($report, $written);
+        $this->assertSame('summary_only', $report['report_mode']);
+        $this->assertSame(2, $report['validated_count']);
+        $this->assertSame(2, $report['omitted_counts']['items']);
+        $this->assertSame(2, $report['omitted_counts']['full_upload_plan_rows']);
+        $this->assertSame(2, $report['allowlisted_slug_count']);
+        $this->assertSame([], $report['items']);
+        $this->assertSame([], $report['allowlisted_slugs']);
+        $this->assertSame([], $report['full_upload_plan']['rows']);
+        $this->assertArrayHasKey('ready_for_display_validation', $report['recommended_next_batch_counts']);
+        $this->assertSame([], $report['recommended_next_batches']['ready_for_display_validation']);
+        $this->assertCount(2, $plan['rows']);
+        $this->assertSame($plan['planner']['upload_manifest_sha256'], $report['full_upload_plan']['planner']['upload_manifest_sha256']);
+    }
+
+    #[Test]
     public function it_changes_manifest_hash_when_workbook_content_changes(): void
     {
         $this->createAuthorityOccupation('ready-upload-slug', '15-2011', '15-2011.00');

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-09T00:00:00Z",
+  "updated_at": "2026-06-11T02:31:06Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -52637,6 +52637,275 @@
         "at": "2026-06-09T17:02:20Z",
         "status": "ready_to_merge",
         "note": "GitHub checks passed and PR #2023 reported mergeStateStatus=CLEAN for head da07e91896d688efbbe5f20461433197db6972aa."
+      }
+    ]
+  },
+  "CAREER-ZH-PARITY-FIX-01": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-parity-fix-01",
+    "base": "origin/main",
+    "status": "github_checks_pending",
+    "train_scope": "career_zh_parity_fix",
+    "title": "CAREER-ZH-PARITY-FIX-01: fix(career): compact zh parity workbook readiness",
+    "depends_on": [],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "No same-train dependency for PR01."
+      },
+      "implementation": {
+        "status": "pass",
+        "evidence": "Added --summary-only compact JSON support to career:validate-display-batch and career:validate-full-display-workbook. Summary-only preserves validated counts, plan hashes, and summary counts while omitting per-row items, full_upload_plan rows, allowlisted slug lists, and recommended batch slug lists."
+      },
+      "php_lint": {
+        "status": "pass",
+        "evidence": "php -l passed for CareerValidateDisplayBatch.php, CareerFullDisplayWorkbookValidator.php, CareerValidateDisplayBatchCommandTest.php, and CareerFullDisplayWorkbookValidatorCommandTest.php."
+      },
+      "focused_tests": {
+        "status": "pass",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=\":memory:\" php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php --no-ansi passed with 14 warnings from existing workbook fixture file_get_contents noise and 195 assertions."
+      },
+      "readiness_run": {
+        "status": "pass",
+        "evidence": "cd backend && php artisan career:validate-full-display-workbook --file=/Users/rainie/Desktop/费马资料文件/职业：人格与职业决策操作系统/职业内容资产/第九版_d23b_schema_repaired.xlsx --json --summary-only --output=/private/tmp/career-zh-parity-fix-01-readiness.json --plan-output=/private/tmp/career-zh-parity-fix-01-plan.json --plan-md-output=/private/tmp/career-zh-parity-fix-01-plan.md completed with exit 0. Summary report is 16319 bytes; full plan artifact is 3203390 bytes."
+      },
+      "generated_report": {
+        "status": "pass",
+        "evidence": "backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json generated from the summary-only readiness run and parsed with python3 -m json.tool."
+      },
+      "format": {
+        "status": "pass",
+        "evidence": "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php passed."
+      },
+      "metadata": {
+        "status": "pass",
+        "evidence": "docs/codex/pr-train-state.json parsed as JSON and docs/codex/pr-train.yaml parsed as YAML using Ruby stdlib."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to PR01 scoped validator commands, focused tests, generated career readiness report, and root docs/codex metadata."
+      },
+      "diff_check": {
+        "status": "pass",
+        "evidence": "git diff --check passed for scoped files; git diff --cached --check will run after staging."
+      },
+      "cached_diff_check": {
+        "status": "pass",
+        "evidence": "git diff --cached --check passed after path-limited staging of the 7 scoped files."
+      },
+      "github": {
+        "status": "pending",
+        "pr_url": "https://github.com/fermatmind/fap-api/pull/2025",
+        "head_sha": "19d3160092b22dce29c18f79c722675fcb243ec0",
+        "evidence": "Opened PR #2025; waiting for GitHub checks."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": "19d3160092b22dce29c18f79c722675fcb243ec0",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2025",
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-11T02:19:47Z",
+        "status": "in_progress",
+        "note": "Initialized from explicit CAREER-ZH-PARITY-FIX train authorization and started branch codex/career-zh-parity-fix-01 from latest fap-api main."
+      },
+      {
+        "at": "2026-06-11T02:27:46Z",
+        "status": "local_checks_passed",
+        "note": "Implemented summary-only full workbook readiness output; lint, focused tests, real workbook readiness run, generated report validation, metadata validation, Pint, and scope validation passed locally."
+      },
+      {
+        "at": "2026-06-11T02:29:20Z",
+        "status": "committed",
+        "note": "Created local commit 6e16c94f7f53a39937913100bbb17326fa74abec for CAREER-ZH-PARITY-FIX-01 after scoped staging and cached diff check."
+      },
+      {
+        "at": "2026-06-11T02:31:06Z",
+        "status": "github_checks_pending",
+        "note": "Opened PR #2025 and pushed branch head 19d3160092b22dce29c18f79c722675fcb243ec0; waiting for GitHub checks."
+      }
+    ]
+  },
+  "CAREER-ZH-PARITY-FIX-02": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-parity-fix-02",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_parity_fix",
+    "title": "CAREER-ZH-PARITY-FIX-02: fix(career): repair reviewed zh display workbook contract",
+    "depends_on": [
+      "CAREER-ZH-PARITY-FIX-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-01 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-11T02:19:47Z",
+        "status": "pending_dependency",
+        "note": "Future workbook contract repair entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-01 is merged."
+      }
+    ]
+  },
+  "CAREER-ZH-PARITY-FIX-03": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-parity-fix-03",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_parity_fix",
+    "title": "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import",
+    "depends_on": [
+      "CAREER-ZH-PARITY-FIX-02"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-02 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-11T02:19:47Z",
+        "status": "pending_dependency",
+        "note": "Future authority-manifest import entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-02 is merged."
+      }
+    ]
+  },
+  "CAREER-ZH-PARITY-FIX-04": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-parity-fix-04",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_parity_fix",
+    "title": "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh",
+    "depends_on": [
+      "CAREER-ZH-PARITY-FIX-03"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-03 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-11T02:19:47Z",
+        "status": "pending_dependency",
+        "note": "Future controlled import/cache refresh entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-03 is merged."
+      }
+    ]
+  },
+  "CAREER-ZH-PARITY-FIX-05": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-parity-fix-05",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_parity_fix",
+    "title": "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy",
+    "depends_on": [
+      "CAREER-ZH-PARITY-FIX-04"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-04 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-11T02:19:47Z",
+        "status": "pending_dependency",
+        "note": "Future runtime integrity policy entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-04 is merged."
+      }
+    ]
+  },
+  "CAREER-ZH-PARITY-FIX-06": {
+    "repo": "fap-api",
+    "branch": "codex/career-zh-parity-fix-06",
+    "base": "origin/main",
+    "status": "pending_dependency",
+    "train_scope": "career_zh_parity_fix",
+    "title": "CAREER-ZH-PARITY-FIX-06: chore(career): assert final zh display parity",
+    "depends_on": [
+      "CAREER-ZH-PARITY-FIX-05"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
+      },
+      "dependency": {
+        "status": "pending",
+        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-05 to merge."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "sidecar_issues": [],
+    "transitions": [
+      {
+        "at": "2026-06-11T02:19:47Z",
+        "status": "pending_dependency",
+        "note": "Future final live parity gate entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-05 is merged."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T02:31:06Z",
+  "updated_at": "2026-06-11T02:39:11Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -52644,7 +52644,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-01",
     "base": "origin/main",
-    "status": "github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-01: fix(career): compact zh parity workbook readiness",
     "depends_on": [],
@@ -52698,14 +52698,30 @@
         "evidence": "git diff --cached --check passed after path-limited staging of the 7 scoped files."
       },
       "github": {
-        "status": "pending",
+        "status": "pass",
         "pr_url": "https://github.com/fermatmind/fap-api/pull/2025",
-        "head_sha": "19d3160092b22dce29c18f79c722675fcb243ec0",
-        "evidence": "Opened PR #2025; waiting for GitHub checks."
+        "head_sha": "9150b0d70769ec72d89016611396698e07aa7caf",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "verify-bigfive",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS"
+        ],
+        "merge_state": "CLEAN",
+        "evidence": "GitHub checks passed for PR #2025 and gh pr view reported mergeStateStatus=CLEAN."
+      },
+      "post_github_scope_validation": {
+        "status": "pass",
+        "evidence": "After GitHub checks passed, git diff --name-only origin/main...HEAD remained confined to the 7 scoped PR01 files and git diff --check origin/main...HEAD passed."
       }
     },
     "failure_reason": null,
-    "commit_sha": "19d3160092b22dce29c18f79c722675fcb243ec0",
+    "commit_sha": "9150b0d70769ec72d89016611396698e07aa7caf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2025",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -52731,6 +52747,11 @@
         "at": "2026-06-11T02:31:06Z",
         "status": "github_checks_pending",
         "note": "Opened PR #2025 and pushed branch head 19d3160092b22dce29c18f79c722675fcb243ec0; waiting for GitHub checks."
+      },
+      {
+        "at": "2026-06-11T02:39:11Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and PR #2025 reported mergeStateStatus=CLEAN for head 9150b0d70769ec72d89016611396698e07aa7caf."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24182,3 +24182,257 @@ prs:
     url_submission: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: CAREER-ZH-PARITY-FIX-01
+    repo: fap-api
+    branch: codex/career-zh-parity-fix-01
+    title: "CAREER-ZH-PARITY-FIX-01: fix(career): compact zh parity workbook readiness"
+    train_scope: career_zh_parity_fix
+    status: in_progress
+    scope:
+      - Fix full-workbook career display validation so large reviewed Chinese workbook scans can emit compact readiness JSON without console OOM.
+      - Preserve read-only behavior and full plan artifact output while omitting per-row detail from summary-only stdout/report artifacts.
+      - Capture a generated readiness summary for the current Chinese career parity fix train.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerValidateDisplayBatch.php
+      - backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php
+      - backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+      - backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
+      - backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Import display assets, modify CMS/database rows, copy English content into Chinese fields, clear or warm caches, publish career pages, deploy, or change sitemap/llms/index strategy in this PR.
+      - Modify fap-web or career frontend rendering.
+    validation:
+      - php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php
+      - php -l backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php
+      - php -l backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+      - php -l backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php --no-ansi
+      - cd backend && php artisan career:validate-full-display-workbook --file='/Users/rainie/Desktop/费马资料文件/职业：人格与职业决策操作系统/职业内容资产/第九版_d23b_schema_repaired.xlsx' --json --summary-only --output=/private/tmp/career-zh-parity-fix-01-readiness.json --plan-output=/private/tmp/career-zh-parity-fix-01-plan.json --plan-md-output=/private/tmp/career-zh-parity-fix-01-plan.md
+      - python3 -m json.tool /private/tmp/career-zh-parity-fix-01-readiness.json >/dev/null
+      - python3 -m json.tool /private/tmp/career-zh-parity-fix-01-plan.json >/dev/null
+      - python3 -m json.tool backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json >/dev/null
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check -- backend/app/Console/Commands/CareerValidateDisplayBatch.php backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-PARITY-FIX-02
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-PARITY-FIX-01
+    branch: codex/career-zh-parity-fix-02
+    title: "CAREER-ZH-PARITY-FIX-02: fix(career): repair reviewed zh display workbook contract"
+    train_scope: career_zh_parity_fix
+    status: pending_dependency
+    scope:
+      - Add controlled workbook contract repair for reviewed Chinese career display assets.
+      - Normalize CTA target, FermatMind interpretation source labels, Product schema leakage, and job-posting sample terms without copying English into Chinese fields.
+      - Output repaired artifact metadata and validation evidence for follow-up import.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerRepairDisplayWorkbookContract.php
+      - backend/app/Services/Career/Import/**
+      - backend/tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php
+      - backend/tests/Unit/Services/Career/**
+      - backend/docs/career/generated/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Import or publish career display assets, mutate CMS/database rows, deploy, modify fap-web, or change sitemap/llms/index strategy.
+    validation:
+      - php -l backend/app/Console/Commands/CareerRepairDisplayWorkbookContract.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php tests/Unit/Services/Career --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerRepairDisplayWorkbookContract.php tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-PARITY-FIX-03
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-PARITY-FIX-02
+    branch: codex/career-zh-parity-fix-03
+    title: "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import"
+    train_scope: career_zh_parity_fix
+    status: pending_dependency
+    scope:
+      - Replace hardcoded selected-slug limitations with production-authority manifest validation for the Chinese parity import scope.
+      - Require reviewed workbook fields, exact manifest hashes, dry-run support, and safe refusal for non-authoritative slugs.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerValidateDisplayBatch.php
+      - backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - backend/app/Services/Career/Import/**
+      - backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+      - backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+      - backend/tests/Unit/Services/Career/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Run production import, publish content, deploy, modify fap-web, or change sitemap/llms/index strategy.
+    validation:
+      - php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php
+      - php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerImportSelectedDisplayAssets.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-PARITY-FIX-04
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-PARITY-FIX-03
+    branch: codex/career-zh-parity-fix-04
+    title: "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh"
+    train_scope: career_zh_parity_fix
+    status: pending_dependency
+    scope:
+      - Add chunked controlled import execution support for the reviewed Chinese display parity manifest.
+      - Clear and warm per-slug zh-CN job detail cache after successful imports.
+      - Produce lineage and cache refresh reports without changing search index strategy.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
+      - backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+      - backend/app/Services/Career/Import/**
+      - backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+      - backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - backend/tests/Unit/Services/Career/**
+      - backend/docs/career/generated/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Execute production import without explicit operator approval, publish pages, deploy, modify fap-web, or change sitemap/llms/index strategy.
+    validation:
+      - php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+      - php -l backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
+      - php -l backend/app/Services/Career/PublicCareerAuthorityResponseCache.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php tests/Unit/Services/Career --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Console/Commands/CareerWarmPublicAuthorityCache.php app/Services/Career/PublicCareerAuthorityResponseCache.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-PARITY-FIX-05
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-PARITY-FIX-04
+    branch: codex/career-zh-parity-fix-05
+    title: "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy"
+    train_scope: career_zh_parity_fix
+    status: pending_dependency
+    scope:
+      - Align runtime integrity policy so reviewed display_asset-backed pages are not misclassified as restricted shells when module and claim boundaries are satisfied.
+      - Preserve public claim limits, noindex/sitemap/llms gates, and private/admin metadata exclusions.
+    allowed_paths:
+      - backend/app/Services/Career/**
+      - backend/tests/Feature/Career/**
+      - backend/tests/Unit/Services/Career/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Weaken unsupported salary/growth/job-market claim gates, expose admin metadata, publish content, deploy, modify fap-web, or change sitemap/llms/index strategy.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career tests/Unit/Services/Career --no-ansi
+      - cd backend && ./vendor/bin/pint --test app/Services/Career tests/Feature/Career tests/Unit/Services/Career
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: true
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend
+
+  - id: CAREER-ZH-PARITY-FIX-06
+    repo: fap-api
+    depends_on:
+      - CAREER-ZH-PARITY-FIX-05
+    branch: codex/career-zh-parity-fix-06
+    title: "CAREER-ZH-PARITY-FIX-06: chore(career): assert final zh display parity"
+    train_scope: career_zh_parity_fix
+    status: pending_dependency
+    scope:
+      - Run and harden the final live parity gate for all 1046 public career job slugs.
+      - Assert EN/ZH API 200 parity, zero English-module-only Chinese gaps, zero unexpected restricted shells, and unchanged sitemap/llms/index strategy.
+      - Commit the final generated parity report.
+    allowed_paths:
+      - backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+      - backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+      - backend/docs/career/generated/**
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Change sitemap, llms.txt, indexability, publish content, deploy, or modify fap-web without explicit authorization.
+    validation:
+      - php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi
+      - cd backend && php artisan career:audit-zh-display-parity --json --summary-only --assert-live-parity --output=/private/tmp/career-zh-parity-fix-06-live.json
+      - python3 -m json.tool /private/tmp/career-zh-parity-fix-06-live.json >/dev/null
+      - python3 -m json.tool backend/docs/career/generated/career-zh-parity-fix-06-live-report.json >/dev/null
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+      - git diff --cached --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    search_channel_action: false
+    url_submission: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added `--summary-only` support to `career:validate-display-batch` and `career:validate-full-display-workbook` so full-workbook career display scans can emit compact JSON without dumping per-row payloads to stdout.
- Kept complete full-upload plan output available through `--plan-output` while compacting report fields that caused large console output: row items, full-upload plan rows, allowlisted slugs, and recommended batch slug lists.
- Added focused command tests and a generated readiness summary for the reviewed Chinese career workbook.
- Initialized the authorized `CAREER-ZH-PARITY-FIX-01` through `CAREER-ZH-PARITY-FIX-06` PR train metadata; only PR01 is implemented here.

## Why
Production/live audit shows 1046 EN/ZH career job pages are API-200, but 672 Chinese pages are missing English display modules and 1029 Chinese pages still present restricted-shell or integrity-gap reasons. The reviewed Chinese workbook covers the affected live slugs, but the existing full-workbook validator emitted very large JSON and previously hit console output memory limits. This PR makes the readiness scan repeatable and small enough for local/ops execution before the repair/import PRs.

## Validation
- `php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php`
- `php -l backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php`
- `php -l backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php`
- `php -l backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php --no-ansi`
- `cd backend && php artisan career:validate-full-display-workbook --file='/Users/rainie/Desktop/费马资料文件/职业：人格与职业决策操作系统/职业内容资产/第九版_d23b_schema_repaired.xlsx' --json --summary-only --output=/private/tmp/career-zh-parity-fix-01-readiness.json --plan-output=/private/tmp/career-zh-parity-fix-01-plan.json --plan-md-output=/private/tmp/career-zh-parity-fix-01-plan.md`
- `python3 -m json.tool /private/tmp/career-zh-parity-fix-01-readiness.json >/dev/null`
- `python3 -m json.tool /private/tmp/career-zh-parity-fix-01-plan.json >/dev/null`
- `python3 -m json.tool backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json >/dev/null`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerFullDisplayWorkbookValidator.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check -- backend/app/Console/Commands/CareerValidateDisplayBatch.php backend/app/Console/Commands/CareerFullDisplayWorkbookValidator.php backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php backend/tests/Feature/Console/CareerFullDisplayWorkbookValidatorCommandTest.php backend/docs/career/generated/career-zh-parity-fix-01-readiness-report.json docs/codex/pr-train.yaml docs/codex/pr-train-state.json`
- `git diff --cached --check`

Focused Laravel tests passed with existing workbook fixture `file_get_contents` warnings and exit code 0.

## Intentionally deferred
- No CMS/database import or mutation.
- No English-to-Chinese content copying.
- No cache clear/warm, publish, deploy, sitemap, llms, or index strategy changes.
- Workbook contract repair remains deferred to `CAREER-ZH-PARITY-FIX-02`.
- Authority-manifest import support remains deferred to `CAREER-ZH-PARITY-FIX-03`.
- Controlled import/cache refresh remains deferred to `CAREER-ZH-PARITY-FIX-04`.
- Runtime integrity policy alignment remains deferred to `CAREER-ZH-PARITY-FIX-05`.
- Final live parity assertion remains deferred to `CAREER-ZH-PARITY-FIX-06`.
