### PR TITLE
CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php
+++ b/backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php
@@ -35,7 +35,7 @@ final class CareerLocaleIntegrityGate
             return false;
         }
 
-        foreach (['primary_cta', 'final_cta', 'cta', 'faq_block', 'sections', 'content_sections', 'definition_block', 'responsibilities_block', 'work_context_block'] as $key) {
+        foreach (['faq_block', 'sections', 'content_sections', 'definition_block', 'responsibilities_block', 'work_context_block'] as $key) {
             $strings = $this->collectStrings($pageContent[$key] ?? null);
             if ($strings !== [] && ! $this->stringsContainCjk($strings) && $this->stringsLookEnglish($strings)) {
                 return false;

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -405,6 +405,64 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.page.content.hero.title', 'Data scientist career fit');
     }
 
+    public function test_zh_display_asset_backed_bundle_allows_shared_english_cta_when_reviewed_zh_content_is_ready(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'reviewed-zh-display-asset', 'status' => 'already_imported_validated'],
+        ]);
+
+        $occupation = $this->createDisplayAssetBackedOccupation('reviewed-zh-display-asset');
+        $this->createDisplayAsset($occupation, [
+            'page_payload_json' => [
+                'page' => [
+                    'zh' => [
+                        'hero' => ['title' => '展示资产职业'],
+                        'primary_cta' => ['label' => 'Start career fit test'],
+                        'definition_block' => [
+                            'heading' => '职业定义',
+                            'body' => '这是一份已经通过中文审阅的职业展示内容。',
+                        ],
+                        'market_signal_card' => [
+                            'salary_data_type' => 'BLS official wage evidence',
+                            'body' => '市场信号仅基于公开来源解释，不替代个人判断。',
+                        ],
+                        'ai_impact_table' => [
+                            'score_normalized' => '82',
+                            'source' => 'FermatMind central score',
+                        ],
+                    ],
+                    'en' => [
+                        'hero' => ['title' => 'Display backed career'],
+                        'primary_cta' => ['label' => 'Start career fit test'],
+                        'market_signal_card' => [
+                            'salary_data_type' => 'BLS official wage evidence',
+                            'body' => 'Official market signal from BLS.',
+                        ],
+                        'ai_impact_table' => [
+                            'score_normalized' => '82',
+                            'source' => 'FermatMind central score',
+                        ],
+                    ],
+                ],
+            ],
+        ]);
+
+        $this->getJson('/api/v0.5/career/jobs/reviewed-zh-display-asset?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('trust_manifest.logic_version', 'career.protocol.job_detail.display_asset_backed.v1')
+            ->assertJsonPath('integrity_summary.integrity_state', 'display_asset_backed')
+            ->assertJsonPath('claim_permissions.allow_strong_claim', false)
+            ->assertJsonPath('claim_permissions.allow_salary_comparison', false)
+            ->assertJsonPath('seo_contract.reason_codes.0', 'validated_display_asset_backed_release')
+            ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN')
+            ->assertJsonPath('display_surface_v1.page.content.hero.title', '展示资产职业')
+            ->assertJsonPath('display_surface_v1.page.content.primary_cta.label', 'Start career fit test')
+            ->assertJsonPath('display_surface_v1.page.content.definition_block.heading', '职业定义')
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_strong_claim', true)
+            ->assertJsonPath('display_surface_v1.claim_permissions.allow_salary_comparison', true)
+            ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'full');
+    }
+
     public function test_runtime_published_occupation_without_display_or_docx_asset_returns_restricted_public_shell(): void
     {
         $this->configurePublicResolutionPlan([

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53092,7 +53092,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-05",
     "base": "origin/main",
-    "status": "local_verified_sidecar_external",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy",
     "depends_on": [
@@ -53124,11 +53124,15 @@
           "git diff --check"
         ],
         "notes": "PHP lint, focused CareerJobDetailApiTest coverage, CareerJobDisplaySurfaceBuilderTest, scoped Pint, JSON/YAML parse, and diff check passed. The manifest-listed broad Career feature/unit suite failed only on the pre-existing FirstWavePublishReadyValidator::validationMemoKey blocker plus downstream readiness assertions and is recorded as sidecar."
+      },
+      "github_checks": {
+        "status": "pending",
+        "evidence": "Opened PR #2030 for CAREER-ZH-PARITY-FIX-05 from head commit 733bf3f09ba7a528611b24cd0655a59de8c66cd1."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "733bf3f09ba7a528611b24cd0655a59de8c66cd1",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2030",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53157,6 +53161,11 @@
         "at": "2026-06-11T05:13:00Z",
         "status": "local_verified_sidecar_external",
         "note": "Scoped PR05 checks passed; broad Career feature/unit suite retains external FirstWavePublishReadyValidator blocker recorded as sidecar."
+      },
+      {
+        "at": "2026-06-11T05:16:00Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2030 for CAREER-ZH-PARITY-FIX-05 from head commit 733bf3f09ba7a528611b24cd0655a59de8c66cd1."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53000,7 +53000,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-04",
     "base": "origin/main",
-    "status": "ready_to_merge",
+    "status": "merged",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh",
     "depends_on": [
@@ -53037,14 +53037,19 @@
       "github_checks": {
         "status": "pass",
         "evidence": "GitHub checks passed for PR #2029: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2029 is MERGED; origin/main contains merge commit d47faf1e1d713d5fef8262fd68a8e381119d4bd2; remote branch codex/career-zh-parity-fix-04 is deleted; local PR04 worktree/branch were removed after merge."
       }
     },
     "failure_reason": null,
-    "commit_sha": "095666733f502a63714090dd409bfd3be0aa997b",
+    "commit_sha": "25893f874aeee616cbc1a5907633937846173efb",
+    "merge_commit_sha": "d47faf1e1d713d5fef8262fd68a8e381119d4bd2",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2029",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T04:53:48Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [
       {
         "id": "CAREER-ZH-PARITY-FIX-04-SIDECAR-01",
@@ -53075,6 +53080,11 @@
         "at": "2026-06-11T04:44:00Z",
         "status": "ready_to_merge",
         "note": "PR #2029 GitHub checks passed; scope remains confined to PR04 allowed paths."
+      },
+      {
+        "at": "2026-06-11T05:05:39Z",
+        "status": "merged",
+        "note": "Reconciled during CAREER-ZH-PARITY-FIX-05 preflight after PR #2029 merge and cleanup."
       }
     ]
   },
@@ -53082,7 +53092,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-05",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_verified_sidecar_external",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy",
     "depends_on": [
@@ -53094,8 +53104,26 @@
         "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-04 to merge."
+        "status": "pass",
+        "evidence": "CAREER-ZH-PARITY-FIX-04 merged as PR #2029 at 2026-06-11T04:53:48Z; origin/main contains d47faf1e1d713d5fef8262fd68a8e381119d4bd2."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to CareerLocaleIntegrityGate, CareerJobDetailApiTest, and docs/codex metadata; no fap-web, publish, deploy, sitemap, llms, or index strategy files changed."
+      },
+      "local": {
+        "status": "pass_with_external_sidecar",
+        "commands": [
+          "php -l backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career/CareerJobDetailApiTest.php --filter='shared_english_cta|locale_surface_is_english' --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Services/Career tests/Feature/Career tests/Unit/Services/Career",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career tests/Unit/Services/Career --no-ansi",
+          "php -r 'json_decode(file_get_contents(\"docs/codex/pr-train-state.json\"), true, 512, JSON_THROW_ON_ERROR); echo \"state json ok\\n\";'",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'train yaml ok'\"",
+          "git diff --check"
+        ],
+        "notes": "PHP lint, focused CareerJobDetailApiTest coverage, CareerJobDisplaySurfaceBuilderTest, scoped Pint, JSON/YAML parse, and diff check passed. The manifest-listed broad Career feature/unit suite failed only on the pre-existing FirstWavePublishReadyValidator::validationMemoKey blocker plus downstream readiness assertions and is recorded as sidecar."
       }
     },
     "failure_reason": null,
@@ -53104,12 +53132,31 @@
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+      {
+        "id": "CAREER-ZH-PARITY-FIX-05-SIDECAR-01",
+        "status": "open",
+        "severity": "external",
+        "title": "Existing Career broad suite failure: FirstWavePublishReadyValidator::validationMemoKey missing",
+        "evidence": "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career tests/Unit/Services/Career --no-ansi exits 2 with 125 failed tests; failures center on Call to undefined method App\\Domain\\Career\\Publish\\FirstWavePublishReadyValidator::validationMemoKey() plus downstream first-wave readiness, release ledger, and dataset assertions. PR05 only touched CareerLocaleIntegrityGate and focused CareerJobDetailApiTest.",
+        "introduced_by_current_pr": false
+      }
+    ],
     "transitions": [
       {
         "at": "2026-06-11T02:19:47Z",
         "status": "pending_dependency",
         "note": "Future runtime integrity policy entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-04 is merged."
+      },
+      {
+        "at": "2026-06-11T05:05:39Z",
+        "status": "in_progress",
+        "note": "Started from origin/main after PR04 merge; implementing runtime integrity policy alignment."
+      },
+      {
+        "at": "2026-06-11T05:13:00Z",
+        "status": "local_verified_sidecar_external",
+        "note": "Scoped PR05 checks passed; broad Career feature/unit suite retains external FirstWavePublishReadyValidator blocker recorded as sidecar."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -26345,7 +26345,7 @@
   "BAIDU-LIVE-00": {
     "repo": "fap-api",
     "branch": "codex/baidu-live-00-readiness-contract",
-    "status": "pr_open_checks_pending",
+    "status": "ready_to_merge",
     "depends_on": [
       "GSC-LIVE-00"
     ],
@@ -53126,12 +53126,12 @@
         "notes": "PHP lint, focused CareerJobDetailApiTest coverage, CareerJobDisplaySurfaceBuilderTest, scoped Pint, JSON/YAML parse, and diff check passed. The manifest-listed broad Career feature/unit suite failed only on the pre-existing FirstWavePublishReadyValidator::validationMemoKey blocker plus downstream readiness assertions and is recorded as sidecar."
       },
       "github_checks": {
-        "status": "pending",
-        "evidence": "Opened PR #2030 for CAREER-ZH-PARITY-FIX-05 from head commit 733bf3f09ba7a528611b24cd0655a59de8c66cd1."
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2030 head 917783ca4b41d2f02e989d1499d1b2d998839db2: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "failure_reason": null,
-    "commit_sha": "733bf3f09ba7a528611b24cd0655a59de8c66cd1",
+    "commit_sha": "917783ca4b41d2f02e989d1499d1b2d998839db2",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2030",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -53166,6 +53166,11 @@
         "at": "2026-06-11T05:16:00Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2030 for CAREER-ZH-PARITY-FIX-05 from head commit 733bf3f09ba7a528611b24cd0655a59de8c66cd1."
+      },
+      {
+        "at": "2026-06-11T05:23:00Z",
+        "status": "ready_to_merge",
+        "note": "PR #2030 GitHub checks passed for head 917783ca4b41d2f02e989d1499d1b2d998839db2; scope remains confined to PR05 allowed paths."
       }
     ]
   },

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19093,7 +19093,7 @@ prs:
     base: main
     title: "docs(foundation): add Daily Giving social sync readiness"
     train_scope: foundation_daily_giving_social_sync
-    status: pr_open_checks_pending
+    status: ready_to_merge
     scope:
       - Produce a read-only readiness/planning report for Foundation Daily Giving social sync.
       - Classify existing manual social URL support and future MVP boundaries.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19093,7 +19093,7 @@ prs:
     base: main
     title: "docs(foundation): add Daily Giving social sync readiness"
     train_scope: foundation_daily_giving_social_sync
-    status: local_verified_sidecar_external
+    status: pr_open_checks_pending
     scope:
       - Produce a read-only readiness/planning report for Foundation Daily Giving social sync.
       - Classify existing manual social URL support and future MVP boundaries.

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -19093,7 +19093,7 @@ prs:
     base: main
     title: "docs(foundation): add Daily Giving social sync readiness"
     train_scope: foundation_daily_giving_social_sync
-    status: in_progress
+    status: local_verified_sidecar_external
     scope:
       - Produce a read-only readiness/planning report for Foundation Daily Giving social sync.
       - Classify existing manual social URL support and future MVP boundaries.
@@ -24320,7 +24320,7 @@ prs:
     branch: codex/career-zh-parity-fix-04
     title: "CAREER-ZH-PARITY-FIX-04: feat(career): controlled zh display import cache refresh"
     train_scope: career_zh_parity_fix
-    status: local_verified_sidecar_external
+    status: merged
     scope:
       - Add chunked controlled import execution support for the reviewed Chinese display parity manifest.
       - Clear and warm per-slug zh-CN job detail cache after successful imports.
@@ -24366,7 +24366,7 @@ prs:
     branch: codex/career-zh-parity-fix-05
     title: "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy"
     train_scope: career_zh_parity_fix
-    status: pending_dependency
+    status: in_progress
     scope:
       - Align runtime integrity policy so reviewed display_asset-backed pages are not misclassified as restricted shells when module and claim boundaries are satisfied.
       - Preserve public claim limits, noindex/sitemap/llms gates, and private/admin metadata exclusions.


### PR DESCRIPTION
## What changed
- Treat CTA controls as shared action affordances instead of Chinese locale content-authority blockers in the display surface readiness gate.
- Added a regression test proving reviewed Chinese display content stays display_asset-backed even when the CTA label is shared English copy.
- Preserved the existing negative case where an English Chinese-locale hero still falls back to the restricted runtime-published shell.
- Reconciled CAREER-ZH-PARITY-FIX-04 post-merge metadata and recorded PR05 local validation state.

## Why
Reviewed Chinese career display assets should not be misclassified as restricted shells solely because an action-control label is shared across locales. Content-bearing Chinese modules, explicit locale readiness flags, claim permissions, public release/index gates, and forbidden metadata exclusions remain enforced.

## Validation commands
- `php -l backend/app/Services/Career/Bundles/CareerLocaleIntegrityGate.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career/CareerJobDetailApiTest.php --filter='shared_english_cta|locale_surface_is_english' --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Unit/Services/Career/CareerJobDisplaySurfaceBuilderTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/Career tests/Feature/Career tests/Unit/Services/Career`
- `php -r 'json_decode(file_get_contents("docs/codex/pr-train-state.json"), true, 512, JSON_THROW_ON_ERROR); echo "state json ok\n";'`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'train yaml ok'"`
- `git diff --check`
- `git diff --cached --check`

## External sidecar
- The manifest broad Career feature/unit suite still fails on the pre-existing `FirstWavePublishReadyValidator::validationMemoKey()` blocker and downstream readiness assertions. Recorded as `CAREER-ZH-PARITY-FIX-05-SIDECAR-01`; PR05 did not touch FirstWave publish readiness files.

## Intentionally deferred
- No CMS import or production publish.
- No deploy.
- No fap-web changes.
- No sitemap, llms, URL submission, or indexability strategy changes.
