### PR TITLE
CAREER-FULL-PARITY-03: fix(career): repair blocked workbook asset contracts

### DIFF
--- a/backend/app/Console/Commands/CareerRepairDisplayWorkbookContract.php
+++ b/backend/app/Console/Commands/CareerRepairDisplayWorkbookContract.php
@@ -18,7 +18,7 @@ final class CareerRepairDisplayWorkbookContract extends Command
 {
     private const SHEET_NAME = 'Career_Assets_v4_1';
 
-    private const REPAIRER_VERSION = 'career_display_workbook_contract_repairer_v0.1';
+    private const REPAIRER_VERSION = 'career_display_workbook_contract_repairer_v0.2';
 
     /** @var list<string> */
     private const REQUIRED_HEADERS = [
@@ -27,6 +27,11 @@ final class CareerRepairDisplayWorkbookContract extends Command
         'CN_Occupation_Schema_JSON',
         'Claim_Level_Source_Refs',
         'Primary_CTA_Target_Action',
+        'Source_Page_Type',
+        'EN_Title',
+        'CN_Title',
+        'EN_H1',
+        'CN_H1',
     ];
 
     /** @var list<string> */
@@ -109,9 +114,12 @@ final class CareerRepairDisplayWorkbookContract extends Command
 
         $repairsByField = [];
         $sampleRepairs = [];
+        $manualReviewRows = [];
         $changedRows = 0;
         $changedCells = 0;
         $selectedRows = 0;
+        $autoRepairableRows = 0;
+        $changedRowsRequiringManualReview = 0;
 
         foreach ($rows as $rowIndex => $row) {
             $slug = strtolower(trim((string) ($row['Slug'] ?? '')));
@@ -124,8 +132,10 @@ final class CareerRepairDisplayWorkbookContract extends Command
             $changes = [];
 
             $this->normalizeCta($rows[$rowIndex], $changes);
+            $this->normalizeSourcePageType($rows[$rowIndex], $changes);
             $this->normalizeSourceRefs($rows[$rowIndex], $changes);
             $this->normalizeOccupationSchemas($rows[$rowIndex], $changes);
+            $manualReasons = $this->manualReviewReasons($rows[$rowIndex]);
 
             foreach ($changes as $field => $change) {
                 $rowChanged = true;
@@ -135,13 +145,27 @@ final class CareerRepairDisplayWorkbookContract extends Command
 
             if ($rowChanged) {
                 $changedRows++;
+                if ($manualReasons === []) {
+                    $autoRepairableRows++;
+                } else {
+                    $changedRowsRequiringManualReview++;
+                }
                 if (count($sampleRepairs) < 12) {
                     $sampleRepairs[] = [
                         'row_number' => $row['_row_number'] ?? null,
                         'slug' => $slug,
                         'fields' => array_keys($changes),
+                        'manual_review_required' => $manualReasons !== [],
                     ];
                 }
+            }
+
+            if ($manualReasons !== []) {
+                $manualReviewRows[] = [
+                    'row_number' => $row['_row_number'] ?? null,
+                    'slug' => $slug,
+                    'reasons' => $manualReasons,
+                ];
             }
         }
 
@@ -167,10 +191,15 @@ final class CareerRepairDisplayWorkbookContract extends Command
             'slug_filter_count' => count($slugAllowlist),
             'changed_rows' => $changedRows,
             'changed_cells' => $changedCells,
+            'auto_repairable_rows' => $autoRepairableRows,
+            'changed_rows_requiring_manual_review' => $changedRowsRequiringManualReview,
+            'manual_review_required_count' => count($manualReviewRows),
+            'manual_review_required_rows' => $manualReviewRows,
             'repairs_by_field' => $repairsByField,
             'sample_repairs' => $sampleRepairs,
             'repair_contract' => [
                 'primary_cta_target_action' => 'start_riasec_test',
+                'source_page_type' => 'career_job_detail',
                 'source_ref_label' => 'FermatMind interpretation',
                 'occupation_schema_forbidden_terms_removed' => [
                     'Product schema',
@@ -180,6 +209,59 @@ final class CareerRepairDisplayWorkbookContract extends Command
             ],
             'decision' => $changedRows === 0 ? 'already_clean' : ($execute ? 'repaired_artifact_written' : 'dry_run_changes_available'),
         ];
+    }
+
+    /**
+     * @param  array<string, string>  $row
+     * @param  array<string, mixed>  $changes
+     */
+    private function normalizeSourcePageType(array &$row, array &$changes): void
+    {
+        $previous = trim((string) ($row['Source_Page_Type'] ?? ''));
+        if ($previous === 'career_job_detail') {
+            return;
+        }
+
+        $row['Source_Page_Type'] = 'career_job_detail';
+        $changes['Source_Page_Type'] = ['from' => $previous, 'to' => 'career_job_detail'];
+    }
+
+    /**
+     * @param  array<string, string>  $row
+     * @return list<string>
+     */
+    private function manualReviewReasons(array $row): array
+    {
+        $reasons = [];
+        $cnTitle = trim((string) ($row['CN_Title'] ?? ''));
+        $cnH1 = trim((string) ($row['CN_H1'] ?? ''));
+        $enTitle = trim((string) ($row['EN_Title'] ?? ''));
+        $enH1 = trim((string) ($row['EN_H1'] ?? ''));
+
+        if ($cnTitle === '') {
+            $reasons[] = 'CN_Title missing';
+        } elseif (! $this->containsCjk($cnTitle)) {
+            $reasons[] = 'CN_Title lacks reviewed Chinese text';
+        }
+        if ($cnTitle !== '' && $enTitle !== '' && mb_strtolower($cnTitle) === mb_strtolower($enTitle)) {
+            $reasons[] = 'CN_Title copied from EN_Title';
+        }
+
+        if ($cnH1 === '') {
+            $reasons[] = 'CN_H1 missing';
+        } elseif (! $this->containsCjk($cnH1)) {
+            $reasons[] = 'CN_H1 lacks reviewed Chinese text';
+        }
+        if ($cnH1 !== '' && $enH1 !== '' && mb_strtolower($cnH1) === mb_strtolower($enH1)) {
+            $reasons[] = 'CN_H1 copied from EN_H1';
+        }
+
+        return array_values(array_unique($reasons));
+    }
+
+    private function containsCjk(string $value): bool
+    {
+        return preg_match('/\p{Han}/u', $value) === 1;
     }
 
     /**

--- a/backend/docs/career/generated/career-full-parity-03-contract-repair-report.json
+++ b/backend/docs/career/generated/career-full-parity-03-contract-repair-report.json
@@ -1,0 +1,199 @@
+{
+    "command": "career:repair-display-workbook-contract",
+    "repairer_version": "career_display_workbook_contract_repairer_v0.2",
+    "sheet": "Career_Assets_v4_1",
+    "source_file_basename": "第九版_d23b_schema_repaired.xlsx",
+    "source_sha256": "c30f8743cfd0d8baa14ac931cc7270807425164952f6a44953b5b4ab448778ef",
+    "execute": false,
+    "writes_database": false,
+    "cms_mutation": false,
+    "output_file": null,
+    "output_sha256": null,
+    "total_rows": 2786,
+    "selected_rows": 136,
+    "slug_filter_count": 136,
+    "changed_rows": 136,
+    "changed_cells": 320,
+    "auto_repairable_rows": 131,
+    "changed_rows_requiring_manual_review": 5,
+    "manual_review_required_count": 5,
+    "manual_review_required_rows": [
+        {
+            "row_number": 1930,
+            "slug": "data-scientists",
+            "reasons": [
+                "CN_Title lacks reviewed Chinese text",
+                "CN_Title copied from EN_Title",
+                "CN_H1 lacks reviewed Chinese text",
+                "CN_H1 copied from EN_H1"
+            ]
+        },
+        {
+            "row_number": 2211,
+            "slug": "human-resources-specialists",
+            "reasons": [
+                "CN_Title lacks reviewed Chinese text",
+                "CN_Title copied from EN_Title",
+                "CN_H1 lacks reviewed Chinese text",
+                "CN_H1 copied from EN_H1"
+            ]
+        },
+        {
+            "row_number": 2304,
+            "slug": "management-analysts",
+            "reasons": [
+                "CN_Title lacks reviewed Chinese text",
+                "CN_Title copied from EN_Title",
+                "CN_H1 lacks reviewed Chinese text",
+                "CN_H1 copied from EN_H1"
+            ]
+        },
+        {
+            "row_number": 2531,
+            "slug": "project-management-specialists",
+            "reasons": [
+                "CN_Title lacks reviewed Chinese text",
+                "CN_Title copied from EN_Title",
+                "CN_H1 lacks reviewed Chinese text",
+                "CN_H1 copied from EN_H1"
+            ]
+        },
+        {
+            "row_number": 2578,
+            "slug": "registered-nurses",
+            "reasons": [
+                "CN_Title lacks reviewed Chinese text",
+                "CN_Title copied from EN_Title",
+                "CN_H1 lacks reviewed Chinese text",
+                "CN_H1 copied from EN_H1"
+            ]
+        }
+    ],
+    "repairs_by_field": {
+        "CN_Occupation_Schema_JSON": 65,
+        "Claim_Level_Source_Refs": 119,
+        "Primary_CTA_Target_Action": 51,
+        "Source_Page_Type": 85
+    },
+    "sample_repairs": [
+        {
+            "row_number": 18,
+            "slug": "aerospace-engineers",
+            "fields": [
+                "Primary_CTA_Target_Action",
+                "Claim_Level_Source_Refs"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 21,
+            "slug": "agricultural-and-food-scientists",
+            "fields": [
+                "Primary_CTA_Target_Action",
+                "Claim_Level_Source_Refs"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 27,
+            "slug": "agricultural-workers",
+            "fields": [
+                "Primary_CTA_Target_Action",
+                "Claim_Level_Source_Refs"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 53,
+            "slug": "announcers",
+            "fields": [
+                "Source_Page_Type",
+                "Claim_Level_Source_Refs"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 54,
+            "slug": "anthropologists-and-archeologists",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 58,
+            "slug": "arbitrators-mediators-and-conciliators",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 74,
+            "slug": "assemblers-and-fabricators",
+            "fields": [
+                "Source_Page_Type",
+                "Claim_Level_Source_Refs"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 77,
+            "slug": "athletes-and-sports-competitors",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 78,
+            "slug": "athletic-trainers",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 81,
+            "slug": "atmospheric-scientists-including-meteorologists",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 83,
+            "slug": "audiologists",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        },
+        {
+            "row_number": 90,
+            "slug": "automotive-service-technicians-and-mechanics",
+            "fields": [
+                "Source_Page_Type",
+                "CN_Occupation_Schema_JSON"
+            ],
+            "manual_review_required": false
+        }
+    ],
+    "repair_contract": {
+        "primary_cta_target_action": "start_riasec_test",
+        "source_page_type": "career_job_detail",
+        "source_ref_label": "FermatMind interpretation",
+        "occupation_schema_forbidden_terms_removed": [
+            "Product schema",
+            "job posting sample",
+            "招聘样本"
+        ]
+    },
+    "decision": "dry_run_changes_available"
+}

--- a/backend/tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php
+++ b/backend/tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php
@@ -18,6 +18,11 @@ final class CareerRepairDisplayWorkbookContractCommandTest extends TestCase
         'CN_Occupation_Schema_JSON',
         'Claim_Level_Source_Refs',
         'Primary_CTA_Target_Action',
+        'Source_Page_Type',
+        'EN_Title',
+        'CN_Title',
+        'EN_H1',
+        'CN_H1',
     ];
 
     #[Test]
@@ -41,8 +46,12 @@ final class CareerRepairDisplayWorkbookContractCommandTest extends TestCase
         $this->assertFalse($report['cms_mutation']);
         $this->assertSame('dry_run_changes_available', $report['decision']);
         $this->assertSame(1, $report['changed_rows']);
-        $this->assertSame(4, $report['changed_cells']);
+        $this->assertSame(5, $report['changed_cells']);
+        $this->assertSame(1, $report['auto_repairable_rows']);
+        $this->assertSame(0, $report['changed_rows_requiring_manual_review']);
+        $this->assertSame(0, $report['manual_review_required_count']);
         $this->assertSame(1, $report['repairs_by_field']['Primary_CTA_Target_Action']);
+        $this->assertSame(1, $report['repairs_by_field']['Source_Page_Type']);
         $this->assertSame(1, $report['repairs_by_field']['Claim_Level_Source_Refs']);
         $this->assertSame(1, $report['repairs_by_field']['EN_Occupation_Schema_JSON']);
         $this->assertSame(1, $report['repairs_by_field']['CN_Occupation_Schema_JSON']);
@@ -86,11 +95,47 @@ final class CareerRepairDisplayWorkbookContractCommandTest extends TestCase
         $this->assertSame(0, $secondReport['changed_cells']);
     }
 
+    #[Test]
+    public function it_isolates_rows_that_need_manual_chinese_title_review(): void
+    {
+        $workbook = $this->writeWorkbook([
+            $this->dirtyRow(
+                'manual-title-review',
+                enTitle: 'Manual Title Review',
+                cnTitle: 'Manual Title Review',
+                enH1: 'Manual Title Review',
+                cnH1: 'Manual Title Review',
+            ),
+        ]);
+
+        $exitCode = Artisan::call('career:repair-display-workbook-contract', [
+            '--file' => $workbook,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame(1, $report['changed_rows']);
+        $this->assertSame(0, $report['auto_repairable_rows']);
+        $this->assertSame(1, $report['changed_rows_requiring_manual_review']);
+        $this->assertSame(1, $report['manual_review_required_count']);
+        $this->assertSame('manual-title-review', $report['manual_review_required_rows'][0]['slug']);
+        $this->assertContains('CN_Title lacks reviewed Chinese text', $report['manual_review_required_rows'][0]['reasons']);
+        $this->assertContains('CN_Title copied from EN_Title', $report['manual_review_required_rows'][0]['reasons']);
+        $this->assertContains('CN_H1 lacks reviewed Chinese text', $report['manual_review_required_rows'][0]['reasons']);
+        $this->assertContains('CN_H1 copied from EN_H1', $report['manual_review_required_rows'][0]['reasons']);
+    }
+
     /**
      * @return array<string, string>
      */
-    private function dirtyRow(string $slug): array
-    {
+    private function dirtyRow(
+        string $slug,
+        string $enTitle = 'Shipping, Receiving, And Inventory Clerks',
+        string $cnTitle = '发运、收货、库存文员',
+        string $enH1 = 'Shipping, Receiving, And Inventory Clerks',
+        string $cnH1 = '发运、收货、库存文员',
+    ): array {
         return [
             'Slug' => $slug,
             'EN_Occupation_Schema_JSON' => $this->encodeJson([
@@ -111,6 +156,11 @@ final class CareerRepairDisplayWorkbookContractCommandTest extends TestCase
                 'jobs' => ['url' => 'https://www.onetonline.org/link/details/43-5071.00', 'claim' => 'jobs employment'],
             ]),
             'Primary_CTA_Target_Action' => 'open_test',
+            'Source_Page_Type' => 'career_article',
+            'EN_Title' => $enTitle,
+            'CN_Title' => $cnTitle,
+            'EN_H1' => $enH1,
+            'CN_H1' => $cnH1,
         ];
     }
 

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T15:26:34Z",
+  "updated_at": "2026-06-11T15:31:40Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -53553,7 +53553,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-03",
     "base": "origin/main",
-    "status": "committed",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-03: fix(career): repair blocked workbook asset contracts",
     "depends_on": [
@@ -53588,7 +53588,7 @@
     },
     "failure_reason": null,
     "commit_sha": "84de772b71e62830804bfd0ca134794571977d0e",
-    "pr_url": null,
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2043",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53622,6 +53622,11 @@
         "at": "2026-06-11T15:26:34Z",
         "status": "committed",
         "note": "Committed CAREER-FULL-PARITY-03 scoped repair command, tests, and generated dry-run report."
+      },
+      {
+        "at": "2026-06-11T15:31:40Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2043 for CAREER-FULL-PARITY-03 and started GitHub checks."
       }
     ],
     "result": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53587,7 +53587,7 @@
       }
     },
     "failure_reason": null,
-    "commit_sha": "87c1fb5536623fb7a5f8e11662ac1da8dc8faa05",
+    "commit_sha": "84de772b71e62830804bfd0ca134794571977d0e",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T13:34:05Z",
+  "updated_at": "2026-06-11T15:26:34Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -10,7 +10,7 @@
     "title": "docs(monetization): scan locale freemium policy readiness",
     "checks": {
       "authorization": {
-        "status": "pass",
+        "status": "pass_with_external_pint_blocker",
         "evidence": "User explicitly authorized the Day 1 Commercial Readiness train, including FREEMIUM-LOCALE-POLICY-SCAN-01, with docs/codex manifest/state updates allowed."
       },
       "dependency": {
@@ -53478,7 +53478,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-02",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "merged",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-02: chore(career): generate full zh parity root-cause manifest",
     "depends_on": [
@@ -53512,9 +53512,9 @@
     "failure_reason": null,
     "commit_sha": "8f3ea0c312ae7c42fb751a2a3e39c6ac40860da1",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2040",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T13:40:44Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-11T13:00:17Z",
@@ -53540,14 +53540,20 @@
         "at": "2026-06-11T13:34:05Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2040 for CAREER-FULL-PARITY-02; waiting for GitHub checks."
+      },
+      {
+        "at": "2026-06-11T13:54:56Z",
+        "status": "merged",
+        "note": "Reconciled during CAREER-FULL-PARITY-03 after confirming PR #2040 merged, origin/main contains merge commit f254f99b6a9726927e1a232c997d2f39a18d4998, local main was fast-forwarded, and task branch cleanup completed."
       }
-    ]
+    ],
+    "merge_commit_sha": "f254f99b6a9726927e1a232c997d2f39a18d4998"
   },
   "CAREER-FULL-PARITY-03": {
     "repo": "fap-api",
     "branch": "codex/career-full-parity-03",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "committed",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-03: fix(career): repair blocked workbook asset contracts",
     "depends_on": [
@@ -53559,12 +53565,29 @@
         "evidence": "User explicitly authorized adding and executing CAREER-FULL-PARITY-01 through CAREER-FULL-PARITY-10 and allowed fap-api docs/codex metadata updates."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-FULL-PARITY-02 to merge before implementation."
+        "status": "pass",
+        "evidence": "CAREER-FULL-PARITY-02 PR #2040 is merged and origin/main contains merge commit f254f99b6a9726927e1a232c997d2f39a18d4998."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console tests/Feature/Career --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerRepairDisplayWorkbookContract.php tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php",
+          "python3 -m json.tool backend/docs/career/generated/career-full-parity-03-contract-repair-report.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "notes": "External broad-test blocker was fixed by ad-hoc PR #2042. CAREER-FULL-PARITY-03 scoped checks pass: broad Feature/Console+Feature/Career suite completed with 704 warnings and 38924 assertions, focused workbook repair test completed with 3 warnings and 42 assertions, scoped Pint pass, generated report JSON pass, state JSON pass, YAML pass, git diff --check pass. Manifest directory-level Pint still reports a pre-existing origin/main style issue in app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php; recorded as external sidecar and kept out of this PR scope."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to CareerRepairDisplayWorkbookContract.php, its console test, backend/docs/career/generated/career-full-parity-03-contract-repair-report.json, and docs/codex/pr-train-state.json."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
+    "commit_sha": "87c1fb5536623fb7a5f8e11662ac1da8dc8faa05",
     "pr_url": null,
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -53574,8 +53597,54 @@
         "at": "2026-06-11T13:00:17Z",
         "status": "pending_dependency",
         "note": "Initialized from explicit CAREER-FULL-PARITY train authorization; implementation deferred until dependencies merge."
+      },
+      {
+        "at": "2026-06-11T13:54:56Z",
+        "status": "in_progress",
+        "note": "Started CAREER-FULL-PARITY-03 from latest origin/main after PR02 merge cleanup; generated dry-run workbook contract repair report for 136 candidate slugs."
+      },
+      {
+        "at": "2026-06-11T13:59:30Z",
+        "status": "local_checks_failed_external_blocker",
+        "note": "Required broad Feature/Console+Feature/Career check failed outside PR03 scope; focused workbook repair validation, scope validation, JSON/YAML, Pint, and diff check passed. Stopped before commit/push/PR per PR-train failure policy."
+      },
+      {
+        "at": "2026-06-11T15:26:34Z",
+        "status": "local_checks_passed",
+        "note": "Resumed after ad-hoc PR #2042 fixed the external broad-test blocker. Rebased CAREER-FULL-PARITY-03 onto origin/main 5120fc21 and reran manifest checks successfully."
+      },
+      {
+        "at": "2026-06-11T15:26:34Z",
+        "status": "external_sidecar_blocker_recorded",
+        "note": "Directory-level Pint check still fails on a pre-existing origin/main style issue in app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php. Scoped Pint for CAREER-FULL-PARITY-03 files passes; the external style issue is not included in this PR."
+      },
+      {
+        "at": "2026-06-11T15:26:34Z",
+        "status": "committed",
+        "note": "Committed CAREER-FULL-PARITY-03 scoped repair command, tests, and generated dry-run report."
       }
-    ]
+    ],
+    "result": {
+      "dry_run_report": "backend/docs/career/generated/career-full-parity-03-contract-repair-report.json",
+      "selected_rows": 136,
+      "auto_repairable_rows": 131,
+      "manual_review_required_rows": 5,
+      "manual_review_required_slugs": [
+        "data-scientists",
+        "human-resources-specialists",
+        "management-analysts",
+        "project-management-specialists",
+        "registered-nurses"
+      ],
+      "external_sidecar_blockers": [
+        {
+          "type": "pre_existing_pint_style_issue",
+          "file": "backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php",
+          "evidence": "cd backend && ./vendor/bin/pint --test app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php fails on origin/main with the same unary_operator_spaces style issue."
+        }
+      ],
+      "decision": "dry_run_changes_available"
+    }
   },
   "CAREER-FULL-PARITY-04": {
     "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Extended `career:repair-display-workbook-contract` to normalize `Source_Page_Type` to `career_job_detail` for blocked career display workbook rows.
- Kept the repairer mechanical-only: it removes Product/job-posting sample schema terms, normalizes CTA/source refs, and now separates rows requiring human Chinese Title/H1 review.
- Added contract coverage for the manual-review split.
- Added `backend/docs/career/generated/career-full-parity-03-contract-repair-report.json` with the 136-row dry-run report.
- Reconciled CAREER-FULL-PARITY-02 merged state and recorded CAREER-FULL-PARITY-03 validation state.

## Why
CAREER-FULL-PARITY-03 needs the 136 blocked workbook/content asset rows split into auto-repairable vs manual Chinese review before the next import/cache PR can operate on clean input.

## Validation commands
- `php -l backend/app/Console/Commands/CareerRepairDisplayWorkbookContract.php && php -l backend/tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console tests/Feature/Career --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerRepairDisplayWorkbookContract.php tests/Feature/Console/CareerRepairDisplayWorkbookContractCommandTest.php`
- `python3 -m json.tool backend/docs/career/generated/career-full-parity-03-contract-repair-report.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Report summary
- selected rows: 136
- changed rows: 136
- auto-repairable rows: 131
- manual-review-required rows: 5
- manual-review-required slugs: `data-scientists`, `human-resources-specialists`, `management-analysts`, `project-management-specialists`, `registered-nurses`

## Intentionally deferred
- No database writes, CMS mutation, import, publish, cache mutation, or deploy.
- The 5 manual Chinese Title/H1 review rows are isolated for a later controlled review path.
- Directory-level Pint still reports a pre-existing `origin/main` style issue in `backend/app/Console/Commands/PersonalityEnsureMbtiVariantSectionStructure.php`; scoped Pint for this PR passes and that external sidecar is not included here.
