### PR TITLE
feat(seo): refresh MBTI personality variant metadata

### DIFF
--- a/backend/app/Console/Commands/PersonalityRefreshMbtiVariantSeoMetadata.php
+++ b/backend/app/Console/Commands/PersonalityRefreshMbtiVariantSeoMetadata.php
@@ -1,0 +1,223 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use App\Services\Cms\MbtiPersonalityVariantSeoMetadataService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class PersonalityRefreshMbtiVariantSeoMetadata extends Command
+{
+    protected $signature = 'personality:refresh-mbti-variant-seo-metadata
+        {--locale=* : Locale to refresh, defaults to en and zh-CN}
+        {--type=* : Canonical MBTI type code to refresh, defaults to all 16 types}
+        {--dry-run : Preview changes without writing}
+        {--json : Emit a machine-readable JSON summary}
+        {--assert-complete : Fail when the selected locale/type scope is missing any A/T variant}';
+
+    protected $description = 'Refresh MBTI personality variant SEO metadata without changing profile content, sections, publication state, canonical, or robots.';
+
+    public function handle(MbtiPersonalityVariantSeoMetadataService $metadataService): int
+    {
+        $locales = $this->selectedLocales();
+        $types = $this->selectedTypes();
+        $dryRun = (bool) $this->option('dry-run');
+        $assertComplete = (bool) $this->option('assert-complete');
+        $summary = [
+            'dry_run' => $dryRun,
+            'locales' => $locales,
+            'types' => $types,
+            'expected_variants' => count($locales) * count($types) * 2,
+            'profiles_scanned' => 0,
+            'variants_scanned' => 0,
+            'metadata_changes' => 0,
+            'writes_committed' => 0,
+            'missing_variants' => [],
+            'sample_changes' => [],
+        ];
+
+        $seen = [];
+        $profiles = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->whereIn('locale', $locales)
+            ->whereIn('type_code', $types)
+            ->with(['variants.seoMeta'])
+            ->orderBy('locale')
+            ->orderBy('type_code')
+            ->get();
+
+        $summary['profiles_scanned'] = $profiles->count();
+
+        foreach ($profiles as $profile) {
+            foreach ($profile->variants as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant) {
+                    continue;
+                }
+
+                if (! in_array((string) $variant->variant_code, ['A', 'T'], true)) {
+                    continue;
+                }
+
+                $runtimeTypeCode = (string) $variant->runtime_type_code;
+                $seen[(string) $profile->locale.'|'.$runtimeTypeCode] = true;
+                $summary['variants_scanned']++;
+
+                $desired = $metadataService->build(
+                    $runtimeTypeCode,
+                    (string) $profile->locale,
+                    $this->profileTypeName($profile),
+                );
+
+                if (! $this->metadataNeedsRefresh($variant, $desired)) {
+                    continue;
+                }
+
+                $summary['metadata_changes']++;
+                if (count($summary['sample_changes']) < 8) {
+                    $summary['sample_changes'][] = [
+                        'locale' => (string) $profile->locale,
+                        'runtime_type_code' => $runtimeTypeCode,
+                        'seo_title' => $desired['seo_title'],
+                    ];
+                }
+
+                if ($dryRun) {
+                    continue;
+                }
+
+                DB::transaction(function () use ($variant, $desired): void {
+                    PersonalityProfileVariantSeoMeta::query()->updateOrCreate(
+                        ['personality_profile_variant_id' => (int) $variant->id],
+                        $desired,
+                    );
+                });
+
+                $summary['writes_committed']++;
+            }
+        }
+
+        foreach ($locales as $locale) {
+            foreach ($types as $type) {
+                foreach (['A', 'T'] as $variant) {
+                    $runtimeTypeCode = $type.'-'.$variant;
+                    if (! isset($seen[$locale.'|'.$runtimeTypeCode])) {
+                        $summary['missing_variants'][] = [
+                            'locale' => $locale,
+                            'runtime_type_code' => $runtimeTypeCode,
+                        ];
+                    }
+                }
+            }
+        }
+
+        $this->emitSummary($summary);
+
+        if ($assertComplete && $summary['missing_variants'] !== []) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedLocales(): array
+    {
+        $input = array_map('strval', (array) $this->option('locale'));
+        $locales = $input === [] ? PersonalityProfile::SUPPORTED_LOCALES : array_map(static function (string $locale): string {
+            $normalized = trim($locale);
+
+            return $normalized === 'zh' ? 'zh-CN' : $normalized;
+        }, $input);
+
+        $locales = array_values(array_unique($locales));
+        sort($locales);
+
+        foreach ($locales as $locale) {
+            if (! in_array($locale, PersonalityProfile::SUPPORTED_LOCALES, true)) {
+                $this->fail('Unsupported locale: '.$locale);
+            }
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedTypes(): array
+    {
+        $input = array_map('strval', (array) $this->option('type'));
+        $types = $input === [] ? PersonalityProfile::BASE_TYPE_CODES : array_map(
+            static fn (string $type): string => strtoupper(trim($type)),
+            $input,
+        );
+
+        $types = array_values(array_unique($types));
+        sort($types);
+
+        foreach ($types as $type) {
+            if (! in_array($type, PersonalityProfile::BASE_TYPE_CODES, true)) {
+                $this->fail('Unsupported MBTI type code: '.$type);
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param  array<string, string>  $desired
+     */
+    private function metadataNeedsRefresh(PersonalityProfileVariant $variant, array $desired): bool
+    {
+        $variant->loadMissing('seoMeta');
+        $current = $variant->seoMeta;
+
+        if (! $current instanceof PersonalityProfileVariantSeoMeta) {
+            return true;
+        }
+
+        foreach ($desired as $field => $value) {
+            if ((string) ($current->{$field} ?? '') !== $value) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private function profileTypeName(PersonalityProfile $profile): ?string
+    {
+        $typeName = trim((string) ($profile->type_name ?? ''));
+
+        return $typeName !== '' ? $typeName : null;
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('dry_run='.($summary['dry_run'] ? 'true' : 'false'));
+        $this->line('expected_variants='.$summary['expected_variants']);
+        $this->line('profiles_scanned='.$summary['profiles_scanned']);
+        $this->line('variants_scanned='.$summary['variants_scanned']);
+        $this->line('metadata_changes='.$summary['metadata_changes']);
+        $this->line('writes_committed='.$summary['writes_committed']);
+        $this->line('missing_variants='.count((array) $summary['missing_variants']));
+    }
+}

--- a/backend/app/Services/Cms/MbtiPersonalityVariantSeoMetadataService.php
+++ b/backend/app/Services/Cms/MbtiPersonalityVariantSeoMetadataService.php
@@ -1,0 +1,108 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use InvalidArgumentException;
+
+final class MbtiPersonalityVariantSeoMetadataService
+{
+    /**
+     * @return list<string>
+     */
+    public function supportedRuntimeTypeCodes(): array
+    {
+        $codes = [];
+
+        foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+            $codes[] = $typeCode.'-A';
+            $codes[] = $typeCode.'-T';
+        }
+
+        sort($codes);
+
+        return $codes;
+    }
+
+    /**
+     * @return array{
+     *   seo_title:string,
+     *   seo_description:string,
+     *   og_title:string,
+     *   og_description:string,
+     *   twitter_title:string,
+     *   twitter_description:string
+     * }
+     */
+    public function build(string $runtimeTypeCode, string $locale, ?string $typeName = null): array
+    {
+        $runtimeTypeCode = strtoupper(trim($runtimeTypeCode));
+        $locale = $this->normalizeLocale($locale);
+        $typeName = $this->normalizeTypeName($typeName);
+
+        if (! in_array($runtimeTypeCode, $this->supportedRuntimeTypeCodes(), true)) {
+            throw new InvalidArgumentException('Unsupported MBTI runtime type code for personality SEO metadata.');
+        }
+
+        $typeLabel = $this->typeLabel($runtimeTypeCode, $typeName, $locale);
+
+        if ($locale === 'zh-CN') {
+            $title = $typeLabel.'人格：特点、爱情、职业与适合工作';
+            $description = '了解 '.$typeLabel.'人格的核心特点、优势盲点、爱情关系、职业倾向与适合工作，并通过 MBTI 测试确认自己的类型。';
+        } else {
+            $title = $typeLabel.' Personality: Traits, Careers & Relationships';
+            $description = 'Explore the '.$typeLabel.' personality type, including traits, strengths, blind spots, relationships, career fit, and how to confirm your type with an MBTI test.';
+        }
+
+        return [
+            'seo_title' => $title,
+            'seo_description' => $description,
+            'og_title' => $title,
+            'og_description' => $description,
+            'twitter_title' => $title,
+            'twitter_description' => $description,
+        ];
+    }
+
+    private function typeLabel(string $runtimeTypeCode, ?string $typeName, string $locale): string
+    {
+        if ($typeName === null) {
+            return $runtimeTypeCode;
+        }
+
+        return $locale === 'zh-CN'
+            ? $runtimeTypeCode.' '.$typeName
+            : $runtimeTypeCode.' '.$typeName;
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = trim($locale);
+
+        if ($normalized === 'zh') {
+            return 'zh-CN';
+        }
+
+        if (in_array($normalized, PersonalityProfile::SUPPORTED_LOCALES, true)) {
+            return $normalized;
+        }
+
+        throw new InvalidArgumentException('Unsupported locale for MBTI personality SEO metadata.');
+    }
+
+    private function normalizeTypeName(?string $typeName): ?string
+    {
+        $normalized = trim((string) $typeName);
+
+        if ($normalized === '') {
+            return null;
+        }
+
+        $normalized = preg_replace('/\s+/', ' ', $normalized) ?: $normalized;
+        $normalized = preg_replace('/[-－](?:A|T)$/i', '', $normalized) ?: $normalized;
+
+        return trim($normalized) !== '' ? trim($normalized) : null;
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityRefreshMbtiVariantSeoMetadataCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityRefreshMbtiVariantSeoMetadataCommandTest.php
@@ -1,0 +1,197 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityRefreshMbtiVariantSeoMetadataCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_reports_complete_64_variant_scope_without_writes(): void
+    {
+        $this->createMbtiVariantMatrix();
+
+        $this->artisan('personality:refresh-mbti-variant-seo-metadata', [
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=64')
+            ->expectsOutputToContain('variants_scanned=64')
+            ->expectsOutputToContain('metadata_changes=64')
+            ->expectsOutputToContain('writes_committed=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, PersonalityProfileVariantSeoMeta::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_command_refreshes_all_variant_seo_metadata_without_touching_canonical_or_robots(): void
+    {
+        $variants = $this->createMbtiVariantMatrix();
+        PersonalityProfileVariantSeoMeta::query()->create([
+            'personality_profile_variant_id' => (int) $variants['zh-CN|INFP-T']->id,
+            'seo_title' => 'Old INFP-T title',
+            'seo_description' => 'Old INFP-T description',
+            'canonical_url' => 'https://fermatmind.com/zh/personality/infp-t',
+            'og_title' => 'Old OG title',
+            'og_description' => 'Old OG description',
+            'og_image_url' => null,
+            'twitter_title' => 'Old Twitter title',
+            'twitter_description' => 'Old Twitter description',
+            'twitter_image_url' => null,
+            'robots' => 'index,follow',
+            'jsonld_overrides_json' => null,
+        ]);
+
+        $this->artisan('personality:refresh-mbti-variant-seo-metadata', [
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=64')
+            ->expectsOutputToContain('variants_scanned=64')
+            ->expectsOutputToContain('writes_committed=64')
+            ->expectsOutputToContain('missing_variants=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(64, PersonalityProfileVariantSeoMeta::query()->withoutGlobalScopes()->count());
+
+        $infpT = PersonalityProfileVariantSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['zh-CN|INFP-T']->id)
+            ->firstOrFail();
+
+        $this->assertSame('INFP-T 调停者人格：特点、爱情、职业与适合工作', $infpT->seo_title);
+        $this->assertStringContainsString('核心特点', (string) $infpT->seo_description);
+        $this->assertStringContainsString('爱情关系', (string) $infpT->seo_description);
+        $this->assertStringContainsString('职业倾向', (string) $infpT->seo_description);
+        $this->assertSame($infpT->seo_title, $infpT->og_title);
+        $this->assertSame($infpT->seo_description, $infpT->og_description);
+        $this->assertSame($infpT->seo_title, $infpT->twitter_title);
+        $this->assertSame($infpT->seo_description, $infpT->twitter_description);
+        $this->assertSame('https://fermatmind.com/zh/personality/infp-t', $infpT->canonical_url);
+        $this->assertSame('index,follow', $infpT->robots);
+
+        $enfpA = PersonalityProfileVariantSeoMeta::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['en|ENFP-A']->id)
+            ->firstOrFail();
+
+        $this->assertSame('ENFP-A Campaigner Personality: Traits, Careers & Relationships', $enfpA->seo_title);
+        $this->assertStringContainsString('traits', (string) $enfpA->seo_description);
+        $this->assertStringContainsString('relationships', (string) $enfpA->seo_description);
+        $this->assertStringContainsString('career fit', (string) $enfpA->seo_description);
+        $this->assertSame($enfpA->seo_title, $enfpA->og_title);
+        $this->assertSame($enfpA->seo_description, $enfpA->twitter_description);
+    }
+
+    public function test_assert_complete_fails_when_selected_variant_scope_is_missing(): void
+    {
+        $profile = $this->createProfile('en', 'INFP', 'Mediator');
+        $this->createVariant($profile, 'INFP-A');
+
+        $this->artisan('personality:refresh-mbti-variant-seo-metadata', [
+            '--locale' => ['en'],
+            '--type' => ['INFP'],
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=2')
+            ->expectsOutputToContain('variants_scanned=1')
+            ->expectsOutputToContain('missing_variants=1')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * @return array<string, PersonalityProfileVariant>
+     */
+    private function createMbtiVariantMatrix(): array
+    {
+        $typeNames = [
+            'ENFJ' => ['en' => 'Protagonist', 'zh-CN' => '主人公'],
+            'ENFP' => ['en' => 'Campaigner', 'zh-CN' => '竞选者'],
+            'ENTJ' => ['en' => 'Commander', 'zh-CN' => '指挥官'],
+            'ENTP' => ['en' => 'Debater', 'zh-CN' => '辩论家'],
+            'ESFJ' => ['en' => 'Consul', 'zh-CN' => '执政官'],
+            'ESFP' => ['en' => 'Entertainer', 'zh-CN' => '表演者'],
+            'ESTJ' => ['en' => 'Executive', 'zh-CN' => '总经理'],
+            'ESTP' => ['en' => 'Entrepreneur', 'zh-CN' => '企业家'],
+            'INFJ' => ['en' => 'Advocate', 'zh-CN' => '提倡者'],
+            'INFP' => ['en' => 'Mediator', 'zh-CN' => '调停者'],
+            'INTJ' => ['en' => 'Architect', 'zh-CN' => '建筑师'],
+            'INTP' => ['en' => 'Logician', 'zh-CN' => '逻辑学家'],
+            'ISFJ' => ['en' => 'Defender', 'zh-CN' => '守卫者'],
+            'ISFP' => ['en' => 'Adventurer', 'zh-CN' => '探险家'],
+            'ISTJ' => ['en' => 'Logistician', 'zh-CN' => '物流师'],
+            'ISTP' => ['en' => 'Virtuoso', 'zh-CN' => '鉴赏家'],
+        ];
+        $variants = [];
+
+        foreach (PersonalityProfile::SUPPORTED_LOCALES as $locale) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $profile = $this->createProfile($locale, $typeCode, $typeNames[$typeCode][$locale]);
+                foreach (['A', 'T'] as $variantCode) {
+                    $runtimeTypeCode = $typeCode.'-'.$variantCode;
+                    $variants[$locale.'|'.$runtimeTypeCode] = $this->createVariant($profile, $runtimeTypeCode);
+                }
+            }
+        }
+
+        return $variants;
+    }
+
+    private function createProfile(string $locale, string $typeCode, string $typeName): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' - '.$typeName,
+            'type_name' => $typeName,
+            'nickname' => $typeName,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'subtitle' => null,
+            'excerpt' => null,
+            'hero_kicker' => $typeName,
+            'hero_quote' => null,
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'hero_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    private function createVariant(PersonalityProfile $profile, string $runtimeTypeCode): PersonalityProfileVariant
+    {
+        [$typeCode, $variantCode] = explode('-', $runtimeTypeCode);
+
+        return PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => $typeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'type_name' => null,
+            'nickname' => null,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -240,6 +240,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_personality_variant_seo_metadata_refresh_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityRefreshMbtiVariantSeoMetadata.php',
+            'backend/app/Services/Cms/MbtiPersonalityVariantSeoMetadataService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_cross_assessment_context_guard_changes(): void
     {
         $changed = [
@@ -2767,6 +2777,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiPersonalityVariantSeoMetadataRefreshFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -3516,6 +3530,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
             'backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php',
             'backend/app/Services/Experiments/ExperimentAssigner.php',
+        ], true);
+    }
+
+    private function isMbtiPersonalityVariantSeoMetadataRefreshFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityRefreshMbtiVariantSeoMetadata.php',
+            'backend/app/Services/Cms/MbtiPersonalityVariantSeoMetadataService.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Adds a metadata-only command to refresh MBTI personality variant SEO fields for zh/en × 16 types × A/T variants.
- Adds a reusable service that builds intent-bearing title, description, OG, and Twitter copy from runtime type code plus profile type name.
- Adds focused tests for dry-run coverage, 64-variant writes, completeness failure, and preservation of canonical/robots fields.

## Why
GSC is already surfacing MBTI personality detail pages, but current search snippets are too weak for type-intent queries. This keeps fap-api/CMS as the authority for public SEO metadata and avoids hardcoding personality SEO copy in fap-web.

## Validation
- php artisan test --filter PersonalityRefreshMbtiVariantSeoMetadataCommandTest
- ./vendor/bin/pint --dirty
- php artisan test tests/Feature/Console/PersonalityRefreshMbtiVariantSeoMetadataCommandTest.php tests/Feature/PersonalityCms/PersonalityVariantAuthorityTest.php
- php -l app/Services/Cms/MbtiPersonalityVariantSeoMetadataService.php
- php -l app/Console/Commands/PersonalityRefreshMbtiVariantSeoMetadata.php
- php -l tests/Feature/Console/PersonalityRefreshMbtiVariantSeoMetadataCommandTest.php
- git diff --check

## Intentionally deferred
- No production command execution.
- No CMS article/content rewrite.
- No frontend H1/hero rendering change.
- No deployment, scheduler, sitemap submission, or search console action.

## Repository rule impact
Backend CMS remains the authority for personality profile SEO. This PR adds a metadata-only backend command and does not move public personality SEO authority to fap-web.