### PR TITLE
feat(seo): allow articles in search channel queue planning

### DIFF
--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -265,6 +265,7 @@ return [
             'shenma_submit',
         ],
         'allowed_page_entity_types' => [
+            'article',
             'research_report',
             'home',
             'test_hub',

--- a/backend/docs/seo/generated/search-channel-queue-runtime-mvp.v1.json
+++ b/backend/docs/seo/generated/search-channel-queue-runtime-mvp.v1.json
@@ -25,6 +25,7 @@
     "shenma_submit"
   ],
   "allowed_page_entity_types": [
+    "article",
     "research_report",
     "home",
     "test_hub",

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
@@ -47,6 +47,108 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
     }
 
     #[Test]
+    public function eligible_backend_cms_article_url_can_be_planned_without_live_submission(): void
+    {
+        $this->seedSeoUrl([
+            'canonical_url' => 'https://www.fermatmind.com/zh/articles/mbti-vs-holland-career-choice',
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_id_or_slug' => '37',
+            'cluster' => 'article',
+            'source_authority' => 'backend_cms',
+            'lastmod_source' => 'articles.updated_at',
+            'metadata_json' => [
+                'claim_safe' => true,
+                'claim_boundary_state' => 'approved',
+                'publication_state' => 'published',
+                'source_table' => 'articles',
+            ],
+        ]);
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--canonical-url' => 'https://www.fermatmind.com/zh/articles/mbti-vs-holland-career-choice',
+            '--channel' => 'indexnow',
+            '--limit' => 20,
+        ]);
+
+        $this->assertSame('success', $output['status'] ?? null);
+        $this->assertSame(1, $output['candidate_count'] ?? null);
+        $this->assertSame(1, $output['eligible_count'] ?? null);
+        $this->assertSame(0, $output['blocked_count'] ?? null);
+        $this->assertSame(1, $output['planned_queue_count'] ?? null);
+        $this->assertSame(['indexnow' => 1], $output['channel_breakdown'] ?? null);
+        $this->assertSame(['article' => 1], $output['page_type_breakdown'] ?? null);
+        $this->assertFalse((bool) ($output['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_items')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_batches')->count());
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+    }
+
+    #[Test]
+    public function unsafe_article_urls_remain_blocked(): void
+    {
+        $unsafeCases = [
+            'draft' => [
+                'metadata_json' => ['publication_state' => 'draft', 'claim_safe' => true],
+                'reason' => 'draft',
+            ],
+            'noindex' => [
+                'indexability_state' => 'noindex',
+                'metadata_json' => ['publication_state' => 'published', 'claim_safe' => true],
+                'reason' => 'noindex',
+            ],
+            'private_flow' => [
+                'is_private_flow' => true,
+                'metadata_json' => ['publication_state' => 'published', 'claim_safe' => true],
+                'reason' => 'private_flow',
+            ],
+            'claim_unsafe' => [
+                'metadata_json' => ['publication_state' => 'published', 'claim_safe' => false],
+                'reason' => 'claim_unsafe',
+            ],
+        ];
+
+        foreach ($unsafeCases as $case => $overrides) {
+            $this->seedSeoUrl(array_merge([
+                'canonical_url' => 'https://www.fermatmind.com/zh/articles/blocked-'.$case,
+                'locale' => 'zh-CN',
+                'page_entity_type' => 'article',
+                'entity_id_or_slug' => 'blocked-'.$case,
+                'cluster' => 'article',
+                'source_authority' => 'backend_cms',
+                'lastmod_source' => 'articles.updated_at',
+            ], $overrides));
+        }
+
+        $output = $this->runQueueCommand([
+            '--dry-run' => true,
+            '--no-write' => true,
+            '--json' => true,
+            '--page-type' => 'article',
+            '--limit' => 20,
+        ]);
+
+        $this->assertSame(0, $output['eligible_count'] ?? null);
+        $this->assertSame(4, $output['blocked_count'] ?? null);
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.draft'));
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.noindex'));
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.private_flow'));
+        $this->assertSame(1, data_get($output, 'reason_code_breakdown.claim_unsafe'));
+        $this->assertFalse((bool) ($output['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($output['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($output['live_submission_attempted'] ?? true));
+    }
+
+    #[Test]
     public function draft_url_is_blocked(): void
     {
         $this->seedSeoUrl(['metadata_json' => ['publication_state' => 'draft']]);
@@ -332,6 +434,7 @@ final class SeoIntelSearchChannelQueueRuntimeTest extends TestCase
         $this->assertSame('search-channel-queue-runtime-mvp.v1', $artifact['schema_version'] ?? null);
         $this->assertSame('search_channel_queue', $artifact['runtime'] ?? null);
         $this->assertContains('indexnow', $artifact['allowed_channels'] ?? []);
+        $this->assertContains('article', $artifact['allowed_page_entity_types'] ?? []);
         $this->assertContains('research_report', $artifact['allowed_page_entity_types'] ?? []);
         $this->assertContains('take', $artifact['forbidden_page_entity_types'] ?? []);
         $this->assertContains('backend_cms', $artifact['approved_source_authorities'] ?? []);


### PR DESCRIPTION
## What changed
- Adds `article` to `seo_intel.search_channel_queue.allowed_page_entity_types`.
- Updates the Search Channel Queue runtime MVP artifact to document `article` as an allowed page entity type.
- Adds runtime tests proving:
  - a backend CMS article URL can be planned in dry-run/no-write mode;
  - planning performs no writes, no external calls, and no live submission;
  - draft, noindex, private, and claim-unsafe article URLs remain blocked.

## Why
The Chinese CMS article is now public, indexable, and present in sitemap/llms, but Search Channel Queue policy still blocked CMS Article URLs because `article` was missing from the allowed page-type list. This PR admits Article URLs to queue eligibility without changing submission or write gates.

## Validation commands
```bash
cd backend
php artisan test tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelQueueContractTest.php
git diff --check -- backend/config/seo_intel.php backend/docs/seo/generated/search-channel-queue-runtime-mvp.v1.json backend/tests/Feature/SeoIntel/SeoIntelSearchChannelQueueRuntimeTest.php
```

## Intentionally deferred
- No CMS mutation.
- No production DB write.
- No Search Channel Queue enqueue.
- No live GSC/Baidu/IndexNow/360/Sogou/Shenma submission.
- No scheduler/collector enablement.
- No sitemap/llms/runtime behavior change.

## Repository rule impact
Search Channel Queue page-type ownership remains backend/seo_intel authoritative. This PR only extends queue planning eligibility for CMS-backed Article URL Truth rows; it does not move content authority to frontend or enable live submission.
