### PR TITLE
CAREER-FULL-PARITY-02: chore(career): generate full zh parity root-cause manifest

### DIFF
--- a/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
+++ b/backend/app/Console/Commands/CareerAuditZhDisplayParity.php
@@ -64,6 +64,7 @@ final class CareerAuditZhDisplayParity extends Command
             $summary = $this->summary($items, $index, $sampleLimit);
             $liveGate = $this->liveGate($summary, $items);
             $assessment = $this->productionLiveAssessment($items, $sampleLimit);
+            $rootCauseManifest = $this->rootCauseManifest($items);
             $controlledImportManifest = $this->controlledImportManifest($items, $assessment);
             $report = [
                 'validator_version' => self::VALIDATOR_VERSION,
@@ -83,6 +84,7 @@ final class CareerAuditZhDisplayParity extends Command
                 'live_gate' => $liveGate,
                 'summary' => $summary,
                 'production_live_assessment' => $assessment,
+                'root_cause_manifest' => $rootCauseManifest,
                 'controlled_import_manifest' => $controlledImportManifest,
                 'items' => (bool) $this->option('summary-only') ? [] : $items,
                 'next_prs' => [
@@ -422,6 +424,92 @@ final class CareerAuditZhDisplayParity extends Command
                 'Do not import without matching reviewed workbook rows and the importer dry-run gate.',
             ],
         ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array<string, mixed>
+     */
+    private function rootCauseManifest(array $items): array
+    {
+        $buckets = [
+            'runtime_shell' => [],
+            'zh_display_asset_present_but_module_subset' => [],
+            'zh_missing_en_display_modules_without_public_asset_evidence' => [],
+            'zh_has_unexpected_extra_modules' => [],
+            'api_failures' => [],
+            'no_runtime_parity_issue_detected' => [],
+            'other' => [],
+        ];
+
+        foreach ($items as $item) {
+            $rootCause = (string) ($item['root_cause'] ?? 'unknown');
+            $bucket = match ($rootCause) {
+                'runtime_shell_missing_or_unpublished_zh_display_asset',
+                'runtime_shell_with_display_asset_present_cache_or_gate_suspect' => 'runtime_shell',
+                'zh_display_asset_present_but_module_subset' => 'zh_display_asset_present_but_module_subset',
+                'zh_missing_en_display_modules_without_public_asset_evidence' => 'zh_missing_en_display_modules_without_public_asset_evidence',
+                'zh_has_unexpected_extra_modules' => 'zh_has_unexpected_extra_modules',
+                'zh_api_not_200', 'en_api_not_200', 'both_locale_api_not_200' => 'api_failures',
+                'no_runtime_parity_issue_detected' => 'no_runtime_parity_issue_detected',
+                default => 'other',
+            };
+
+            $buckets[$bucket][] = $this->rootCauseManifestRow($item);
+        }
+
+        foreach ($buckets as &$rows) {
+            usort($rows, static fn (array $a, array $b): int => strcmp((string) $a['slug'], (string) $b['slug']));
+        }
+        unset($rows);
+
+        return [
+            'schema_version' => 'career_full_parity_root_cause_manifest.v0.1',
+            'source_validator_version' => self::VALIDATOR_VERSION,
+            'total_slugs' => count($items),
+            'bucket_counts' => array_map('count', $buckets),
+            'buckets' => $buckets,
+            'cache_status_policy' => [
+                'unknown_public_api_only' => 'Do not label cache stale without target cache or DB evidence.',
+                'possible' => 'Run a read-only target cache/DB check or controlled forget/warm before concluding stale cache.',
+                'not_proven' => 'Treat as missing/unpublished asset until a separate target check proves otherwise.',
+                'not_indicated' => 'No runtime parity issue was detected from public API output.',
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function rootCauseManifestRow(array $item): array
+    {
+        $cacheState = (string) Arr::get($item, 'cache_stale_assessment.cache_stale', 'unknown_public_api_only');
+
+        return [
+            'slug' => (string) ($item['slug'] ?? ''),
+            'classification' => (string) ($item['classification'] ?? 'unknown'),
+            'root_cause' => (string) ($item['root_cause'] ?? 'unknown'),
+            'status' => $item['status'] ?? [],
+            'module_counts' => $item['module_counts'] ?? [],
+            'missing_modules' => $item['missing_modules'] ?? [],
+            'zh_gate_reasons' => $item['zh_gate_reasons'] ?? [],
+            'zh_public_asset_state' => $item['zh_public_asset_state'] ?? [],
+            'cache_stale_assessment' => $item['cache_stale_assessment'] ?? [],
+            'cache_status_recommendation' => $this->cacheStatusRecommendation($cacheState),
+            'api_errors' => $item['api_errors'] ?? [],
+            'sample_urls' => $item['sample_urls'] ?? [],
+        ];
+    }
+
+    private function cacheStatusRecommendation(string $cacheState): string
+    {
+        return match ($cacheState) {
+            'possible' => 'verify_target_cache_or_run_controlled_forget_warm',
+            'not_proven' => 'treat_as_missing_or_unpublished_until_target_check',
+            'not_indicated' => 'no_cache_action_indicated',
+            default => 'requires_separate_target_cache_or_db_evidence',
+        };
     }
 
     /**

--- a/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php
@@ -96,6 +96,14 @@ final class CareerAuditZhDisplayParityCommandTest extends TestCase
         $this->assertSame(1, $report['live_gate']['restricted_shell_count']);
         $this->assertSame(1, $report['production_live_assessment']['runtime_shell_count']);
         $this->assertSame(['zh-missing-modules'], $report['production_live_assessment']['runtime_shell_slugs']);
+        $this->assertSame(1, $report['root_cause_manifest']['bucket_counts']['runtime_shell']);
+        $this->assertSame(1, $report['root_cause_manifest']['bucket_counts']['zh_has_unexpected_extra_modules']);
+        $this->assertSame(2, $report['root_cause_manifest']['bucket_counts']['api_failures']);
+        $this->assertSame('zh-missing-modules', $report['root_cause_manifest']['buckets']['runtime_shell'][0]['slug']);
+        $this->assertSame(
+            'treat_as_missing_or_unpublished_until_target_check',
+            $report['root_cause_manifest']['buckets']['runtime_shell'][0]['cache_status_recommendation'],
+        );
         $this->assertSame(1, $report['controlled_import_manifest']['candidate_count']);
         $this->assertSame(['zh-missing-modules'], $report['controlled_import_manifest']['candidate_slugs']);
         $this->assertSame(5, $report['summary']['total_slugs']);
@@ -189,6 +197,8 @@ final class CareerAuditZhDisplayParityCommandTest extends TestCase
         $this->assertNull($unstable['status']['zh-CN']);
         $this->assertSame('zh_detail_http_unknown', $unstable['zh_gate_reasons'][0]);
         $this->assertSame('zh_api_not_200', $unstable['root_cause']);
+        $this->assertSame(1, $report['root_cause_manifest']['bucket_counts']['api_failures']);
+        $this->assertSame('unstable-slug', $report['root_cause_manifest']['buckets']['api_failures'][0]['slug']);
         $this->assertSame('zh-CN', $unstable['api_errors'][0]['locale']);
         $this->assertSame('ConnectionException', $unstable['api_errors'][0]['type']);
         $this->assertSame(

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T13:32:12Z",
+  "updated_at": "2026-06-11T13:34:05Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -53478,7 +53478,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-02",
     "base": "origin/main",
-    "status": "local_verified",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-02: chore(career): generate full zh parity root-cause manifest",
     "depends_on": [
@@ -53510,8 +53510,8 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "8f3ea0c312ae7c42fb751a2a3e39c6ac40860da1",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2040",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53535,6 +53535,11 @@
         "at": "2026-06-11T13:32:12Z",
         "status": "scope_validated",
         "note": "Validated changed files against CAREER-FULL-PARITY-02 allowed paths before staging."
+      },
+      {
+        "at": "2026-06-11T13:34:05Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2040 for CAREER-FULL-PARITY-02; waiting for GitHub checks."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T13:15:48Z",
+  "updated_at": "2026-06-11T13:32:12Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -53379,7 +53379,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-01",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "merged",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-01: fix(career): harden zh display parity audit failures",
     "depends_on": [
@@ -53408,14 +53408,22 @@
           "python3 -m json.tool backend/docs/career/generated/career-full-parity-01-live-report.json >/dev/null"
         ],
         "notes": "Focused lint and console tests passed. Production read-only full scan generated 1046 item details; current public API instability was degraded into per-slug report evidence instead of aborting: api_failure_count=25, detail_api_error_count=2. Content/runtime parity remains for later PRs: same_module_set=259, en_has_modules_zh_missing=658, zh_has_modules_en_missing=104, runtime_shell_count=130."
+      },
+      "github_checks": {
+        "status": "pass",
+        "evidence": "GitHub checks passed for PR #2038 head c9d669c38eb9f0b46c9b351274e06ce0cd5daf48: hygiene, supply-chain, content-pack-build-validate, Semgrep OSS, Semgrep blocking secrets, semgrep sarif non-blocking upload, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "merge_containment": {
+        "status": "pass",
+        "evidence": "PR #2038 is MERGED and origin/main/main contain merge commit b5b33a289847263bd535d34387fd50dc8660431a; remote and local task branches were deleted. Primary main has unrelated pre-existing generated/seo-ops-* untracked directories."
       }
     },
     "failure_reason": null,
     "commit_sha": "84d1c53c12af7601d5bb63bd2144f7527187fc31",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2038",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T13:22:40Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "sidecar_issues": [
       {
         "id": "CAREER-FULL-PARITY-01-SIDECAR-01",
@@ -53457,14 +53465,20 @@
         "at": "2026-06-11T13:15:48Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2038 for CAREER-FULL-PARITY-01; waiting for GitHub checks."
+      },
+      {
+        "at": "2026-06-11T13:31:14Z",
+        "status": "merged",
+        "note": "Reconciled during CAREER-FULL-PARITY-02 after confirming PR #2038 merged, origin/main containment, local main fast-forward, and task branch cleanup."
       }
-    ]
+    ],
+    "merge_commit_sha": "b5b33a289847263bd535d34387fd50dc8660431a"
   },
   "CAREER-FULL-PARITY-02": {
     "repo": "fap-api",
     "branch": "codex/career-full-parity-02",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_verified",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-02: chore(career): generate full zh parity root-cause manifest",
     "depends_on": [
@@ -53476,8 +53490,23 @@
         "evidence": "User explicitly authorized adding and executing CAREER-FULL-PARITY-01 through CAREER-FULL-PARITY-10 and allowed fap-api docs/codex metadata updates."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-FULL-PARITY-01 to merge before implementation."
+        "status": "pass",
+        "evidence": "CAREER-FULL-PARITY-01 PR #2038 is merged and origin/main contains merge commit b5b33a289847263bd535d34387fd50dc8660431a."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to CareerAuditZhDisplayParity.php, its focused console test, backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json, and docs/codex/pr-train-state.json. No import, publish, cache mutation, deploy, sitemap/llms/index strategy, or fap-web changes."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php",
+          "php -l backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi",
+          "cd backend && php artisan career:audit-zh-display-parity --timeout=30 --batch-size=20 --sample-limit=30 --output=docs/career/generated/career-full-parity-02-root-cause-manifest.json || test $? -eq 1",
+          "python3 -m json.tool backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json >/dev/null"
+        ],
+        "notes": "Generated 1046-slug root-cause manifest with api_failure_count=0 and detail_api_error_count=0. Buckets: {'runtime_shell': 131, 'zh_display_asset_present_but_module_subset': 667, 'zh_missing_en_display_modules_without_public_asset_evidence': 5, 'zh_has_unexpected_extra_modules': 106, 'api_failures': 0, 'no_runtime_parity_issue_detected': 137, 'other': 0}. Root causes: {'no_runtime_parity_issue_detected': 137, 'runtime_shell_missing_or_unpublished_zh_display_asset': 131, 'zh_display_asset_present_but_module_subset': 667, 'zh_has_unexpected_extra_modules': 106, 'zh_missing_en_display_modules_without_public_asset_evidence': 5}."
       }
     },
     "failure_reason": null,
@@ -53491,6 +53520,21 @@
         "at": "2026-06-11T13:00:17Z",
         "status": "pending_dependency",
         "note": "Initialized from explicit CAREER-FULL-PARITY train authorization; implementation deferred until dependencies merge."
+      },
+      {
+        "at": "2026-06-11T13:31:14Z",
+        "status": "in_progress",
+        "note": "Started CAREER-FULL-PARITY-02 from latest origin/main after PR01 merge cleanup."
+      },
+      {
+        "at": "2026-06-11T13:31:14Z",
+        "status": "local_verified",
+        "note": "Added root_cause_manifest generator/test and generated the production 1046-slug root-cause manifest report."
+      },
+      {
+        "at": "2026-06-11T13:32:12Z",
+        "status": "scope_validated",
+        "note": "Validated changed files against CAREER-FULL-PARITY-02 allowed paths before staging."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Added a `root_cause_manifest` section to `career:audit-zh-display-parity` reports.
- Buckets every slug into operational root-cause groups: runtime shell, zh display asset module subset, missing public asset evidence, zh extra/en subset, API failures, clean/no issue, and other.
- Each manifest row includes status, module counts, missing modules, zh gate reasons, public asset-state inference, cache-stale assessment, cache recommendation, API errors, and sample URLs.
- Generated `backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json` from a production read-only 1046-slug scan.
- Reconciled `CAREER-FULL-PARITY-01` merged state in the ledger.

## Why
The next repair/import steps need a deterministic manifest, not just aggregate counts. This PR turns the observed parity state into explicit slug-level inputs for the following PRs.

## Validation
- `php -l backend/app/Console/Commands/CareerAuditZhDisplayParity.php`
- `php -l backend/tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerAuditZhDisplayParityCommandTest.php --no-ansi`
- `cd backend && php artisan career:audit-zh-display-parity --timeout=30 --batch-size=20 --sample-limit=30 --output=docs/career/generated/career-full-parity-02-root-cause-manifest.json || test $? -eq 1`
- `python3 -m json.tool backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- `git diff --cached --check`

## Current manifest result
- Full item details generated: 1046
- `api_failure_count`: 0
- `detail_api_error_count`: 0
- `runtime_shell`: 131
- `zh_display_asset_present_but_module_subset`: 667
- `zh_missing_en_display_modules_without_public_asset_evidence`: 5
- `zh_has_unexpected_extra_modules`: 106
- `no_runtime_parity_issue_detected`: 137

## Intentionally deferred
- No workbook repair.
- No display asset import.
- No content publish.
- No database/cache mutation.
- No deployment.
- No sitemap, llms, or index strategy change.
