### PR TITLE
CAREER-ZH-PARITY-FIX-06: chore(career): assert final zh display parity

### DIFF
--- a/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+++ b/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
@@ -16,7 +16,7 @@ use Throwable;
 
 final class CareerAuditZhDisplayParity extends Command
 {
-    private const VALIDATOR_VERSION = 'career_zh_display_parity_audit_v0.1';
+    private const VALIDATOR_VERSION = 'career_zh_display_parity_audit_v0.2';
 
     private const DEFAULT_API_BASE = 'https://api.fermatmind.com/api/v0.5/career/jobs';
 
@@ -257,15 +257,8 @@ final class CareerAuditZhDisplayParity extends Command
     {
         $restrictedShellCount = 0;
         foreach ($items as $item) {
-            $reasons = (array) ($item['zh_gate_reasons'] ?? []);
-            foreach ($reasons as $reason) {
-                $reason = (string) $reason;
-                if (str_contains($reason, 'runtime_published_shell')
-                    || str_contains($reason, 'critical_missing_field:')) {
-                    $restrictedShellCount++;
-
-                    break;
-                }
+            if ($this->hasRuntimePublishedShellReason((array) ($item['zh_gate_reasons'] ?? []))) {
+                $restrictedShellCount++;
             }
         }
 
@@ -301,6 +294,20 @@ final class CareerAuditZhDisplayParity extends Command
             'llms_changed' => false,
             'index_strategy_changed' => false,
         ];
+    }
+
+    /**
+     * @param  list<mixed>  $reasons
+     */
+    private function hasRuntimePublishedShellReason(array $reasons): bool
+    {
+        foreach ($reasons as $reason) {
+            if (str_contains((string) $reason, 'runtime_published_shell')) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/docs/career/generated/career-zh-parity-fix-06-live-report.json
+++ b/backend/docs/career/generated/career-zh-parity-fix-06-live-report.json
@@ -1,0 +1,932 @@
+{
+    "validator_version": "career_zh_display_parity_audit_v0.2",
+    "decision": "blocked",
+    "read_only": true,
+    "writes_database": false,
+    "cms_mutation": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "index_strategy_changed": false,
+    "api_base": "https://api.fermatmind.com/api/v0.5/career/jobs",
+    "site_base": "https://fermatmind.com",
+    "scan_scope": "public_index_union",
+    "assert_live_parity": true,
+    "live_gate": {
+        "decision": "blocked",
+        "blockers": [
+            "zh_missing_en_display_modules",
+            "zh_restricted_shell_or_integrity_gap"
+        ],
+        "total_slugs": 1046,
+        "same_module_set": 374,
+        "module_mismatch_count": 672,
+        "restricted_shell_count": 237,
+        "api_failure_count": 0,
+        "index_mismatch_count": 0,
+        "sitemap_changed": false,
+        "llms_changed": false,
+        "index_strategy_changed": false
+    },
+    "summary": {
+        "total_slugs": 1046,
+        "en_index_count": 1046,
+        "zh_index_count": 1046,
+        "index_en_only_count": 0,
+        "index_zh_only_count": 0,
+        "same_module_set": 374,
+        "en_has_modules_zh_missing": 672,
+        "zh_has_modules_en_missing": 0,
+        "en_200_zh_not_200": 0,
+        "zh_200_en_not_200": 0,
+        "both_missing_or_failed": 0,
+        "api_failure_count": 0,
+        "classification_counts": {
+            "same_module_set": 374,
+            "en_has_modules_zh_missing": 672
+        },
+        "index_failures": [],
+        "samples": {
+            "same_module_set": [
+                {
+                    "slug": "accountants-and-auditors",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/accountants-and-auditors",
+                        "zh": "https://fermatmind.com/zh/career/jobs/accountants-and-auditors",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/accountants-and-auditors?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:fit_score.provisional",
+                        "amber_flag:strain_score.restricted",
+                        "amber_flag:ai_survival_score.provisional",
+                        "critical_missing_field:task_prototype_signature",
+                        "critical_missing_field:structural_stability"
+                    ]
+                },
+                {
+                    "slug": "actors",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/actors",
+                        "zh": "https://fermatmind.com/zh/career/jobs/actors",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/actors?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/actors?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 4,
+                        "zh-CN": 4,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "aerospace-engineers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/aerospace-engineers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/aerospace-engineers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 12,
+                        "zh-CN": 12,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:runtime_published_navigation_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "blocked_claim:display_asset_claims_unavailable",
+                        "integrity_state:runtime_published_shell",
+                        "critical_missing_field:compiled_recommendation_snapshot",
+                        "critical_missing_field:display_asset_claims"
+                    ]
+                },
+                {
+                    "slug": "agricultural-and-food-scientists",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-and-food-scientists",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-and-food-scientists",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-scientists?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-scientists?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 12,
+                        "zh-CN": 12,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:runtime_published_navigation_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "blocked_claim:display_asset_claims_unavailable",
+                        "integrity_state:runtime_published_shell",
+                        "critical_missing_field:compiled_recommendation_snapshot",
+                        "critical_missing_field:display_asset_claims"
+                    ]
+                },
+                {
+                    "slug": "agricultural-workers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-workers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-workers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-workers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-workers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 12,
+                        "zh-CN": 12,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:runtime_published_navigation_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "blocked_claim:display_asset_claims_unavailable",
+                        "integrity_state:runtime_published_shell",
+                        "critical_missing_field:compiled_recommendation_snapshot",
+                        "critical_missing_field:display_asset_claims"
+                    ]
+                },
+                {
+                    "slug": "animal-scientists",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/animal-scientists",
+                        "zh": "https://fermatmind.com/zh/career/jobs/animal-scientists",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-scientists?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-scientists?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "animal-trainers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/animal-trainers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/animal-trainers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-trainers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/animal-trainers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "announcers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/announcers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/announcers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/announcers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/announcers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 12,
+                        "zh-CN": 12,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:runtime_published_navigation_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "blocked_claim:display_asset_claims_unavailable",
+                        "integrity_state:runtime_published_shell",
+                        "critical_missing_field:compiled_recommendation_snapshot",
+                        "critical_missing_field:display_asset_claims"
+                    ]
+                },
+                {
+                    "slug": "anthropologists-and-archeologists",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/anthropologists-and-archeologists",
+                        "zh": "https://fermatmind.com/zh/career/jobs/anthropologists-and-archeologists",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropologists-and-archeologists?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropologists-and-archeologists?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 12,
+                        "zh-CN": 12,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:runtime_published_navigation_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "blocked_claim:display_asset_claims_unavailable",
+                        "integrity_state:runtime_published_shell",
+                        "critical_missing_field:compiled_recommendation_snapshot",
+                        "critical_missing_field:display_asset_claims"
+                    ]
+                },
+                {
+                    "slug": "anthropology-and-archeology-teachers-postsecondary",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/anthropology-and-archeology-teachers-postsecondary",
+                        "zh": "https://fermatmind.com/zh/career/jobs/anthropology-and-archeology-teachers-postsecondary",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropology-and-archeology-teachers-postsecondary?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/anthropology-and-archeology-teachers-postsecondary?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "appraisers-and-assessors-of-real-estate",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/appraisers-and-assessors-of-real-estate",
+                        "zh": "https://fermatmind.com/zh/career/jobs/appraisers-and-assessors-of-real-estate",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-and-assessors-of-real-estate?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-and-assessors-of-real-estate?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "appraisers-of-personal-and-business-property",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/appraisers-of-personal-and-business-property",
+                        "zh": "https://fermatmind.com/zh/career/jobs/appraisers-of-personal-and-business-property",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-of-personal-and-business-property?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/appraisers-of-personal-and-business-property?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "arbitrators-mediators-and-conciliators",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/arbitrators-mediators-and-conciliators",
+                        "zh": "https://fermatmind.com/zh/career/jobs/arbitrators-mediators-and-conciliators",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/arbitrators-mediators-and-conciliators?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/arbitrators-mediators-and-conciliators?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 12,
+                        "zh-CN": 12,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:runtime_published_navigation_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "blocked_claim:display_asset_claims_unavailable",
+                        "integrity_state:runtime_published_shell",
+                        "critical_missing_field:compiled_recommendation_snapshot",
+                        "critical_missing_field:display_asset_claims"
+                    ]
+                },
+                {
+                    "slug": "architects",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/architects",
+                        "zh": "https://fermatmind.com/zh/career/jobs/architects",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architects?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architects?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "architects-except-landscape-and-naval",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/architects-except-landscape-and-naval",
+                        "zh": "https://fermatmind.com/zh/career/jobs/architects-except-landscape-and-naval",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architects-except-landscape-and-naval?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architects-except-landscape-and-naval?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "architectural-and-civil-drafters",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/architectural-and-civil-drafters",
+                        "zh": "https://fermatmind.com/zh/career/jobs/architectural-and-civil-drafters",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-civil-drafters?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-civil-drafters?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "architectural-and-engineering-managers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/architectural-and-engineering-managers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/architectural-and-engineering-managers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-engineering-managers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architectural-and-engineering-managers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "architecture-teachers-postsecondary",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/architecture-teachers-postsecondary",
+                        "zh": "https://fermatmind.com/zh/career/jobs/architecture-teachers-postsecondary",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/architecture-teachers-postsecondary?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/architecture-teachers-postsecondary?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "archivists",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/archivists",
+                        "zh": "https://fermatmind.com/zh/career/jobs/archivists",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/archivists?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/archivists?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "area-ethnic-and-cultural-studies-teachers-postsecondary",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary",
+                        "zh": "https://fermatmind.com/zh/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/area-ethnic-and-cultural-studies-teachers-postsecondary?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 26,
+                        "en_only": 0,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                }
+            ],
+            "en_has_modules_zh_missing": [
+                {
+                    "slug": "actuaries",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/actuaries",
+                        "zh": "https://fermatmind.com/zh/career/jobs/actuaries",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/actuaries?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/actuaries?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "acupuncturists",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/acupuncturists",
+                        "zh": "https://fermatmind.com/zh/career/jobs/acupuncturists",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/acupuncturists?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/acupuncturists?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "acute-care-nurses",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/acute-care-nurses",
+                        "zh": "https://fermatmind.com/zh/career/jobs/acute-care-nurses",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/acute-care-nurses?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/acute-care-nurses?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "adapted-physical-education-specialists",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/adapted-physical-education-specialists",
+                        "zh": "https://fermatmind.com/zh/career/jobs/adapted-physical-education-specialists",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adapted-physical-education-specialists?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adapted-physical-education-specialists?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "adhesive-bonding-machine-operators-and-tenders",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/adhesive-bonding-machine-operators-and-tenders",
+                        "zh": "https://fermatmind.com/zh/career/jobs/adhesive-bonding-machine-operators-and-tenders",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adhesive-bonding-machine-operators-and-tenders?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adhesive-bonding-machine-operators-and-tenders?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "administrative-law-judges-adjudicators-and-hearing-officers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-law-judges-adjudicators-and-hearing-officers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "administrative-services-managers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/administrative-services-managers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/administrative-services-managers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-services-managers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/administrative-services-managers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+                        "zh": "https://fermatmind.com/zh/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-basic-education-adult-secondary-education-and-english-as-a-second-language-instructors?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "adult-literacy-and-ged-teachers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/adult-literacy-and-ged-teachers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/adult-literacy-and-ged-teachers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-literacy-and-ged-teachers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/adult-literacy-and-ged-teachers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "advanced-practice-psychiatric-nurses",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/advanced-practice-psychiatric-nurses",
+                        "zh": "https://fermatmind.com/zh/career/jobs/advanced-practice-psychiatric-nurses",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advanced-practice-psychiatric-nurses?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advanced-practice-psychiatric-nurses?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "advertising-and-promotions-managers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/advertising-and-promotions-managers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/advertising-and-promotions-managers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-and-promotions-managers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-and-promotions-managers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "advertising-promotions-and-marketing-managers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/advertising-promotions-and-marketing-managers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/advertising-promotions-and-marketing-managers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-promotions-and-marketing-managers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-promotions-and-marketing-managers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "advertising-sales-agents",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/advertising-sales-agents",
+                        "zh": "https://fermatmind.com/zh/career/jobs/advertising-sales-agents",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-sales-agents?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/advertising-sales-agents?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "aerospace-engineering-and-operations-technicians",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/aerospace-engineering-and-operations-technicians",
+                        "zh": "https://fermatmind.com/zh/career/jobs/aerospace-engineering-and-operations-technicians",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineering-and-operations-technicians?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/aerospace-engineering-and-operations-technicians?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "agents-and-business-managers-of-artists-performers-and-athletes",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agents-and-business-managers-of-artists-performers-and-athletes?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "agricultural-and-food-science-technicians",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-and-food-science-technicians",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-and-food-science-technicians",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-science-technicians?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-and-food-science-technicians?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "agricultural-engineers",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-engineers",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-engineers",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-engineers?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-engineers?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "agricultural-equipment-operators",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-equipment-operators",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-equipment-operators",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-equipment-operators?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-equipment-operators?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "agricultural-inspectors",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-inspectors",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-inspectors",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-inspectors?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-inspectors?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                },
+                {
+                    "slug": "agricultural-sciences-teachers-postsecondary",
+                    "sample_urls": {
+                        "en": "https://fermatmind.com/en/career/jobs/agricultural-sciences-teachers-postsecondary",
+                        "zh": "https://fermatmind.com/zh/career/jobs/agricultural-sciences-teachers-postsecondary",
+                        "api_en": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-sciences-teachers-postsecondary?locale=en",
+                        "api_zh": "https://api.fermatmind.com/api/v0.5/career/jobs/agricultural-sciences-teachers-postsecondary?locale=zh-CN"
+                    },
+                    "module_counts": {
+                        "en": 26,
+                        "zh-CN": 12,
+                        "en_only": 14,
+                        "zh_only": 0
+                    },
+                    "zh_gate_reasons": [
+                        "zh_missing_en_display_modules",
+                        "amber_flag:display_asset_backed_directory_draft_shell",
+                        "blocked_claim:compiled_recommendation_claims_unavailable",
+                        "integrity_state:display_asset_backed",
+                        "critical_missing_field:compiled_recommendation_snapshot"
+                    ]
+                }
+            ]
+        }
+    },
+    "items": [],
+    "next_prs": {
+        "controlled_import_required": "If live_gate.decision is blocked because zh pages remain restricted shells or structurally mismatched, run only an explicitly approved reviewed-workbook import/publish/cache refresh before asserting live parity."
+    }
+}

--- a/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
@@ -189,6 +189,40 @@ final class CareerAuditZhDisplayParityCommandTest extends TestCase
         $this->assertContains('zh_restricted_shell_or_integrity_gap', $report['live_gate']['blockers']);
     }
 
+    #[Test]
+    public function it_does_not_count_display_asset_missing_recommendation_snapshot_as_runtime_shell(): void
+    {
+        Http::fake([
+            'https://api.example.test/api/v0.5/career/jobs/display-asset-backed?locale=en' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'source_card',
+            ]), 200),
+            'https://api.example.test/api/v0.5/career/jobs/display-asset-backed?locale=zh-CN' => Http::response($this->detailPayload([
+                'hero',
+                'path',
+                'source_card',
+            ], criticalMissingFields: ['compiled_recommendation_snapshot']), 200),
+        ]);
+
+        $exitCode = Artisan::call('career:audit-zh-display-parity', [
+            '--api-base' => 'https://api.example.test/api/v0.5/career/jobs',
+            '--slugs' => 'display-asset-backed',
+            '--assert-live-parity' => true,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, Artisan::output());
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('pass', $report['live_gate']['decision']);
+        $this->assertSame(0, $report['live_gate']['restricted_shell_count']);
+        $this->assertContains(
+            'critical_missing_field:compiled_recommendation_snapshot',
+            $report['items'][0]['zh_gate_reasons'],
+        );
+    }
+
     /**
      * @param  list<string>  $slugs
      * @return array<string, mixed>

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53092,7 +53092,7 @@
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-05",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "merged",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy",
     "depends_on": [
@@ -53127,15 +53127,19 @@
       },
       "github_checks": {
         "status": "pass",
-        "evidence": "GitHub checks passed for PR #2030 head 917783ca4b41d2f02e989d1499d1b2d998839db2: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+        "evidence": "GitHub checks passed for PR #2030 head 99950f3fec3f384bf116b83e0bc776bf78e2698e: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "post_merge_reconciliation": {
+        "status": "pass",
+        "evidence": "GitHub PR #2030 is MERGED; origin/main contains merge commit 0f6152ae29e3576caa930495ec0578469dec60a8; remote branch codex/career-zh-parity-fix-05 is deleted; local PR05 worktree/branch were removed after merge."
       }
     },
     "failure_reason": null,
-    "commit_sha": "917783ca4b41d2f02e989d1499d1b2d998839db2",
+    "commit_sha": "99950f3fec3f384bf116b83e0bc776bf78e2698e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2030",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T05:32:43Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [
       {
         "id": "CAREER-ZH-PARITY-FIX-05-SIDECAR-01",
@@ -53171,14 +53175,20 @@
         "at": "2026-06-11T05:23:00Z",
         "status": "ready_to_merge",
         "note": "PR #2030 GitHub checks passed for head 917783ca4b41d2f02e989d1499d1b2d998839db2; scope remains confined to PR05 allowed paths."
+      },
+      {
+        "at": "2026-06-11T05:49:48Z",
+        "status": "merged",
+        "note": "Reconciled during CAREER-ZH-PARITY-FIX-06 preflight after PR #2030 merge, origin/main containment, branch deletion, and local cleanup."
       }
-    ]
+    ],
+    "merge_commit_sha": "0f6152ae29e3576caa930495ec0578469dec60a8"
   },
   "CAREER-ZH-PARITY-FIX-06": {
     "repo": "fap-api",
     "branch": "codex/career-zh-parity-fix-06",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "ready_to_merge",
     "train_scope": "career_zh_parity_fix",
     "title": "CAREER-ZH-PARITY-FIX-06: chore(career): assert final zh display parity",
     "depends_on": [
@@ -53190,22 +53200,74 @@
         "evidence": "User explicitly authorized adding and executing CAREER-ZH-PARITY-FIX-01 through CAREER-ZH-PARITY-FIX-06, including fap-api docs/codex metadata updates, on 2026-06-11."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-ZH-PARITY-FIX-05 to merge."
+        "status": "pass",
+        "evidence": "CAREER-ZH-PARITY-FIX-05 merged as PR #2030 at 2026-06-11T05:32:43Z; origin/main contains 0f6152ae29e3576caa930495ec0578469dec60a8."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to CareerAuditZhDisplayParity, its focused console test, backend/docs/career/generated/career-zh-parity-fix-06-live-report.json, and docs/codex metadata; no fap-web, publish, deploy, sitemap, llms, or index strategy files changed."
+      },
+      "local": {
+        "status": "pass_with_external_sidecar",
+        "commands": [
+          "php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi",
+          "cd backend && php artisan career:audit-zh-display-parity --json --summary-only --assert-live-parity --output=docs/career/generated/career-zh-parity-fix-06-live-report.json",
+          "python3 -m json.tool backend/docs/career/generated/career-zh-parity-fix-06-live-report.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check",
+          "git diff --cached --check"
+        ],
+        "notes": "PHP lint and focused console tests passed. The live read-only parity gate completed and wrote the PR06 report, but exited 1 because production still has 672 EN-only zh module gaps and 237 runtime published shell signals; API failures, public index mismatch, sitemap changes, llms changes, and index strategy changes are all zero/false. This is recorded as an external sidecar blocker not introduced by PR06."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2032 head a10e9de005c4bfe7eb2fd1f90ae583a80609d77f: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "a10e9de005c4bfe7eb2fd1f90ae583a80609d77f",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2032",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
-    "sidecar_issues": [],
+    "sidecar_issues": [
+      {
+        "id": "CAREER-ZH-PARITY-FIX-06-SIDECAR-01",
+        "status": "open",
+        "severity": "external",
+        "title": "Production career zh live parity still blocked after final read-only gate",
+        "evidence": "career:audit-zh-display-parity v0.2 scanned 1046 production career job slugs: EN/ZH API/index parity is 1046/1046 with api_failure_count=0 and index_mismatch_count=0, but same_module_set=374, en_has_modules_zh_missing=672, zh_has_modules_en_missing=0, and restricted_shell_count=237. sitemap_changed=false, llms_changed=false, index_strategy_changed=false. Generated report: backend/docs/career/generated/career-zh-parity-fix-06-live-report.json.",
+        "introduced_by_current_pr": false,
+        "required_followup": "Requires explicitly approved backend production deployment/import/cache refresh or equivalent controlled content operation before assert-live-parity can pass."
+      }
+    ],
     "transitions": [
       {
         "at": "2026-06-11T02:19:47Z",
         "status": "pending_dependency",
         "note": "Future final live parity gate entry initialized only; implementation deferred until CAREER-ZH-PARITY-FIX-05 is merged."
+      },
+      {
+        "at": "2026-06-11T05:49:48Z",
+        "status": "in_progress",
+        "note": "Started from origin/main after PR05 merge; implementing final read-only parity gate/report hardening."
+      },
+      {
+        "at": "2026-06-11T05:49:48Z",
+        "status": "local_verified_sidecar_external",
+        "note": "Focused lint/test and report JSON parse passed; production live gate remains blocked by external zh module/runtime-shell parity state recorded as sidecar."
+      },
+      {
+        "at": "2026-06-11T05:56:00Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2032 for CAREER-ZH-PARITY-FIX-06 from head commit 1135dfb5b3afbc4f8f2a6d25d336b7445a57721a."
+      },
+      {
+        "at": "2026-06-11T06:03:30Z",
+        "status": "ready_to_merge",
+        "note": "PR #2032 GitHub checks passed; scope remains confined to PR06 allowed paths. Live parity blocker remains external sidecar."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24366,7 +24366,7 @@ prs:
     branch: codex/career-zh-parity-fix-05
     title: "CAREER-ZH-PARITY-FIX-05: fix(career): align display-asset integrity release policy"
     train_scope: career_zh_parity_fix
-    status: in_progress
+    status: merged
     scope:
       - Align runtime integrity policy so reviewed display_asset-backed pages are not misclassified as restricted shells when module and claim boundaries are satisfied.
       - Preserve public claim limits, noindex/sitemap/llms gates, and private/admin metadata exclusions.
@@ -24403,7 +24403,7 @@ prs:
     branch: codex/career-zh-parity-fix-06
     title: "CAREER-ZH-PARITY-FIX-06: chore(career): assert final zh display parity"
     train_scope: career_zh_parity_fix
-    status: pending_dependency
+    status: local_verified_sidecar_external
     scope:
       - Run and harden the final live parity gate for all 1046 public career job slugs.
       - Assert EN/ZH API 200 parity, zero English-module-only Chinese gaps, zero unexpected restricted shells, and unchanged sitemap/llms/index strategy.


### PR DESCRIPTION
## What changed
- Hardened the read-only `career:audit-zh-display-parity` gate so `restricted_shell_count` counts actual `runtime_published_shell` signals instead of every critical-missing advisory.
- Added focused console coverage that a reviewed `display_asset_backed` zh page missing only the recommendation snapshot is not counted as a runtime restricted shell.
- Committed the current production live parity report at `backend/docs/career/generated/career-zh-parity-fix-06-live-report.json`.
- Reconciled `CAREER-ZH-PARITY-FIX-05` merge state and recorded the current PR06 live parity blocker as an external sidecar issue.

## Why
The final parity gate needs to distinguish real runtime shell pages from display-asset-backed pages that still carry non-public recommendation warnings. The current production scan remains blocked, but the remaining blocker is content/import/cache state rather than a PR06 code regression.

## Validation commands
- `php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerAuditZhDisplayParity.php tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php`
- `cd backend && php artisan career:audit-zh-display-parity --json --summary-only --assert-live-parity --output=docs/career/generated/career-zh-parity-fix-06-live-report.json` exited 1 as expected for the external production live parity blocker and wrote the report.
- `python3 -m json.tool backend/docs/career/generated/career-zh-parity-fix-06-live-report.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- `git diff --cached --check`

## Current live gate result
- total slugs: 1046
- EN/ZH index parity: 1046 / 1046
- API failures: 0
- index mismatch: 0
- same module set: 374
- EN has modules that ZH lacks: 672
- ZH has modules that EN lacks: 0
- runtime restricted shell signals: 237
- sitemap changed: false
- llms changed: false
- index strategy changed: false

## Intentionally deferred
- No production deploy.
- No production import or publish execution.
- No sitemap, llms.txt, or indexability changes.
- No fap-web changes.
- Clearing the live blocker requires a separately approved backend deployment/import/cache refresh or equivalent controlled content operation.
