### PR TITLE
fix(cms): normalize personality section json compare

### DIFF
--- a/backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php
+++ b/backend/app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php
@@ -187,7 +187,25 @@ final class PersonalityEnrichMbtiEnglishVariantSections extends Command
             }
         }
 
-        return $section->payload_json !== $desired['payload_json'];
+        return $this->canonicalComparableValue($section->payload_json) !== $this->canonicalComparableValue($desired['payload_json']);
+    }
+
+    private function canonicalComparableValue(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
+        }
+
+        $normalized = [];
+        foreach ($value as $key => $item) {
+            $normalized[$key] = $this->canonicalComparableValue($item);
+        }
+
+        if (! array_is_list($normalized)) {
+            ksort($normalized);
+        }
+
+        return $normalized;
     }
 
     private function variantOrProfileTypeName(PersonalityProfileVariant $variant, PersonalityProfile $profile): ?string
@@ -230,7 +248,7 @@ final class PersonalityEnrichMbtiEnglishVariantSections extends Command
     {
         return json_encode([
             'body_md' => $section['body_md'] ?? null,
-            'payload_json' => $section['payload_json'] ?? null,
+            'payload_json' => $this->canonicalComparableValue($section['payload_json'] ?? null),
         ], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE) ?: '';
     }
 

--- a/backend/tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php
+++ b/backend/tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php
@@ -148,6 +148,45 @@ final class PersonalityEnrichMbtiEnglishVariantSectionsCommandTest extends TestC
         }
     }
 
+    public function test_dry_run_ignores_json_object_key_order_after_write(): void
+    {
+        $variants = $this->createEnglishMbtiVariantMatrix();
+
+        $this->artisan('personality:enrich-mbti-english-variant-sections', [
+            '--type' => ['ENFJ'],
+            '--write' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('section_changes=36')
+            ->expectsOutputToContain('writes_committed=36')
+            ->assertExitCode(0);
+
+        $section = PersonalityProfileVariantSection::query()
+            ->withoutGlobalScopes()
+            ->where('personality_profile_variant_id', (int) $variants['ENFJ-A']->id)
+            ->where('section_key', 'career.advantages')
+            ->firstOrFail();
+
+        $section->payload_json = [
+            'items' => collect($section->payload_json['items'] ?? [])
+                ->map(static fn (array $item): array => [
+                    'body' => (string) $item['body'],
+                    'title' => (string) $item['title'],
+                ])
+                ->all(),
+        ];
+        $section->save();
+
+        $this->artisan('personality:enrich-mbti-english-variant-sections', [
+            '--type' => ['ENFJ'],
+            '--dry-run' => true,
+            '--assert-complete' => true,
+        ])
+            ->expectsOutputToContain('section_changes=0')
+            ->expectsOutputToContain('writes_committed=0')
+            ->assertExitCode(0);
+    }
+
     public function test_assert_complete_fails_when_selected_english_variant_scope_is_missing(): void
     {
         $profile = $this->createProfile('en', 'INFP', 'Mediator');


### PR DESCRIPTION
## What changed
- Normalizes nested JSON object key order before comparing `payload_json` in `personality:enrich-mbti-english-variant-sections`.
- Keeps list order significant, so real array item-order changes are still detected.
- Adds focused coverage for the MySQL JSON key-order case that caused dry-run false positives after production write.

## Why
After the production English MBTI section enrichment write, semantic comparison showed `normalized_diffs=0`, but command dry-run still reported raw `section_changes=320` because JSON object key order differed after storage. This PR makes the command comparison match the intended semantic contract.

## Validation
- `vendor/bin/pint --test app/Console/Commands/PersonalityEnrichMbtiEnglishVariantSections.php tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php`
- `php artisan test tests/Feature/Console/PersonalityEnrichMbtiEnglishVariantSectionsCommandTest.php --no-ansi`
- `php artisan route:list --path=api/v0.5/personality --no-ansi`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No production command execution.
- No CMS content mutation.
- No sitemap/llms/search submission changes.
- No PR-train metadata changes.
