### PR TITLE
CAREER-FULL-PARITY-04: chore(career): prepare runtime shell zh asset import

### DIFF
--- a/backend/app/Console/Commands/CareerPrepareZhParityControlledImport.php
+++ b/backend/app/Console/Commands/CareerPrepareZhParityControlledImport.php
@@ -11,12 +11,17 @@ use Throwable;
 
 final class CareerPrepareZhParityControlledImport extends Command
 {
-    private const VALIDATOR_VERSION = 'career_zh_parity_controlled_import_readiness_v0.1';
+    private const VALIDATOR_VERSION = 'career_zh_parity_controlled_import_readiness_v0.2';
 
     private const SOURCE_MANIFEST_SCHEMA = 'career_zh_parity_controlled_import_manifest.v0.1';
 
+    private const DEFAULT_SOURCE_REPORT = 'backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json';
+
+    private const DEFAULT_CONTRACT_REPAIR_REPORT = 'backend/docs/career/generated/career-full-parity-03-contract-repair-report.json';
+
     protected $signature = 'career:prepare-zh-parity-controlled-import
-        {--source-report=backend/docs/career/generated/career-zh-parity-live-01-production-report.json : CAREER-ZH-PARITY-LIVE-01 production report JSON}
+        {--source-report=backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json : CAREER-FULL-PARITY-02 root-cause manifest JSON}
+        {--contract-repair-report=backend/docs/career/generated/career-full-parity-03-contract-repair-report.json : CAREER-FULL-PARITY-03 workbook contract repair report JSON}
         {--chunk-size=50 : Positive candidate chunk size for dry-run/import/cache command planning}
         {--output= : Optional JSON output path}
         {--json : Emit machine-readable report}';
@@ -27,11 +32,20 @@ final class CareerPrepareZhParityControlledImport extends Command
     {
         try {
             $sourceReportPath = $this->sourceReportPath();
+            $contractRepairReportPath = $this->contractRepairReportPath();
             $chunkSize = $this->chunkSize();
             $sourceReport = $this->readJsonFile($sourceReportPath);
+            $contractRepairReport = $this->readJsonFile($contractRepairReportPath);
             $sourceManifest = $this->sourceManifest($sourceReport);
-            $candidates = $this->candidateSlugs($sourceManifest);
-            $errors = $this->validateSourceReport($sourceReport, $sourceManifest, $candidates);
+            $sourceCandidates = $this->candidateSlugs($sourceManifest);
+            $manualReviewSlugs = $this->manualReviewSlugs($contractRepairReport);
+            $eligibleCandidates = $this->eligibleCandidateSlugs($sourceCandidates, $manualReviewSlugs);
+            $heldRows = $this->heldManualReviewRows($contractRepairReport);
+            $eligibleRows = $this->manifestRowsForSlugs($sourceManifest, $eligibleCandidates);
+            $errors = array_merge(
+                $this->validateSourceReport($sourceReport, $sourceManifest, $sourceCandidates),
+                $this->validateContractRepairReport($contractRepairReport, $sourceCandidates, $manualReviewSlugs, $eligibleCandidates),
+            );
 
             if ($errors !== []) {
                 return $this->finish([
@@ -42,11 +56,12 @@ final class CareerPrepareZhParityControlledImport extends Command
                     'cache_mutation' => false,
                     'content_mutation' => false,
                     'source_report' => $this->sourceReportSummary($sourceReportPath, $sourceReport),
+                    'contract_repair_report' => $this->contractRepairReportSummary($contractRepairReportPath, $contractRepairReport),
                     'errors' => array_values(array_unique($errors)),
                 ], false);
             }
 
-            $chunks = $this->chunks($candidates, $chunkSize);
+            $chunks = $this->chunks($eligibleCandidates, $chunkSize);
             $report = [
                 'validator_version' => self::VALIDATOR_VERSION,
                 'decision' => 'pass',
@@ -60,20 +75,34 @@ final class CareerPrepareZhParityControlledImport extends Command
                 'llms_changed' => false,
                 'index_strategy_changed' => false,
                 'source_report' => $this->sourceReportSummary($sourceReportPath, $sourceReport),
-                'readiness_decision' => 'ready_for_reviewed_workbook_dry_run',
+                'contract_repair_report' => $this->contractRepairReportSummary($contractRepairReportPath, $contractRepairReport),
+                'readiness_decision' => 'ready_for_auto_repairable_runtime_shell_dry_run',
                 'blocked_until_explicit_approval' => [
+                    'reviewed_workbook_upload',
+                    'authority_crosswalk_force_alignment',
                     'force_import',
                     'production_cache_forget_warm',
                     'production_controlled_execution',
+                ],
+                'operator_review_hold' => [
+                    'manual_review_required_count' => count($manualReviewSlugs),
+                    'manual_review_required_slugs' => $manualReviewSlugs,
+                    'manual_review_required_rows' => $heldRows,
+                    'reason' => 'CN_Title/CN_H1 require reviewed Chinese text before controlled import.',
                 ],
                 'controlled_import_input_manifest' => [
                     'schema_version' => (string) $sourceManifest['schema_version'],
                     'source_scope' => (string) $sourceManifest['source_scope'],
                     'target_command' => (string) $sourceManifest['target_command'],
                     'target_locale' => (string) $sourceManifest['target_locale'],
-                    'candidate_count' => count($candidates),
-                    'candidate_slugs_sha256' => $this->slugListSha256($candidates),
-                    'candidate_slugs' => $candidates,
+                    'source_candidate_count' => count($sourceCandidates),
+                    'source_candidate_slugs_sha256' => $this->slugListSha256($sourceCandidates),
+                    'eligible_candidate_count' => count($eligibleCandidates),
+                    'eligible_candidate_slugs_sha256' => $this->slugListSha256($eligibleCandidates),
+                    'candidate_count' => count($eligibleCandidates),
+                    'candidate_slugs_sha256' => $this->slugListSha256($eligibleCandidates),
+                    'candidate_slugs' => $eligibleCandidates,
+                    'rows' => $eligibleRows,
                 ],
                 'source_live_counts' => [
                     'total_slugs' => (int) data_get($sourceReport, 'summary.total_slugs', 0),
@@ -96,12 +125,26 @@ final class CareerPrepareZhParityControlledImport extends Command
                         'reviewed_workbook' => '<reviewed_workbook.xlsx>',
                         'validated_full_upload_plan_manifest' => '<validated_full_upload_plan.json>',
                     ],
+                    'authority_crosswalk_alignment' => [
+                        'dry_run_command' => 'php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --dry-run --json',
+                        'force_command_requires_explicit_approval' => 'php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --force --json',
+                    ],
+                    'controlled_display_asset_import' => [
+                        'dry_run_command' => 'php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size='.$chunkSize.' --manifest-chunk-index=1 --dry-run --json',
+                        'force_command_requires_explicit_approval' => 'php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size='.$chunkSize.' --manifest-chunk-index=1 --force --json',
+                    ],
+                    'post_import_cache_refresh' => [
+                        'command_requires_explicit_approval' => 'php backend/artisan career:warm-public-authority-cache --job-detail-slugs=<chunk_slugs_csv> --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json',
+                    ],
                     'chunks' => $this->executionChunks($chunks, $chunkSize),
                 ],
                 'acceptance_commands' => [
-                    'validate_readiness_report' => 'python3 -m json.tool backend/docs/career/generated/career-zh-parity-controlled-import-readiness-01.json >/dev/null',
-                    'readiness_command' => 'php backend/artisan career:prepare-zh-parity-controlled-import --source-report=backend/docs/career/generated/career-zh-parity-live-01-production-report.json --output=backend/docs/career/generated/career-zh-parity-controlled-import-readiness-01.json --json',
+                    'validate_readiness_report' => 'python3 -m json.tool backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json >/dev/null',
+                    'readiness_command' => 'php backend/artisan career:prepare-zh-parity-controlled-import --source-report='.self::DEFAULT_SOURCE_REPORT.' --contract-repair-report='.self::DEFAULT_CONTRACT_REPAIR_REPORT.' --output=backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json --json',
+                    'authority_crosswalk_dry_run_template' => 'php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --dry-run --json',
+                    'authority_crosswalk_force_template_after_approval' => 'php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --force --json',
                     'dry_run_template' => 'php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size='.$chunkSize.' --manifest-chunk-index=1 --dry-run --json',
+                    'force_import_template_after_approval' => 'php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size='.$chunkSize.' --manifest-chunk-index=1 --force --json',
                     'cache_refresh_template_after_import_approval' => 'php backend/artisan career:warm-public-authority-cache --job-detail-slugs=<chunk_slugs_csv> --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json',
                 ],
             ];
@@ -128,6 +171,19 @@ final class CareerPrepareZhParityControlledImport extends Command
         }
         if (! is_file($path)) {
             throw new RuntimeException('--source-report does not exist: '.$path);
+        }
+
+        return $path;
+    }
+
+    private function contractRepairReportPath(): string
+    {
+        $path = trim((string) $this->option('contract-repair-report'));
+        if ($path === '') {
+            throw new RuntimeException('--contract-repair-report is required.');
+        }
+        if (! is_file($path)) {
+            throw new RuntimeException('--contract-repair-report does not exist: '.$path);
         }
 
         return $path;
@@ -258,6 +314,51 @@ final class CareerPrepareZhParityControlledImport extends Command
     }
 
     /**
+     * @param  array<string, mixed>  $repairReport
+     * @param  list<string>  $sourceCandidateSlugs
+     * @param  list<string>  $manualReviewSlugs
+     * @param  list<string>  $eligibleCandidateSlugs
+     * @return list<string>
+     */
+    private function validateContractRepairReport(
+        array $repairReport,
+        array $sourceCandidateSlugs,
+        array $manualReviewSlugs,
+        array $eligibleCandidateSlugs,
+    ): array {
+        $errors = [];
+        if ((bool) ($repairReport['writes_database'] ?? true) !== false) {
+            $errors[] = 'Contract repair report must not write database.';
+        }
+        if ((bool) ($repairReport['cms_mutation'] ?? true) !== false) {
+            $errors[] = 'Contract repair report must not mutate CMS.';
+        }
+        if ((bool) ($repairReport['execute'] ?? true) !== false) {
+            $errors[] = 'Contract repair report must be a dry-run report.';
+        }
+        if ((int) ($repairReport['selected_rows'] ?? -1) !== count($sourceCandidateSlugs)) {
+            $errors[] = 'Contract repair report selected_rows must match source candidate count.';
+        }
+        if ((int) ($repairReport['manual_review_required_count'] ?? -1) !== count($manualReviewSlugs)) {
+            $errors[] = 'Contract repair report manual_review_required_count must match manual rows.';
+        }
+        if ((int) ($repairReport['auto_repairable_rows'] ?? -1) !== count($eligibleCandidateSlugs)) {
+            $errors[] = 'Contract repair report auto_repairable_rows must match eligible candidates.';
+        }
+        $sourceSet = array_flip($sourceCandidateSlugs);
+        foreach ($manualReviewSlugs as $slug) {
+            if (! isset($sourceSet[$slug])) {
+                $errors[] = 'Manual review slug is not present in source candidates: '.$slug.'.';
+            }
+        }
+        if ($eligibleCandidateSlugs === []) {
+            $errors[] = 'At least one auto-repairable runtime shell candidate is required.';
+        }
+
+        return $errors;
+    }
+
+    /**
      * @param  list<string>  $slugs
      * @return list<list<string>>
      */
@@ -281,11 +382,81 @@ final class CareerPrepareZhParityControlledImport extends Command
                 'candidate_count' => count($chunk),
                 'candidate_slugs_sha256' => $this->slugListSha256($chunk),
                 'candidate_slugs' => $chunk,
+                'authority_crosswalk_dry_run_command' => 'php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs='.$chunkSlugs.' --dry-run --json',
+                'authority_crosswalk_force_command_requires_explicit_approval' => 'php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs='.$chunkSlugs.' --force --json',
                 'dry_run_command' => 'php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size='.$chunkSize.' --manifest-chunk-index='.$chunkIndex.' --dry-run --json',
                 'force_command_requires_explicit_approval' => 'php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size='.$chunkSize.' --manifest-chunk-index='.$chunkIndex.' --force --json',
                 'post_import_cache_refresh_command_requires_explicit_approval' => 'php backend/artisan career:warm-public-authority-cache --job-detail-slugs='.$chunkSlugs.' --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json',
             ];
         }, $chunks, array_keys($chunks));
+    }
+
+    /**
+     * @param  array<string, mixed>  $repairReport
+     * @return list<string>
+     */
+    private function manualReviewSlugs(array $repairReport): array
+    {
+        $rows = (array) ($repairReport['manual_review_required_rows'] ?? []);
+
+        return array_values(array_unique(array_filter(array_map(
+            static fn (mixed $row): string => is_array($row) ? strtolower(trim((string) ($row['slug'] ?? ''))) : '',
+            $rows,
+        ), static fn (string $slug): bool => $slug !== '')));
+    }
+
+    /**
+     * @param  list<string>  $sourceCandidates
+     * @param  list<string>  $manualReviewSlugs
+     * @return list<string>
+     */
+    private function eligibleCandidateSlugs(array $sourceCandidates, array $manualReviewSlugs): array
+    {
+        $manual = array_flip($manualReviewSlugs);
+
+        return array_values(array_filter(
+            $sourceCandidates,
+            static fn (string $slug): bool => ! isset($manual[$slug]),
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $repairReport
+     * @return list<array<string, mixed>>
+     */
+    private function heldManualReviewRows(array $repairReport): array
+    {
+        return array_values(array_map(static fn (mixed $row): array => [
+            'slug' => is_array($row) ? strtolower(trim((string) ($row['slug'] ?? ''))) : '',
+            'row_number' => is_array($row) ? (int) ($row['row_number'] ?? 0) : 0,
+            'reasons' => is_array($row) ? array_values((array) ($row['reasons'] ?? [])) : [],
+        ], (array) ($repairReport['manual_review_required_rows'] ?? [])));
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     * @param  list<string>  $slugs
+     * @return list<array<string, mixed>>
+     */
+    private function manifestRowsForSlugs(array $manifest, array $slugs): array
+    {
+        $wanted = array_flip($slugs);
+        $rows = [];
+        foreach ((array) ($manifest['rows'] ?? []) as $row) {
+            if (! is_array($row)) {
+                continue;
+            }
+            $slug = strtolower(trim((string) ($row['slug'] ?? '')));
+            if ($slug === '' || ! isset($wanted[$slug])) {
+                continue;
+            }
+            $rows[] = array_merge($row, [
+                'slug' => $slug,
+                'import_readiness' => 'auto_repairable_after_contract_repair',
+            ]);
+        }
+
+        return $rows;
     }
 
     /**
@@ -308,6 +479,23 @@ final class CareerPrepareZhParityControlledImport extends Command
             'validator_version' => (string) ($sourceReport['validator_version'] ?? ''),
             'decision' => (string) ($sourceReport['decision'] ?? ''),
             'live_gate_decision' => (string) data_get($sourceReport, 'live_gate.decision', ''),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $contractRepairReport
+     * @return array<string, mixed>
+     */
+    private function contractRepairReportSummary(string $contractRepairReportPath, array $contractRepairReport): array
+    {
+        return [
+            'path' => $contractRepairReportPath,
+            'sha256' => hash_file('sha256', $contractRepairReportPath) ?: null,
+            'repairer_version' => (string) ($contractRepairReport['repairer_version'] ?? ''),
+            'decision' => (string) ($contractRepairReport['decision'] ?? ''),
+            'selected_rows' => (int) ($contractRepairReport['selected_rows'] ?? 0),
+            'auto_repairable_rows' => (int) ($contractRepairReport['auto_repairable_rows'] ?? 0),
+            'manual_review_required_count' => (int) ($contractRepairReport['manual_review_required_count'] ?? 0),
         ];
     }
 

--- a/backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json
+++ b/backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json
@@ -1,0 +1,2699 @@
+{
+    "validator_version": "career_zh_parity_controlled_import_readiness_v0.2",
+    "decision": "pass",
+    "read_only": true,
+    "writes_database": false,
+    "cache_mutation": false,
+    "content_mutation": false,
+    "publish_mutation": false,
+    "deploy_mutation": false,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "index_strategy_changed": false,
+    "source_report": {
+        "path": "backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json",
+        "sha256": "86ec5872e0fe4fe5bb4bb1def0d55060b7fac2c8aff12efc9311b06ac999f07e",
+        "validator_version": "career_zh_display_parity_audit_v0.3",
+        "decision": "pass",
+        "live_gate_decision": "blocked"
+    },
+    "contract_repair_report": {
+        "path": "backend/docs/career/generated/career-full-parity-03-contract-repair-report.json",
+        "sha256": "83994947e4336fb7cf56b13445b9658a527a8a7c6eac6b04969bd0257d53c27e",
+        "repairer_version": "career_display_workbook_contract_repairer_v0.2",
+        "decision": "dry_run_changes_available",
+        "selected_rows": 136,
+        "auto_repairable_rows": 131,
+        "manual_review_required_count": 5
+    },
+    "readiness_decision": "ready_for_auto_repairable_runtime_shell_dry_run",
+    "blocked_until_explicit_approval": [
+        "reviewed_workbook_upload",
+        "authority_crosswalk_force_alignment",
+        "force_import",
+        "production_cache_forget_warm",
+        "production_controlled_execution"
+    ],
+    "operator_review_hold": {
+        "manual_review_required_count": 5,
+        "manual_review_required_slugs": [
+            "data-scientists",
+            "human-resources-specialists",
+            "management-analysts",
+            "project-management-specialists",
+            "registered-nurses"
+        ],
+        "manual_review_required_rows": [
+            {
+                "slug": "data-scientists",
+                "row_number": 1930,
+                "reasons": [
+                    "CN_Title lacks reviewed Chinese text",
+                    "CN_Title copied from EN_Title",
+                    "CN_H1 lacks reviewed Chinese text",
+                    "CN_H1 copied from EN_H1"
+                ]
+            },
+            {
+                "slug": "human-resources-specialists",
+                "row_number": 2211,
+                "reasons": [
+                    "CN_Title lacks reviewed Chinese text",
+                    "CN_Title copied from EN_Title",
+                    "CN_H1 lacks reviewed Chinese text",
+                    "CN_H1 copied from EN_H1"
+                ]
+            },
+            {
+                "slug": "management-analysts",
+                "row_number": 2304,
+                "reasons": [
+                    "CN_Title lacks reviewed Chinese text",
+                    "CN_Title copied from EN_Title",
+                    "CN_H1 lacks reviewed Chinese text",
+                    "CN_H1 copied from EN_H1"
+                ]
+            },
+            {
+                "slug": "project-management-specialists",
+                "row_number": 2531,
+                "reasons": [
+                    "CN_Title lacks reviewed Chinese text",
+                    "CN_Title copied from EN_Title",
+                    "CN_H1 lacks reviewed Chinese text",
+                    "CN_H1 copied from EN_H1"
+                ]
+            },
+            {
+                "slug": "registered-nurses",
+                "row_number": 2578,
+                "reasons": [
+                    "CN_Title lacks reviewed Chinese text",
+                    "CN_Title copied from EN_Title",
+                    "CN_H1 lacks reviewed Chinese text",
+                    "CN_H1 copied from EN_H1"
+                ]
+            }
+        ],
+        "reason": "CN_Title/CN_H1 require reviewed Chinese text before controlled import."
+    },
+    "controlled_import_input_manifest": {
+        "schema_version": "career_zh_parity_controlled_import_manifest.v0.1",
+        "source_scope": "post_deploy_production_public_api_read_only",
+        "target_command": "career:import-selected-display-assets",
+        "target_locale": "zh-CN",
+        "source_candidate_count": 136,
+        "source_candidate_slugs_sha256": "3bdcccb6aaa6fabd235fccd124cc49d25f1cb3582eaa253fd647912f51605c49",
+        "eligible_candidate_count": 131,
+        "eligible_candidate_slugs_sha256": "e02da5816e0ce82bc322810d628a2a71e23303b1990266f09cdcbce5c358ed07",
+        "candidate_count": 131,
+        "candidate_slugs_sha256": "e02da5816e0ce82bc322810d628a2a71e23303b1990266f09cdcbce5c358ed07",
+        "candidate_slugs": [
+            "aerospace-engineers",
+            "agricultural-and-food-scientists",
+            "agricultural-workers",
+            "announcers",
+            "anthropologists-and-archeologists",
+            "arbitrators-mediators-and-conciliators",
+            "assemblers-and-fabricators",
+            "athletes-and-sports-competitors",
+            "athletic-trainers",
+            "atmospheric-scientists-including-meteorologists",
+            "audiologists",
+            "automotive-service-technicians-and-mechanics",
+            "bakers",
+            "barbers-hairstylists-and-cosmetologists",
+            "bartenders",
+            "biological-technicians",
+            "boilermakers",
+            "brickmasons-blockmasons-and-stonemasons",
+            "broadcast-and-sound-engineering-technicians",
+            "bus-drivers",
+            "calibration-technologists-and-technicians",
+            "cartographers-and-photogrammetrists",
+            "chemical-engineers",
+            "chemical-technicians",
+            "childcare-workers",
+            "civil-engineering-technicians",
+            "claims-adjusters-appraisers-examiners-and-investigators",
+            "construction-equipment-operators",
+            "construction-laborers-and-helpers",
+            "cooks",
+            "cost-estimators",
+            "craft-and-fine-artists",
+            "curators-museum-technicians-and-conservators",
+            "customer-service-representatives",
+            "dancers-and-choreographers",
+            "delivery-truck-drivers-and-driver-sales-workers",
+            "dental-and-ophthalmic-laboratory-technicians-and-medical-appliance-technicians",
+            "diesel-service-technicians-and-mechanics",
+            "drafters",
+            "drywall-and-ceiling-tile-installers-and-tapers",
+            "electrical-and-electronics-installers-and-repairers",
+            "elementary-middle-and-high-school-principals",
+            "emts-and-paramedics",
+            "entertainment-and-recreation-managers",
+            "environmental-science-and-protection-technicians",
+            "environmental-scientists-and-specialists",
+            "film-and-video-editors-and-camera-operators",
+            "financial-clerks",
+            "fitness-trainers-and-instructors",
+            "food-and-beverage-serving-and-related-workers",
+            "food-and-tobacco-processing-workers",
+            "funeral-service-occupations",
+            "gaming-services-occupations",
+            "general-maintenance-and-repair-workers",
+            "general-office-clerks",
+            "geological-and-petroleum-technicians",
+            "geoscientists",
+            "grounds-maintenance-workers",
+            "hand-laborers-and-material-movers",
+            "health-and-safety-engineers",
+            "heavy-vehicle-and-mobile-equipment-service-technicians",
+            "home-health-aides-and-personal-care-aides",
+            "industrial-designers",
+            "industrial-engineering-technicians",
+            "industrial-machinery-mechanics-and-maintenance-workers-and-millwrights",
+            "industrial-production-managers",
+            "information-clerks",
+            "insulation-workers",
+            "insurance-sales-agents",
+            "janitors-and-building-cleaners",
+            "judges-and-hearing-officers",
+            "kindergarten-and-elementary-school-teachers",
+            "librarians",
+            "library-technicians-and-assistants",
+            "logging-workers",
+            "machinists-and-tool-and-die-makers",
+            "material-moving-machine-operators",
+            "material-recording-clerks",
+            "materials-engineers",
+            "medical-scientists",
+            "metal-and-plastic-machine-workers",
+            "middle-school-teachers",
+            "military-careers",
+            "mining-and-geological-engineers",
+            "multimedia-artists-and-animators",
+            "nuclear-technicians",
+            "nurse-anesthetists-nurse-midwives-and-nurse-practitioners",
+            "occupational-health-and-safety-specialists-and-technicians",
+            "occupational-therapy-assistants-and-aides",
+            "oil-and-gas-workers",
+            "painting-and-coating-workers",
+            "petroleum-engineers",
+            "physical-therapist-assistants-and-aides",
+            "physicians-and-surgeons",
+            "physicists-and-astronomers",
+            "police-and-detectives",
+            "postal-service-workers",
+            "postsecondary-education-administrators",
+            "postsecondary-teachers",
+            "power-plant-operators-distributors-and-dispatchers",
+            "preschool-and-childcare-center-directors",
+            "preschool-teachers",
+            "producers-and-directors",
+            "psychiatric-technicians-and-aides",
+            "psychologists",
+            "purchasing-managers-buyers-and-purchasing-agents",
+            "quality-control-inspectors",
+            "radiologic-technologists",
+            "railroad-occupations",
+            "real-estate-brokers-and-sales-agents",
+            "receptionists",
+            "retail-sales-workers",
+            "sales-managers",
+            "school-and-career-counselors",
+            "secretaries-and-administrative-assistants",
+            "set-and-exhibit-designers",
+            "sheet-metal-workers",
+            "small-engine-mechanics",
+            "social-workers",
+            "special-education-teachers",
+            "substance-abuse-behavioral-disorder-and-mental-health-counselors",
+            "taxi-drivers-and-chauffeurs",
+            "teacher-assistants",
+            "tile-and-marble-setters",
+            "top-executives",
+            "tour-and-travel-guides",
+            "water-transportation-occupations",
+            "welders-cutters-solderers-and-brazers",
+            "wholesale-and-manufacturing-sales-representatives",
+            "wind-turbine-technicians",
+            "woodworkers"
+        ],
+        "rows": [
+            {
+                "slug": "aerospace-engineers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "agricultural-and-food-scientists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "agricultural-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "announcers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "anthropologists-and-archeologists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "arbitrators-mediators-and-conciliators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "assemblers-and-fabricators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "athletes-and-sports-competitors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "athletic-trainers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "atmospheric-scientists-including-meteorologists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "audiologists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "automotive-service-technicians-and-mechanics",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "bakers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "barbers-hairstylists-and-cosmetologists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "bartenders",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "biological-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "boilermakers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "brickmasons-blockmasons-and-stonemasons",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "broadcast-and-sound-engineering-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "bus-drivers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "calibration-technologists-and-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "cartographers-and-photogrammetrists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "chemical-engineers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "chemical-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "childcare-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "civil-engineering-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "claims-adjusters-appraisers-examiners-and-investigators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "construction-equipment-operators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "construction-laborers-and-helpers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "cooks",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "cost-estimators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "craft-and-fine-artists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "curators-museum-technicians-and-conservators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "customer-service-representatives",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "dancers-and-choreographers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "delivery-truck-drivers-and-driver-sales-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "dental-and-ophthalmic-laboratory-technicians-and-medical-appliance-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "diesel-service-technicians-and-mechanics",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "drafters",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "drywall-and-ceiling-tile-installers-and-tapers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "electrical-and-electronics-installers-and-repairers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "elementary-middle-and-high-school-principals",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "emts-and-paramedics",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "entertainment-and-recreation-managers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "environmental-science-and-protection-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "environmental-scientists-and-specialists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "film-and-video-editors-and-camera-operators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "financial-clerks",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "fitness-trainers-and-instructors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "food-and-beverage-serving-and-related-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "food-and-tobacco-processing-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "funeral-service-occupations",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "gaming-services-occupations",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "general-maintenance-and-repair-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "general-office-clerks",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "geological-and-petroleum-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "geoscientists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "grounds-maintenance-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "hand-laborers-and-material-movers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "health-and-safety-engineers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "heavy-vehicle-and-mobile-equipment-service-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "home-health-aides-and-personal-care-aides",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "industrial-designers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "industrial-engineering-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "industrial-machinery-mechanics-and-maintenance-workers-and-millwrights",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "industrial-production-managers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "information-clerks",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "insulation-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "insurance-sales-agents",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "janitors-and-building-cleaners",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "judges-and-hearing-officers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "kindergarten-and-elementary-school-teachers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "librarians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "library-technicians-and-assistants",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "logging-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "machinists-and-tool-and-die-makers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "material-moving-machine-operators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "material-recording-clerks",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "materials-engineers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "medical-scientists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "metal-and-plastic-machine-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "middle-school-teachers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "military-careers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "mining-and-geological-engineers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "multimedia-artists-and-animators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "nuclear-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "nurse-anesthetists-nurse-midwives-and-nurse-practitioners",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "occupational-health-and-safety-specialists-and-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "occupational-therapy-assistants-and-aides",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "oil-and-gas-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "painting-and-coating-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "petroleum-engineers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "physical-therapist-assistants-and-aides",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "physicians-and-surgeons",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "physicists-and-astronomers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "police-and-detectives",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "postal-service-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "postsecondary-education-administrators",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "postsecondary-teachers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "power-plant-operators-distributors-and-dispatchers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "preschool-and-childcare-center-directors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "preschool-teachers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "producers-and-directors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "psychiatric-technicians-and-aides",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "psychologists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "purchasing-managers-buyers-and-purchasing-agents",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "quality-control-inspectors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "radiologic-technologists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "railroad-occupations",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "real-estate-brokers-and-sales-agents",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "receptionists",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "retail-sales-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "sales-managers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "school-and-career-counselors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "secretaries-and-administrative-assistants",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "set-and-exhibit-designers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "sheet-metal-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "small-engine-mechanics",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "social-workers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "special-education-teachers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "substance-abuse-behavioral-disorder-and-mental-health-counselors",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "taxi-drivers-and-chauffeurs",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "teacher-assistants",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "tile-and-marble-setters",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "top-executives",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "tour-and-travel-guides",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "water-transportation-occupations",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "welders-cutters-solderers-and-brazers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "wholesale-and-manufacturing-sales-representatives",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "wind-turbine-technicians",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            },
+            {
+                "slug": "woodworkers",
+                "locale": "zh-CN",
+                "root_cause": "runtime_shell_missing_or_unpublished_zh_display_asset",
+                "missing_modules": [],
+                "zh_gate_reasons": [
+                    "amber_flag:runtime_published_navigation_shell",
+                    "blocked_claim:compiled_recommendation_claims_unavailable",
+                    "blocked_claim:display_asset_claims_unavailable",
+                    "integrity_state:runtime_published_shell",
+                    "critical_missing_field:compiled_recommendation_snapshot",
+                    "critical_missing_field:display_asset_claims"
+                ],
+                "cms_asset_exists": "inferred_absent_or_not_published_from_public_payload",
+                "cache_stale": "not_proven",
+                "import_readiness": "auto_repairable_after_contract_repair"
+            }
+        ]
+    },
+    "source_live_counts": {
+        "total_slugs": 1046,
+        "runtime_shell_count": 131,
+        "missing_modules_by_slug_count": 672,
+        "root_cause_counts": {
+            "no_runtime_parity_issue_detected": 137,
+            "runtime_shell_missing_or_unpublished_zh_display_asset": 131,
+            "zh_display_asset_present_but_module_subset": 667,
+            "zh_has_unexpected_extra_modules": 106,
+            "zh_missing_en_display_modules_without_public_asset_evidence": 5
+        },
+        "cache_stale_counts": {
+            "not_indicated": 137,
+            "not_proven": 131,
+            "unknown_public_api_only": 778
+        },
+        "cms_asset_exists_counts": {
+            "inferred_absent_or_not_published_from_public_payload": 131,
+            "inferred_present_from_public_payload": 892,
+            "unknown_from_public_payload": 23
+        }
+    },
+    "execution_plan": {
+        "chunk_size": 50,
+        "chunk_count": 3,
+        "requires_reviewed_workbook": true,
+        "requires_validated_full_upload_manifest": true,
+        "dry_run_first": true,
+        "force_import_requires_explicit_approval": true,
+        "cache_refresh_requires_explicit_post_import_approval": true,
+        "must_not_change_sitemap_llms_or_index_strategy": true,
+        "placeholder_inputs": {
+            "reviewed_workbook": "<reviewed_workbook.xlsx>",
+            "validated_full_upload_plan_manifest": "<validated_full_upload_plan.json>"
+        },
+        "authority_crosswalk_alignment": {
+            "dry_run_command": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --dry-run --json",
+            "force_command_requires_explicit_approval": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --force --json"
+        },
+        "controlled_display_asset_import": {
+            "dry_run_command": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=1 --dry-run --json",
+            "force_command_requires_explicit_approval": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=1 --force --json"
+        },
+        "post_import_cache_refresh": {
+            "command_requires_explicit_approval": "php backend/artisan career:warm-public-authority-cache --job-detail-slugs=<chunk_slugs_csv> --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json"
+        },
+        "chunks": [
+            {
+                "chunk_index": 1,
+                "candidate_count": 50,
+                "candidate_slugs_sha256": "7619ac7700b03080c5a90927905fdc8f1ce0cc93aeb588ecb837f1dac2f87315",
+                "candidate_slugs": [
+                    "aerospace-engineers",
+                    "agricultural-and-food-scientists",
+                    "agricultural-workers",
+                    "announcers",
+                    "anthropologists-and-archeologists",
+                    "arbitrators-mediators-and-conciliators",
+                    "assemblers-and-fabricators",
+                    "athletes-and-sports-competitors",
+                    "athletic-trainers",
+                    "atmospheric-scientists-including-meteorologists",
+                    "audiologists",
+                    "automotive-service-technicians-and-mechanics",
+                    "bakers",
+                    "barbers-hairstylists-and-cosmetologists",
+                    "bartenders",
+                    "biological-technicians",
+                    "boilermakers",
+                    "brickmasons-blockmasons-and-stonemasons",
+                    "broadcast-and-sound-engineering-technicians",
+                    "bus-drivers",
+                    "calibration-technologists-and-technicians",
+                    "cartographers-and-photogrammetrists",
+                    "chemical-engineers",
+                    "chemical-technicians",
+                    "childcare-workers",
+                    "civil-engineering-technicians",
+                    "claims-adjusters-appraisers-examiners-and-investigators",
+                    "construction-equipment-operators",
+                    "construction-laborers-and-helpers",
+                    "cooks",
+                    "cost-estimators",
+                    "craft-and-fine-artists",
+                    "curators-museum-technicians-and-conservators",
+                    "customer-service-representatives",
+                    "dancers-and-choreographers",
+                    "delivery-truck-drivers-and-driver-sales-workers",
+                    "dental-and-ophthalmic-laboratory-technicians-and-medical-appliance-technicians",
+                    "diesel-service-technicians-and-mechanics",
+                    "drafters",
+                    "drywall-and-ceiling-tile-installers-and-tapers",
+                    "electrical-and-electronics-installers-and-repairers",
+                    "elementary-middle-and-high-school-principals",
+                    "emts-and-paramedics",
+                    "entertainment-and-recreation-managers",
+                    "environmental-science-and-protection-technicians",
+                    "environmental-scientists-and-specialists",
+                    "film-and-video-editors-and-camera-operators",
+                    "financial-clerks",
+                    "fitness-trainers-and-instructors",
+                    "food-and-beverage-serving-and-related-workers"
+                ],
+                "authority_crosswalk_dry_run_command": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=aerospace-engineers,agricultural-and-food-scientists,agricultural-workers,announcers,anthropologists-and-archeologists,arbitrators-mediators-and-conciliators,assemblers-and-fabricators,athletes-and-sports-competitors,athletic-trainers,atmospheric-scientists-including-meteorologists,audiologists,automotive-service-technicians-and-mechanics,bakers,barbers-hairstylists-and-cosmetologists,bartenders,biological-technicians,boilermakers,brickmasons-blockmasons-and-stonemasons,broadcast-and-sound-engineering-technicians,bus-drivers,calibration-technologists-and-technicians,cartographers-and-photogrammetrists,chemical-engineers,chemical-technicians,childcare-workers,civil-engineering-technicians,claims-adjusters-appraisers-examiners-and-investigators,construction-equipment-operators,construction-laborers-and-helpers,cooks,cost-estimators,craft-and-fine-artists,curators-museum-technicians-and-conservators,customer-service-representatives,dancers-and-choreographers,delivery-truck-drivers-and-driver-sales-workers,dental-and-ophthalmic-laboratory-technicians-and-medical-appliance-technicians,diesel-service-technicians-and-mechanics,drafters,drywall-and-ceiling-tile-installers-and-tapers,electrical-and-electronics-installers-and-repairers,elementary-middle-and-high-school-principals,emts-and-paramedics,entertainment-and-recreation-managers,environmental-science-and-protection-technicians,environmental-scientists-and-specialists,film-and-video-editors-and-camera-operators,financial-clerks,fitness-trainers-and-instructors,food-and-beverage-serving-and-related-workers --dry-run --json",
+                "authority_crosswalk_force_command_requires_explicit_approval": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=aerospace-engineers,agricultural-and-food-scientists,agricultural-workers,announcers,anthropologists-and-archeologists,arbitrators-mediators-and-conciliators,assemblers-and-fabricators,athletes-and-sports-competitors,athletic-trainers,atmospheric-scientists-including-meteorologists,audiologists,automotive-service-technicians-and-mechanics,bakers,barbers-hairstylists-and-cosmetologists,bartenders,biological-technicians,boilermakers,brickmasons-blockmasons-and-stonemasons,broadcast-and-sound-engineering-technicians,bus-drivers,calibration-technologists-and-technicians,cartographers-and-photogrammetrists,chemical-engineers,chemical-technicians,childcare-workers,civil-engineering-technicians,claims-adjusters-appraisers-examiners-and-investigators,construction-equipment-operators,construction-laborers-and-helpers,cooks,cost-estimators,craft-and-fine-artists,curators-museum-technicians-and-conservators,customer-service-representatives,dancers-and-choreographers,delivery-truck-drivers-and-driver-sales-workers,dental-and-ophthalmic-laboratory-technicians-and-medical-appliance-technicians,diesel-service-technicians-and-mechanics,drafters,drywall-and-ceiling-tile-installers-and-tapers,electrical-and-electronics-installers-and-repairers,elementary-middle-and-high-school-principals,emts-and-paramedics,entertainment-and-recreation-managers,environmental-science-and-protection-technicians,environmental-scientists-and-specialists,film-and-video-editors-and-camera-operators,financial-clerks,fitness-trainers-and-instructors,food-and-beverage-serving-and-related-workers --force --json",
+                "dry_run_command": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=1 --dry-run --json",
+                "force_command_requires_explicit_approval": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=1 --force --json",
+                "post_import_cache_refresh_command_requires_explicit_approval": "php backend/artisan career:warm-public-authority-cache --job-detail-slugs=aerospace-engineers,agricultural-and-food-scientists,agricultural-workers,announcers,anthropologists-and-archeologists,arbitrators-mediators-and-conciliators,assemblers-and-fabricators,athletes-and-sports-competitors,athletic-trainers,atmospheric-scientists-including-meteorologists,audiologists,automotive-service-technicians-and-mechanics,bakers,barbers-hairstylists-and-cosmetologists,bartenders,biological-technicians,boilermakers,brickmasons-blockmasons-and-stonemasons,broadcast-and-sound-engineering-technicians,bus-drivers,calibration-technologists-and-technicians,cartographers-and-photogrammetrists,chemical-engineers,chemical-technicians,childcare-workers,civil-engineering-technicians,claims-adjusters-appraisers-examiners-and-investigators,construction-equipment-operators,construction-laborers-and-helpers,cooks,cost-estimators,craft-and-fine-artists,curators-museum-technicians-and-conservators,customer-service-representatives,dancers-and-choreographers,delivery-truck-drivers-and-driver-sales-workers,dental-and-ophthalmic-laboratory-technicians-and-medical-appliance-technicians,diesel-service-technicians-and-mechanics,drafters,drywall-and-ceiling-tile-installers-and-tapers,electrical-and-electronics-installers-and-repairers,elementary-middle-and-high-school-principals,emts-and-paramedics,entertainment-and-recreation-managers,environmental-science-and-protection-technicians,environmental-scientists-and-specialists,film-and-video-editors-and-camera-operators,financial-clerks,fitness-trainers-and-instructors,food-and-beverage-serving-and-related-workers --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json"
+            },
+            {
+                "chunk_index": 2,
+                "candidate_count": 50,
+                "candidate_slugs_sha256": "236aedfcb71f4b4a4d11beb4b4d03100f56915d2fef1cd972666ba187bc00d50",
+                "candidate_slugs": [
+                    "food-and-tobacco-processing-workers",
+                    "funeral-service-occupations",
+                    "gaming-services-occupations",
+                    "general-maintenance-and-repair-workers",
+                    "general-office-clerks",
+                    "geological-and-petroleum-technicians",
+                    "geoscientists",
+                    "grounds-maintenance-workers",
+                    "hand-laborers-and-material-movers",
+                    "health-and-safety-engineers",
+                    "heavy-vehicle-and-mobile-equipment-service-technicians",
+                    "home-health-aides-and-personal-care-aides",
+                    "industrial-designers",
+                    "industrial-engineering-technicians",
+                    "industrial-machinery-mechanics-and-maintenance-workers-and-millwrights",
+                    "industrial-production-managers",
+                    "information-clerks",
+                    "insulation-workers",
+                    "insurance-sales-agents",
+                    "janitors-and-building-cleaners",
+                    "judges-and-hearing-officers",
+                    "kindergarten-and-elementary-school-teachers",
+                    "librarians",
+                    "library-technicians-and-assistants",
+                    "logging-workers",
+                    "machinists-and-tool-and-die-makers",
+                    "material-moving-machine-operators",
+                    "material-recording-clerks",
+                    "materials-engineers",
+                    "medical-scientists",
+                    "metal-and-plastic-machine-workers",
+                    "middle-school-teachers",
+                    "military-careers",
+                    "mining-and-geological-engineers",
+                    "multimedia-artists-and-animators",
+                    "nuclear-technicians",
+                    "nurse-anesthetists-nurse-midwives-and-nurse-practitioners",
+                    "occupational-health-and-safety-specialists-and-technicians",
+                    "occupational-therapy-assistants-and-aides",
+                    "oil-and-gas-workers",
+                    "painting-and-coating-workers",
+                    "petroleum-engineers",
+                    "physical-therapist-assistants-and-aides",
+                    "physicians-and-surgeons",
+                    "physicists-and-astronomers",
+                    "police-and-detectives",
+                    "postal-service-workers",
+                    "postsecondary-education-administrators",
+                    "postsecondary-teachers",
+                    "power-plant-operators-distributors-and-dispatchers"
+                ],
+                "authority_crosswalk_dry_run_command": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=food-and-tobacco-processing-workers,funeral-service-occupations,gaming-services-occupations,general-maintenance-and-repair-workers,general-office-clerks,geological-and-petroleum-technicians,geoscientists,grounds-maintenance-workers,hand-laborers-and-material-movers,health-and-safety-engineers,heavy-vehicle-and-mobile-equipment-service-technicians,home-health-aides-and-personal-care-aides,industrial-designers,industrial-engineering-technicians,industrial-machinery-mechanics-and-maintenance-workers-and-millwrights,industrial-production-managers,information-clerks,insulation-workers,insurance-sales-agents,janitors-and-building-cleaners,judges-and-hearing-officers,kindergarten-and-elementary-school-teachers,librarians,library-technicians-and-assistants,logging-workers,machinists-and-tool-and-die-makers,material-moving-machine-operators,material-recording-clerks,materials-engineers,medical-scientists,metal-and-plastic-machine-workers,middle-school-teachers,military-careers,mining-and-geological-engineers,multimedia-artists-and-animators,nuclear-technicians,nurse-anesthetists-nurse-midwives-and-nurse-practitioners,occupational-health-and-safety-specialists-and-technicians,occupational-therapy-assistants-and-aides,oil-and-gas-workers,painting-and-coating-workers,petroleum-engineers,physical-therapist-assistants-and-aides,physicians-and-surgeons,physicists-and-astronomers,police-and-detectives,postal-service-workers,postsecondary-education-administrators,postsecondary-teachers,power-plant-operators-distributors-and-dispatchers --dry-run --json",
+                "authority_crosswalk_force_command_requires_explicit_approval": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=food-and-tobacco-processing-workers,funeral-service-occupations,gaming-services-occupations,general-maintenance-and-repair-workers,general-office-clerks,geological-and-petroleum-technicians,geoscientists,grounds-maintenance-workers,hand-laborers-and-material-movers,health-and-safety-engineers,heavy-vehicle-and-mobile-equipment-service-technicians,home-health-aides-and-personal-care-aides,industrial-designers,industrial-engineering-technicians,industrial-machinery-mechanics-and-maintenance-workers-and-millwrights,industrial-production-managers,information-clerks,insulation-workers,insurance-sales-agents,janitors-and-building-cleaners,judges-and-hearing-officers,kindergarten-and-elementary-school-teachers,librarians,library-technicians-and-assistants,logging-workers,machinists-and-tool-and-die-makers,material-moving-machine-operators,material-recording-clerks,materials-engineers,medical-scientists,metal-and-plastic-machine-workers,middle-school-teachers,military-careers,mining-and-geological-engineers,multimedia-artists-and-animators,nuclear-technicians,nurse-anesthetists-nurse-midwives-and-nurse-practitioners,occupational-health-and-safety-specialists-and-technicians,occupational-therapy-assistants-and-aides,oil-and-gas-workers,painting-and-coating-workers,petroleum-engineers,physical-therapist-assistants-and-aides,physicians-and-surgeons,physicists-and-astronomers,police-and-detectives,postal-service-workers,postsecondary-education-administrators,postsecondary-teachers,power-plant-operators-distributors-and-dispatchers --force --json",
+                "dry_run_command": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=2 --dry-run --json",
+                "force_command_requires_explicit_approval": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=2 --force --json",
+                "post_import_cache_refresh_command_requires_explicit_approval": "php backend/artisan career:warm-public-authority-cache --job-detail-slugs=food-and-tobacco-processing-workers,funeral-service-occupations,gaming-services-occupations,general-maintenance-and-repair-workers,general-office-clerks,geological-and-petroleum-technicians,geoscientists,grounds-maintenance-workers,hand-laborers-and-material-movers,health-and-safety-engineers,heavy-vehicle-and-mobile-equipment-service-technicians,home-health-aides-and-personal-care-aides,industrial-designers,industrial-engineering-technicians,industrial-machinery-mechanics-and-maintenance-workers-and-millwrights,industrial-production-managers,information-clerks,insulation-workers,insurance-sales-agents,janitors-and-building-cleaners,judges-and-hearing-officers,kindergarten-and-elementary-school-teachers,librarians,library-technicians-and-assistants,logging-workers,machinists-and-tool-and-die-makers,material-moving-machine-operators,material-recording-clerks,materials-engineers,medical-scientists,metal-and-plastic-machine-workers,middle-school-teachers,military-careers,mining-and-geological-engineers,multimedia-artists-and-animators,nuclear-technicians,nurse-anesthetists-nurse-midwives-and-nurse-practitioners,occupational-health-and-safety-specialists-and-technicians,occupational-therapy-assistants-and-aides,oil-and-gas-workers,painting-and-coating-workers,petroleum-engineers,physical-therapist-assistants-and-aides,physicians-and-surgeons,physicists-and-astronomers,police-and-detectives,postal-service-workers,postsecondary-education-administrators,postsecondary-teachers,power-plant-operators-distributors-and-dispatchers --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json"
+            },
+            {
+                "chunk_index": 3,
+                "candidate_count": 31,
+                "candidate_slugs_sha256": "95fcef46c7b1f5dd3bb581b1141680cf33e902be666095685d8a915b07e0be90",
+                "candidate_slugs": [
+                    "preschool-and-childcare-center-directors",
+                    "preschool-teachers",
+                    "producers-and-directors",
+                    "psychiatric-technicians-and-aides",
+                    "psychologists",
+                    "purchasing-managers-buyers-and-purchasing-agents",
+                    "quality-control-inspectors",
+                    "radiologic-technologists",
+                    "railroad-occupations",
+                    "real-estate-brokers-and-sales-agents",
+                    "receptionists",
+                    "retail-sales-workers",
+                    "sales-managers",
+                    "school-and-career-counselors",
+                    "secretaries-and-administrative-assistants",
+                    "set-and-exhibit-designers",
+                    "sheet-metal-workers",
+                    "small-engine-mechanics",
+                    "social-workers",
+                    "special-education-teachers",
+                    "substance-abuse-behavioral-disorder-and-mental-health-counselors",
+                    "taxi-drivers-and-chauffeurs",
+                    "teacher-assistants",
+                    "tile-and-marble-setters",
+                    "top-executives",
+                    "tour-and-travel-guides",
+                    "water-transportation-occupations",
+                    "welders-cutters-solderers-and-brazers",
+                    "wholesale-and-manufacturing-sales-representatives",
+                    "wind-turbine-technicians",
+                    "woodworkers"
+                ],
+                "authority_crosswalk_dry_run_command": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=preschool-and-childcare-center-directors,preschool-teachers,producers-and-directors,psychiatric-technicians-and-aides,psychologists,purchasing-managers-buyers-and-purchasing-agents,quality-control-inspectors,radiologic-technologists,railroad-occupations,real-estate-brokers-and-sales-agents,receptionists,retail-sales-workers,sales-managers,school-and-career-counselors,secretaries-and-administrative-assistants,set-and-exhibit-designers,sheet-metal-workers,small-engine-mechanics,social-workers,special-education-teachers,substance-abuse-behavioral-disorder-and-mental-health-counselors,taxi-drivers-and-chauffeurs,teacher-assistants,tile-and-marble-setters,top-executives,tour-and-travel-guides,water-transportation-occupations,welders-cutters-solderers-and-brazers,wholesale-and-manufacturing-sales-representatives,wind-turbine-technicians,woodworkers --dry-run --json",
+                "authority_crosswalk_force_command_requires_explicit_approval": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=preschool-and-childcare-center-directors,preschool-teachers,producers-and-directors,psychiatric-technicians-and-aides,psychologists,purchasing-managers-buyers-and-purchasing-agents,quality-control-inspectors,radiologic-technologists,railroad-occupations,real-estate-brokers-and-sales-agents,receptionists,retail-sales-workers,sales-managers,school-and-career-counselors,secretaries-and-administrative-assistants,set-and-exhibit-designers,sheet-metal-workers,small-engine-mechanics,social-workers,special-education-teachers,substance-abuse-behavioral-disorder-and-mental-health-counselors,taxi-drivers-and-chauffeurs,teacher-assistants,tile-and-marble-setters,top-executives,tour-and-travel-guides,water-transportation-occupations,welders-cutters-solderers-and-brazers,wholesale-and-manufacturing-sales-representatives,wind-turbine-technicians,woodworkers --force --json",
+                "dry_run_command": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=3 --dry-run --json",
+                "force_command_requires_explicit_approval": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=3 --force --json",
+                "post_import_cache_refresh_command_requires_explicit_approval": "php backend/artisan career:warm-public-authority-cache --job-detail-slugs=preschool-and-childcare-center-directors,preschool-teachers,producers-and-directors,psychiatric-technicians-and-aides,psychologists,purchasing-managers-buyers-and-purchasing-agents,quality-control-inspectors,radiologic-technologists,railroad-occupations,real-estate-brokers-and-sales-agents,receptionists,retail-sales-workers,sales-managers,school-and-career-counselors,secretaries-and-administrative-assistants,set-and-exhibit-designers,sheet-metal-workers,small-engine-mechanics,social-workers,special-education-teachers,substance-abuse-behavioral-disorder-and-mental-health-counselors,taxi-drivers-and-chauffeurs,teacher-assistants,tile-and-marble-setters,top-executives,tour-and-travel-guides,water-transportation-occupations,welders-cutters-solderers-and-brazers,wholesale-and-manufacturing-sales-representatives,wind-turbine-technicians,woodworkers --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json"
+            }
+        ]
+    },
+    "acceptance_commands": {
+        "validate_readiness_report": "python3 -m json.tool backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json >/dev/null",
+        "readiness_command": "php backend/artisan career:prepare-zh-parity-controlled-import --source-report=backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json --contract-repair-report=backend/docs/career/generated/career-full-parity-03-contract-repair-report.json --output=backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json --json",
+        "authority_crosswalk_dry_run_template": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --dry-run --json",
+        "authority_crosswalk_force_template_after_approval": "php backend/artisan career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=<chunk_slugs_csv> --force --json",
+        "dry_run_template": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=1 --dry-run --json",
+        "force_import_template_after_approval": "php backend/artisan career:import-selected-display-assets --file=<reviewed_workbook.xlsx> --manifest=<validated_full_upload_plan.json> --manifest-chunk-size=50 --manifest-chunk-index=1 --force --json",
+        "cache_refresh_template_after_import_approval": "php backend/artisan career:warm-public-authority-cache --job-detail-slugs=<chunk_slugs_csv> --job-detail-locales=zh-CN --forget-job-detail --job-detail-only --json"
+    }
+}

--- a/backend/tests/Feature/Console/CareerPrepareZhParityControlledImportCommandTest.php
+++ b/backend/tests/Feature/Console/CareerPrepareZhParityControlledImportCommandTest.php
@@ -19,11 +19,16 @@ final class CareerPrepareZhParityControlledImportCommandTest extends TestCase
             'agricultural-and-food-scientists',
             'agricultural-workers',
         ]));
+        $contractRepairReport = $this->writeSourceReport($this->contractRepairReport(
+            ['aerospace-engineers', 'agricultural-and-food-scientists'],
+            ['agricultural-workers'],
+        ));
         $output = sys_get_temp_dir().'/career-zh-parity-controlled-import-readiness-test.json';
         @unlink($output);
 
         $exitCode = Artisan::call('career:prepare-zh-parity-controlled-import', [
             '--source-report' => $sourceReport,
+            '--contract-repair-report' => $contractRepairReport,
             '--chunk-size' => '2',
             '--output' => $output,
             '--json' => true,
@@ -37,10 +42,24 @@ final class CareerPrepareZhParityControlledImportCommandTest extends TestCase
         $this->assertFalse($report['writes_database']);
         $this->assertFalse($report['cache_mutation']);
         $this->assertFalse($report['content_mutation']);
-        $this->assertSame('ready_for_reviewed_workbook_dry_run', $report['readiness_decision']);
-        $this->assertSame(3, $report['controlled_import_input_manifest']['candidate_count']);
-        $this->assertSame(2, $report['execution_plan']['chunk_count']);
+        $this->assertSame('ready_for_auto_repairable_runtime_shell_dry_run', $report['readiness_decision']);
+        $this->assertSame(3, $report['controlled_import_input_manifest']['source_candidate_count']);
+        $this->assertSame(2, $report['controlled_import_input_manifest']['candidate_count']);
+        $this->assertSame(['agricultural-workers'], $report['operator_review_hold']['manual_review_required_slugs']);
+        $this->assertSame([
+            'aerospace-engineers',
+            'agricultural-and-food-scientists',
+        ], $report['controlled_import_input_manifest']['candidate_slugs']);
+        $this->assertSame(1, $report['execution_plan']['chunk_count']);
         $this->assertSame(2, $report['execution_plan']['chunks'][0]['candidate_count']);
+        $this->assertStringContainsString(
+            'career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=aerospace-engineers,agricultural-and-food-scientists --dry-run --json',
+            $report['execution_plan']['chunks'][0]['authority_crosswalk_dry_run_command'],
+        );
+        $this->assertStringContainsString(
+            'career:align-career-authority-batch --file=<reviewed_workbook.xlsx> --slugs=aerospace-engineers,agricultural-and-food-scientists --force --json',
+            $report['execution_plan']['chunks'][0]['authority_crosswalk_force_command_requires_explicit_approval'],
+        );
         $this->assertStringContainsString('--dry-run --json', $report['execution_plan']['chunks'][0]['dry_run_command']);
         $this->assertStringContainsString('--force --json', $report['execution_plan']['chunks'][0]['force_command_requires_explicit_approval']);
         $this->assertStringContainsString(
@@ -57,9 +76,14 @@ final class CareerPrepareZhParityControlledImportCommandTest extends TestCase
         $report['index_strategy_changed'] = true;
         $report['controlled_import_manifest']['candidate_count'] = 99;
         $sourceReport = $this->writeSourceReport($report);
+        $contractRepairReport = $this->writeSourceReport($this->contractRepairReport(
+            ['aerospace-engineers', 'agricultural-workers'],
+            [],
+        ));
 
         $exitCode = Artisan::call('career:prepare-zh-parity-controlled-import', [
             '--source-report' => $sourceReport,
+            '--contract-repair-report' => $contractRepairReport,
             '--json' => true,
         ]);
         $output = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
@@ -72,6 +96,36 @@ final class CareerPrepareZhParityControlledImportCommandTest extends TestCase
         );
         $this->assertContains(
             'Source report must not change index strategy.',
+            $output['errors'],
+        );
+    }
+
+    #[Test]
+    public function it_rejects_contract_repair_reports_that_do_not_match_the_source_candidates(): void
+    {
+        $sourceReport = $this->writeSourceReport($this->sourceReport([
+            'aerospace-engineers',
+            'agricultural-workers',
+        ]));
+        $repairReport = $this->contractRepairReport(['aerospace-engineers'], []);
+        $repairReport['auto_repairable_rows'] = 1;
+        $contractRepairReport = $this->writeSourceReport($repairReport);
+
+        $exitCode = Artisan::call('career:prepare-zh-parity-controlled-import', [
+            '--source-report' => $sourceReport,
+            '--contract-repair-report' => $contractRepairReport,
+            '--json' => true,
+        ]);
+        $output = json_decode(Artisan::output(), true, flags: JSON_THROW_ON_ERROR);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $output['decision']);
+        $this->assertContains(
+            'Contract repair report selected_rows must match source candidate count.',
+            $output['errors'],
+        );
+        $this->assertContains(
+            'Contract repair report auto_repairable_rows must match eligible candidates.',
             $output['errors'],
         );
     }
@@ -137,6 +191,34 @@ final class CareerPrepareZhParityControlledImportCommandTest extends TestCase
                 'requires_cache_forget_warm_after_import' => true,
                 'must_not_change_sitemap_llms_or_index_strategy' => true,
             ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $autoRepairableSlugs
+     * @param  list<string>  $manualReviewSlugs
+     * @return array<string, mixed>
+     */
+    private function contractRepairReport(array $autoRepairableSlugs, array $manualReviewSlugs): array
+    {
+        return [
+            'command' => 'career:repair-display-workbook-contract',
+            'repairer_version' => 'career_display_workbook_contract_repairer_v0.2',
+            'execute' => false,
+            'writes_database' => false,
+            'cms_mutation' => false,
+            'selected_rows' => count($autoRepairableSlugs) + count($manualReviewSlugs),
+            'auto_repairable_rows' => count($autoRepairableSlugs),
+            'manual_review_required_count' => count($manualReviewSlugs),
+            'manual_review_required_rows' => array_map(static fn (string $slug, int $index): array => [
+                'row_number' => $index + 10,
+                'slug' => $slug,
+                'reasons' => [
+                    'CN_Title lacks reviewed Chinese text',
+                    'CN_H1 lacks reviewed Chinese text',
+                ],
+            ], $manualReviewSlugs, array_keys($manualReviewSlugs)),
+            'decision' => 'dry_run_changes_available',
         ];
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T15:52:35Z",
+  "updated_at": "2026-06-11T15:54:39Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -53664,7 +53664,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-04",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-04: chore(career): prepare runtime shell zh asset import",
     "depends_on": [
@@ -53700,11 +53700,15 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to CareerPrepareZhParityControlledImport.php, its console test, backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json, and docs/codex/pr-train-state.json."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2044 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "659f8446a5bf1fd27dab70d33cd9e31618b137c2",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2044",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53723,6 +53727,11 @@
         "at": "2026-06-11T15:52:35Z",
         "status": "local_checks_passed",
         "note": "Generated PR04 readiness report and completed focused, broad, scoped Pint, JSON/YAML, diff, and scope validation checks."
+      },
+      {
+        "at": "2026-06-11T15:54:39Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2044 from codex/career-full-parity-04 after local validation and scope validation passed."
       }
     ],
     "result": {

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T15:31:40Z",
+  "updated_at": "2026-06-11T15:52:35Z",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -53553,7 +53553,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-03",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "merged",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-03: fix(career): repair blocked workbook asset contracts",
     "depends_on": [
@@ -53584,14 +53584,18 @@
       "scope_validation": {
         "status": "pass",
         "evidence": "Changed files are confined to CareerRepairDisplayWorkbookContract.php, its console test, backend/docs/career/generated/career-full-parity-03-contract-repair-report.json, and docs/codex/pr-train-state.json."
+      },
+      "github": {
+        "status": "pass",
+        "evidence": "GitHub PR #2043 merged at 2026-06-11T15:39:33Z; origin/main contains merge commit 8db469441b81670cda8949e9babb50d3005c95f1."
       }
     },
     "failure_reason": null,
     "commit_sha": "84de772b71e62830804bfd0ca134794571977d0e",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2043",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T15:39:33Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-11T13:00:17Z",
@@ -53627,6 +53631,11 @@
         "at": "2026-06-11T15:31:40Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2043 for CAREER-FULL-PARITY-03 and started GitHub checks."
+      },
+      {
+        "at": "2026-06-11T15:49:29Z",
+        "status": "merged_reconciled_in_next_pr",
+        "note": "Reconciled CAREER-FULL-PARITY-03 in CAREER-FULL-PARITY-04 after PR #2043 merge, remote branch deletion, local cleanup, and origin/main containment were verified before this branch started."
       }
     ],
     "result": {
@@ -53655,7 +53664,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-04",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-04: chore(career): prepare runtime shell zh asset import",
     "depends_on": [
@@ -53667,8 +53676,30 @@
         "evidence": "User explicitly authorized adding and executing CAREER-FULL-PARITY-01 through CAREER-FULL-PARITY-10 and allowed fap-api docs/codex metadata updates."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-FULL-PARITY-03 to merge before implementation."
+        "status": "pass",
+        "evidence": "CAREER-FULL-PARITY-03 PR #2043 is merged and origin/main contains merge commit 8db469441b81670cda8949e9babb50d3005c95f1."
+      },
+      "implementation": {
+        "status": "in_progress",
+        "evidence": "Preparing read-only runtime shell controlled import readiness from CAREER-FULL-PARITY-02 root-cause manifest plus CAREER-FULL-PARITY-03 contract repair report; generated 131 auto-repairable candidates and 5 manual-review holds."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console tests/Feature/Career --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerPrepareZhParityControlledImportCommandTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerPrepareZhParityControlledImport.php tests/Feature/Console/CareerPrepareZhParityControlledImportCommandTest.php",
+          "php backend/artisan career:prepare-zh-parity-controlled-import --source-report=backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json --contract-repair-report=backend/docs/career/generated/career-full-parity-03-contract-repair-report.json --output=backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json --json",
+          "python3 -m json.tool backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json >/dev/null",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "notes": "Focused readiness test passed with 3 warnings and 33 assertions. Required broad Feature/Console+Feature/Career suite passed with 705 warnings and 38937 assertions. Scoped Pint passed. PR04 generated readiness report passed JSON parse and splits 136 source candidates into 131 auto-repairable import candidates plus 5 manual-review holds."
+      },
+      "scope_validation": {
+        "status": "pass",
+        "evidence": "Changed files are confined to CareerPrepareZhParityControlledImport.php, its console test, backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json, and docs/codex/pr-train-state.json."
       }
     },
     "failure_reason": null,
@@ -53682,8 +53713,34 @@
         "at": "2026-06-11T13:00:17Z",
         "status": "pending_dependency",
         "note": "Initialized from explicit CAREER-FULL-PARITY train authorization; implementation deferred until dependencies merge."
+      },
+      {
+        "at": "2026-06-11T15:49:29Z",
+        "status": "in_progress",
+        "note": "Started CAREER-FULL-PARITY-04 from latest origin/main after CAREER-FULL-PARITY-03 merge cleanup; generated read-only controlled import/cache readiness report."
+      },
+      {
+        "at": "2026-06-11T15:52:35Z",
+        "status": "local_checks_passed",
+        "note": "Generated PR04 readiness report and completed focused, broad, scoped Pint, JSON/YAML, diff, and scope validation checks."
       }
-    ]
+    ],
+    "result": {
+      "readiness_report": "backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json",
+      "source_candidate_count": 136,
+      "auto_repairable_candidate_count": 131,
+      "manual_review_required_count": 5,
+      "manual_review_required_slugs": [
+        "data-scientists",
+        "human-resources-specialists",
+        "management-analysts",
+        "project-management-specialists",
+        "registered-nurses"
+      ],
+      "chunk_size": 50,
+      "chunk_count": 3,
+      "production_writes": "none; report only, all force/import/cache commands require explicit operator approval"
+    }
   },
   "CAREER-FULL-PARITY-05": {
     "repo": "fap-api",


### PR DESCRIPTION
## What changed
- Extended `career:prepare-zh-parity-controlled-import` to consume the CAREER-FULL-PARITY-03 contract repair report in addition to the PR02 root-cause manifest.
- Generated `backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json` as the controlled import/cache readiness report.
- Split the 136 source candidates into 131 auto-repairable zh runtime-shell import candidates and 5 manual-review holds.
- Added authority crosswalk dry-run/force SOP and post-import cache forget/warm SOP to the readiness output.
- Reconciled CAREER-FULL-PARITY-03 merged state in the train ledger.

## Why
CAREER-FULL-PARITY-04 prepares the next controlled operation without mutating production content, CMS data, cache, sitemap, llms, or index strategy. The 5 Title/H1 manual-review rows must not be imported until reviewed Chinese fields are supplied.

## Validation commands
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerPrepareZhParityControlledImportCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console tests/Feature/Career --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerPrepareZhParityControlledImport.php tests/Feature/Console/CareerPrepareZhParityControlledImportCommandTest.php`
- `php backend/artisan career:prepare-zh-parity-controlled-import --source-report=backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json --contract-repair-report=backend/docs/career/generated/career-full-parity-03-contract-repair-report.json --output=backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json --json`
- `python3 -m json.tool backend/docs/career/generated/career-full-parity-04-runtime-shell-import-readiness.json >/dev/null`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No production import, no authority force alignment, no cache mutation, no publish, no deploy.
- The 5 manual-review slugs remain held: `data-scientists`, `human-resources-specialists`, `management-analysts`, `project-management-specialists`, `registered-nurses`.
- Actual controlled production execution requires separate explicit operator approval.
