### PR TITLE
PERSONALITY-EN-CONTENT-00: feat(cms): enrich English MBTI variant page sections

### DIFF
--- a/backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php
+++ b/backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php
@@ -1,0 +1,259 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use App\Services\Cms\MbtiEnglishVariantSectionEnrichmentService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class PersonalityEnrichMbtiEnglishVariantSections extends Command
+{
+    protected $signature = 'personality:enrich-mbti-english-variant-sections
+        {--type=* : Canonical MBTI type code to enrich, defaults to all 16 types}
+        {--write : Commit CMS section updates; default is dry-run/no-write}
+        {--dry-run : Explicitly preview changes without writing}
+        {--json : Emit a machine-readable JSON summary}
+        {--assert-complete : Fail when the selected type scope is missing any A/T variant}';
+
+    protected $description = 'Enrich English MBTI A/T personality variant sections without changing frontend, publication state, sitemap, or search submission.';
+
+    public function handle(MbtiEnglishVariantSectionEnrichmentService $enrichmentService): int
+    {
+        $write = (bool) $this->option('write');
+        $dryRun = ! $write || (bool) $this->option('dry-run');
+        if ($write && (bool) $this->option('dry-run')) {
+            $this->error('Use either --write or --dry-run, not both.');
+
+            return self::FAILURE;
+        }
+
+        $types = $this->selectedTypes();
+        $sectionKeys = $enrichmentService->sectionKeys();
+        $summary = [
+            'task_id' => 'PERSONALITY-EN-CONTENT-00',
+            'dry_run' => $dryRun,
+            'writes_committed' => 0,
+            'locale' => 'en',
+            'types' => $types,
+            'expected_variants' => count($types) * 2,
+            'variants_scanned' => 0,
+            'expected_sections' => count($types) * 2 * count($sectionKeys),
+            'sections_scanned' => 0,
+            'section_changes' => 0,
+            'a_t_differentiated_sections' => [],
+            'missing_variants' => [],
+            'sample_changes' => [],
+            'guardrails' => [
+                'frontend_changed' => false,
+                'publication_state_changed' => false,
+                'sitemap_changed' => false,
+                'search_submission' => false,
+            ],
+        ];
+
+        $seen = [];
+        $desiredByRuntime = [];
+        $profiles = PersonalityProfile::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('scale_code', PersonalityProfile::SCALE_CODE_MBTI)
+            ->where('locale', 'en')
+            ->whereIn('type_code', $types)
+            ->with(['variants.sections'])
+            ->orderBy('type_code')
+            ->get();
+
+        foreach ($profiles as $profile) {
+            foreach ($profile->variants as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant) {
+                    continue;
+                }
+
+                if (! in_array((string) $variant->variant_code, ['A', 'T'], true)) {
+                    continue;
+                }
+
+                $runtimeTypeCode = (string) $variant->runtime_type_code;
+                $seen[$runtimeTypeCode] = true;
+                $summary['variants_scanned']++;
+
+                $existingSections = $variant->sections
+                    ->filter(static fn (mixed $section): bool => $section instanceof PersonalityProfileVariantSection)
+                    ->keyBy(static fn (PersonalityProfileVariantSection $section): string => (string) $section->section_key);
+
+                foreach ($sectionKeys as $sectionKey) {
+                    $desired = $enrichmentService->build(
+                        $runtimeTypeCode,
+                        $this->variantOrProfileTypeName($variant, $profile),
+                        $sectionKey,
+                    );
+                    $desiredByRuntime[$runtimeTypeCode][$sectionKey] = $desired;
+                    $summary['sections_scanned']++;
+
+                    /** @var PersonalityProfileVariantSection|null $existing */
+                    $existing = $existingSections->get($sectionKey);
+                    if ($existing instanceof PersonalityProfileVariantSection && ! $this->sectionNeedsRefresh($existing, $desired)) {
+                        continue;
+                    }
+
+                    $summary['section_changes']++;
+                    if (count($summary['sample_changes']) < 12) {
+                        $summary['sample_changes'][] = [
+                            'runtime_type_code' => $runtimeTypeCode,
+                            'section_key' => $sectionKey,
+                        ];
+                    }
+
+                    if ($dryRun) {
+                        continue;
+                    }
+
+                    DB::transaction(function () use ($variant, $sectionKey, $desired): void {
+                        PersonalityProfileVariantSection::query()->updateOrCreate(
+                            [
+                                'personality_profile_variant_id' => (int) $variant->id,
+                                'section_key' => $sectionKey,
+                            ],
+                            $desired,
+                        );
+                    });
+                    $summary['writes_committed']++;
+                }
+            }
+        }
+
+        foreach ($types as $type) {
+            foreach (['A', 'T'] as $variantCode) {
+                $runtimeTypeCode = $type.'-'.$variantCode;
+                if (! isset($seen[$runtimeTypeCode])) {
+                    $summary['missing_variants'][] = [
+                        'locale' => 'en',
+                        'runtime_type_code' => $runtimeTypeCode,
+                    ];
+                }
+            }
+
+            $summary['a_t_differentiated_sections'][$type] = $this->differentiatedSections(
+                $desiredByRuntime[$type.'-A'] ?? [],
+                $desiredByRuntime[$type.'-T'] ?? [],
+            );
+        }
+
+        $this->emitSummary($summary);
+
+        if ((bool) $this->option('assert-complete') && $summary['missing_variants'] !== []) {
+            return self::FAILURE;
+        }
+
+        return self::SUCCESS;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function selectedTypes(): array
+    {
+        $input = array_map('strval', (array) $this->option('type'));
+        $types = $input === [] ? PersonalityProfile::BASE_TYPE_CODES : array_map(
+            static fn (string $type): string => strtoupper(trim($type)),
+            $input,
+        );
+
+        $types = array_values(array_unique($types));
+        sort($types);
+
+        foreach ($types as $type) {
+            if (! in_array($type, PersonalityProfile::BASE_TYPE_CODES, true)) {
+                $this->fail('Unsupported MBTI type code: '.$type);
+            }
+        }
+
+        return $types;
+    }
+
+    /**
+     * @param  array<string,mixed>  $desired
+     */
+    private function sectionNeedsRefresh(PersonalityProfileVariantSection $section, array $desired): bool
+    {
+        foreach (['render_variant', 'body_md', 'body_html', 'sort_order', 'is_enabled'] as $field) {
+            if ($section->{$field} !== $desired[$field]) {
+                return true;
+            }
+        }
+
+        return $section->payload_json !== $desired['payload_json'];
+    }
+
+    private function variantOrProfileTypeName(PersonalityProfileVariant $variant, PersonalityProfile $profile): ?string
+    {
+        $variantTypeName = trim((string) ($variant->type_name ?? ''));
+        if ($variantTypeName !== '') {
+            return $variantTypeName;
+        }
+
+        $profileTypeName = trim((string) ($profile->type_name ?? ''));
+
+        return $profileTypeName !== '' ? $profileTypeName : null;
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $assertive
+     * @param  array<string,array<string,mixed>>  $turbulent
+     * @return list<string>
+     */
+    private function differentiatedSections(array $assertive, array $turbulent): array
+    {
+        $differentiated = [];
+        foreach ($assertive as $sectionKey => $assertiveSection) {
+            if (! isset($turbulent[$sectionKey])) {
+                continue;
+            }
+
+            if ($this->comparableSectionFingerprint($assertiveSection) !== $this->comparableSectionFingerprint($turbulent[$sectionKey])) {
+                $differentiated[] = $sectionKey;
+            }
+        }
+
+        return $differentiated;
+    }
+
+    /**
+     * @param  array<string,mixed>  $section
+     */
+    private function comparableSectionFingerprint(array $section): string
+    {
+        return json_encode([
+            'body_md' => $section['body_md'] ?? null,
+            'payload_json' => $section['payload_json'] ?? null,
+        ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '';
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+            return;
+        }
+
+        $this->line('task_id='.$summary['task_id']);
+        $this->line('dry_run='.($summary['dry_run'] ? 'true' : 'false'));
+        $this->line('locale='.$summary['locale']);
+        $this->line('expected_variants='.$summary['expected_variants']);
+        $this->line('variants_scanned='.$summary['variants_scanned']);
+        $this->line('expected_sections='.$summary['expected_sections']);
+        $this->line('sections_scanned='.$summary['sections_scanned']);
+        $this->line('section_changes='.$summary['section_changes']);
+        $this->line('writes_committed='.$summary['writes_committed']);
+        $this->line('missing_variants='.count((array) $summary['missing_variants']));
+    }
+}

--- a/backend/app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php
+++ b/backend/app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php
@@ -1,0 +1,566 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\PersonalityProfile;
+use App\Support\Mbti\MbtiCanonicalSectionRegistry;
+use InvalidArgumentException;
+
+final class MbtiEnglishVariantSectionEnrichmentService
+{
+    /**
+     * @return list<string>
+     */
+    public function sectionKeys(): array
+    {
+        return [
+            'letters_intro',
+            'overview',
+            'trait_overview',
+            'career.summary',
+            'career.advantages',
+            'career.weaknesses',
+            'career.preferred_roles',
+            'career.upgrade_suggestions',
+            'growth.summary',
+            'growth.strengths',
+            'growth.weaknesses',
+            'growth.motivators',
+            'growth.drainers',
+            'relationships.summary',
+            'relationships.strengths',
+            'relationships.weaknesses',
+            'relationships.rel_advantages',
+            'relationships.rel_risks',
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    public function supportedRuntimeTypeCodes(): array
+    {
+        $codes = [];
+
+        foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+            $codes[] = $typeCode.'-A';
+            $codes[] = $typeCode.'-T';
+        }
+
+        sort($codes);
+
+        return $codes;
+    }
+
+    /**
+     * @return array{
+     *   section_key:string,
+     *   render_variant:string,
+     *   body_md:?string,
+     *   body_html:null,
+     *   payload_json:?array<string,mixed>,
+     *   sort_order:int,
+     *   is_enabled:bool
+     * }
+     */
+    public function build(string $runtimeTypeCode, ?string $typeName, string $sectionKey): array
+    {
+        $runtimeTypeCode = strtoupper(trim($runtimeTypeCode));
+        if (! in_array($runtimeTypeCode, $this->supportedRuntimeTypeCodes(), true)) {
+            throw new InvalidArgumentException('Unsupported English MBTI runtime type code for enrichment.');
+        }
+
+        if (! in_array($sectionKey, $this->sectionKeys(), true)) {
+            throw new InvalidArgumentException('Unsupported English MBTI enrichment section key.');
+        }
+
+        $definition = MbtiCanonicalSectionRegistry::definition($sectionKey);
+        $context = $this->context($runtimeTypeCode, $typeName);
+
+        return [
+            'section_key' => $sectionKey,
+            'render_variant' => (string) $definition['render_variant'],
+            'body_md' => $this->body($sectionKey, $context),
+            'body_html' => null,
+            'payload_json' => $this->payload($sectionKey, $context),
+            'sort_order' => (int) $definition['sort_order'],
+            'is_enabled' => true,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     */
+    private function body(string $sectionKey, array $context): ?string
+    {
+        $label = (string) $context['label'];
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return match ($sectionKey) {
+            'overview' => "{$label} describes a {$base['identity']} pattern with {$variant['identity']} identity signals. You are usually at your best when {$base['best_when']}.\n\nThis page is meant to answer practical search intent: what this type is, how the {$context['variant_code']} side changes the pattern, what relationships tend to need, which work environments fit, and when taking the test can clarify your next move.",
+            'trait_overview' => "{$label} combines {$context['energy_phrase']}, {$context['information_phrase']}, {$context['decision_phrase']}, and {$context['rhythm_phrase']}. The {$context['variant_code']} variant adds {$variant['state']} rather than creating a separate personality type.",
+            'career.summary' => "{$label} usually does its best work when the role rewards {$base['career_anchor']} and gives enough room for {$base['work_need']}. The {$context['variant_label']} side changes how you handle feedback: {$variant['career_signal']}.\n\nUse this section as a starting filter, then test the fit against your skills, industry, education, and real work history.",
+            'career.upgrade_suggestions' => "For {$label}, career growth should be built around small experiments instead of a fixed job title. Start by choosing one role cluster, one work-environment condition, and one feedback habit that fits the {$context['variant_code']} pattern.",
+            'growth.summary' => "{$label} growth usually starts by protecting the strengths that already work, then noticing where those strengths become automatic. The {$context['variant_code']} variant adds a specific growth edge: {$variant['growth_edge']}.",
+            'growth.motivators' => "{$label} is usually energized by {$base['motivator']}. The {$context['variant_code']} side tends to feel most alive when {$variant['motivator']}.",
+            'growth.drainers' => "{$label} is usually drained by {$base['drainer']}. The {$context['variant_code']} side can make that drain sharper when {$variant['drainer']}.",
+            'relationships.summary' => "In relationships, {$label} tends to bring {$base['relationship_gift']} while needing {$base['relationship_need']}. The {$context['variant_label']} side changes the emotional rhythm: {$variant['relationship_signal']}.\n\nThis is not a compatibility verdict. It is a practical map for communication, repair, boundaries, and the moments when taking the test together can turn vague tension into clearer language.",
+            'relationships.rel_advantages' => "{$label} often creates trust through {$base['relationship_gift']}. The {$context['variant_code']} side can make that advantage more visible when {$variant['relationship_advantage']}.",
+            'relationships.rel_risks' => "{$label} relationship risk rises when {$base['relationship_risk']}. The {$context['variant_code']} side needs extra care because {$variant['relationship_risk']}.",
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>|null
+     */
+    private function payload(string $sectionKey, array $context): ?array
+    {
+        return match ($sectionKey) {
+            'letters_intro' => $this->lettersIntroPayload($context),
+            'trait_overview' => $this->traitOverviewPayload($context),
+            'career.advantages' => ['items' => $this->careerAdvantages($context)],
+            'career.weaknesses' => ['items' => $this->careerWeaknesses($context)],
+            'career.preferred_roles' => $this->preferredRolesPayload($context),
+            'career.upgrade_suggestions' => ['items' => $this->careerUpgradeSuggestions($context)],
+            'growth.strengths' => ['items' => $this->growthStrengths($context)],
+            'growth.weaknesses' => ['items' => $this->growthWeaknesses($context)],
+            'growth.motivators', 'growth.drainers', 'relationships.rel_advantages', 'relationships.rel_risks' => [
+                'teaser' => $this->body($sectionKey, $context),
+                'is_premium' => true,
+            ],
+            'relationships.strengths' => ['items' => $this->relationshipStrengths($context)],
+            'relationships.weaknesses' => ['items' => $this->relationshipWeaknesses($context)],
+            default => null,
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function lettersIntroPayload(array $context): array
+    {
+        return [
+            'headline' => "{$context['label']} can be read as four MBTI preference signals plus the {$context['variant_label']} identity state.",
+            'letters' => [
+                ['letter' => $context['energy_letter'], 'title' => (string) $context['energy_title'], 'description' => (string) $context['energy_phrase']],
+                ['letter' => $context['information_letter'], 'title' => (string) $context['information_title'], 'description' => (string) $context['information_phrase']],
+                ['letter' => $context['decision_letter'], 'title' => (string) $context['decision_title'], 'description' => (string) $context['decision_phrase']],
+                ['letter' => $context['rhythm_letter'], 'title' => (string) $context['rhythm_title'], 'description' => (string) $context['rhythm_phrase']],
+                ['letter' => $context['variant_code'], 'title' => (string) $context['variant_label'], 'description' => (string) ((array) $context['variant'])['state']],
+            ],
+            'structure_contract' => 'mbti_personality_variant_english_content.v1',
+            'intent' => 'what_this_type_is_and_at_difference',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function traitOverviewPayload(array $context): array
+    {
+        return [
+            'summary' => "{$context['label']} is easiest to understand through the four base preferences plus the {$context['variant_label']} state. The A/T layer explains confidence, stress sensitivity, and feedback rhythm inside the same base type.",
+            'dimensions' => [
+                $this->dimension('EI', $context, 'energy'),
+                $this->dimension('SN', $context, 'information'),
+                $this->dimension('TF', $context, 'decision'),
+                $this->dimension('JP', $context, 'rhythm'),
+                $this->dimension('AT', $context, 'variant'),
+            ],
+            'structure_contract' => 'mbti_personality_variant_english_content.v1',
+            'intent' => 'common_traits_and_at_difference',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,string>
+     */
+    private function dimension(string $axisId, array $context, string $kind): array
+    {
+        $letter = (string) ($context[$kind.'_letter'] ?? $context['variant_code']);
+
+        return [
+            'id' => $axisId,
+            'code' => $axisId,
+            'name' => (string) $context[$kind.'_name'],
+            'label' => (string) $context[$kind.'_title'],
+            'summary' => (string) $context[$kind.'_phrase'],
+            'description' => $axisId === 'AT'
+                ? 'A/T describes identity-state differences; it does not replace the four-letter base type.'
+                : 'This preference shapes search intent around traits, relationships, career fit, and daily decisions.',
+            'source' => 'cms_english_enrichment',
+            'side' => $letter,
+            'state' => 'authored_enrichment',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return array<string,mixed>
+     */
+    private function preferredRolesPayload(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            'intro' => "The paths below are not the only jobs that can fit {$context['label']}. They are role families that tend to match {$base['career_anchor']} and the {$context['variant_code']} feedback rhythm.",
+            'outro' => 'Treat these as a career exploration map, then validate the fit with skills, market demand, and real work samples.',
+            'groups' => [
+                [
+                    'group_title' => (string) $base['role_group_one'],
+                    'description' => (string) $base['role_group_one_desc'],
+                    'examples' => (array) $base['role_examples_one'],
+                ],
+                [
+                    'group_title' => (string) $base['role_group_two'],
+                    'description' => (string) $base['role_group_two_desc'],
+                    'examples' => (array) $base['role_examples_two'],
+                ],
+                [
+                    'group_title' => (string) $variant['role_group'],
+                    'description' => (string) $variant['role_desc'],
+                    'examples' => (array) $variant['role_examples'],
+                ],
+            ],
+            'structure_contract' => 'mbti_personality_variant_english_content.v1',
+            'intent' => 'career_and_best_fit_work',
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function careerAdvantages(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Work style fit', 'body' => "{$context['label']} often contributes best through {$base['work_strength']}."],
+            ['title' => 'Decision advantage', 'body' => "Your {$context['decision_title']} pattern helps you {$base['decision_advantage']}."],
+            ['title' => 'Environment signal', 'body' => "You tend to notice whether a role supports {$base['work_need']} quickly."],
+            ['title' => "{$context['variant_label']} edge", 'body' => (string) $variant['career_advantage']],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function careerWeaknesses(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Poor-fit environments', 'body' => "{$context['label']} can lose energy when work rewards {$base['career_misfit']}."],
+            ['title' => 'Overuse pattern', 'body' => "A useful strength can become a blind spot when {$base['overuse']}."],
+            ['title' => 'Feedback friction', 'body' => (string) $variant['career_risk']],
+            ['title' => 'Next-step risk', 'body' => 'Do not choose a job title only because it sounds like a type match; test the actual tasks and feedback loop.'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function careerUpgradeSuggestions(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Pick one work sample', 'body' => "Choose a small project that proves {$base['career_anchor']} instead of only reading job descriptions."],
+            ['title' => 'Name your environment filter', 'body' => "Write down the conditions that protect {$base['work_need']} and the conditions that drain it."],
+            ['title' => 'Use the variant signal', 'body' => (string) $variant['career_experiment']],
+            ['title' => 'Retake or compare results', 'body' => 'If your result feels close, take the test again after a stable week and compare which sections still feel true.'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function growthStrengths(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Natural growth route', 'body' => "{$context['label']} grows fastest by turning {$base['core_strength']} into a repeatable practice."],
+            ['title' => 'Self-awareness signal', 'body' => "Your {$context['information_title']} pattern helps you notice {$base['learning_signal']}."],
+            ['title' => 'Identity strength', 'body' => (string) $variant['growth_strength']],
+            ['title' => 'Practical reset', 'body' => "When the pattern is working, you can usually return to clarity by {$base['reset']}."],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function growthWeaknesses(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Overextension risk', 'body' => "{$context['label']} can get stuck when {$base['growth_risk']}."],
+            ['title' => 'Blind spot', 'body' => "Your {$context['decision_title']} pattern can miss context when {$base['blind_spot']}."],
+            ['title' => "{$context['variant_label']} watchout", 'body' => (string) $variant['growth_risk']],
+            ['title' => 'Repair move', 'body' => 'The useful move is not to reject the type label, but to choose one small behavior that balances it.'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function relationshipStrengths(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Connection style', 'body' => "{$context['label']} often builds trust through {$base['relationship_gift']}."],
+            ['title' => 'Communication value', 'body' => "Your {$context['decision_title']} pattern can help others understand {$base['communication_value']}."],
+            ['title' => 'Support rhythm', 'body' => "You usually support people best when {$base['support_rhythm']}."],
+            ['title' => "{$context['variant_label']} signal", 'body' => (string) $variant['relationship_strength']],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $context
+     * @return list<array<string,string>>
+     */
+    private function relationshipWeaknesses(array $context): array
+    {
+        $base = (array) $context['base'];
+        $variant = (array) $context['variant'];
+
+        return [
+            ['title' => 'Conflict pattern', 'body' => "{$context['label']} can create friction when {$base['relationship_risk']}."],
+            ['title' => 'Misread signal', 'body' => "Other people may misread {$base['misread_signal']} if you do not explain the need underneath."],
+            ['title' => "{$context['variant_label']} risk", 'body' => (string) $variant['relationship_risk']],
+            ['title' => 'Repair move', 'body' => 'Name the need, name the trade-off, and choose one concrete next conversation instead of turning the type into a fixed verdict.'],
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function context(string $runtimeTypeCode, ?string $typeName): array
+    {
+        [$baseType, $variantCode] = explode('-', $runtimeTypeCode);
+        $base = $this->baseTypeData()[$baseType];
+        $variant = $this->variantData()[$variantCode];
+        $letters = str_split($baseType);
+
+        return array_merge([
+            'runtime_type_code' => $runtimeTypeCode,
+            'base_type' => $baseType,
+            'variant_code' => $variantCode,
+            'type_name' => $this->normalizeTypeName($typeName),
+            'label' => $runtimeTypeCode.' '.$this->normalizeTypeName($typeName),
+            'variant_label' => (string) $variant['label'],
+            'base' => $base,
+            'variant' => $variant,
+        ], $this->axisContext($letters, $variantCode));
+    }
+
+    /**
+     * @param  list<string>  $letters
+     * @return array<string,string>
+     */
+    private function axisContext(array $letters, string $variantCode): array
+    {
+        $copy = [
+            'E' => ['energy', 'Extraversion', 'Draws momentum from interaction, visible activity, and external feedback.'],
+            'I' => ['energy', 'Introversion', 'Builds clarity through private processing, focused attention, and lower-noise settings.'],
+            'S' => ['information', 'Sensing', 'Trusts concrete evidence, lived experience, and details that can be verified.'],
+            'N' => ['information', 'Intuition', 'Looks for patterns, possibilities, and the deeper meaning behind what is visible.'],
+            'T' => ['decision', 'Thinking', 'Uses logic, principles, and cause-effect reasoning to make decisions.'],
+            'F' => ['decision', 'Feeling', 'Uses values, human impact, and relationship context to make decisions.'],
+            'J' => ['rhythm', 'Judging', 'Prefers structure, closure, planning, and clear follow-through.'],
+            'P' => ['rhythm', 'Perceiving', 'Prefers flexibility, discovery, options, and adaptation as new information appears.'],
+        ];
+
+        $axis = [];
+        foreach ($letters as $letter) {
+            [$kind, $title, $phrase] = $copy[$letter];
+            $axis[$kind.'_letter'] = $letter;
+            $axis[$kind.'_name'] = match ($kind) {
+                'energy' => 'Energy orientation',
+                'information' => 'Information style',
+                'decision' => 'Decision style',
+                default => 'Life rhythm',
+            };
+            $axis[$kind.'_title'] = $title;
+            $axis[$kind.'_phrase'] = $phrase;
+        }
+
+        $axis['variant_letter'] = $variantCode;
+        $axis['variant_name'] = 'A/T identity state';
+        $axis['variant_title'] = $variantCode === 'A' ? 'Assertive' : 'Turbulent';
+        $axis['variant_phrase'] = $this->variantData()[$variantCode]['state'];
+
+        return $axis;
+    }
+
+    private function normalizeTypeName(?string $typeName): string
+    {
+        $normalized = trim((string) $typeName);
+        if ($normalized === '') {
+            return 'Personality';
+        }
+
+        $normalized = preg_replace('/\s+/', ' ', $normalized) ?: $normalized;
+        $normalized = preg_replace('/\b(?:Assertive|Turbulent)\b/i', '', $normalized) ?: $normalized;
+
+        return trim($normalized) !== '' ? trim($normalized) : 'Personality';
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function variantData(): array
+    {
+        return [
+            'A' => [
+                'label' => 'Assertive',
+                'identity' => 'steadier self-trust, lower reactivity, and a stronger bias toward moving on after feedback',
+                'state' => 'more stable self-confidence, lower stress reactivity, and a tendency to recover faster from criticism',
+                'career_signal' => 'you may commit faster and need deliberate check-ins so confidence does not skip useful feedback',
+                'career_advantage' => 'You can often keep momentum when a role is ambiguous or feedback is mixed.',
+                'career_risk' => 'Assertive confidence can make weak signals look less urgent than they are.',
+                'career_experiment' => 'Add one scheduled feedback checkpoint before you finalize a plan.',
+                'role_group' => 'Self-directed ownership',
+                'role_desc' => 'Roles where confidence, autonomy, and accountable decision-making are useful.',
+                'role_examples' => ['independent project ownership', 'strategy execution', 'founder-style problem solving'],
+                'growth_edge' => 'learning to invite feedback before the cost of adjustment becomes high',
+                'growth_strength' => 'You can stabilize yourself and others when a situation becomes noisy.',
+                'growth_risk' => 'You may move past discomfort too quickly and miss the information inside it.',
+                'motivator' => 'you can act with trust in your judgment and see visible progress',
+                'drainer' => 'feedback is delayed until a problem is already expensive',
+                'relationship_signal' => 'you may bring calm and independence, but you need to show others when you are still listening',
+                'relationship_advantage' => 'your calm helps reduce emotional escalation',
+                'relationship_strength' => 'You can stay steady during tension and avoid turning every disagreement into a crisis.',
+                'relationship_risk' => 'others may experience your confidence as dismissiveness if you do not make room for their doubts',
+            ],
+            'T' => [
+                'label' => 'Turbulent',
+                'identity' => 'higher self-monitoring, stronger sensitivity to feedback, and a drive to keep improving',
+                'state' => 'more self-questioning, stronger stress awareness, and a tendency to scan for what should be improved',
+                'career_signal' => 'you may refine work more carefully, but need boundaries so improvement does not become endless revision',
+                'career_advantage' => 'You can catch weak signals early and improve a plan before problems become public.',
+                'career_risk' => 'Turbulent self-monitoring can turn normal ambiguity into overcorrection or delay.',
+                'career_experiment' => 'Set a good-enough threshold before you start refining.',
+                'role_group' => 'Quality and improvement loops',
+                'role_desc' => 'Roles where sensitivity to feedback, iteration, and careful adjustment create value.',
+                'role_examples' => ['quality improvement', 'research refinement', 'customer insight loops'],
+                'growth_edge' => 'turning self-critique into one clear adjustment instead of a full identity verdict',
+                'growth_strength' => 'You can notice small issues early and use them as useful signals for growth.',
+                'growth_risk' => 'You may treat every flaw as urgent and exhaust yourself before the pattern is clear.',
+                'motivator' => 'you can turn feedback into visible improvement without losing the original purpose',
+                'drainer' => 'every choice feels like a referendum on your competence',
+                'relationship_signal' => 'you may be more sensitive and repair-oriented, but you need to avoid making every silence mean rejection',
+                'relationship_advantage' => 'your sensitivity helps you notice emotional shifts before they harden',
+                'relationship_strength' => 'You can repair and improve relationships because you notice subtle feedback.',
+                'relationship_risk' => 'self-doubt can make neutral feedback feel like rejection or proof that something is wrong',
+            ],
+        ];
+    }
+
+    /**
+     * @return array<string,array<string,mixed>>
+     */
+    private function baseTypeData(): array
+    {
+        return [
+            'ENFJ' => $this->data('people-focused leadership and shared purpose', 'guiding people toward a meaningful direction', 'you can align people, purpose, and next steps', 'relational leadership', 'visible cooperation and values-aligned progress', 'people-first strategy', 'warm structure', 'too many unspoken obligations', 'you carry everyone else before naming your own limits', 'emotional responsibility overload', 'you postpone hard truths to protect harmony', 'steady encouragement and moral clarity', 'reciprocal effort and honest appreciation', 'people feel seen before they are pushed', 'the emotional temperature in the room', 'you turn empathy into practical direction', 'taking a quiet reset before re-entering the group', 'personal distance as rejection', 'mission-led leadership', ['team leadership', 'coaching', 'community building'], 'people systems and communication', ['learning design', 'employee experience', 'brand storytelling']),
+            'ENFP' => $this->data('possibility-seeking connection and imaginative momentum', 'opening new options and energizing people around them', 'you can connect ideas, people, and meaning', 'creative exploration', 'freedom to explore and human relevance', 'idea generation', 'adaptive enthusiasm', 'rigid routines with little meaning', 'you chase novelty without finishing the useful signal', 'scattered execution', 'you delay structure until others feel uncertain', 'curiosity, warmth, and imaginative reframing', 'space for authenticity and change', 'the relationship keeps room for growth', 'whether people still feel emotionally engaged', 'you turn possibility into renewed energy', 'choosing one idea to test this week', 'inconsistency as lack of care', 'creative communication', ['content strategy', 'community growth', 'innovation workshops'], 'human-centered exploration', ['user research', 'coaching', 'campaign design']),
+            'ENTJ' => $this->data('decisive strategy and system-level leadership', 'turning complexity into direction and execution', 'you can set direction, organize resources, and move decisively', 'strategic leadership', 'authority to improve systems and raise standards', 'executive decision-making', 'commanding focus', 'low-accountability environments', 'you push speed before alignment is real', 'impatience with slower processing', 'you under-explain the human cost of the plan', 'clarity, protection, and decisive problem solving', 'competence and directness', 'the plan and the people are both respected', 'whether the system is actually working', 'you turn ambition into structure', 'checking whether the team understood the why', 'intensity as control', 'strategy and operations leadership', ['business strategy', 'operations leadership', 'product leadership'], 'high-stakes execution', ['management consulting', 'growth operations', 'organizational design']),
+            'ENTP' => $this->data('inventive debate and rapid pattern testing', 'challenging assumptions and testing better possibilities', 'you can reframe stuck problems and expose hidden options', 'strategic experimentation', 'room to question assumptions and iterate', 'idea testing', 'restless ingenuity', 'repetitive work with fixed answers', 'you keep reopening decisions after the team needs closure', 'argument without landing', 'you treat emotional cues as optional data', 'energy, humor, and new angles', 'mental stimulation and honest debate', 'debate leads to discovery, not domination', 'where the argument gets more interesting', 'you turn friction into invention', 'writing the decision rule before debating', 'challenge as criticism', 'innovation and experimentation', ['product discovery', 'venture building', 'strategy workshops'], 'problem reframing', ['market research', 'creative technology', 'systems innovation']),
+            'ESFJ' => $this->data('practical care and dependable social coordination', 'making people feel supported and systems feel usable', 'you can organize support around real human needs', 'service leadership', 'clear expectations and visible usefulness', 'community operations', 'dependable warmth', 'cold environments with little appreciation', 'you over-function to keep everyone comfortable', 'approval dependence', 'you avoid conflict until resentment appears', 'dependability, warmth, and practical help', 'appreciation and clear commitments', 'care is returned, not only expected', 'whether everyone has what they need', 'you turn care into reliable action', 'asking directly for what you need', 'helpfulness as pressure', 'service and operations', ['customer success', 'education support', 'healthcare coordination'], 'relationship-centered execution', ['community management', 'HR operations', 'event coordination']),
+            'ESFP' => $this->data('present-moment energy and people-centered action', 'bringing experience, responsiveness, and real-time warmth', 'you can make people feel alive, included, and ready to act', 'experiential connection', 'visible impact and freedom to respond', 'hands-on engagement', 'adaptive presence', 'abstract planning without human contact', 'you follow the immediate feeling before checking the long-term cost', 'short-term overcommitment', 'you avoid heavy conversations until they interrupt the fun', 'warmth, responsiveness, and shared experience', 'presence and emotional honesty', 'the moment feels real and mutual', 'what is happening right now', 'you turn energy into participation', 'pausing before saying yes', 'spontaneity as unreliability', 'experience and engagement', ['sales enablement', 'hospitality', 'event experience'], 'hands-on people work', ['training facilitation', 'community activation', 'creative production']),
+            'ESTJ' => $this->data('orderly execution and accountable leadership', 'turning standards into reliable action', 'you can clarify expectations and make progress measurable', 'operational leadership', 'clear authority, standards, and responsibility', 'structured execution', 'practical command', 'unclear ownership and shifting rules', 'you treat exceptions as discipline problems before understanding context', 'rigidity under pressure', 'you correct before you connect', 'reliability, protection, and follow-through', 'respect and shared standards', 'commitments are clear and honored', 'whether the agreement is being kept', 'you turn standards into stability', 'checking context before correcting behavior', 'directness as judgment', 'operations and management', ['operations management', 'compliance leadership', 'project delivery'], 'process and accountability', ['logistics planning', 'finance operations', 'administration leadership']),
+            'ESTP' => $this->data('fast tactical action and real-world problem solving', 'reading the situation and acting before momentum disappears', 'you can respond quickly, negotiate reality, and keep people moving', 'tactical execution', 'autonomy, action, and practical stakes', 'rapid problem solving', 'bold responsiveness', 'slow theory without visible payoff', 'you act before the quieter risks are understood', 'impulsiveness under stimulation', 'you move on before others feel heard', 'courage, presence, and practical rescue energy', 'freedom and direct honesty', 'problems are handled, not endlessly discussed', 'what move works in the real world', 'you turn pressure into action', 'naming the risk before taking the leap', 'directness as carelessness', 'field execution and negotiation', ['sales strategy', 'emergency operations', 'field leadership'], 'hands-on problem solving', ['business development', 'sports operations', 'technical troubleshooting']),
+            'INFJ' => $this->data('quiet vision and values-led insight', 'connecting deep meaning with practical care for people', 'you can see underlying patterns and guide change with intention', 'purpose-driven insight', 'privacy, meaning, and ethical alignment', 'deep interpretation', 'focused idealism', 'surface-level work with no human meaning', 'you hold the whole emotional pattern alone', 'private over-responsibility', 'you expect others to infer what you have not said', 'depth, loyalty, and thoughtful care', 'trust, sincerity, and emotional safety', 'the bond has meaning beyond convenience', 'what the pattern says about the future', 'you turn insight into compassionate direction', 'putting one need into plain language', 'quietness as withdrawal', 'mission and insight work', ['counseling support', 'research synthesis', 'nonprofit strategy'], 'human-centered strategy', ['UX research', 'writing', 'organizational culture']),
+            'INFP' => $this->data('inner values and imaginative meaning-making', 'protecting authenticity while turning feeling into expression', 'you can translate inner values into words, art, care, or guidance', 'values-led creativity', 'autonomy, meaning, and emotional truth', 'creative meaning-making', 'gentle conviction', 'cynical environments with no room for sincerity', 'you keep the ideal private instead of testing it', 'avoidant idealism', 'you wait too long to name a boundary', 'empathy, sincerity, and emotional imagination', 'gentleness and room for inner truth', 'both people can be honest without being flattened', 'whether something still feels true', 'you turn feeling into meaning', 'choosing one value to express concretely', 'silence as lack of love', 'writing and helping professions', ['creative writing', 'counseling support', 'content strategy'], 'values-based work', ['education support', 'advocacy', 'brand storytelling']),
+            'INTJ' => $this->data('strategic independence and long-range system design', 'solving complex problems and improving systems over time', 'you can build coherent plans and protect high-leverage progress', 'strategic systems thinking', 'autonomy, competence, and rational structure', 'system design', 'independent strategy', 'political noise and irrational process', 'you perfect the system before enough people understand it', 'detached over-optimization', 'you assume clarity is obvious because it is logical', 'loyalty, depth, and long-term seriousness', 'intellectual honesty and independence', 'the relationship has substance and future logic', 'what makes the system coherent', 'you turn complexity into architecture', 'sharing the reasoning before the conclusion', 'distance as indifference', 'strategy and systems', ['strategy and planning', 'systems architecture', 'product strategy'], 'analytical depth', ['data analysis', 'research', 'technical consulting']),
+            'INTP' => $this->data('analytical curiosity and conceptual precision', 'understanding how ideas work and where assumptions break', 'you can model complexity and find cleaner explanations', 'conceptual analysis', 'time to think, explore, and refine ideas', 'theory and analysis', 'independent curiosity', 'busywork and forced certainty', 'you keep analyzing after a useful answer is ready', 'analysis paralysis', 'you explain the idea but not the emotional implication', 'intellectual honesty, curiosity, and calm perspective', 'mental space and low-pressure honesty', 'ideas and feelings can both be examined safely', 'whether the explanation fits', 'you turn confusion into models', 'choosing the smallest useful conclusion', 'detachment as disinterest', 'research and analysis', ['research science', 'software architecture', 'data modeling'], 'conceptual problem solving', ['technical writing', 'systems analysis', 'product research']),
+            'ISFJ' => $this->data('quiet reliability and attentive practical care', 'protecting people through memory, detail, and steady support', 'you can notice what others need and make care reliable', 'dependable service', 'clear expectations, trust, and useful routines', 'supportive operations', 'attentive steadiness', 'constant change without appreciation', 'you keep serving after your capacity is gone', 'hidden resentment', 'you hope people notice needs you have not named', 'loyalty, attentiveness, and practical care', 'consistency and appreciation', 'care is specific, steady, and mutual', 'which details make people feel safe', 'you turn memory into care', 'stating one preference before helping', 'quiet service as obligation', 'care and coordination', ['healthcare support', 'education operations', 'administrative coordination'], 'detail-rich service', ['customer support', 'quality assurance', 'community care']),
+            'ISFP' => $this->data('sensitive presence and values expressed through action', 'staying true to personal values while responding to the moment', 'you can bring taste, gentleness, and real human presence', 'values-in-action creativity', 'freedom, sincerity, and tangible expression', 'creative craft', 'quiet authenticity', 'harsh judgment or rigid conformity', 'you disappear instead of explaining the boundary', 'avoidant withdrawal', 'you protect harmony by hiding the real preference', 'gentleness, aesthetic care, and emotional presence', 'acceptance and room to be real', 'the relationship feels safe enough to be unpolished', 'whether the moment feels authentic', 'you turn values into lived choices', 'naming the boundary before leaving', 'privacy as distance', 'creative and hands-on work', ['design craft', 'wellness support', 'visual storytelling'], 'people-centered experience', ['hospitality design', 'personal services', 'community art']),
+            'ISTJ' => $this->data('disciplined reliability and evidence-based execution', 'turning proven information into dependable results', 'you can create order, protect standards, and finish what matters', 'reliable execution', 'clear rules, competence, and factual grounding', 'process reliability', 'steady responsibility', 'vague change with no evidence', 'you resist adaptation after the facts have changed', 'over-reliance on precedent', 'you show care through duty while others need words', 'dependability, honesty, and concrete support', 'trustworthiness and follow-through', 'promises are specific and kept', 'which facts prove the commitment', 'you turn duty into stability', 'checking whether the old rule still fits', 'reserved care as coldness', 'operations and compliance', ['accounting', 'operations analysis', 'quality management'], 'evidence-based work', ['logistics', 'data stewardship', 'public administration']),
+            'ISTP' => $this->data('practical precision and independent troubleshooting', 'understanding systems through direct action and calm experimentation', 'you can solve concrete problems without unnecessary drama', 'hands-on problem solving', 'autonomy, tools, and observable results', 'technical troubleshooting', 'calm precision', 'abstract meetings with no practical result', 'you detach before others know what you are testing', 'under-communication', 'you solve the practical issue while skipping emotional repair', 'calm competence, independence, and useful action', 'space and directness', 'problems are handled without performance', 'what works under real conditions', 'you turn pressure into practical fixes', 'explaining the experiment before disappearing into it', 'independence as disconnection', 'technical and field problem solving', ['engineering support', 'mechanical systems', 'security operations'], 'applied analysis', ['forensics', 'IT troubleshooting', 'product prototyping']),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function data(
+        string $identity,
+        string $theme,
+        string $bestWhen,
+        string $careerAnchor,
+        string $workNeed,
+        string $workStrength,
+        string $coreStrength,
+        string $careerMisfit,
+        string $overuse,
+        string $growthRisk,
+        string $blindSpot,
+        string $relationshipGift,
+        string $relationshipNeed,
+        string $supportRhythm,
+        string $learningSignal,
+        string $motivator,
+        string $reset,
+        string $misreadSignal,
+        string $roleGroupOne,
+        array $roleExamplesOne,
+        string $roleGroupTwo,
+        array $roleExamplesTwo,
+    ): array {
+        return [
+            'identity' => $identity,
+            'theme' => $theme,
+            'best_when' => $bestWhen,
+            'career_anchor' => $careerAnchor,
+            'work_need' => $workNeed,
+            'work_strength' => $workStrength,
+            'core_strength' => $coreStrength,
+            'career_misfit' => $careerMisfit,
+            'overuse' => $overuse,
+            'growth_risk' => $growthRisk,
+            'blind_spot' => $blindSpot,
+            'relationship_gift' => $relationshipGift,
+            'relationship_need' => $relationshipNeed,
+            'support_rhythm' => $supportRhythm,
+            'learning_signal' => $learningSignal,
+            'motivator' => $motivator,
+            'drainer' => $careerMisfit,
+            'reset' => $reset,
+            'relationship_risk' => $overuse,
+            'misread_signal' => $misreadSignal,
+            'communication_value' => $learningSignal,
+            'decision_advantage' => $bestWhen,
+            'role_group_one' => $roleGroupOne,
+            'role_group_one_desc' => "Work that rewards {$careerAnchor} and makes {$workNeed} useful.",
+            'role_examples_one' => $roleExamplesOne,
+            'role_group_two' => $roleGroupTwo,
+            'role_group_two_desc' => "Contexts where {$workStrength} can become visible output.",
+            'role_examples_two' => $roleExamplesTwo,
+        ];
+    }
+}

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -1,11 +1,71 @@
 {
   "train_name": "career-night-train",
   "started_at": "2026-04-09T00:00:00Z",
-  "updated_at": "2026-06-09T15:23:28+08:00",
+  "updated_at": "2026-06-11T20:24:49+08:00",
   "mode": "local_clone_preferred",
   "base_branch": "main",
   "stop_on_failure": true,
   "items": {
+    "PERSONALITY-EN-CONTENT-00": {
+      "repo": "fap-api",
+      "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
+      "status": "pr_open",
+      "branch": "codex/personality-en-content-00",
+      "commit_sha": "c0ed5562dc07f937f4d29674ba276cc7835dfc68",
+      "pr_url": "https://github.com/fermatmind/fap-api/pull/2037",
+      "checks": {
+        "local": [
+          {
+            "command": "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+            "status": "passed"
+          },
+          {
+            "command": "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'",
+            "status": "passed"
+          },
+          {
+            "command": "vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php",
+            "status": "passed"
+          },
+          {
+            "command": "php artisan test tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php --no-ansi",
+            "status": "passed",
+            "details": "4 tests and 73 assertions passed."
+          },
+          {
+            "command": "php artisan list | rg 'personality:enrich-mbti-english-variant-sections'",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --check && git diff --cached --check",
+            "status": "passed"
+          }
+        ],
+        "github": []
+      },
+      "failure_reason": "",
+      "resume_policy": "manual_only",
+      "merged_at": "",
+      "remote_branch_deleted": false,
+      "local_cleanup_executed": false,
+      "history": [
+        {
+          "at": "2026-06-11T20:24:49+08:00",
+          "status": "in_progress",
+          "summary": "Initialized PERSONALITY-EN-CONTENT-00 for backend/CMS-only English MBTI A/T personality variant section enrichment. Scope excludes fap-web, publishing, sitemap/llms, search submission, scheduler, and production mutation during the PR."
+        },
+        {
+          "at": "2026-06-11T20:24:49+08:00",
+          "status": "local_checks_passed",
+          "summary": "Added dry-run/no-write default English MBTI variant section enrichment command, CMS enrichment service, and focused tests. Scoped JSON/YAML, Pint, PHPUnit, artisan command discovery, and diff checks passed."
+        },
+        {
+          "at": "2026-06-11T20:24:49+08:00",
+          "status": "pr_open",
+          "summary": "Opened PR #2037 for PERSONALITY-EN-CONTENT-00."
+        }
+      ]
+    },
     "PR-CMS-01": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "pr_open",
       "branch": "codex/personality-en-content-00",
-      "commit_sha": "c0ed5562dc07f937f4d29674ba276cc7835dfc68",
+      "commit_sha": "4d319ae448c2fd605d0cdebc47bb44c138f1249a",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2037",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -9,7 +9,7 @@
     "PERSONALITY-EN-CONTENT-00": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "pr_open",
+      "status": "ci_fix_local_checks_passed",
       "branch": "codex/personality-en-content-00",
       "commit_sha": "4d319ae448c2fd605d0cdebc47bb44c138f1249a",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2037",
@@ -24,7 +24,7 @@
             "status": "passed"
           },
           {
-            "command": "vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php",
+            "command": "vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php",
             "status": "passed"
           },
           {
@@ -33,15 +33,30 @@
             "details": "4 tests and 73 assertions passed."
           },
           {
+            "command": "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=mbti_personality_english_variant_section_enrichment --no-ansi",
+            "status": "passed",
+            "details": "1 test and 1 assertion passed."
+          },
+          {
             "command": "php artisan list | rg 'personality:enrich-mbti-english-variant-sections'",
             "status": "passed"
           },
           {
-            "command": "git diff --check && git diff --cached --check",
+            "command": "git diff --check",
+            "status": "passed"
+          },
+          {
+            "command": "git diff --cached --check",
             "status": "passed"
           }
         ],
-        "github": []
+        "github": [
+          {
+            "name": "verify-bigfive",
+            "status": "failed_fix_applied",
+            "details": "GitHub verify-bigfive failed because the runtime freeze classifier did not yet exempt the new backend MBTI English variant section enrichment command/service; added a focused classifier exception and regression test."
+          }
+        ]
       },
       "failure_reason": "",
       "resume_policy": "manual_only",
@@ -63,6 +78,11 @@
           "at": "2026-06-11T20:24:49+08:00",
           "status": "pr_open",
           "summary": "Opened PR #2037 for PERSONALITY-EN-CONTENT-00."
+        },
+        {
+          "at": "2026-06-11T20:43:02+08:00",
+          "status": "ci_fix_local_checks_passed",
+          "summary": "Fixed PR #2037 verify-bigfive failure by exempting the backend MBTI English variant section enrichment command/service from the BigFive runtime freeze classifier and adding a focused regression test. JSON/YAML, Pint, focused PHPUnit, command discovery, and diff checks passed."
         }
       ]
     },

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -11,7 +11,7 @@
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
       "status": "ci_fix_local_checks_passed",
       "branch": "codex/personality-en-content-00",
-      "commit_sha": "4d319ae448c2fd605d0cdebc47bb44c138f1249a",
+      "commit_sha": "324c6e30ec6a11f4e77355259b8ca8068f094138",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2037",
       "checks": {
         "local": [

--- a/backend/docs/codex/pr-train-state.json
+++ b/backend/docs/codex/pr-train-state.json
@@ -9,9 +9,9 @@
     "PERSONALITY-EN-CONTENT-00": {
       "repo": "fap-api",
       "repo_path": "/Users/rainie/Desktop/GitHub/fap-api/backend",
-      "status": "ci_fix_local_checks_passed",
+      "status": "ready_to_merge",
       "branch": "codex/personality-en-content-00",
-      "commit_sha": "324c6e30ec6a11f4e77355259b8ca8068f094138",
+      "commit_sha": "8ff2b65edd0b4a32f948f1424e9aad58fb9ef7b8",
       "pr_url": "https://github.com/fermatmind/fap-api/pull/2037",
       "checks": {
         "local": [
@@ -52,9 +52,44 @@
         ],
         "github": [
           {
+            "name": "hygiene",
+            "status": "passed",
+            "details": "GitHub push and pull_request hygiene checks passed on PR #2037."
+          },
+          {
+            "name": "supply-chain",
+            "status": "passed",
+            "details": "GitHub push and pull_request supply-chain checks passed on PR #2037."
+          },
+          {
+            "name": "content-pack-build-validate",
+            "status": "passed",
+            "details": "GitHub push and pull_request content-pack-build-validate checks passed on PR #2037."
+          },
+          {
+            "name": "Semgrep blocking secrets",
+            "status": "passed",
+            "details": "GitHub Semgrep blocking secrets passed on PR #2037."
+          },
+          {
+            "name": "semgrep sarif non-blocking upload",
+            "status": "passed",
+            "details": "GitHub semgrep SARIF upload passed on PR #2037."
+          },
+          {
             "name": "verify-bigfive",
-            "status": "failed_fix_applied",
-            "details": "GitHub verify-bigfive failed because the runtime freeze classifier did not yet exempt the new backend MBTI English variant section enrichment command/service; added a focused classifier exception and regression test."
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-bigfive checks passed on PR #2037 after the scoped classifier fix."
+          },
+          {
+            "name": "verify-mbti-legacy",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-legacy checks passed on PR #2037."
+          },
+          {
+            "name": "verify-mbti-v2",
+            "status": "passed",
+            "details": "GitHub push and pull_request verify-mbti-v2 checks passed on PR #2037."
           }
         ]
       },
@@ -83,6 +118,11 @@
           "at": "2026-06-11T20:43:02+08:00",
           "status": "ci_fix_local_checks_passed",
           "summary": "Fixed PR #2037 verify-bigfive failure by exempting the backend MBTI English variant section enrichment command/service from the BigFive runtime freeze classifier and adding a focused regression test. JSON/YAML, Pint, focused PHPUnit, command discovery, and diff checks passed."
+        },
+        {
+          "at": "2026-06-11T20:49:11+08:00",
+          "status": "ready_to_merge",
+          "summary": "GitHub checks for PR #2037 passed after the scoped CI classifier fix. Ready for merge under github_checks_or_local_verify policy."
         }
       ]
     },

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -3795,8 +3795,9 @@ prs:
     checks:
       - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
       - "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'"
-      - "vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php"
+      - "vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php"
       - "php artisan test tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php --no-ansi"
+      - "php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter=mbti_personality_english_variant_section_enrichment --no-ansi"
       - "php artisan list | rg 'personality:enrich-mbti-english-variant-sections'"
       - "git diff --check"
       - "git diff --cached --check"

--- a/backend/docs/codex/pr-train.yaml
+++ b/backend/docs/codex/pr-train.yaml
@@ -3774,3 +3774,38 @@ prs:
     cleanup:
       delete_remote_branch: true
       run_local_cleanup: true
+
+  - id: PERSONALITY-EN-CONTENT-00
+    repo: fap-api
+    repo_path: /Users/rainie/Desktop/GitHub/fap-api/backend
+    branch: codex/personality-en-content-00
+    base: main
+    depends_on: []
+    mode: execute
+    title: "PERSONALITY-EN-CONTENT-00: feat(cms): enrich English MBTI variant page sections"
+    scope: >
+      Backend/CMS-only English MBTI variant section enrichment. Add a guarded
+      Artisan command and CMS projection service to enrich en 16 MBTI types x
+      A/T = 32 personality variant pages across existing section keys, with
+      dry-run/no-write default, explicit --write for CMS section updates, and
+      contract tests for A/T differentiation, CTA/content intent, and English
+      scope isolation. Do not change fap-web, publish articles, change sitemap
+      or llms, alter robots/indexability/canonical metadata, submit to Google
+      or Baidu, enable scheduler, or mutate production content during this PR.
+    checks:
+      - "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null"
+      - "ruby -e 'require \"yaml\"; YAML.load_file(\"docs/codex/pr-train.yaml\")'"
+      - "vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php"
+      - "php artisan test tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php --no-ansi"
+      - "php artisan list | rg 'personality:enrich-mbti-english-variant-sections'"
+      - "git diff --check"
+      - "git diff --cached --check"
+    stop_if_changed_files_outside_scope: true
+    resume_policy: manual_only
+    merge_policy:
+      mode: github_checks_or_local_verify
+      local_verify_required: true
+      github_checks_required: false
+    cleanup:
+      delete_remote_branch: true
+      run_local_cleanup: true

--- a/backend/tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php
@@ -1,0 +1,253 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\PersonalityProfile;
+use App\Models\PersonalityProfileVariant;
+use App\Models\PersonalityProfileVariantSection;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+final class PersonalityEnrichMbtiEnglishVariantSectionsCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_dry_run_reports_complete_english_32_variant_scope_without_writes(): void
+    {
+        $this->createEnglishMbtiVariantMatrix();
+
+        $this->artisan('personality:enrich-mbti-english-variant-sections', [
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('task_id=PERSONALITY-EN-CONTENT-00')
+            ->expectsOutputToContain('dry_run=true')
+            ->expectsOutputToContain('locale=en')
+            ->expectsOutputToContain('expected_variants=32')
+            ->expectsOutputToContain('variants_scanned=32')
+            ->expectsOutputToContain('expected_sections=576')
+            ->expectsOutputToContain('section_changes=576')
+            ->expectsOutputToContain('writes_committed=0')
+            ->expectsOutputToContain('missing_variants=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, PersonalityProfileVariantSection::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_write_enriches_english_variant_sections_without_touching_publication_or_chinese_rows(): void
+    {
+        $variants = $this->createEnglishMbtiVariantMatrix();
+        $zhProfile = $this->createProfile('zh-CN', 'INFP', '调停者');
+        $zhVariant = $this->createVariant($zhProfile, 'INFP-T');
+        PersonalityProfileVariantSection::query()->create([
+            'personality_profile_variant_id' => (int) $zhVariant->id,
+            'section_key' => 'overview',
+            'render_variant' => 'rich_text',
+            'body_md' => '中文内容不应被英文增强命令改写。',
+            'body_html' => null,
+            'payload_json' => null,
+            'sort_order' => 20,
+            'is_enabled' => true,
+        ]);
+
+        $this->artisan('personality:enrich-mbti-english-variant-sections', [
+            '--write' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('dry_run=false')
+            ->expectsOutputToContain('expected_variants=32')
+            ->expectsOutputToContain('variants_scanned=32')
+            ->expectsOutputToContain('expected_sections=576')
+            ->expectsOutputToContain('writes_committed=576')
+            ->expectsOutputToContain('missing_variants=0')
+            ->assertExitCode(0);
+
+        $this->assertSame(577, PersonalityProfileVariantSection::query()->withoutGlobalScopes()->count());
+
+        $infpT = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['INFP-T']->id)
+            ->where('section_key', 'relationships.summary')
+            ->firstOrFail();
+
+        $this->assertStringContainsString('INFP-T Mediator', (string) $infpT->body_md);
+        $this->assertStringContainsString('Turbulent', (string) $infpT->body_md);
+        $this->assertStringContainsString('communication, repair, boundaries', (string) $infpT->body_md);
+
+        $infpA = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['INFP-A']->id)
+            ->where('section_key', 'relationships.summary')
+            ->firstOrFail();
+
+        $this->assertNotSame($infpA->body_md, $infpT->body_md);
+
+        $preferredRoles = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['INTJ-A']->id)
+            ->where('section_key', 'career.preferred_roles')
+            ->firstOrFail();
+
+        $this->assertSame('preferred_role_list', $preferredRoles->render_variant);
+        $this->assertSame('mbti_personality_variant_english_content.v1', data_get($preferredRoles->payload_json, 'structure_contract'));
+        $this->assertNotEmpty(data_get($preferredRoles->payload_json, 'groups.2.examples'));
+
+        $traitOverview = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['INTJ-A']->id)
+            ->where('section_key', 'trait_overview')
+            ->firstOrFail();
+
+        $this->assertSame('authored_enrichment', data_get($traitOverview->payload_json, 'dimensions.4.state'));
+        $this->assertSame('A', data_get($traitOverview->payload_json, 'dimensions.4.side'));
+
+        $zhOverview = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $zhVariant->id)
+            ->where('section_key', 'overview')
+            ->firstOrFail();
+
+        $this->assertSame('中文内容不应被英文增强命令改写。', $zhOverview->body_md);
+        $this->assertTrue((bool) $variants['INFP-T']->fresh()?->is_published);
+    }
+
+    public function test_generated_content_differentiates_all_sections_for_selected_at_pair(): void
+    {
+        $variants = $this->createEnglishMbtiVariantMatrix();
+
+        $this->artisan('personality:enrich-mbti-english-variant-sections', [
+            '--type' => ['INFP'],
+            '--write' => true,
+            '--assert-complete' => true,
+        ])
+            ->assertExitCode(0);
+
+        $assertive = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['INFP-A']->id)
+            ->get()
+            ->keyBy('section_key');
+        $turbulent = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['INFP-T']->id)
+            ->get()
+            ->keyBy('section_key');
+
+        $this->assertSame(18, $assertive->count());
+        $this->assertSame(18, $turbulent->count());
+
+        foreach ($assertive as $sectionKey => $assertiveSection) {
+            $this->assertTrue($turbulent->has($sectionKey));
+            $this->assertNotSame(
+                json_encode([$assertiveSection->body_md, $assertiveSection->payload_json]),
+                json_encode([$turbulent->get($sectionKey)?->body_md, $turbulent->get($sectionKey)?->payload_json]),
+                'Expected A/T differentiation for '.$sectionKey,
+            );
+        }
+    }
+
+    public function test_assert_complete_fails_when_selected_english_variant_scope_is_missing(): void
+    {
+        $profile = $this->createProfile('en', 'INFP', 'Mediator');
+        $this->createVariant($profile, 'INFP-A');
+
+        $this->artisan('personality:enrich-mbti-english-variant-sections', [
+            '--type' => ['INFP'],
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('expected_variants=2')
+            ->expectsOutputToContain('variants_scanned=1')
+            ->expectsOutputToContain('missing_variants=1')
+            ->assertExitCode(1);
+    }
+
+    /**
+     * @return array<string, PersonalityProfileVariant>
+     */
+    private function createEnglishMbtiVariantMatrix(): array
+    {
+        $typeNames = [
+            'ENFJ' => 'Protagonist',
+            'ENFP' => 'Campaigner',
+            'ENTJ' => 'Commander',
+            'ENTP' => 'Debater',
+            'ESFJ' => 'Consul',
+            'ESFP' => 'Entertainer',
+            'ESTJ' => 'Executive',
+            'ESTP' => 'Entrepreneur',
+            'INFJ' => 'Advocate',
+            'INFP' => 'Mediator',
+            'INTJ' => 'Architect',
+            'INTP' => 'Logician',
+            'ISFJ' => 'Defender',
+            'ISFP' => 'Adventurer',
+            'ISTJ' => 'Logistician',
+            'ISTP' => 'Virtuoso',
+        ];
+        $variants = [];
+
+        foreach (PersonalityProfile::BASE_TYPE_CODES as $typeCode) {
+            $profile = $this->createProfile('en', $typeCode, $typeNames[$typeCode]);
+            foreach (['A', 'T'] as $variantCode) {
+                $runtimeTypeCode = $typeCode.'-'.$variantCode;
+                $variants[$runtimeTypeCode] = $this->createVariant($profile, $runtimeTypeCode);
+            }
+        }
+
+        return $variants;
+    }
+
+    private function createProfile(string $locale, string $typeCode, string $typeName): PersonalityProfile
+    {
+        return PersonalityProfile::query()->create([
+            'org_id' => 0,
+            'scale_code' => PersonalityProfile::SCALE_CODE_MBTI,
+            'type_code' => $typeCode,
+            'canonical_type_code' => $typeCode,
+            'slug' => strtolower($typeCode),
+            'locale' => $locale,
+            'title' => $typeCode.' - '.$typeName,
+            'type_name' => $typeName,
+            'nickname' => $typeName,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'subtitle' => null,
+            'excerpt' => null,
+            'hero_kicker' => $typeName,
+            'hero_quote' => null,
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'hero_image_url' => null,
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+            'scheduled_at' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+    }
+
+    private function createVariant(PersonalityProfile $profile, string $runtimeTypeCode): PersonalityProfileVariant
+    {
+        [$typeCode, $variantCode] = explode('-', $runtimeTypeCode);
+
+        return PersonalityProfileVariant::query()->create([
+            'personality_profile_id' => (int) $profile->id,
+            'canonical_type_code' => $typeCode,
+            'variant_code' => $variantCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'type_name' => null,
+            'nickname' => null,
+            'rarity_text' => null,
+            'keywords_json' => [],
+            'hero_summary_md' => null,
+            'hero_summary_html' => null,
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+            'is_published' => true,
+            'published_at' => now(),
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -260,6 +260,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_mbti_personality_english_variant_section_enrichment_files(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php',
+            'backend/app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_eq_cross_assessment_context_guard_changes(): void
     {
         $changed = [
@@ -2804,6 +2814,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isMbtiPersonalityEnglishVariantSectionEnrichmentFile($file)) {
+                continue;
+            }
+
             if ($this->isPublicContentReleaseGuardCommandFile($file)) {
                 continue;
             }
@@ -3573,6 +3587,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php',
             'backend/app/Services/Cms/MbtiPersonalityVariantSectionStructureService.php',
+        ], true);
+    }
+
+    private function isMbtiPersonalityEnglishVariantSectionEnrichmentFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php',
+            'backend/app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added a backend-only `personality:enrich-mbti-english-variant-sections` command for English MBTI A/T variant section enrichment.
- Added a CMS enrichment service that generates structured English section payloads for 16 MBTI types x A/T = 32 pages.
- Added focused feature tests for dry-run/no-write default, explicit write behavior, English-only scope, A/T section differentiation, and missing variant fail-fast.
- Added `PERSONALITY-EN-CONTENT-00` to PR-train manifest/state.

## Why
English MBTI variant pages already have metadata and structure, but many A/T pairs share too much section content. This PR keeps backend/CMS authority while improving the read model for relationships, careers, strengths, weaknesses, growth, and test-intent CTAs.

## Validation
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e 'require "yaml"; YAML.load_file("docs/codex/pr-train.yaml")'`\n- `vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php app/Services/Cms/MbtiEnglishVariantSectionEnrichmentService.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php`\n- `php artisan test tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php --no-ansi`\n- `php artisan list | rg 'personality:enrich-mbti-english-variant-sections'`\n- `git diff --check && git diff --cached --check`\n\n## Intentionally deferred\n- No fap-web changes.\n- No production CMS write during this PR.\n- No article publish.\n- No sitemap, llms, robots, canonical, or indexability changes.\n- No Google/Baidu/search submission.\n- No scheduler enablement.\n\n## Repository rule impact\nThis keeps personality page content backend/CMS-authoritative. The new command is a guarded CMS section update path with dry-run/no-write default and explicit `--write` for later approval-gated production use.