### PR TITLE
CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import

### DIFF
--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -345,6 +345,7 @@ final class CareerImportSelectedDisplayAssets extends Command
         }
 
         $candidateSlugs = [];
+        $candidateRowHashes = [];
         foreach ($rows as $row) {
             if (! is_array($row)) {
                 continue;
@@ -356,9 +357,13 @@ final class CareerImportSelectedDisplayAssets extends Command
                 continue;
             }
             $publicResolutionType = trim((string) ($row['public_resolution_type'] ?? ''));
+            $workbookRowSha = strtolower(trim((string) ($row['workbook_row_sha256'] ?? '')));
 
             if ($slug === '' || $slug === 'software-developers') {
                 $errors[] = 'Manifest import candidates must not include empty slugs or software-developers.';
+            }
+            if (preg_match('/\A[a-f0-9]{64}\z/i', $workbookRowSha) !== 1) {
+                $errors[] = "Manifest import candidate {$slug} must declare workbook_row_sha256.";
             }
             if ($publicResolutionType === '') {
                 $errors[] = "Manifest import candidate {$slug} must declare public_resolution_type public_canonical_job.";
@@ -393,9 +398,14 @@ final class CareerImportSelectedDisplayAssets extends Command
             }
 
             $candidateSlugs[] = $slug;
+            $candidateRowHashes[] = [
+                'slug' => $slug,
+                'workbook_row_sha256' => $workbookRowSha,
+            ];
         }
 
         $candidateSlugs = array_values(array_unique(array_filter($candidateSlugs)));
+        $candidateRowHashes = array_values($candidateRowHashes ?? []);
         if ($candidateSlugs === []) {
             $errors[] = 'Manifest must include at least one import_eligible upload_candidate row.';
         }
@@ -409,6 +419,7 @@ final class CareerImportSelectedDisplayAssets extends Command
             'workbook_sha256' => $workbookSha,
             'row_count' => count($rows),
             'upload_candidate_slugs' => $candidateSlugs,
+            'upload_candidate_row_hashes' => $candidateRowHashes,
         ];
         if ($manifestScope === self::ZH_DISPLAY_PARITY_SCOPE) {
             $manifestPayload['scope'] = $manifestScope;
@@ -425,6 +436,7 @@ final class CareerImportSelectedDisplayAssets extends Command
 
         $decoded['manifest_sha256'] = hash_file('sha256', $path) ?: null;
         $decoded['manifest_candidate_slugs'] = $candidateSlugs;
+        $decoded['manifest_candidate_row_hashes'] = $candidateRowHashes;
         $decoded['manifest_scope'] = $manifestScope !== '' ? $manifestScope : null;
         $decoded['manifest_target_locale'] = $targetLocale !== '' ? $targetLocale : null;
         $decoded['manifest_expected_display_delta'] = (int) ($expectedDelta['career_job_display_assets'] ?? 0);
@@ -490,6 +502,8 @@ final class CareerImportSelectedDisplayAssets extends Command
         $socCode = (string) ($workbookRow['SOC_Code'] ?? '');
         $onetCode = (string) ($workbookRow['O_NET_Code'] ?? '');
         $status = (string) ($manifestRow['status'] ?? '');
+        $expectedRowSha = strtolower(trim((string) ($manifestRow['workbook_row_sha256'] ?? '')));
+        $actualRowSha = CareerSelectedDisplayAssetMapper::workbookRowAuthorityHash($workbookRow);
 
         if ($slug === 'software-developers') {
             $errors[] = 'Manifest must not include software-developers.';
@@ -502,6 +516,9 @@ final class CareerImportSelectedDisplayAssets extends Command
         }
         if (in_array($status, ['manual_hold', 'duplicate_identity_hold', 'broad_group_hold', 'CN_proxy_hold'], true)) {
             $errors[] = 'Manifest must not include held rows.';
+        }
+        if ($manifestRow !== null && $expectedRowSha !== $actualRowSha) {
+            $errors[] = 'Manifest workbook_row_sha256 must match reviewed workbook row.';
         }
 
         return $errors;

--- a/backend/app/Console/Commands/CareerValidateDisplayBatch.php
+++ b/backend/app/Console/Commands/CareerValidateDisplayBatch.php
@@ -10,6 +10,7 @@ use App\Models\Occupation;
 use App\Models\Scopes\TenantScope;
 use App\Services\Career\Authority\CareerCrosswalkModePolicy;
 use App\Services\Career\Governance\CareerTrustFactReviewPolicy;
+use App\Services\Career\Import\CareerSelectedDisplayAssetMapper;
 use App\Support\Xlsx\XlsxCellReference;
 use DOMDocument;
 use DOMElement;
@@ -398,6 +399,7 @@ final class CareerValidateDisplayBatch extends Command
                 'title_zh' => $this->stringValue($row, 'CN_Title'),
                 'SOC_Code' => $this->stringValue($row, 'SOC_Code'),
                 'O_NET_Code' => $this->stringValue($row, 'O_NET_Code'),
+                'workbook_row_sha256' => CareerSelectedDisplayAssetMapper::workbookRowAuthorityHash($row),
             ],
             'content_gate' => $contentGate,
             'json_gate' => $jsonGate,
@@ -1226,6 +1228,13 @@ final class CareerValidateDisplayBatch extends Command
                 static fn (array $row): string => (string) $row['slug'],
                 array_filter($rows, static fn (array $row): bool => (bool) $row['import_eligible']),
             )),
+            'upload_candidate_row_hashes' => array_values(array_map(
+                static fn (array $row): array => [
+                    'slug' => (string) $row['slug'],
+                    'workbook_row_sha256' => (string) $row['workbook_row_sha256'],
+                ],
+                array_filter($rows, static fn (array $row): bool => (bool) $row['import_eligible']),
+            )),
             'scope' => 'career_zh_display_parity_v0.1',
             'target_locale' => 'zh-CN',
         ];
@@ -1268,6 +1277,7 @@ final class CareerValidateDisplayBatch extends Command
         return [
             'row_number' => (int) ($identity['row_number'] ?? 0),
             'slug' => (string) ($identity['slug'] ?? ''),
+            'workbook_row_sha256' => (string) ($identity['workbook_row_sha256'] ?? ''),
             'status' => $status,
             'public_resolution_type' => $importEligible
                 ? CareerPublicResolutionTypeMatrix::PUBLIC_CANONICAL_JOB

--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -455,6 +455,21 @@ final class CareerSelectedDisplayAssetMapper
         'QA_Status',
     ];
 
+    /**
+     * @param  array<string, string|int>  $row
+     */
+    public static function workbookRowAuthorityHash(array $row): string
+    {
+        $payload = [];
+        foreach (self::REQUIRED_HEADERS as $header) {
+            $payload[$header] = trim((string) ($row[$header] ?? ''));
+        }
+
+        $encoded = json_encode($payload, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        return hash('sha256', is_string($encoded) ? $encoded : serialize($payload));
+    }
+
     /** @var list<string> */
     private const FORBIDDEN_PUBLIC_KEYS = [
         'release_gate',

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -192,6 +192,13 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
 
         [$exitCode, $report] = $this->runImportWithManifest(
             $workbook,
+            $this->writeManifest($workbook, [$row], rowHashOverride: str_repeat('0', 64)),
+        );
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('workbook_row_sha256 must match reviewed workbook row', implode(' ', $report['errors']));
+
+        [$exitCode, $report] = $this->runImportWithManifest(
+            $workbook,
             $this->writeManifest($workbook, [$row], publicResolutionType: null),
         );
         $this->assertSame(1, $exitCode);
@@ -1022,11 +1029,13 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         ?bool $reviewedChineseFields = null,
         ?string $contentAuthority = null,
         ?bool $seoReleaseGatesUnchanged = null,
+        ?string $rowHashOverride = null,
     ): string {
-        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus, $manifestScope, $targetLocale, $reviewedChineseFields, $contentAuthority, $seoReleaseGatesUnchanged): array {
+        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus, $manifestScope, $targetLocale, $reviewedChineseFields, $contentAuthority, $seoReleaseGatesUnchanged, $rowHashOverride): array {
             $manifestRow = [
                 'row_number' => $index + 2,
                 'slug' => $row['Slug'],
+                'workbook_row_sha256' => $rowHashOverride ?? CareerSelectedDisplayAssetMapper::workbookRowAuthorityHash($row),
                 'status' => $rowStatus,
                 'canonical_slug' => $row['Slug'],
                 'hold_reason' => null,
@@ -1058,6 +1067,13 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
             'workbook_sha256' => $actualWorkbookSha,
             'row_count' => count($manifestRows),
             'upload_candidate_slugs' => $candidateSlugs,
+            'upload_candidate_row_hashes' => array_values(array_map(
+                static fn (array $row): array => [
+                    'slug' => strtolower((string) $row['slug']),
+                    'workbook_row_sha256' => strtolower((string) $row['workbook_row_sha256']),
+                ],
+                $manifestRows,
+            )),
         ];
         if ($manifestScope === 'career_zh_display_parity_v0.1') {
             $payload['scope'] = $manifestScope;

--- a/backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php
@@ -168,6 +168,7 @@ final class CareerValidateDisplayBatchCommandTest extends TestCase
         $this->assertSame('reviewed_workbook', $rows->get('ready-upload-slug')['content_authority']);
         $this->assertTrue($rows->get('ready-upload-slug')['reviewed_chinese_fields']);
         $this->assertTrue($rows->get('ready-upload-slug')['seo_release_gates_unchanged']);
+        $this->assertMatchesRegularExpression('/\A[a-f0-9]{64}\z/', $rows->get('ready-upload-slug')['workbook_row_sha256']);
         $this->assertSame('needs_workbook_repair', $rows->get('needs-repair-slug')['status']);
         $this->assertFalse($rows->get('needs-repair-slug')['import_eligible']);
         $this->assertSame('manual_hold', $rows->get('software-developers')['status']);

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T04:01:13Z",
+  "updated_at": "2026-06-11T04:06:00Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -52904,7 +52904,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-03",
     "base": "origin/main",
-    "status": "local_checks_passed_with_external_sidecar",
+    "status": "pr_open",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import",
     "depends_on": [
@@ -52941,8 +52941,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "bf193e4045cd9644c0341b89073f1fb0e7b1ece6",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2028",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -52967,6 +52967,12 @@
         "from": "pending_dependency",
         "to": "local_checks_passed_with_external_sidecar",
         "note": "Implemented authority manifest row-hash validation for zh display import. Focused local checks passed; broad Career unit suite failure is external to PR03 and recorded as sidecar."
+      },
+      {
+        "at": "2026-06-11T12:06:00+08:00",
+        "from": "local_checks_passed_with_external_sidecar",
+        "to": "pr_open",
+        "note": "Opened GitHub PR #2028 after scoped implementation, focused local validation, and external broad Career unit sidecar recording."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T04:06:00Z",
+  "updated_at": "2026-06-11T04:10:30Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -52904,7 +52904,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-03",
     "base": "origin/main",
-    "status": "pr_open",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import",
     "depends_on": [
@@ -52938,6 +52938,10 @@
           "git diff --name-only"
         ],
         "notes": "PHP lint, focused feature tests, scoped mapper unit test, scoped Pint, JSON/YAML parse, diff check, and scope validation passed. The manifest-listed broad tests/Unit/Services/Career command failed only on pre-existing career publish readiness failures outside PR03 scope and is recorded as sidecar."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2028 head ecd0b161f73848485518ee878a75ef6d181a9961: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "failure_reason": null,
@@ -52973,6 +52977,12 @@
         "from": "local_checks_passed_with_external_sidecar",
         "to": "pr_open",
         "note": "Opened GitHub PR #2028 after scoped implementation, focused local validation, and external broad Career unit sidecar recording."
+      },
+      {
+        "at": "2026-06-11T12:10:30+08:00",
+        "from": "pr_open",
+        "to": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2028 head ecd0b161f73848485518ee878a75ef6d181a9961."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T02:39:11Z",
+  "updated_at": "2026-06-11T04:01:13Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -52768,7 +52768,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-02",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-02: fix(career): repair reviewed zh display workbook contract",
     "depends_on": [
@@ -52834,14 +52834,18 @@
       "github_checks": {
         "status": "pass",
         "evidence": "GitHub checks passed for PR #2026 head eb095864b3f0efa6c94a4cdc54c581eae34fdaa3: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2026 is merged; origin/main contains merge commit fd66af83e5a029900ddd1616efdd0339057d1cb8; task branch was deleted/pruned and the PR02 worktree was removed before PR03 started."
       }
     },
     "failure_reason": null,
     "commit_sha": "9a23cf25b126ba106890b71b97d84e40c6a7f406",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2026",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T03:42:53Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [
       {
         "id": "CAREER-ZH-PARITY-FIX-02-SIDECAR-01",
@@ -52886,14 +52890,21 @@
         "at": "2026-06-11T04:20:00Z",
         "status": "ready_to_merge",
         "note": "GitHub checks passed for PR #2026 head eb095864b3f0efa6c94a4cdc54c581eae34fdaa3 after the scoped verify-bigfive fix."
+      },
+      {
+        "at": "2026-06-11T12:01:13+08:00",
+        "from": "ready_to_merge",
+        "to": "merged",
+        "note": "Reconciled PR02 merged state inside CAREER-ZH-PARITY-FIX-03 metadata scope after confirming GitHub merge, origin/main containment, branch cleanup, and PR02 worktree removal."
       }
-    ]
+    ],
+    "merge_commit_sha": "fd66af83e5a029900ddd1616efdd0339057d1cb8"
   },
   "CAREER-ZH-PARITY-FIX-03": {
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-03",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed_with_external_sidecar",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import",
     "depends_on": [
@@ -52905,8 +52916,28 @@
         "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-02 to merge."
+        "status": "pass",
+        "evidence": "CAREER-ZH-PARITY-FIX-02 merged as PR #2026 at 2026-06-11T03:42:53Z; origin/main contains fd66af83e5a029900ddd1616efdd0339057d1cb8."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to Career display import commands, CareerSelectedDisplayAssetMapper, focused console tests, and docs/codex metadata."
+      },
+      "local": {
+        "status": "pass_with_external_sidecar",
+        "commands": [
+          "php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php",
+          "php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php",
+          "php -l backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerImportSelectedDisplayAssets.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php",
+          "php -r 'json_decode(file_get_contents(\"docs/codex/pr-train-state.json\"), true, 512, JSON_THROW_ON_ERROR); echo \"state json ok\\n\";'",
+          "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\"); puts \"train yaml ok\"'",
+          "git diff --check",
+          "git diff --name-only"
+        ],
+        "notes": "PHP lint, focused feature tests, scoped mapper unit test, scoped Pint, JSON/YAML parse, diff check, and scope validation passed. The manifest-listed broad tests/Unit/Services/Career command failed only on pre-existing career publish readiness failures outside PR03 scope and is recorded as sidecar."
       }
     },
     "failure_reason": null,
@@ -52915,12 +52946,27 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+      {
+        "id": "CAREER-ZH-PARITY-FIX-03-SIDECAR-01",
+        "status": "open",
+        "severity": "external",
+        "title": "Existing Career unit suite failure: FirstWavePublishReadyValidator::validationMemoKey missing",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career --no-ansi exits 2 with 82 failed tests; failures center on Call to undefined method App\\Domain\\Career\\Publish\\FirstWavePublishReadyValidator::validationMemoKey() plus downstream first-wave readiness assertions. PR03 changed only display import manifest hash validation files, not FirstWavePublishReadyValidator or first-wave release ledger code.",
+        "introduced_by_current_pr": false
+      }
+    ],
     "transitions": [
       {
         "at": "2026-06-11T02:19:47Z",
         "status": "pending_dependency",
         "note": "Future authority-manifest import entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-02 is merged."
+      },
+      {
+        "at": "2026-06-11T12:01:13+08:00",
+        "from": "pending_dependency",
+        "to": "local_checks_passed_with_external_sidecar",
+        "note": "Implemented authority manifest row-hash validation for zh display import. Focused local checks passed; broad Career unit suite failure is external to PR03 and recorded as sidecar."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24278,7 +24278,7 @@ prs:
     branch: codex/career-zh-parity-fix-03
     title: "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import"
     train_scope: career_zh_parity_fix
-    status: local_checks_passed_with_external_sidecar
+    status: pr_open
     scope:
       - Replace hardcoded selected-slug limitations with production-authority manifest validation for the Chinese parity import scope.
       - Require reviewed workbook fields, exact manifest hashes, dry-run support, and safe refusal for non-authoritative slugs.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24278,7 +24278,7 @@ prs:
     branch: codex/career-zh-parity-fix-03
     title: "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import"
     train_scope: career_zh_parity_fix
-    status: pr_open
+    status: ready_to_merge
     scope:
       - Replace hardcoded selected-slug limitations with production-authority manifest validation for the Chinese parity import scope.
       - Require reviewed workbook fields, exact manifest hashes, dry-run support, and safe refusal for non-authoritative slugs.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24278,7 +24278,7 @@ prs:
     branch: codex/career-zh-parity-fix-03
     title: "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import"
     train_scope: career_zh_parity_fix
-    status: pending_dependency
+    status: local_checks_passed_with_external_sidecar
     scope:
       - Replace hardcoded selected-slug limitations with production-authority manifest validation for the Chinese parity import scope.
       - Require reviewed workbook fields, exact manifest hashes, dry-run support, and safe refusal for non-authoritative slugs.


### PR DESCRIPTION
## What changed
- Added a deterministic `workbook_row_sha256` authority hash for reviewed career display workbook rows.
- Extended the zh display full-upload plan manifest to include candidate row hashes in the manifest hash payload.
- Tightened `career:import-selected-display-assets --manifest` so manifest candidates must declare a valid row hash and the hash must match the current reviewed workbook row before dry-run/force import proceeds.
- Added focused coverage for manifest row hash emission and stale/tampered row hash rejection.
- Reconciled CAREER-ZH-PARITY-FIX-02 merged state and recorded the existing broad Career unit-suite blocker as an external sidecar.

## Why
The zh display import path needs to trust a production-authority manifest without falling back to a static selected-slug list. The manifest must bind candidate slugs to the reviewed workbook row content, otherwise stale or manually edited manifest rows could drift from the workbook authority.

## Validation
- `php -l backend/app/Console/Commands/CareerValidateDisplayBatch.php`
- `php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php`
- `php -l backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerValidateDisplayBatch.php app/Console/Commands/CareerImportSelectedDisplayAssets.php tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `php -r 'json_decode(file_get_contents("docs/codex/pr-train-state.json"), true, 512, JSON_THROW_ON_ERROR); echo "state json ok\n";'`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml"); puts "train yaml ok"'`
- `git diff --check`
- `git diff --cached --check`

## Sidecar / deferred
- No production import, CMS mutation, publish, deploy, fap-web change, sitemap/llms/index change, or production write is included.
- Manifest-listed broad command `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerValidateDisplayBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Unit/Services/Career --no-ansi` still fails on existing `FirstWavePublishReadyValidator::validationMemoKey()` and downstream first-wave readiness assertions. This is recorded as `CAREER-ZH-PARITY-FIX-03-SIDECAR-01` because PR03 only changes display import manifest validation files.
