### PR TITLE
feat(cms): define MBTI personality page section structure

### DIFF
--- a/backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php
+++ b/backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Services\Cms\MbtiPersonalityVariantSectionStructureService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class PersonalityEnsureMbtiVariantSectionStructure extends Command
+{
+    protected $signature = 'personality:ensure-mbti-variant-section-structure
+        {--locale=* : Locale to ensure, defaults to en and zh-CN}
+        {--type=* : Canonical MBTI type code to ensure, defaults to all 16 types}
+        {--dry-run : Preview changes without writing}
+        {--json : Emit a machine-readable JSON summary}
+        {--assert-complete : Fail when the selected locale/type scope is missing any A/T variant}';
+
+    protected $description = 'Ensure MBTI personality variant pages have the canonical section structure without publishing articles, changing sitemap, or submitting search surfaces.';
+
+    public function handle(MbtiPersonalityVariantSectionStructureService $structureService): int
+    {
+        $locales = $this->selectedLocales();
+        $types = $this->selectedTypes();
+        $dryRun = (bool) $this->option('dry-run');
+        $requiredSectionKeys = $structureService->requiredSectionKeys();
+        $summary = [
+            'dry_run' => $dryRun,
+            'locales' => $locales,
+            'types' => $types,
+            'required_section_keys' => $requiredSectionKeys,
+            'expected_variants' => count($locales) * count($types) * 2,
+            'variants_scanned' => 0,
+            'expected_required_sections' => count($locales) * count($types) * 2 * count($requiredSectionKeys),
+            'existing_required_sections' => 0,
+            'section_changes' => 0,
+            'writes_committed' => 0,
+            'preserved_existing_sections' => 0,
+            'missing_variants' => [],
+            'sample_changes' => [],
+        ];
+
+        $seen = [];
+        $profiles = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->whereIn('locale', $locales)
+            ->whereIn('type_code', $types)
+            ->with(['variants.sections'])
+            ->orderBy('locale')
+            ->orderBy('type_code')
+            ->get();
+
+        foreach ($profiles as $profile) {
+            foreach ($profile->variants as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant) {
+                    continue;
+                }
+
+                if (! in_array((string) $variant->variant_code, ['A', 'T'], true)) {
+                    continue;
+                }
+
+                $runtimeTypeCode = (string) $variant->runtime_type_code;
+                $seen[(string) $profile->locale.'|'.$runtimeTypeCode] = true;
+                $summary['variants_scanned']++;
+
+                $existingSections = $variant->sections
+                    ->filter(static fn (mixed $section): bool => $section instanceof PersonalityProfileVariantSection)
+                    ->keyBy(static fn (PersonalityProfileVariantSection $section): string => (string) $section->section_key);
+
+                foreach ($requiredSectionKeys as $sectionKey) {
+                    /** @var PersonalityProfileVariantSection|null $existing */
+                    $existing = $existingSections->get($sectionKey);
+                    if ($existing instanceof PersonalityProfileVariantSection && $this->sectionHasContent($existing)) {
+                        $summary['existing_required_sections']++;
+                        $summary['preserved_existing_sections']++;
+                        continue;
+                    }
+
+                    if ($existing instanceof PersonalityProfileVariantSection) {
+                        $summary['existing_required_sections']++;
+                    }
+
+                    $desired = $structureService->build(
+                        $runtimeTypeCode,
+                        (string) $profile->locale,
+                        $this->variantOrProfileTypeName($variant, $profile),
+                        $sectionKey,
+                    );
+
+                    if ($existing instanceof PersonalityProfileVariantSection && ! $this->sectionNeedsRefresh($existing, $desired)) {
+                        continue;
+                    }
+
+                    $summary['section_changes']++;
+                    if (count($summary['sample_changes']) < 10) {
+                        $summary['sample_changes'][] = [
+                            'locale' => (string) $profile->locale,
+                            'runtime_type_code' => $runtimeTypeCode,
+                            'section_key' => $sectionKey,
+                        ];
+                    }
+
+                    if ($dryRun) {
+                        continue;
+                    }
+
+                    DB::transaction(function () use ($variant, $sectionKey, $desired): void {
+                        PersonalityProfileVariantSection::query()->updateOrCreate(
+                            [
+                                'personality_profile_variant_id' => (int) $variant->id,
+                                'section_key' => $sectionKey,
+                            ],
+                            $desired,
+                        );
+                    });
+                    $summary['writes_committed']++;
+                }
+            }
+        }
+
+        foreach ($locales as $locale) {
+            foreach ($types as $type) {
+                foreach (['A', 'T'] as $variant) {
+                    $runtimeTypeCode = $type.'-'.$variant;
+                    if (! isset($seen[$locale.'|'.$runtimeTypeCode])) {
+                        $summary['missing_variants'][] = [
+                            'locale' => $locale,
+                            'runtime_type_code' => $runtimeTypeCode,
+                        ];
+                    }
+                }
+            }
+        }
+
+        $this->emitSummary($summary);
+
+        if ((bool) $this->option('assert-complete') && $summary['missing_variants'] !== []) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedLocales(): array
+    {
+        $input = array_map('strval', (array) $this->option('locale'));
+        $locales = $input === [] ? PersonalityProfile::SUPPORTED_LOCALES : array_map(static function (string $locale): string {
+            $normalized = trim($locale);
+
+            return $normalized === 'zh' ? 'zh-CN' : $normalized;
+        }, $input);
+
+        $locales = array_values(array_unique($locales));
+        sort($locales);
+
+        foreach ($locales as $locale) {
+            if (! in_array($locale, PersonalityProfile::SUPPORTED_LOCALES, true)) {
+                $this->fail('Unsupported locale: '.$locale);
+            }
+        }
+
+        return $locales;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedTypes(): array
+    {
+        $input = array_map('strval', (array) $this->option('type'));
+        $types = $input === [] ? PersonalityProfile::BASE_TYPE_CODES : array_map(
+            static fn (string $type): string => strtoupper(trim($type)),
+            $input,
+        );
+
+        $types = array_values(array_unique($types));
+        sort($types);
+
+        foreach ($types as $type) {
+            if (! in_array($type, PersonalityProfile::BASE_TYPE_CODES, true)) {
+                $this->fail('Unsupported MBTI type code: '.$type);
+            }
+        }
+
+        return $types;
+    }
+
+    private function sectionHasContent(PersonalityProfileVariantSection $section): bool
+    {
+        if (trim((string) $section->body_md) !== '' || trim((string) $section->body_html) !== '') {
+            return true;
+        }
+
+        return is_array($section->payload_json) && $section->payload_json !== [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $desired
+     */
+    private function sectionNeedsRefresh(PersonalityProfileVariantSection $section, array $desired): bool
+    {
+        foreach (['render_variant', 'body_md', 'body_html', 'sort_order', 'is_enabled'] as $field) {
+            if ($section->{$field} !== $desired[$field]) {
+                return true;
+            }
+        }
+
+        return $section->payload_json !== $desired['payload_json'];
+    }
+
+    private function variantOrProfileTypeName(PersonalityProfileVariant $variant, PersonalityProfile $profile): ?string
+    {
+        $variantTypeName = trim((string) ($variant->type_name ?? ''));
+        if ($variantTypeName !== '') {
+            return $variantTypeName;
+        }
+
+        $profileTypeName = trim((string) ($profile->type_name ?? ''));
+
+        return $profileTypeName !== '' ? $profileTypeName : null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('dry_run='.($summary['dry_run'] ? 'true' : 'false'));
+        $this->line('expected_variants='.$summary['expected_variants']);
+        $this->line('variants_scanned='.$summary['variants_scanned']);
+        $this->line('expected_required_sections='.$summary['expected_required_sections']);
+        $this->line('existing_required_sections='.$summary['existing_required_sections']);
+        $this->line('section_changes='.$summary['section_changes']);
+        $this->line('writes_committed='.$summary['writes_committed']);
+        $this->line('preserved_existing_sections='.$summary['preserved_existing_sections']);
+        $this->line('missing_variants='.count((array) $summary['missing_variants']));
+    }
+}

--- a/backend/app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php
+++ b/backend/app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php
@@ -1,0 +1,451 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use InvalidArgumentException;
+
+final class MbtiPersonalityVariantSectionStructureService
+{
+    /**
+     * @return list<string>
+     */
+    public function requiredSectionKeys(): array
+    {
+        return [
+            'letters_intro',
+            'overview',
+            'trait_overview',
+            'relationships.summary',
+            'career.summary',
+            'career.preferred_roles',
+            'growth.strengths',
+            'growth.weaknesses',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedRuntimeTypeCodes(): array
+    {
+        $codes = [];
+
+        foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+            $codes[] = $typeCode.'-A';
+            $codes[] = $typeCode.'-T';
+        }
+
+        sort($codes);
+
+        return $codes;
+    }
+
+    /**
+     * @return array{
+     *   section_key:string,
+     *   render_variant:string,
+     *   body_md:?string,
+     *   body_html:null,
+     *   payload_json:array<string,mixed>,
+     *   sort_order:int,
+     *   is_enabled:bool
+     * }
+     */
+    public function build(string $runtimeTypeCode, string $locale, ?string $typeName, string $sectionKey): array
+    {
+        $runtimeTypeCode = strtoupper(trim($runtimeTypeCode));
+        $locale = $this->normalizeLocale($locale);
+        $typeName = $this->normalizeTypeName($typeName);
+
+        if (! in_array($runtimeTypeCode, $this->supportedRuntimeTypeCodes(), true)) {
+            throw new InvalidArgumentException('Unsupported MBTI runtime type code for personality section structure.');
+        }
+
+        if (! in_array($sectionKey, $this->requiredSectionKeys(), true)) {
+            throw new InvalidArgumentException('Unsupported MBTI personality structure section key.');
+        }
+
+        $definition = MbtiCanonicalSectionRegistry::definition($sectionKey);
+        $typeLabel = $this->typeLabel($runtimeTypeCode, $typeName);
+        $body = $this->body($sectionKey, $runtimeTypeCode, $typeLabel, $locale);
+
+        return [
+            'section_key' => $sectionKey,
+            'render_variant' => (string) $definition['render_variant'],
+            'body_md' => $body,
+            'body_html' => null,
+            'payload_json' => $this->payload($sectionKey, $runtimeTypeCode, $typeLabel, $locale),
+            'sort_order' => (int) $definition['sort_order'],
+            'is_enabled' => true,
+        ];
+    }
+
+    private function body(string $sectionKey, string $runtimeTypeCode, string $typeLabel, string $locale): ?string
+    {
+        $baseType = substr($runtimeTypeCode, 0, 4);
+        $variant = substr($runtimeTypeCode, -1);
+
+        if ($locale === 'zh-CN') {
+            return match ($sectionKey) {
+                'overview' => "{$typeLabel} 用来描述 {$baseType} 核心倾向与 {$variant} 型状态的组合。阅读时可以先看整体画像，再对照常见特征、关系模式和职业适配，而不是把类型当成固定标签。",
+                'relationships.summary' => "{$typeLabel} 的关系模式可以从表达节奏、冲突处理、边界感和支持方式来理解。适合把这里当作亲密关系、朋友相处和团队沟通的快速入口。",
+                'career.summary' => "{$typeLabel} 的职业判断应优先看任务偏好、协作方式、反馈需求和长期动机。这里用于连接人格类型页、职业推荐页和后续具体岗位解释。",
+                default => null,
+            };
+        }
+
+        return match ($sectionKey) {
+            'overview' => "{$typeLabel} describes the combination of the {$baseType} core pattern and the {$variant} variant state. Use this page as a practical map for traits, relationships, career fit, strengths, and blind spots rather than as a fixed label.",
+            'relationships.summary' => "{$typeLabel} relationship patterns are easiest to read through communication pace, conflict repair, boundaries, and support needs. Use this section as the entry point for close relationships, friendship, and team dynamics.",
+            'career.summary' => "{$typeLabel} career fit should be read through task preference, collaboration style, feedback needs, and long-term motivation. This section connects the type profile with career recommendations and role-level exploration.",
+            default => null,
+        };
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function payload(string $sectionKey, string $runtimeTypeCode, string $typeLabel, string $locale): array
+    {
+        return match ($sectionKey) {
+            'letters_intro' => $this->lettersIntroPayload($runtimeTypeCode, $typeLabel, $locale),
+            'trait_overview' => $this->traitOverviewPayload($runtimeTypeCode, $typeLabel, $locale),
+            'career.preferred_roles' => $this->preferredRolesPayload($runtimeTypeCode, $typeLabel, $locale),
+            'growth.strengths' => ['items' => $this->strengthItems($runtimeTypeCode, $typeLabel, $locale)],
+            'growth.weaknesses' => ['items' => $this->weaknessItems($runtimeTypeCode, $typeLabel, $locale)],
+            default => [
+                'structure_contract' => 'mbti_personality_variant_page_structure.v1',
+                'intent' => $this->intentForSection($sectionKey),
+                'runtime_type_code' => $runtimeTypeCode,
+            ],
+        };
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function lettersIntroPayload(string $runtimeTypeCode, string $typeLabel, string $locale): array
+    {
+        $letters = str_replace('-', '', $runtimeTypeCode);
+
+        return [
+            'headline' => $locale === 'zh-CN'
+                ? "{$typeLabel} 可以拆成 5 个信号：4 个 MBTI 基础偏好，加上 A/T 状态差异。"
+                : "{$typeLabel} can be read as five signals: four MBTI preferences plus the A/T variant state.",
+            'letters' => array_map(
+                fn (string $letter, int $index): array => $this->letterCopy($letter, $locale, $index === 4),
+                str_split($letters),
+                array_keys(str_split($letters))
+            ),
+            'structure_contract' => 'mbti_personality_variant_page_structure.v1',
+            'intent' => 'what_this_type_is_and_at_difference',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function traitOverviewPayload(string $runtimeTypeCode, string $typeLabel, string $locale): array
+    {
+        return [
+            'summary' => $locale === 'zh-CN'
+                ? "{$typeLabel} 的常见特征来自这些维度的组合。A/T 不是新类型，而是同一类型在自信、压力感和稳定感上的状态差异。"
+                : "{$typeLabel} traits come from the combination of these dimensions. A/T is not a separate type; it describes confidence, stress sensitivity, and stability within the same type.",
+            'dimensions' => [
+                $this->axisPayload('EI', $runtimeTypeCode, $locale),
+                $this->axisPayload('SN', $runtimeTypeCode, $locale),
+                $this->axisPayload('TF', $runtimeTypeCode, $locale),
+                $this->axisPayload('JP', $runtimeTypeCode, $locale),
+                $this->axisPayload('AT', $runtimeTypeCode, $locale),
+            ],
+            'structure_contract' => 'mbti_personality_variant_page_structure.v1',
+            'intent' => 'common_traits_and_at_difference',
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function preferredRolesPayload(string $runtimeTypeCode, string $typeLabel, string $locale): array
+    {
+        $baseTypeCode = substr($runtimeTypeCode, 0, 4);
+        $isJudging = str_contains($baseTypeCode, 'J');
+        $isThinking = str_contains($baseTypeCode, 'T');
+
+        if ($locale === 'zh-CN') {
+            return [
+                'title' => "{$typeLabel} 的适合工作先看工作方式，而不是直接套岗位清单。",
+                'intro' => '这些岗位簇是初筛方向，后续仍需要结合技能、行业、教育背景和真实经历判断。',
+                'groups' => [
+                    [
+                        'group_title' => $isThinking ? '分析与系统型任务' : '沟通与支持型任务',
+                        'description' => $isThinking ? '适合从问题拆解、系统优化、策略判断开始验证。' : '适合从人际理解、服务设计、内容表达和支持协作开始验证。',
+                        'examples' => $isThinking ? ['分析研究', '产品策略', '系统规划'] : ['咨询支持', '内容策划', '用户研究'],
+                    ],
+                    [
+                        'group_title' => $isJudging ? '结构化推进环境' : '探索型弹性环境',
+                        'description' => $isJudging ? '更适合目标清晰、反馈稳定、责任边界明确的场景。' : '更适合允许探索、迭代和灵活调整的场景。',
+                        'examples' => $isJudging ? ['项目管理', '运营规划', '流程优化'] : ['创意项目', '早期探索', '跨职能协作'],
+                    ],
+                ],
+                'structure_contract' => 'mbti_personality_variant_page_structure.v1',
+                'intent' => 'career_and_best_fit_work',
+            ];
+        }
+
+        return [
+            'title' => "{$typeLabel} work fit starts with work style, not a fixed job list.",
+            'intro' => 'Use these role clusters as an initial screen, then validate against skills, industry context, education, and real experience.',
+            'groups' => [
+                [
+                    'group_title' => $isThinking ? 'Analytical and systems work' : 'Communication and support work',
+                    'description' => $isThinking ? 'Start with problem decomposition, system improvement, and strategic judgment.' : 'Start with interpersonal understanding, service design, content expression, and support work.',
+                    'examples' => $isThinking ? ['Research analysis', 'Product strategy', 'Systems planning'] : ['Advisory support', 'Content planning', 'User research'],
+                ],
+                [
+                    'group_title' => $isJudging ? 'Structured execution environments' : 'Exploratory flexible environments',
+                    'description' => $isJudging ? 'Often fits clearer goals, stable feedback, and defined ownership.' : 'Often fits exploration, iteration, and flexible adjustment.',
+                    'examples' => $isJudging ? ['Project management', 'Operations planning', 'Process improvement'] : ['Creative projects', 'Early exploration', 'Cross-functional work'],
+                ],
+            ],
+            'structure_contract' => 'mbti_personality_variant_page_structure.v1',
+            'intent' => 'career_and_best_fit_work',
+        ];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function strengthItems(string $runtimeTypeCode, string $typeLabel, string $locale): array
+    {
+        $baseTypeCode = substr($runtimeTypeCode, 0, 4);
+        $isIntroverted = str_starts_with($baseTypeCode, 'I');
+        $isIntuitive = str_contains($baseTypeCode, 'N');
+        $isAssertive = str_ends_with($runtimeTypeCode, '-A');
+
+        if ($locale === 'zh-CN') {
+            return [
+                ['title' => '稳定优势', 'body' => "{$typeLabel} 通常可以从".($isIntroverted ? '独立思考' : '外部协同').'中形成稳定输出。'],
+                ['title' => '判断方式', 'body' => $isIntuitive ? '更容易从模式、可能性和长期方向中找到线索。' : '更容易从事实、经验和可验证细节中推进判断。'],
+                ['title' => '状态倾向', 'body' => $isAssertive ? 'A 型通常更容易保持自我确认和节奏稳定。' : 'T 型通常更容易捕捉风险、反馈和需要修正的细节。'],
+            ];
+        }
+
+        return [
+            ['title' => 'Stable advantage', 'body' => "{$typeLabel} often creates reliable output through ".($isIntroverted ? 'independent reflection' : 'external collaboration').'.'],
+            ['title' => 'Judgment pattern', 'body' => $isIntuitive ? 'Often notices patterns, possibilities, and long-range direction.' : 'Often advances through facts, experience, and verifiable detail.'],
+            ['title' => 'Variant signal', 'body' => $isAssertive ? 'A variants often hold steadier self-confirmation and pace.' : 'T variants often notice risk, feedback, and details that need adjustment.'],
+        ];
+    }
+
+    /**
+     * @return list<array<string,string>>
+     */
+    private function weaknessItems(string $runtimeTypeCode, string $typeLabel, string $locale): array
+    {
+        $baseTypeCode = substr($runtimeTypeCode, 0, 4);
+        $isPerceiving = str_contains($baseTypeCode, 'P');
+        $isFeeling = str_contains($baseTypeCode, 'F');
+        $isTurbulent = str_ends_with($runtimeTypeCode, '-T');
+
+        if ($locale === 'zh-CN') {
+            return [
+                ['title' => '过度使用风险', 'body' => "{$typeLabel} 的优势如果过度使用，可能变成决策惯性或沟通盲点。"],
+                ['title' => '协作风险', 'body' => $isFeeling ? '需要避免只照顾氛围而推迟关键边界。' : '需要避免只强调效率而忽略关系修复。'],
+                ['title' => '执行风险', 'body' => $isPerceiving ? '需要把探索转成明确的下一步。' : '需要为计划保留调整空间。'],
+                ['title' => '状态风险', 'body' => $isTurbulent ? 'T 型需要留意自我怀疑和压力放大。' : 'A 型需要留意过早确定和低估反馈。'],
+            ];
+        }
+
+        return [
+            ['title' => 'Overuse risk', 'body' => "{$typeLabel} strengths can become decision habits or communication blind spots when overused."],
+            ['title' => 'Collaboration risk', 'body' => $isFeeling ? 'Watch for delaying boundaries to preserve harmony.' : 'Watch for prioritizing efficiency while under-investing in repair.'],
+            ['title' => 'Execution risk', 'body' => $isPerceiving ? 'Convert exploration into a clear next step.' : 'Leave room for revision inside the plan.'],
+            ['title' => 'Variant risk', 'body' => $isTurbulent ? 'T variants should watch for self-doubt and amplified stress.' : 'A variants should watch for deciding too early or underweighting feedback.'],
+        ];
+    }
+
+    /**
+     * @return array{letter:string,title:string,description:string}
+     */
+    private function letterCopy(string $letter, string $locale, bool $isVariantLetter = false): array
+    {
+        $copy = [
+            'zh-CN' => [
+                'E' => ['外向倾向', '从外部互动、行动反馈和现场信息中获得能量。'],
+                'I' => ['内向倾向', '更依赖独立思考、内部整理和低干扰环境。'],
+                'S' => ['现实感知', '更重视事实、经验、细节和当前可验证的信息。'],
+                'N' => ['直觉感知', '更关注模式、可能性、抽象关系和长期方向。'],
+                'T' => ['逻辑判断', '更倾向用原则、结构和因果关系做决定。'],
+                'F' => ['价值判断', '更倾向用价值、关系影响和人的感受做决定。'],
+                'J' => ['计划判断', '更喜欢清晰计划、确定节奏和可控推进。'],
+                'P' => ['灵活探索', '更喜欢保留选项、边走边看和适应变化。'],
+                'A' => ['A 型状态', '更稳定自信，通常较少被短期反馈扰动。'],
+                'T_VARIANT' => ['T 型状态', '更敏感自省，通常更关注风险、反馈和修正空间。'],
+            ],
+            'en' => [
+                'E' => ['Extraversion signal', 'Draws energy from interaction, action feedback, and live context.'],
+                'I' => ['Introversion signal', 'Relies more on independent reflection, internal processing, and lower-noise settings.'],
+                'S' => ['Sensing signal', 'Prioritizes facts, experience, detail, and verifiable present information.'],
+                'N' => ['Intuition signal', 'Tracks patterns, possibilities, abstract connections, and long-range direction.'],
+                'T' => ['Thinking signal', 'Decides through principles, structure, and cause-effect logic.'],
+                'F' => ['Feeling signal', 'Decides through values, relationship impact, and human context.'],
+                'J' => ['Judging signal', 'Prefers plans, clear pace, and controlled follow-through.'],
+                'P' => ['Perceiving signal', 'Prefers optionality, discovery, and adapting as new information appears.'],
+                'A' => ['Assertive state', 'More steady in self-confidence and less disrupted by short-term feedback.'],
+                'T_VARIANT' => ['Turbulent state', 'More self-monitoring and more attentive to risk, feedback, and room for adjustment.'],
+            ],
+        ];
+
+        $key = $letter === 'T' && $isVariantLetter ? 'T_VARIANT' : $letter;
+        $label = $copy[$locale][$key] ?? [$letter, ''];
+
+        return ['letter' => $letter, 'title' => $label[0], 'description' => $label[1]];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function axisPayload(string $axisId, string $runtimeTypeCode, string $locale): array
+    {
+        $axis = [
+            'EI' => ['E', 'I'],
+            'SN' => ['S', 'N'],
+            'TF' => ['T', 'F'],
+            'JP' => ['J', 'P'],
+            'AT' => ['A', 'T'],
+        ][$axisId];
+        $baseTypeCode = substr($runtimeTypeCode, 0, 4);
+        $side = $axisId === 'AT' ? substr($runtimeTypeCode, -1) : $this->matchedLetter($baseTypeCode, $axis);
+
+        $labels = $locale === 'zh-CN'
+            ? [
+                'EI' => ['能量来源', '外向', '内向'],
+                'SN' => ['信息获取', '现实感知', '直觉感知'],
+                'TF' => ['决策方式', '逻辑判断', '价值判断'],
+                'JP' => ['生活节奏', '计划判断', '灵活探索'],
+                'AT' => ['A/T 状态', '稳定自信', '敏感自省'],
+            ]
+            : [
+                'EI' => ['Energy orientation', 'Extraversion', 'Introversion'],
+                'SN' => ['Information style', 'Sensing', 'Intuition'],
+                'TF' => ['Decision style', 'Thinking', 'Feeling'],
+                'JP' => ['Life rhythm', 'Judging', 'Perceiving'],
+                'AT' => ['A/T state', 'Assertive', 'Turbulent'],
+            ];
+
+        return [
+            'id' => $axisId,
+            'code' => $axisId,
+            'name' => $labels[$axisId][0],
+            'label' => $labels[$axisId][0],
+            'axis_left' => $labels[$axisId][1],
+            'axis_right' => $labels[$axisId][2],
+            'summary' => $this->axisSummary($axisId, $side, $locale),
+            'description' => $this->axisDescription($axisId, $side, $locale),
+            'source' => 'cms_structure',
+            'side' => $side,
+            'state' => 'authored_skeleton',
+        ];
+    }
+
+    /**
+     * @param  array{0:string,1:string}  $axis
+     */
+    private function matchedLetter(string $runtimeTypeCode, array $axis): string
+    {
+        return str_contains($runtimeTypeCode, $axis[0]) ? $axis[0] : $axis[1];
+    }
+
+    private function axisSummary(string $axisId, string $side, string $locale): string
+    {
+        $summary = [
+            'zh-CN' => [
+                'EI:E' => '更容易通过互动和外部反馈启动。',
+                'EI:I' => '更容易通过独立整理和内部思考启动。',
+                'SN:S' => '更重视事实、经验和具体信息。',
+                'SN:N' => '更重视模式、可能性和抽象关系。',
+                'TF:T' => '更倾向用逻辑结构和原则判断。',
+                'TF:F' => '更倾向用价值影响和人的感受判断。',
+                'JP:J' => '更偏好计划、确定性和清晰推进。',
+                'JP:P' => '更偏好灵活、探索和开放选项。',
+                'AT:A' => 'A 型更稳定自信，较少被短期反馈扰动。',
+                'AT:T' => 'T 型更敏感自省，更关注风险和修正空间。',
+            ],
+            'en' => [
+                'EI:E' => 'Starts more easily through interaction and external feedback.',
+                'EI:I' => 'Starts more easily through independent processing and reflection.',
+                'SN:S' => 'Prioritizes facts, experience, and concrete information.',
+                'SN:N' => 'Prioritizes patterns, possibilities, and abstract relationships.',
+                'TF:T' => 'Leans on logical structure and principles when deciding.',
+                'TF:F' => 'Leans on values, impact, and human context when deciding.',
+                'JP:J' => 'Prefers planning, certainty, and clear follow-through.',
+                'JP:P' => 'Prefers flexibility, exploration, and open options.',
+                'AT:A' => 'Assertive variants are steadier and less disrupted by short-term feedback.',
+                'AT:T' => 'Turbulent variants are more self-monitoring and attentive to risk and adjustment.',
+            ],
+        ];
+
+        return $summary[$locale][$axisId.':'.$side] ?? $axisId;
+    }
+
+    private function axisDescription(string $axisId, string $side, string $locale): string
+    {
+        if ($locale === 'zh-CN') {
+            return $axisId === 'AT'
+                ? 'A/T 只说明状态差异，不改变 4 字母基础类型。'
+                : '这个维度影响信息处理、沟通节奏和行动偏好。';
+        }
+
+        return $axisId === 'AT'
+            ? 'A/T describes state differences; it does not replace the four-letter base type.'
+            : 'This dimension shapes information processing, communication pace, and action preference.';
+    }
+
+    private function intentForSection(string $sectionKey): string
+    {
+        return match ($sectionKey) {
+            'relationships.summary' => 'love_and_relationships',
+            'career.summary', 'career.preferred_roles' => 'career_and_best_fit_work',
+            'growth.strengths', 'growth.weaknesses' => 'strengths_and_weaknesses',
+            default => 'personality_detail_structure',
+        };
+    }
+
+    private function normalizeLocale(string $locale): string
+    {
+        $normalized = trim($locale);
+
+        if ($normalized === 'zh') {
+            return 'zh-CN';
+        }
+
+        if (in_array($normalized, PersonalityProfile::SUPPORTED_LOCALES, true)) {
+            return $normalized;
+        }
+
+        throw new InvalidArgumentException('Unsupported locale for MBTI personality section structure.');
+    }
+
+    private function normalizeTypeName(?string $typeName): ?string
+    {
+        $normalized = trim((string) $typeName);
+        if ($normalized === '') {
+            return null;
+        }
+
+        $normalized = preg_replace('/\s+/', ' ', $normalized) ?: $normalized;
+        $normalized = preg_replace('/[-－](?:A|T)$/i', '', $normalized) ?: $normalized;
+
+        return trim($normalized) !== '' ? trim($normalized) : null;
+    }
+
+    private function typeLabel(string $runtimeTypeCode, ?string $typeName): string
+    {
+        return $typeName !== null ? $runtimeTypeCode.' '.$typeName : $runtimeTypeCode;
+    }
+}

--- a/backend/tests/Feature/Console/PersonalityEnsureMbtiVariantSectionStructureCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityEnsureMbtiVariantSectionStructureCommandTest.php
@@ -1,0 +1,254 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityEnsureMbtiVariantSectionStructureCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_reports_complete_64_variant_section_scope_without_writes(): void
+    {
+        $this->createMbtiVariantMatrix();
+
+        $this->artisan('personality:ensure-mbti-variant-section-structure', [
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=64')
+            ->expectsOutputToContain('variants_scanned=64')
+            ->expectsOutputToContain('expected_required_sections=512')
+            ->expectsOutputToContain('section_changes=512')
+            ->expectsOutputToContain('writes_committed=0')
+            ->expectsOutputToContain('missing_variants=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_command_creates_required_structure_sections_without_overwriting_authored_content(): void
+    {
+        $variants = $this->createMbtiVariantMatrix();
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $variants['zh-CN|INFP-T']->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+            'body_md' => '人工写好的 INFP-T 总览。',
+            'body_html' => null,
+            'payload_json' => null,
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+
+        $this->artisan('personality:ensure-mbti-variant-section-structure', [
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=64')
+            ->expectsOutputToContain('variants_scanned=64')
+            ->expectsOutputToContain('expected_required_sections=512')
+            ->expectsOutputToContain('writes_committed=511')
+            ->expectsOutputToContain('preserved_existing_sections=1')
+            ->expectsOutputToContain('missing_variants=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(512, PersonalityProfileVariantSection::query()->withoutGlobalScopes()->count());
+
+        $infpTSections = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['zh-CN|INFP-T']->id)
+            ->orderBy('sort_order')
+            ->pluck('section_key')
+            ->all();
+
+        $this->assertSame([
+            'letters_intro',
+            'overview',
+            'trait_overview',
+            'career.summary',
+            'career.preferred_roles',
+            'growth.strengths',
+            'growth.weaknesses',
+            'relationships.summary',
+        ], $infpTSections);
+
+        $preserved = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['zh-CN|INFP-T']->id)
+            ->where('section_key', 'overview')
+            ->firstOrFail();
+
+        $this->assertSame('人工写好的 INFP-T 总览。', $preserved->body_md);
+
+        $traitOverview = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['zh-CN|INFP-T']->id)
+            ->where('section_key', 'trait_overview')
+            ->firstOrFail();
+
+        $this->assertSame('trait_dimension_grid', $traitOverview->render_variant);
+        $this->assertSame('mbti_personality_variant_page_structure.v1', data_get($traitOverview->payload_json, 'structure_contract'));
+        $this->assertSame('TF', data_get($traitOverview->payload_json, 'dimensions.2.id'));
+        $this->assertSame('F', data_get($traitOverview->payload_json, 'dimensions.2.side'));
+        $this->assertSame('AT', data_get($traitOverview->payload_json, 'dimensions.4.id'));
+        $this->assertSame('T', data_get($traitOverview->payload_json, 'dimensions.4.side'));
+        $this->assertStringContainsString('A/T', (string) data_get($traitOverview->payload_json, 'dimensions.4.description'));
+
+        $lettersIntro = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['zh-CN|INFP-T']->id)
+            ->where('section_key', 'letters_intro')
+            ->firstOrFail();
+
+        $this->assertSame('T 型状态', data_get($lettersIntro->payload_json, 'letters.4.title'));
+
+        $preferredRoles = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['en|ENFP-A']->id)
+            ->where('section_key', 'career.preferred_roles')
+            ->firstOrFail();
+
+        $this->assertSame('preferred_role_list', $preferredRoles->render_variant);
+        $this->assertNotEmpty(data_get($preferredRoles->payload_json, 'groups.0.examples'));
+    }
+
+    public function test_public_api_exposes_the_structured_sections_for_variant_routes(): void
+    {
+        $variants = $this->createMbtiVariantMatrix();
+
+        $this->artisan('personality:ensure-mbti-variant-section-structure', [
+            '--locale' => ['en'],
+            '--type' => ['ENFP'],
+            '--assert-complete' => true,
+        ])->assertExitCode(0);
+
+        $this->getJson('/api/v0.5/personality/enfp-a?locale=en')
+            ->assertOk()
+            ->assertJsonPath('profile.type_code', 'ENFP')
+            ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', 'ENFP-A')
+            ->assertJsonPath('mbti_public_projection_v1.sections.0.key', 'letters_intro')
+            ->assertJsonPath('mbti_public_projection_v1.sections.1.key', 'overview')
+            ->assertJsonPath('mbti_public_projection_v1.sections.2.key', 'trait_overview')
+            ->assertJsonPath('mbti_public_projection_v1.sections.2.payload.dimensions.4.id', 'AT')
+            ->assertJsonPath('mbti_public_projection_v1.sections.4.key', 'career.preferred_roles')
+            ->assertJsonPath('landing_surface_v1.cta_bundle.0.key', 'start_test')
+            ->assertJsonPath('answer_surface_v1.next_step_blocks.0.key', 'start_test');
+
+        $this->assertSame(8, PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['en|ENFP-A']->id)
+            ->count());
+    }
+
+    public function test_assert_complete_fails_when_selected_variant_scope_is_missing(): void
+    {
+        $profile = $this->createProfile('en', 'INFP', 'Mediator');
+        $this->createVariant($profile, 'INFP-A');
+
+        $this->artisan('personality:ensure-mbti-variant-section-structure', [
+            '--locale' => ['en'],
+            '--type' => ['INFP'],
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=2')
+            ->expectsOutputToContain('variants_scanned=1')
+            ->expectsOutputToContain('missing_variants=1')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * @return array<string, PersonalityProfileVariant>
+     */
+    private function createMbtiVariantMatrix(): array
+    {
+        $typeNames = [
+            'ENFJ' => ['en' => 'Protagonist', 'zh-CN' => '主人公'],
+            'ENFP' => ['en' => 'Campaigner', 'zh-CN' => '竞选者'],
+            'ENTJ' => ['en' => 'Commander', 'zh-CN' => '指挥官'],
+            'ENTP' => ['en' => 'Debater', 'zh-CN' => '辩论家'],
+            'ESFJ' => ['en' => 'Consul', 'zh-CN' => '执政官'],
+            'ESFP' => ['en' => 'Entertainer', 'zh-CN' => '表演者'],
+            'ESTJ' => ['en' => 'Executive', 'zh-CN' => '总经理'],
+            'ESTP' => ['en' => 'Entrepreneur', 'zh-CN' => '企业家'],
+            'INFJ' => ['en' => 'Advocate', 'zh-CN' => '提倡者'],
+            'INFP' => ['en' => 'Mediator', 'zh-CN' => '调停者'],
+            'INTJ' => ['en' => 'Architect', 'zh-CN' => '建筑师'],
+            'INTP' => ['en' => 'Logician', 'zh-CN' => '逻辑学家'],
+            'ISFJ' => ['en' => 'Defender', 'zh-CN' => '守卫者'],
+            'ISFP' => ['en' => 'Adventurer', 'zh-CN' => '探险家'],
+            'ISTJ' => ['en' => 'Logistician', 'zh-CN' => '物流师'],
+            'ISTP' => ['en' => 'Virtuoso', 'zh-CN' => '鉴赏家'],
+        ];
+        $variants = [];
+
+        foreach (PersonalityProfile::SUPPORTED_LOCALES as $locale) {
+            foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+                $profile = $this->createProfile($locale, $typeCode, $typeNames[$typeCode][$locale]);
+                foreach (['A', 'T'] as $variantCode) {
+                    $runtimeTypeCode = $typeCode.'-'.$variantCode;
+                    $variants[$locale.'|'.$runtimeTypeCode] = $this->createVariant($profile, $runtimeTypeCode);
+                }
+            }
+        }
+
+        return $variants;
+    }
+
+    private function createProfile(string $locale, string $typeCode, string $typeName): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' - '.$typeName,
+            'type_name' => $typeName,
+            'nickname' => $typeName,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'subtitle' => null,
+            'excerpt' => $locale === 'zh-CN' ? $typeName.' 类型摘要' : $typeName.' type summary',
+            'hero_kicker' => $typeName,
+            'hero_quote' => null,
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'hero_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    private function createVariant(PersonalityProfile $profile, string $runtimeTypeCode): PersonalityProfileVariant
+    {
+        [$typeCode, $variantCode] = explode('-', $runtimeTypeCode);
+
+        return PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => $typeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'type_name' => null,
+            'nickname' => null,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -250,6 +250,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_personality_variant_section_structure_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php',
+            'backend/app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_cross_assessment_context_guard_changes(): void
     {
         $changed = [
@@ -2781,6 +2791,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiPersonalityVariantSectionStructureFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -3538,6 +3552,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityRefreshMbtiVariantSeoMetadata.php',
             'backend/app/Services/Cms/MbtiPersonalityVariantSeoMetadataService.php',
+        ], true);
+    }
+
+    private function isMbtiPersonalityVariantSectionStructureFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php',
+            'backend/app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added `personality:ensure-mbti-variant-section-structure` to ensure the 64 MBTI personality variant pages can receive a consistent public section skeleton.
- Added `MbtiPersonalityVariantSectionStructureService` with the required page structure:
  - letters intro / what this type is
  - overview
  - trait overview with A/T state dimension
  - relationships
  - career summary
  - preferred role clusters
  - strengths
  - weaknesses
- Added focused tests for dry-run, full 64-variant coverage, preservation of authored CMS content, public API projection, missing-variant assertion, and BigFive runtime freeze classifier scope.

## Why
GSC is starting to surface personality variant pages. The backend/CMS layer should own the page structure before the frontend consumes it further, so fap-web does not become the content authority and we avoid creating many standalone articles prematurely.

## Validation
- `php artisan test --filter=PersonalityEnsureMbtiVariantSectionStructureCommandTest --no-ansi`
- `php artisan test --filter=PersonalityPublicApiTest --no-ansi`
- `php artisan test --filter=PersonalityRefreshMbtiVariantSeoMetadataCommandTest --no-ansi`
- `php artisan test --filter=PersonalityVariantAuthorityTest --no-ansi`
- `php artisan test --filter=MbtiCanonicalSectionRegistryTest --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_paths_have_no_uncommitted_diff --no-ansi`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest::test_runtime_freeze_classifier_ignores_mbti_personality_variant_section_structure_files --no-ansi`
- `php -l app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php && php -l app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php && php -l tests/Feature/Console/PersonalityEnsureMbtiVariantSectionStructureCommandTest.php`
- `git diff --cached --check`

## Intentionally deferred
- Did not run the command against production CMS.
- Did not publish articles or CMS records.
- Did not modify sitemap, llms, robots, canonical policy, or search submission.
- Did not change fap-web rendering in this PR.
- Did not add PR-train metadata because this was handled as an ordinary scoped backend PR without explicit manifest/state authorization.

## Repository rule impact
- CMS/backend remains the authority for personality profile sections and SEO.
- This PR adds an operator command for CMS-backed personality section structure only; it does not move content authority into fap-web.
