### PR TITLE
CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh

### DIFF
--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -35,6 +35,8 @@ final class CareerImportSelectedDisplayAssets extends Command
         {--file= : Absolute path to repaired second-pilot workbook}
         {--slugs= : Comma-separated explicit slug allowlist}
         {--manifest= : Optional validated full-upload plan manifest JSON}
+        {--manifest-chunk-size= : Optional positive manifest candidate chunk size for controlled execution}
+        {--manifest-chunk-index=1 : 1-based manifest candidate chunk index}
         {--dry-run : Validate and report without writing}
         {--force : Required to write selected display asset rows}
         {--json : Emit machine-readable report}
@@ -67,7 +69,8 @@ final class CareerImportSelectedDisplayAssets extends Command
 
             $file = $this->requiredFile();
             $manifest = $this->optionalManifest($file);
-            $slugs = $manifest === null ? $this->requiredSlugs() : $this->manifestSlugs($manifest);
+            $manifestCandidateSlugs = $manifest === null ? null : $this->manifestSlugs($manifest);
+            [$slugs, $manifestExecution] = $this->executionSlugs($manifest, $manifestCandidateSlugs ?? $this->requiredSlugs());
             $workbook = $this->mapper->readWorkbook($file, $slugs);
             $missingHeaders = array_values(array_diff(CareerSelectedDisplayAssetMapper::REQUIRED_HEADERS, $workbook['headers']));
             if ($missingHeaders !== []) {
@@ -76,6 +79,7 @@ final class CareerImportSelectedDisplayAssets extends Command
                     'source_file_basename' => basename($file),
                     'source_file_sha256' => hash_file('sha256', $file) ?: null,
                     'manifest_sha256' => $manifest['manifest_sha256'] ?? null,
+                    'manifest_execution' => $manifestExecution,
                     'requested_slugs' => $slugs,
                     'decision' => 'fail',
                     'errors' => ['Workbook is missing required headers: '.implode(', ', $missingHeaders).'.'],
@@ -117,7 +121,7 @@ final class CareerImportSelectedDisplayAssets extends Command
                 );
                 if ($manifest !== null
                     && ($authority['existing_display_asset'] ?? false) === true
-                    && ! $this->manifestAllowsExistingDisplayAssets($manifest)) {
+                    && ! $this->manifestAllowsExistingDisplayAssets($manifest, count($slugs))) {
                     $itemErrors[] = 'Manifest slug already has a selected display asset.';
                 }
                 if ($manifest !== null && $manifestRow === null) {
@@ -139,6 +143,7 @@ final class CareerImportSelectedDisplayAssets extends Command
                 'manifest_scope' => $manifest['manifest_scope'] ?? null,
                 'manifest_target_locale' => $manifest['manifest_target_locale'] ?? null,
                 'manifest_expected_delta' => $manifest['expected_delta'] ?? null,
+                'manifest_execution' => $manifestExecution,
                 'requested_slugs' => $slugs,
                 'total_rows' => $workbook['total_rows'],
                 'validated_count' => count($items),
@@ -206,12 +211,13 @@ final class CareerImportSelectedDisplayAssets extends Command
 
                 return $written;
             });
-            $forgotDetailCaches = $this->forgetWrittenJobDetailCaches($written);
+            $refreshedDetailCaches = $this->refreshWrittenJobDetailCaches($written);
 
             return $this->finish(array_merge($report, [
                 'did_write' => count($written) > 0,
                 'written_assets' => $written,
-                'forgot_detail_caches' => $forgotDetailCaches,
+                'forgot_detail_caches' => $this->forgottenCacheSummaries($refreshedDetailCaches),
+                'refreshed_detail_caches' => $refreshedDetailCaches,
                 'created_count' => count(array_filter($written, static fn (array $row): bool => ($row['created'] ?? false) === true)),
                 'updated_count' => count(array_filter($written, static fn (array $row): bool => ($row['created'] ?? false) !== true)),
             ]), true);
@@ -225,11 +231,11 @@ final class CareerImportSelectedDisplayAssets extends Command
 
     /**
      * @param  list<array{slug: string, row_id: int|string, created: bool}>  $written
-     * @return list<array{slug: string, locale: string, cache_key: string, forgotten: bool}>
+     * @return list<array{slug: string, locale: string, cache_key: string, forgotten: bool, warm_status: string, member_count: int}>
      */
-    private function forgetWrittenJobDetailCaches(array $written): array
+    private function refreshWrittenJobDetailCaches(array $written): array
     {
-        $forgotten = [];
+        $refreshed = [];
         foreach ($written as $row) {
             $slug = strtolower(trim((string) ($row['slug'] ?? '')));
             if ($slug === '') {
@@ -238,15 +244,33 @@ final class CareerImportSelectedDisplayAssets extends Command
 
             $locale = 'zh-CN';
             $cacheKey = $this->authorityResponseCache->jobDetailCacheKey($slug, $locale);
-            $forgotten[] = [
+            $forgotten = $this->authorityResponseCache->forgetJobDetailPayload($slug, $locale);
+            $warm = $this->authorityResponseCache->warmJobDetailPayload($slug, $locale);
+            $refreshed[] = [
                 'slug' => $slug,
                 'locale' => $locale,
                 'cache_key' => $cacheKey,
-                'forgotten' => $this->authorityResponseCache->forgetJobDetailPayload($slug, $locale),
+                'forgotten' => $forgotten,
+                'warm_status' => (string) ($warm['status'] ?? 'unknown'),
+                'member_count' => (int) ($warm['member_count'] ?? 0),
             ];
         }
 
-        return $forgotten;
+        return $refreshed;
+    }
+
+    /**
+     * @param  list<array{slug: string, locale: string, cache_key: string, forgotten: bool, warm_status: string, member_count: int}>  $refreshed
+     * @return list<array{slug: string, locale: string, cache_key: string, forgotten: bool}>
+     */
+    private function forgottenCacheSummaries(array $refreshed): array
+    {
+        return array_map(static fn (array $row): array => [
+            'slug' => $row['slug'],
+            'locale' => $row['locale'],
+            'cache_key' => $row['cache_key'],
+            'forgotten' => $row['forgotten'],
+        ], $refreshed);
     }
 
     private function requiredFile(): string
@@ -455,6 +479,64 @@ final class CareerImportSelectedDisplayAssets extends Command
     }
 
     /**
+     * @param  array<string, mixed>|null  $manifest
+     * @param  list<string>  $candidateSlugs
+     * @return array{0: list<string>, 1: array<string, mixed>|null}
+     */
+    private function executionSlugs(?array $manifest, array $candidateSlugs): array
+    {
+        $chunkSizeRaw = trim((string) ($this->option('manifest-chunk-size') ?? ''));
+        $chunkIndexRaw = trim((string) ($this->option('manifest-chunk-index') ?? '1'));
+        $normalizedCandidates = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            $candidateSlugs,
+        ), static fn (string $slug): bool => $slug !== '')));
+
+        $execution = $manifest === null ? null : [
+            'strategy' => 'manifest_full',
+            'chunked' => false,
+            'chunk_size' => null,
+            'chunk_index' => null,
+            'total_candidates' => count($normalizedCandidates),
+            'selected_count' => count($normalizedCandidates),
+            'selected_offset' => 0,
+            'selected_slugs_sha256' => $this->slugListSha256($normalizedCandidates),
+        ];
+
+        if ($chunkSizeRaw === '') {
+            return [$normalizedCandidates, $execution];
+        }
+        if ($manifest === null) {
+            throw new RuntimeException('--manifest-chunk-size requires --manifest.');
+        }
+        if (! ctype_digit($chunkSizeRaw) || (int) $chunkSizeRaw < 1) {
+            throw new RuntimeException('--manifest-chunk-size must be a positive integer.');
+        }
+        if (! ctype_digit($chunkIndexRaw) || (int) $chunkIndexRaw < 1) {
+            throw new RuntimeException('--manifest-chunk-index must be a positive 1-based integer.');
+        }
+
+        $chunkSize = (int) $chunkSizeRaw;
+        $chunkIndex = (int) $chunkIndexRaw;
+        $offset = ($chunkIndex - 1) * $chunkSize;
+        $selected = array_slice($normalizedCandidates, $offset, $chunkSize);
+        if ($selected === []) {
+            throw new RuntimeException('--manifest-chunk-index selects no manifest candidates.');
+        }
+
+        return [$selected, [
+            'strategy' => 'manifest_chunk',
+            'chunked' => true,
+            'chunk_size' => $chunkSize,
+            'chunk_index' => $chunkIndex,
+            'total_candidates' => count($normalizedCandidates),
+            'selected_count' => count($selected),
+            'selected_offset' => $offset,
+            'selected_slugs_sha256' => $this->slugListSha256($selected),
+        ]];
+    }
+
+    /**
      * @param  array<string, mixed>  $manifest
      * @return array<string, array<string, mixed>>
      */
@@ -475,9 +557,17 @@ final class CareerImportSelectedDisplayAssets extends Command
     }
 
     /**
+     * @param  list<string>  $slugs
+     */
+    private function slugListSha256(array $slugs): string
+    {
+        return hash('sha256', json_encode(array_values($slugs), JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '');
+    }
+
+    /**
      * @param  array<string, mixed>  $manifest
      */
-    private function manifestAllowsExistingDisplayAssets(array $manifest): bool
+    private function manifestAllowsExistingDisplayAssets(array $manifest, ?int $selectedCount = null): bool
     {
         try {
             $current = CareerJobDisplayAsset::query()->count();
@@ -487,8 +577,9 @@ final class CareerImportSelectedDisplayAssets extends Command
 
         $baseline = (int) ($manifest['manifest_baseline_display_assets'] ?? 0);
         $expectedDelta = (int) ($manifest['manifest_expected_display_delta'] ?? 0);
+        $requiredDelta = $selectedCount === null ? $expectedDelta : min($expectedDelta, $selectedCount);
 
-        return $current >= ($baseline + $expectedDelta);
+        return $current >= ($baseline + $requiredDelta);
     }
 
     /**

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -108,6 +108,49 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
+    public function manifest_import_can_execute_a_controlled_candidate_chunk_with_lineage(): void
+    {
+        $rows = [
+            $this->row('manifest-only-career-one', title: 'Manifest Only Career One', soc: '15-2011', onet: '15-2011.00'),
+            $this->row('manifest-only-career-two', title: 'Manifest Only Career Two', soc: '15-2021', onet: '15-2021.00'),
+        ];
+        foreach ($rows as $row) {
+            $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        }
+        $workbook = $this->writeWorkbook($rows);
+        $manifest = $this->writeManifest($workbook, $rows);
+
+        [$exitCode, $report] = $this->runImportWithManifest($workbook, $manifest, [
+            '--manifest-chunk-size' => 1,
+            '--manifest-chunk-index' => 2,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame(['manifest-only-career-two'], $report['requested_slugs']);
+        $this->assertSame(1, $report['validated_count']);
+        $this->assertSame(2, $report['manifest_execution']['total_candidates']);
+        $this->assertSame(1, $report['manifest_execution']['selected_count']);
+        $this->assertSame(1, $report['manifest_execution']['chunk_size']);
+        $this->assertSame(2, $report['manifest_execution']['chunk_index']);
+        $this->assertSame('manifest_chunk', $report['manifest_execution']['strategy']);
+        $this->assertIsString($report['manifest_execution']['selected_slugs_sha256']);
+    }
+
+    #[Test]
+    public function manifest_chunk_options_require_manifest_execution(): void
+    {
+        $workbook = $this->writeWorkbook([$this->row('data-scientists')]);
+
+        [$exitCode, $report] = $this->runImport($workbook, 'data-scientists', [
+            '--manifest-chunk-size' => 1,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertStringContainsString('--manifest-chunk-size requires --manifest.', implode(' ', $report['errors']));
+    }
+
+    #[Test]
     public function zh_display_parity_manifest_requires_reviewed_chinese_workbook_authority(): void
     {
         $row = $this->row('manifest-only-career', title: 'Manifest Only Career', soc: '15-2011', onet: '15-2011.00');
@@ -541,6 +584,7 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         $this->assertSame(6, OccupationCrosswalk::query()->count());
         $this->assertSame(3, CareerJobDisplayAsset::query()->count());
         $this->assertCount(3, $report['forgot_detail_caches']);
+        $this->assertCount(3, $report['refreshed_detail_caches']);
 
         foreach ($this->selectedRows() as $row) {
             $this->assertDatabaseHas('career_job_display_assets', [
@@ -551,7 +595,13 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
                 'asset_role' => 'formal_pilot_master',
                 'status' => 'ready_for_pilot',
             ]);
-            $this->assertFalse(Cache::has(PublicCareerAuthorityResponseCache::JOB_DETAIL_CACHE_KEY_PREFIX.':'.$row['Slug'].':zh-CN'));
+            $zhCacheKey = PublicCareerAuthorityResponseCache::JOB_DETAIL_CACHE_KEY_PREFIX.':'.$row['Slug'].':zh-CN';
+            $refreshReport = collect($report['refreshed_detail_caches'])
+                ->firstWhere('slug', $row['Slug']);
+            $this->assertSame($zhCacheKey, $refreshReport['cache_key']);
+            $this->assertTrue($refreshReport['forgotten']);
+            $this->assertContains($refreshReport['warm_status'], ['cached', 'missing']);
+            $this->assertFalse(Cache::has($zhCacheKey));
             $this->assertTrue(Cache::has(PublicCareerAuthorityResponseCache::JOB_DETAIL_CACHE_KEY_PREFIX.':'.$row['Slug'].':en'));
         }
     }

--- a/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+++ b/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
@@ -6,6 +6,7 @@ namespace Tests\Feature\Console;
 
 use App\Services\Career\PublicCareerAuthorityResponseCache;
 use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\Cache;
 use Tests\TestCase;
 
@@ -85,6 +86,28 @@ final class CareerWarmPublicAuthorityCacheCommandTest extends TestCase
             ->expectsOutputToContain('status=warmed')
             ->assertExitCode(0);
 
+        $this->assertFalse(Cache::has($cacheKey));
+    }
+
+    public function test_command_emits_json_report_for_targeted_job_detail_cache_refresh(): void
+    {
+        $cacheKey = PublicCareerAuthorityResponseCache::JOB_DETAIL_CACHE_KEY_PREFIX.':missing-career:zh-CN';
+        Cache::forever($cacheKey, ['stale' => true]);
+
+        $exitCode = Artisan::call('career:warm-public-authority-cache', [
+            '--job-detail-slugs' => 'missing-career',
+            '--job-detail-locales' => 'zh-CN',
+            '--forget-job-detail' => true,
+            '--job-detail-only' => true,
+            '--json' => true,
+        ]);
+
+        $report = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('warmed', $report['status']);
+        $this->assertSame($cacheKey, $report['entries']['job_detail_zh_cn_missing-career']['cache_key']);
+        $this->assertSame('missing', $report['entries']['job_detail_zh_cn_missing-career']['status']);
+        $this->assertSame(0, $report['entries']['job_detail_zh_cn_missing-career']['member_count']);
         $this->assertFalse(Cache::has($cacheKey));
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53000,7 +53000,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-04",
     "base": "origin/main",
-    "status": "local_verified_sidecar_external",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh",
     "depends_on": [
@@ -53033,11 +53033,15 @@
           "git diff --check"
         ],
         "notes": "PHP lint, focused feature tests, and scoped Pint passed. The manifest-listed broad tests/Unit/Services/Career command failed only on pre-existing career publish readiness failures outside PR04 scope and is recorded as sidecar."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "PR #2029 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "9a1389e3810b92770501157205c4513ea5b1e91e",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2029",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53061,6 +53065,11 @@
         "at": "2026-06-11T04:35:00Z",
         "status": "local_verified_sidecar_external",
         "note": "Implemented controlled manifest chunk execution and zh-CN job detail cache refresh reporting; focused checks passed; broad Career unit suite retains external FirstWavePublishReadyValidator blocker."
+      },
+      {
+        "at": "2026-06-11T04:38:00Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2029 for CAREER-ZH-PARITY-FIX-04 from head commit 9a1389e3810b92770501157205c4513ea5b1e91e."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53000,7 +53000,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-04",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh",
     "depends_on": [
@@ -53035,12 +53035,12 @@
         "notes": "PHP lint, focused feature tests, and scoped Pint passed. The manifest-listed broad tests/Unit/Services/Career command failed only on pre-existing career publish readiness failures outside PR04 scope and is recorded as sidecar."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "PR #2029 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2029: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "failure_reason": null,
-    "commit_sha": "9a1389e3810b92770501157205c4513ea5b1e91e",
+    "commit_sha": "095666733f502a63714090dd409bfd3be0aa997b",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2029",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -53070,6 +53070,11 @@
         "at": "2026-06-11T04:38:00Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2029 for CAREER-ZH-PARITY-FIX-04 from head commit 9a1389e3810b92770501157205c4513ea5b1e91e."
+      },
+      {
+        "at": "2026-06-11T04:44:00Z",
+        "status": "ready_to_merge",
+        "note": "PR #2029 GitHub checks passed; scope remains confined to PR04 allowed paths."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -52904,7 +52904,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-03",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import",
     "depends_on": [
@@ -52942,14 +52942,18 @@
       "github_checks": {
         "status": "pass",
         "evidence": "GitHub checks passed for PR #2028 head ecd0b161f73848485518ee878a75ef6d181a9961: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2028 is MERGED; origin/main contains merge commit 26a3eede150a9f8e60084960ab28cc52e2c43a38; remote branch codex/career-zh-parity-fix-03 is deleted; local PR03 worktree/branch were removed after merge."
       }
     },
     "failure_reason": null,
     "commit_sha": "bf193e4045cd9644c0341b89073f1fb0e7b1ece6",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2028",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T04:20:22Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [
       {
         "id": "CAREER-ZH-PARITY-FIX-03-SIDECAR-01",
@@ -52983,14 +52987,20 @@
         "from": "pr_open",
         "to": "ready_to_merge",
         "note": "GitHub checks passed for PR #2028 head ecd0b161f73848485518ee878a75ef6d181a9961."
+      },
+      {
+        "at": "2026-06-11T04:20:22Z",
+        "status": "merged",
+        "note": "Reconciled during CAREER-ZH-PARITY-FIX-04 start after PR #2028 merge and cleanup."
       }
-    ]
+    ],
+    "merge_commit_sha": "26a3eede150a9f8e60084960ab28cc52e2c43a38"
   },
   "CAREER-ZH-PARITY-FIX-04": {
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-04",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_verified_sidecar_external",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh",
     "depends_on": [
@@ -53002,8 +53012,27 @@
         "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-03 to merge."
+        "status": "pass",
+        "evidence": "CAREER-ZH-PARITY-FIX-03 merged as PR #2028 at 2026-06-11T04:20:22Z; origin/main contains 26a3eede150a9f8e60084960ab28cc52e2c43a38."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to Career import/cache commands, focused console tests, and docs/codex metadata."
+      },
+      "local": {
+        "status": "pass_with_external_sidecar",
+        "commands": [
+          "php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php",
+          "php -l backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php",
+          "php -l backend/app/Services/Career/PublicCareerAuthorityResponseCache.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Console/Commands/CareerWarmPublicAuthorityCache.php app/Services/Career/PublicCareerAuthorityResponseCache.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career --no-ansi",
+          "php -r 'json_decode(file_get_contents(\"docs/codex/pr-train-state.json\"), true, 512, JSON_THROW_ON_ERROR); echo \"state json ok\\n\";'",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'train yaml ok'\"",
+          "git diff --check"
+        ],
+        "notes": "PHP lint, focused feature tests, and scoped Pint passed. The manifest-listed broad tests/Unit/Services/Career command failed only on pre-existing career publish readiness failures outside PR04 scope and is recorded as sidecar."
       }
     },
     "failure_reason": null,
@@ -53012,12 +53041,26 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+      {
+        "id": "CAREER-ZH-PARITY-FIX-04-SIDECAR-01",
+        "status": "open",
+        "severity": "external",
+        "title": "Existing Career unit suite failure: FirstWavePublishReadyValidator::validationMemoKey missing",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career --no-ansi exits 2 with 82 failed tests; failures center on Call to undefined method App\\Domain\\Career\\Publish\\FirstWavePublishReadyValidator::validationMemoKey() plus downstream first-wave readiness assertions. PR04 did not touch FirstWavePublishReadyValidator or first-wave release policy files.",
+        "introduced_by_current_pr": false
+      }
+    ],
     "transitions": [
       {
         "at": "2026-06-11T02:19:47Z",
         "status": "pending_dependency",
         "note": "Future controlled import/cache refresh entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-03 is merged."
+      },
+      {
+        "at": "2026-06-11T04:35:00Z",
+        "status": "local_verified_sidecar_external",
+        "note": "Implemented controlled manifest chunk execution and zh-CN job detail cache refresh reporting; focused checks passed; broad Career unit suite retains external FirstWavePublishReadyValidator blocker."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24278,7 +24278,7 @@ prs:
     branch: codex/career-zh-parity-fix-03
     title: "CAREER-ZH-PARITY-FIX-03: feat(career): support authority-manifest zh display import"
     train_scope: career_zh_parity_fix
-    status: ready_to_merge
+    status: merged
     scope:
       - Replace hardcoded selected-slug limitations with production-authority manifest validation for the Chinese parity import scope.
       - Require reviewed workbook fields, exact manifest hashes, dry-run support, and safe refusal for non-authoritative slugs.
@@ -24320,7 +24320,7 @@ prs:
     branch: codex/career-zh-parity-fix-04
     title: "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh"
     train_scope: career_zh_parity_fix
-    status: pending_dependency
+    status: local_verified_sidecar_external
     scope:
       - Add chunked controlled import execution support for the reviewed Chinese display parity manifest.
       - Clear and warm per-slug zh-CN job detail cache after successful imports.


### PR DESCRIPTION
## What changed
- Added manifest chunk execution options to `career:import-selected-display-assets` for controlled reviewed zh display imports.
- Added force-import zh-CN job detail cache refresh reporting: existing zh-CN detail cache is forgotten and warm is attempted per written slug.
- Added JSON report coverage for targeted `career:warm-public-authority-cache` job detail refresh.
- Reconciled CAREER-ZH-PARITY-FIX-03 ledger state after PR #2028 merged.

## Why
The Chinese career display parity import needs an operator-safe path to execute reviewed manifest candidates in chunks and refresh per-slug runtime detail cache immediately after successful writes, without changing public search/index strategy.

## Validation
- `php -l backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php`
- `php -l backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php`
- `php -l backend/app/Services/Career/PublicCareerAuthorityResponseCache.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerImportSelectedDisplayAssets.php app/Console/Commands/CareerWarmPublicAuthorityCache.php app/Services/Career/PublicCareerAuthorityResponseCache.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `php -r 'json_decode(file_get_contents("docs/codex/pr-train-state.json"), true, 512, JSON_THROW_ON_ERROR); echo "state json ok\n";'`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'train yaml ok'"`
- `git diff --check`
- `git diff --cached --check`

## Sidecar / deferred
- The manifest-listed broad `tests/Unit/Services/Career` command still fails on the pre-existing external `FirstWavePublishReadyValidator::validationMemoKey()` blocker and downstream first-wave assertions. This is recorded as `CAREER-ZH-PARITY-FIX-04-SIDECAR-01` and was not introduced by this PR.
- No production import was executed.
- No content was published.
- No deployment was performed.
- No sitemap, llms, or search index strategy changed.

## Repository rule impact
Backend remains the authority for career display content and runtime cache behavior. This PR adds operator-safe backend import/cache execution support only; it does not add frontend content fallback or change publication authority.
