### PR TITLE
feat(ops): add article draft preview route

### DIFF
--- a/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php
@@ -48,6 +48,12 @@ class EditArticle extends EditRecord
                 ->url(ArticleResource::getUrl())
                 ->icon('heroicon-o-arrow-left')
                 ->color('gray'),
+            Action::make('previewDraft')
+                ->label('Preview draft')
+                ->url(fn (): ?string => ArticleWorkspace::previewUrl($this->getRecord()), shouldOpenInNewTab: true)
+                ->icon('heroicon-o-eye')
+                ->color('info')
+                ->visible(fn (): bool => filled(ArticleWorkspace::previewUrl($this->getRecord()))),
             Action::make('openPublicUrl')
                 ->label(__('ops.resources.articles.actions.open_public_url'))
                 ->url(fn (): ?string => ArticleWorkspace::publicUrl(

--- a/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php
+++ b/backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php
@@ -27,6 +27,15 @@ final class ArticleWorkspace
         return $baseUrl.'/'.$segment.'/articles/'.rawurlencode($resolvedSlug);
     }
 
+    public static function previewUrl(?Article $record): ?string
+    {
+        if (! $record instanceof Article || ! $record->getKey()) {
+            return null;
+        }
+
+        return route('ops.articles.preview', ['article' => $record->getKey()]);
+    }
+
     public static function renderEditorialCues(Get $get, ?Article $record = null): Htmlable
     {
         $status = trim((string) ($get('status') ?? $record?->status ?? 'draft'));

--- a/backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php
+++ b/backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php
@@ -1,0 +1,182 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers\Ops;
+
+use App\Http\Controllers\Controller;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Support\PublicMediaUrlGuard;
+use Illuminate\Http\Request;
+use Illuminate\Http\Response;
+use Illuminate\Support\Facades\View;
+use Illuminate\Support\Str;
+
+final class ArticleDraftPreviewController extends Controller
+{
+    public function __invoke(Request $request, string $article): Response
+    {
+        $articleId = (int) $article;
+        abort_unless($articleId > 0, 404);
+
+        $orgId = $this->trustedOrgId($request);
+        $record = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'category' => static fn ($query) => $query->withoutGlobalScopes(),
+                'tags' => static fn ($query) => $query->withoutGlobalScopes(),
+                'seoMeta' => static fn ($query) => $query->withoutGlobalScopes(),
+                'workingRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+                'publishedRevision' => static fn ($query) => $query->withoutGlobalScopes(),
+            ])
+            ->whereKey($articleId)
+            ->whereIn('org_id', $this->allowedOrgIds($orgId))
+            ->firstOrFail();
+
+        $revision = $record->workingRevision instanceof ArticleTranslationRevision
+            ? $record->workingRevision
+            : null;
+        $seoMeta = $record->seoMeta instanceof ArticleSeoMeta ? $record->seoMeta : null;
+
+        $title = $this->firstNonEmpty($revision?->title, $record->title, 'Untitled article draft');
+        $excerpt = $this->firstNonEmpty($revision?->excerpt, $record->excerpt, '');
+        $contentMd = $this->firstNonEmpty($revision?->content_md, $record->content_md, '');
+        $seoTitle = $this->firstNonEmpty($revision?->seo_title, $seoMeta?->seo_title, $title);
+        $seoDescription = $this->firstNonEmpty($revision?->seo_description, $seoMeta?->seo_description, $excerpt);
+        $redacted = $this->redactSensitivePreviewText($contentMd);
+        $bodyHtml = (string) Str::markdown($redacted['text'], [
+            'html_input' => 'strip',
+            'allow_unsafe_links' => false,
+        ]);
+
+        $html = View::make('ops.article-draft-preview', [
+            'article' => $record,
+            'revision' => $revision,
+            'title' => $title,
+            'excerpt' => $excerpt,
+            'bodyHtml' => $bodyHtml,
+            'seoTitle' => $seoTitle,
+            'seoDescription' => $seoDescription,
+            'canonicalUrl' => $this->safeCanonicalUrl($seoMeta?->canonical_url),
+            'publicUrl' => $this->publicUrl($record),
+            'coverImageUrl' => PublicMediaUrlGuard::sanitizeNullableUrl($record->cover_image_url),
+            'redactionCount' => $redacted['count'],
+            'previewContext' => [
+                'is_preview' => true,
+                'article_id' => (int) $record->id,
+                'working_revision_id' => $revision?->id !== null ? (int) $revision->id : null,
+                'published_revision_id' => $record->published_revision_id !== null ? (int) $record->published_revision_id : null,
+                'status' => (string) $record->status,
+                'is_public' => (bool) $record->is_public,
+                'is_indexable' => false,
+                'sitemap_eligible' => false,
+                'llms_eligible' => false,
+                'search_submission_allowed' => false,
+                'schema_enabled' => false,
+                'hreflang_enabled' => false,
+                'revalidation_allowed' => false,
+            ],
+        ])->render();
+
+        return response($html, 200, [
+            'Content-Type' => 'text/html; charset=UTF-8',
+            'X-Robots-Tag' => 'noindex, noarchive, nosnippet',
+            'Cache-Control' => 'no-store',
+            'Referrer-Policy' => 'no-referrer',
+        ]);
+    }
+
+    /**
+     * @return array{text:string,count:int}
+     */
+    private function redactSensitivePreviewText(string $value): array
+    {
+        $count = 0;
+        $patterns = [
+            '#https?://[^\s)>\"]*/(?:result|results|orders?|payment|pay|share|history|take)(?:/[^\s)>\"]*)?#i',
+            '#(?<![A-Za-z0-9_-])/(?:result|results|orders?|payment|pay|share|history)(?:/[^\s)>\"]*)?#i',
+            '#(?<![A-Za-z0-9_-])/(?:en|zh)/tests/[A-Za-z0-9_-]+/take(?:/[^\s)>\"]*)?#i',
+        ];
+
+        foreach ($patterns as $pattern) {
+            $value = preg_replace($pattern, '[redacted-private-url]', $value, -1, $replacements) ?? $value;
+            $count += $replacements;
+        }
+
+        $value = preg_replace(
+            '/([?&](?:token|access_token|result_access_token|order_id|payment_intent|payment_recovery_token|session_id|checkout_id)=)[^&#\s)>\"]+/i',
+            '$1[redacted]',
+            $value,
+            -1,
+            $replacements
+        ) ?? $value;
+        $count += $replacements;
+
+        return ['text' => $value, 'count' => $count];
+    }
+
+    private function trustedOrgId(Request $request): int
+    {
+        foreach ([
+            $request->attributes->get('fm_org_id'),
+            $request->attributes->get('org_id'),
+            $request->hasSession() ? $request->session()->get('ops_org_id') : null,
+        ] as $candidate) {
+            if (! is_int($candidate) && ! is_string($candidate) && ! is_numeric($candidate)) {
+                continue;
+            }
+
+            $raw = trim((string) $candidate);
+            if ($raw !== '' && preg_match('/^\d+$/', $raw) === 1) {
+                return max(0, (int) $raw);
+            }
+        }
+
+        return 0;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function allowedOrgIds(int $trustedOrgId): array
+    {
+        return $trustedOrgId > 0 ? [0, $trustedOrgId] : [0];
+    }
+
+    private function firstNonEmpty(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            $normalized = trim((string) ($value ?? ''));
+            if ($normalized !== '') {
+                return $normalized;
+            }
+        }
+
+        return '';
+    }
+
+    private function safeCanonicalUrl(?string $value): ?string
+    {
+        $url = trim((string) $value);
+        if ($url === '') {
+            return null;
+        }
+
+        return filter_var($url, FILTER_VALIDATE_URL) ? $url : null;
+    }
+
+    private function publicUrl(Article $article): ?string
+    {
+        $baseUrl = rtrim((string) config('app.frontend_url', config('app.url', '')), '/');
+        $slug = trim((string) $article->slug);
+        if ($baseUrl === '' || $slug === '') {
+            return null;
+        }
+
+        $segment = str_starts_with(strtolower(trim((string) $article->locale)), 'zh') ? 'zh' : 'en';
+
+        return $baseUrl.'/'.$segment.'/articles/'.rawurlencode($slug);
+    }
+}

--- a/backend/resources/views/ops/article-draft-preview.blade.php
+++ b/backend/resources/views/ops/article-draft-preview.blade.php
@@ -1,0 +1,129 @@
+<!doctype html>
+<html lang="{{ str_starts_with(strtolower((string) $article->locale), 'zh') ? 'zh-CN' : 'en' }}">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <meta name="robots" content="noindex,noarchive,nosnippet">
+    <meta name="googlebot" content="noindex,noarchive,nosnippet">
+    <title>{{ $seoTitle }} · Draft preview</title>
+    <style>
+        :root {
+            color-scheme: light;
+            --bg: #f6f3ed;
+            --card: #fffaf1;
+            --ink: #231f1a;
+            --muted: #746b60;
+            --line: #ded5c8;
+            --accent: #0f766e;
+            --danger: #b42318;
+        }
+        * { box-sizing: border-box; }
+        body {
+            margin: 0;
+            background: radial-gradient(circle at top left, #e5f3ef, transparent 32rem), var(--bg);
+            color: var(--ink);
+            font-family: ui-serif, Georgia, Cambria, "Times New Roman", Times, serif;
+            line-height: 1.65;
+        }
+        a { color: var(--accent); }
+        .shell { margin: 0 auto; max-width: 1120px; padding: 32px 20px 56px; }
+        .notice, .card {
+            border: 1px solid var(--line);
+            border-radius: 22px;
+            background: rgba(255, 250, 241, 0.92);
+            box-shadow: 0 18px 48px rgba(35, 31, 26, 0.08);
+        }
+        .notice { padding: 18px 20px; }
+        .notice strong { color: var(--danger); }
+        .grid { display: grid; grid-template-columns: minmax(0, 1fr) 320px; gap: 22px; margin-top: 22px; }
+        .card { padding: 28px; }
+        .rail { align-self: start; position: sticky; top: 20px; }
+        .eyebrow {
+            display: inline-flex;
+            border: 1px solid #99d5ce;
+            border-radius: 999px;
+            padding: 4px 10px;
+            color: #115e59;
+            font: 700 12px/1.2 ui-sans-serif, system-ui, sans-serif;
+            letter-spacing: .08em;
+            text-transform: uppercase;
+        }
+        h1 { margin: 18px 0 12px; font-size: clamp(36px, 7vw, 68px); line-height: .95; letter-spacing: -.045em; }
+        h2 { margin-top: 32px; font-size: 28px; line-height: 1.15; }
+        h3 { margin-top: 24px; font-size: 22px; }
+        .meta, .summary { color: var(--muted); }
+        .body { font-size: 18px; }
+        .body img { max-width: 100%; border-radius: 18px; }
+        .body code, .field code {
+            border-radius: 8px;
+            background: #efe7da;
+            padding: 2px 6px;
+        }
+        .fields { display: grid; gap: 12px; margin-top: 18px; }
+        .field {
+            border-top: 1px solid var(--line);
+            padding-top: 12px;
+            font: 14px/1.45 ui-sans-serif, system-ui, sans-serif;
+        }
+        .field span { display: block; color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: .08em; }
+        .flag-list { margin: 0; padding-left: 18px; color: var(--muted); font: 14px/1.6 ui-sans-serif, system-ui, sans-serif; }
+        @media (max-width: 840px) {
+            .grid { grid-template-columns: 1fr; }
+            .rail { position: static; }
+        }
+    </style>
+</head>
+<body>
+    <main class="shell">
+        <section class="notice" aria-label="Preview safety boundary">
+            <strong>Draft preview only.</strong>
+            This page is authenticated, noindex, noarchive, nosnippet, no-store, and is not a canonical public article URL.
+            It does not publish, index, submit, revalidate, emit schema, or emit hreflang.
+        </section>
+
+        <div class="grid">
+            <article class="card">
+                <span class="eyebrow">CMS Article Draft Preview</span>
+                <h1>{{ $title }}</h1>
+                @if ($excerpt !== '')
+                    <p class="summary">{{ $excerpt }}</p>
+                @endif
+
+                @if ($coverImageUrl)
+                    <p><img src="{{ $coverImageUrl }}" alt="{{ $article->cover_image_alt ?: $title }}"></p>
+                @endif
+
+                <section class="body">
+                    {!! $bodyHtml !!}
+                </section>
+            </article>
+
+            <aside class="card rail">
+                <span class="eyebrow">Safety state</span>
+                <div class="fields">
+                    <div class="field"><span>Article ID</span>{{ $previewContext['article_id'] }}</div>
+                    <div class="field"><span>Working revision</span>{{ $previewContext['working_revision_id'] ?? 'none' }}</div>
+                    <div class="field"><span>Status</span>{{ $previewContext['status'] }}</div>
+                    <div class="field"><span>Public URL candidate</span>{{ $publicUrl ?? 'not available' }}</div>
+                    <div class="field"><span>Canonical metadata value</span>{{ $canonicalUrl ?? 'not set' }}</div>
+                    <div class="field"><span>SEO title</span>{{ $seoTitle }}</div>
+                    <div class="field"><span>SEO description</span>{{ $seoDescription !== '' ? $seoDescription : 'not set' }}</div>
+                    <div class="field"><span>Private URL redactions</span>{{ $redactionCount }}</div>
+                </div>
+
+                <h2>Hard holds</h2>
+                <ul class="flag-list">
+                    <li>is_public: {{ $previewContext['is_public'] ? 'true' : 'false' }}</li>
+                    <li>is_indexable: false for preview</li>
+                    <li>sitemap_eligible: false</li>
+                    <li>llms_eligible: false</li>
+                    <li>search_submission_allowed: false</li>
+                    <li>schema_enabled: false</li>
+                    <li>hreflang_enabled: false</li>
+                    <li>revalidation_allowed: false</li>
+                </ul>
+            </aside>
+        </div>
+    </main>
+</body>
+</html>

--- a/backend/routes/web.php
+++ b/backend/routes/web.php
@@ -1,5 +1,13 @@
 <?php
 
+use App\Http\Controllers\Ops\ArticleDraftPreviewController;
+use App\Http\Middleware\AdminAuth;
+use App\Http\Middleware\EnsureAdminTotpVerified;
+use App\Http\Middleware\EnsureCmsAdminAuthorized;
+use App\Http\Middleware\OpsAccessControl;
+use App\Http\Middleware\RequireOpsOrgSelected;
+use App\Http\Middleware\ResolveOrgContext;
+use App\Http\Middleware\SetOpsRequestContext;
 use App\Http\Controllers\SitemapController;
 use Illuminate\Http\Request;
 use Illuminate\Support\Facades\Route;
@@ -46,6 +54,19 @@ if (config('admin.panel_enabled')) {
     Route::permanentRedirect('/admin', '/ops');
     Route::get('/admin/{path}', fn (string $path) => redirect('/ops/'.$path, 301))
         ->where('path', '.*');
+
+    Route::get('/ops/article-preview/{article}', ArticleDraftPreviewController::class)
+        ->middleware([
+            SetOpsRequestContext::class,
+            AdminAuth::class,
+            ResolveOrgContext::class,
+            EnsureAdminTotpVerified::class,
+            RequireOpsOrgSelected::class,
+            OpsAccessControl::class,
+            EnsureCmsAdminAuthorized::class.':read',
+        ])
+        ->whereNumber('article')
+        ->name('ops.articles.preview');
 
     foreach ([
         'categories' => 'article-categories',

--- a/backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+++ b/backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Ops;
+
+use App\Filament\Ops\Resources\ArticleResource\Support\ArticleWorkspace;
+use App\Models\AdminUser;
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Models\Organization;
+use App\Models\Permission;
+use App\Models\Role;
+use App\Support\Rbac\PermissionNames;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleDraftPreviewRouteTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_content_read_admin_can_preview_unpublished_noindex_article_without_publication_side_effects(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_CONTENT_READ]);
+        $org = $this->createOrganization();
+        $article = $this->createDraftArticle();
+        $revision = $this->createWorkingRevision($article);
+        ArticleSeoMeta::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'en',
+            'seo_title' => 'Preview SEO Title',
+            'seo_description' => 'Preview SEO description.',
+            'canonical_url' => 'https://fermatmind.com/en/articles/preview-draft',
+            'robots' => 'noindex,nofollow',
+            'is_indexable' => false,
+        ]);
+
+        $response = $this
+            ->withSession($this->opsSession($admin, $org))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/article-preview/'.$article->id);
+
+        $response
+            ->assertOk()
+            ->assertHeader('X-Robots-Tag', 'noindex, noarchive, nosnippet')
+            ->assertSee('CMS Article Draft Preview')
+            ->assertSee('Working Revision Preview Title')
+            ->assertSee('Draft preview only')
+            ->assertSee('schema_enabled: false')
+            ->assertSee('hreflang_enabled: false')
+            ->assertSee('revalidation_allowed: false')
+            ->assertSee('[redacted-private-url]')
+            ->assertDontSee('abc123', false)
+            ->assertDontSee('application/ld+json', false)
+            ->assertDontSee('rel=\"canonical\"', false)
+            ->assertDontSee('rel=\"alternate\"', false);
+        $this->assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));
+
+        $article->refresh();
+        $this->assertSame('draft', $article->status);
+        $this->assertFalse((bool) $article->is_public);
+        $this->assertFalse((bool) $article->is_indexable);
+        $this->assertNull($article->published_revision_id);
+        $this->assertSame((int) $revision->id, (int) $article->working_revision_id);
+    }
+
+    public function test_preview_route_requires_content_read_authorization(): void
+    {
+        $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_OPS_READ]);
+        $org = $this->createOrganization();
+        $article = $this->createDraftArticle();
+
+        $this
+            ->withSession($this->opsSession($admin, $org))
+            ->actingAs($admin, (string) config('admin.guard', 'admin'))
+            ->get('/ops/article-preview/'.$article->id)
+            ->assertForbidden()
+            ->assertJsonPath('message', 'admin_content_read_required');
+    }
+
+    public function test_article_workspace_builds_ops_preview_url_instead_of_public_canonical_url(): void
+    {
+        $article = $this->createDraftArticle();
+
+        $this->assertSame(
+            url('/ops/article-preview/'.$article->id),
+            ArticleWorkspace::previewUrl($article)
+        );
+    }
+
+    private function createDraftArticle(): Article
+    {
+        return Article::query()->create([
+            'org_id' => 0,
+            'slug' => 'preview-draft-'.Str::lower(Str::random(6)),
+            'locale' => 'en',
+            'title' => 'Article Row Draft Title',
+            'excerpt' => 'Article row excerpt.',
+            'content_md' => 'Article row body.',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+        ]);
+    }
+
+    private function createWorkingRevision(Article $article): ArticleTranslationRevision
+    {
+        $revision = ArticleTranslationRevision::query()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'locale' => 'en',
+            'source_locale' => 'en',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_MACHINE_DRAFT,
+            'title' => 'Working Revision Preview Title',
+            'excerpt' => 'Working revision excerpt.',
+            'content_md' => "## Body\\n\\nDraft body with /result/abc123?token=abc123 private link.",
+            'seo_title' => 'Revision SEO Title',
+            'seo_description' => 'Revision SEO description.',
+        ]);
+
+        $article->forceFill(['working_revision_id' => $revision->id])->save();
+
+        return $revision;
+    }
+
+    /**
+     * @param  list<string>  $permissions
+     */
+    private function createAdminWithPermissions(array $permissions): AdminUser
+    {
+        $admin = AdminUser::query()->create([
+            'name' => 'admin_'.Str::lower(Str::random(6)),
+            'email' => 'admin_'.Str::lower(Str::random(6)).'@example.test',
+            'password' => bcrypt('secret'),
+            'is_active' => 1,
+        ]);
+
+        $role = Role::query()->create([
+            'name' => 'article_preview_'.Str::lower(Str::random(6)),
+            'guard_name' => (string) config('admin.guard', 'admin'),
+        ]);
+
+        foreach ($permissions as $permissionName) {
+            $permission = Permission::query()->firstOrCreate(
+                ['name' => $permissionName],
+                ['guard_name' => (string) config('admin.guard', 'admin')]
+            );
+            $role->permissions()->syncWithoutDetaching([$permission->id]);
+        }
+
+        $admin->roles()->syncWithoutDetaching([$role->id]);
+
+        return $admin;
+    }
+
+    private function createOrganization(): Organization
+    {
+        return Organization::query()->create([
+            'name' => 'Article Preview Org',
+            'owner_user_id' => 9101,
+            'status' => 'active',
+            'domain' => 'article-preview.example.test',
+            'timezone' => 'Asia/Shanghai',
+            'locale' => 'en',
+        ]);
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function opsSession(AdminUser $admin, Organization $org): array
+    {
+        return [
+            'ops_org_id' => $org->id,
+            'ops_locale' => 'en',
+            'ops_admin_totp_verified_user_id' => $admin->id,
+        ];
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1560,6 +1560,45 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_draft_preview_ops_route_changes(): void
+    {
+        $changed = [
+            'backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php',
+            'backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php',
+            'backend/routes/web.php',
+        ];
+        $webRouteChangedLines = [
+            '+use App\Http\Controllers\Ops\ArticleDraftPreviewController;',
+            '+use App\Http\Middleware\AdminAuth;',
+            '+use App\Http\Middleware\EnsureAdminTotpVerified;',
+            '+use App\Http\Middleware\EnsureCmsAdminAuthorized;',
+            '+use App\Http\Middleware\OpsAccessControl;',
+            '+use App\Http\Middleware\RequireOpsOrgSelected;',
+            '+use App\Http\Middleware\ResolveOrgContext;',
+            '+use App\Http\Middleware\SetOpsRequestContext;',
+            '+    Route::get(\'/ops/article-preview/{article}\', ArticleDraftPreviewController::class)',
+            '+        ->middleware([',
+            '+            SetOpsRequestContext::class,',
+            '+            AdminAuth::class,',
+            '+            ResolveOrgContext::class,',
+            '+            EnsureAdminTotpVerified::class,',
+            '+            RequireOpsOrgSelected::class,',
+            '+            OpsAccessControl::class,',
+            '+            EnsureCmsAdminAuthorized::class.\':read\',',
+            '+        ])',
+            '+        ->whereNumber(\'article\')',
+            '+        ->name(\'ops.articles.preview\');',
+            '+',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            $changed,
+            '',
+            '',
+            webRouteChangedLines: $webRouteChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_controlled_article_publish_sop_changes(): void
     {
         $changed = [
@@ -2830,6 +2869,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleDraftPreviewOpsRouteFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleMultiTestGraphEdgeFile($file)) {
                 continue;
             }
@@ -3125,6 +3168,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 && (
                     $this->routeDiffIsPublicHealthzAliasOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
                     || $this->routeDiffIsApiRootServiceLandingOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
+                    || $this->routeDiffIsArticleDraftPreviewOpsOnly($webRouteChangedLines ?? $this->webRouteChangedLines($repoRoot, $baseRef))
                 )
             ) {
                 continue;
@@ -3674,6 +3718,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Filament/Ops/Pages/EditorialReviewPage.php',
             'backend/app/Services/Cms/ArticleTranslationWorkflowService.php',
+        ], true);
+    }
+
+    private function isArticleDraftPreviewOpsRouteFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php',
+            'backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php',
         ], true);
     }
 
@@ -5444,6 +5496,60 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             '\'healthz\' => \'restricted\',',
             ']);',
             '}',
+        ];
+
+        foreach ($changedLines as $line) {
+            if (str_starts_with($line, '-')) {
+                return false;
+            }
+
+            if (! str_starts_with($line, '+')) {
+                return false;
+            }
+
+            $changedBody = trim(substr($line, 1));
+            if ($changedBody === '') {
+                continue;
+            }
+
+            if (! in_array($changedBody, $allowedLines, true)) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function routeDiffIsArticleDraftPreviewOpsOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        $allowedLines = [
+            'use App\Http\Controllers\Ops\ArticleDraftPreviewController;',
+            'use App\Http\Middleware\AdminAuth;',
+            'use App\Http\Middleware\EnsureAdminTotpVerified;',
+            'use App\Http\Middleware\EnsureCmsAdminAuthorized;',
+            'use App\Http\Middleware\OpsAccessControl;',
+            'use App\Http\Middleware\RequireOpsOrgSelected;',
+            'use App\Http\Middleware\ResolveOrgContext;',
+            'use App\Http\Middleware\SetOpsRequestContext;',
+            'Route::get(\'/ops/article-preview/{article}\', ArticleDraftPreviewController::class)',
+            '->middleware([',
+            'SetOpsRequestContext::class,',
+            'AdminAuth::class,',
+            'ResolveOrgContext::class,',
+            'EnsureAdminTotpVerified::class,',
+            'RequireOpsOrgSelected::class,',
+            'OpsAccessControl::class,',
+            'EnsureCmsAdminAuthorized::class.\':read\',',
+            '])',
+            '->whereNumber(\'article\')',
+            '->name(\'ops.articles.preview\');',
         ];
 
         foreach ($changedLines as $line) {

--- a/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_DESIGN.md
+++ b/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_DESIGN.md
@@ -1,0 +1,74 @@
+# Article Preview Route Design
+
+## Decision
+
+Implement as a fap-api-only PR.
+
+Chosen path:
+- Add authenticated Ops route: `/ops/article-preview/{article}`
+- Add Article edit page action: `Preview draft`
+- Render a backend noindex/no-store preview page from the Article working revision
+- Do not modify fap-web, sitemap, llms, search queues, ISR, schema, hreflang, or publish state
+
+## Why fap-api-only
+
+The preview need is operator QA inside the CMS/Ops surface. A backend Ops route can reuse existing admin session, org context, and CMS read authorization while directly setting response headers. This avoids a two-repo PR and avoids weakening the public article route.
+
+## Route
+
+```text
+GET /ops/article-preview/{article}
+Route name: ops.articles.preview
+```
+
+## Auth boundary
+
+The route is registered only when the Ops/Admin panel is enabled and uses:
+
+- `SetOpsRequestContext`
+- `AdminAuth`
+- `ResolveOrgContext`
+- `EnsureAdminTotpVerified`
+- `RequireOpsOrgSelected`
+- `OpsAccessControl`
+- `EnsureCmsAdminAuthorized:read`
+
+## Data source
+
+The controller reads only:
+
+- `articles`
+- `article_translation_revisions` via `workingRevision`
+- `article_seo_meta`
+- category/tags display metadata
+
+No user, order, payment, result, session, or token data is read.
+
+## Preview rendering
+
+The preview page renders:
+
+- title
+- excerpt
+- markdown body from working revision if present
+- SEO title / description snapshot
+- canonical metadata value as text only
+- public URL candidate as text only
+- safety state rail
+
+It intentionally does not emit:
+
+- canonical link tag
+- hreflang / alternate link tag
+- Article JSON-LD
+- FAQ JSON-LD
+- Breadcrumb JSON-LD
+- analytics payload
+
+## Preview URL for Draft ID 42
+
+```text
+https://ops.fermatmind.com/ops/article-preview/42
+```
+
+This is an Ops-authenticated preview URL, not a public canonical URL.

--- a/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_IMPLEMENTATION_REPORT.md
+++ b/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_IMPLEMENTATION_REPORT.md
@@ -1,0 +1,52 @@
+# Article Preview Route Implementation Report
+
+## Implemented
+
+- Added authenticated Ops article draft preview route.
+- Added read-only preview controller.
+- Added noindex/no-store Blade preview page.
+- Added Article edit page `Preview draft` action.
+- Added `ArticleWorkspace::previewUrl()` helper.
+- Added focused Feature test coverage.
+
+## Changed files
+
+Added:
+
+- `backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php`
+- `backend/resources/views/ops/article-draft-preview.blade.php`
+- `backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php`
+- `generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_DESIGN.md`
+- `generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_SECURITY_REVIEW.md`
+- `generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_IMPLEMENTATION_REPORT.md`
+- `generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_TEST_REPORT.md`
+- `generated/seo-ops-article-preview-route-pr-00/NEXT_ENGLISH_PREVIEW_QA_INSTRUCTIONS.md`
+
+Modified:
+
+- `backend/routes/web.php`
+- `backend/app/Filament/Ops/Resources/ArticleResource/Pages/EditArticle.php`
+- `backend/app/Filament/Ops/Resources/ArticleResource/Support/ArticleWorkspace.php`
+
+## Not changed
+
+- No fap-web files changed.
+- No `components/marketing/HomePageExperience.tsx` touched.
+- No sitemap/llms/search/ISR code changed.
+- No migrations added.
+- No CMS content package or zip added.
+- No production data written.
+
+## Preview route usage
+
+```text
+https://ops.fermatmind.com/ops/article-preview/{article_id}
+```
+
+Draft ID 42:
+
+```text
+https://ops.fermatmind.com/ops/article-preview/42
+```
+
+The route requires current Ops login, TOTP/org context if configured, and CMS content read permission.

--- a/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_SECURITY_REVIEW.md
+++ b/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_SECURITY_REVIEW.md
@@ -1,0 +1,30 @@
+# Article Preview Route Security Review
+
+## Security decision
+
+PASS_FOR_PR_REVIEW
+
+## Guards implemented
+
+| Guard | Implementation | Evidence |
+|---|---|---|
+| Ops-only access | Route uses existing Ops/admin/CMS-read middleware stack. | `backend/routes/web.php` |
+| Content read authorization | `EnsureCmsAdminAuthorized:read` required. | `backend/routes/web.php` |
+| No publish side effect | Controller only reads Article/working revision and returns a response. It does not call Article publish services or mutate models. | `backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php` |
+| noindex | Response header `X-Robots-Tag: noindex, noarchive, nosnippet`; page meta robots mirrors this. | controller + Blade view |
+| no-store | Response header `Cache-Control: no-store`; session middleware may append `private`, but no-store remains present. | controller + test |
+| no canonical public authority | Preview page prints canonical metadata value as text only and does not emit `<link rel="canonical">`. | Blade view + test |
+| no hreflang | Preview page does not emit alternate/hreflang link tags. | Blade view + test |
+| no schema | Preview page does not emit `application/ld+json`. | Blade view + test |
+| no sitemap/llms | New route is under `/ops/article-preview/{article}` and no sitemap/llms source was modified. | scoped changed files |
+| no search submission | No search channel, seo_intel, or submission writer files were touched. | scoped changed files |
+| no ISR revalidation | No content-release/revalidation route or job is called. | controller implementation |
+| private URL redaction | Preview body redacts private result/order/payment/pay/share/history/take routes and sensitive query tokens before markdown rendering. | controller implementation + test |
+
+## Private data boundary
+
+The implementation does not query raw PII, orders, payments, users, attempts, results, shares, or sessions. It reads CMS Article content and SEO fields only.
+
+## Known limitation
+
+This is an Ops-rendered preview, not a pixel-identical fap-web public runtime preview. It is intentionally minimal and safe. If pixel parity is required later, add a separate fap-web preview route backed by a read-only preview API in a follow-up two-repo plan.

--- a/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_TEST_REPORT.md
+++ b/generated/seo-ops-article-preview-route-pr-00/ARTICLE_PREVIEW_ROUTE_TEST_REPORT.md
@@ -1,0 +1,39 @@
+# Article Preview Route Test Report
+
+## Commands run
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --name=ops.articles.preview
+php artisan test --filter=ArticleDraftPreviewRouteTest
+git diff --check
+```
+
+## Results
+
+| Command | Result | Notes |
+|---|---|---|
+| `FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --name=ops.articles.preview` | PASS | Listed `GET|HEAD ops/article-preview/{article}` route named `ops.articles.preview`. |
+| `php artisan test --filter=ArticleDraftPreviewRouteTest` | PASS | 3 tests, 23 assertions. |
+| `git diff --check` | PASS | No whitespace errors. |
+
+## Focused test coverage
+
+`ArticleDraftPreviewRouteTest` verifies:
+
+- content-read admin can preview a draft article
+- response has `X-Robots-Tag: noindex, noarchive, nosnippet`
+- `Cache-Control` contains `no-store`
+- preview renders working revision title/body
+- preview redacts private URL/token content
+- preview does not emit JSON-LD
+- preview does not emit canonical link
+- preview does not emit alternate/hreflang link
+- preview does not change article `draft`, `is_public=false`, `is_indexable=false`, or `published_revision_id=null`
+- non-content-read admin is forbidden
+- `ArticleWorkspace::previewUrl()` builds `/ops/article-preview/{id}`
+
+## Not run
+
+- Full `bash backend/scripts/ci_verify_mbti.sh` was not run; this PR is scoped to an Ops CMS preview route and focused tests passed.
+- `php artisan migrate` was not run because this PR adds no migration.

--- a/generated/seo-ops-article-preview-route-pr-00/NEXT_ENGLISH_PREVIEW_QA_INSTRUCTIONS.md
+++ b/generated/seo-ops-article-preview-route-pr-00/NEXT_ENGLISH_PREVIEW_QA_INSTRUCTIONS.md
@@ -1,0 +1,43 @@
+# Next English Preview QA Instructions
+
+## Use this preview URL after deploy
+
+Draft ID 42:
+
+```text
+https://ops.fermatmind.com/ops/article-preview/42
+```
+
+This URL is authenticated under Ops. It is not the public candidate URL.
+
+## Rerun task
+
+After this PR is merged and deployed to the Ops backend, rerun:
+
+```text
+SEO-OPS-ENGLISH-PREVIEW-QA-00
+```
+
+## QA checks to perform
+
+1. Open `https://ops.fermatmind.com/ops/article-preview/42` while logged into Ops.
+2. Confirm HTTP response header includes `X-Robots-Tag: noindex, noarchive, nosnippet`.
+3. Confirm `Cache-Control` includes `no-store`.
+4. Confirm page meta robots is `noindex,noarchive,nosnippet`.
+5. Confirm no canonical link tag is emitted.
+6. Confirm no hreflang/alternate link tag is emitted.
+7. Confirm no `application/ld+json` is emitted.
+8. Confirm body renders from the CMS working revision.
+9. Confirm visible FAQ/body content can be manually reviewed.
+10. Confirm CTA/internal links do not expose private result/order/payment/take URLs.
+11. Confirm public candidate remains 404 until publish:
+
+```text
+https://fermatmind.com/en/articles/why-mbti-and-holland-code-results-dont-match
+```
+
+## Decision gate
+
+If the preview page is accessible and the safety checks pass, proceed to operator publish review.
+
+Do not publish, index, submit, or revalidate from this task.


### PR DESCRIPTION
## What changed

- Added an authenticated Ops-only CMS Article draft preview route: `/ops/article-preview/{article}`.
- Added `Preview draft` action on the Article edit page.
- Added `ArticleWorkspace::previewUrl()` helper.
- Added a noindex/no-store Blade preview surface that renders the Article working revision and SEO snapshot for operator QA.
- Added focused Feature tests for auth, headers, redaction, no schema/canonical/hreflang, and no publish side effects.
- Added generated implementation/security/test reports for `SEO-OPS-ARTICLE-PREVIEW-ROUTE-PR-00`.

## Why

The English CMS draft exists, but the public article route correctly returns 404 for unpublished drafts. This PR adds the smallest safe backend Ops preview mechanism so SEO preview QA can continue without publishing, indexing, sitemap/llms inclusion, search submission, schema/hreflang enablement, or ISR revalidation.

## Validation commands

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --name=ops.articles.preview
php artisan test --filter=ArticleDraftPreviewRouteTest
git diff --check
```

Results:

- `FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --name=ops.articles.preview`: passed, listed `GET|HEAD ops/article-preview/{article}`.
- `php artisan test --filter=ArticleDraftPreviewRouteTest`: passed, 3 tests / 23 assertions.
- `git diff --check`: passed.

## Intentionally deferred

- No fap-web public runtime preview route in this PR.
- No preview API for public frontend consumption.
- No publishing, indexability, sitemap, llms, search submission, schema, hreflang, or ISR revalidation changes.
- No content package or zip included.
- Full `bash backend/scripts/ci_verify_mbti.sh` was not run; this PR is scoped to an Ops CMS preview route and focused tests passed.
- `php artisan migrate` was not run because this PR adds no migration.

## Repository rule impact

This keeps CMS/backend as the authority for article content and publication state. It adds an authenticated backend operator preview surface only; it does not add frontend fallback content or public editorial runtime authority.
