### PR TITLE
feat(seo): add baidu live push adapter readiness gates

### DIFF
--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
@@ -50,11 +50,7 @@ final class SearchChannelQueueLiveSubmissionExecutor
         }
 
         $now = now();
-        $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.endpoint');
-        $key = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key');
-        $keyLocation = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location');
         $canonicalUrl = (string) $item->canonical_url;
-        $host = (string) parse_url($canonicalUrl, PHP_URL_HOST);
 
         $claimed = $connection->table('seo_search_channel_queue_items')
             ->where('id', (int) $item->id)
@@ -87,21 +83,10 @@ final class SearchChannelQueueLiveSubmissionExecutor
         $accepted = false;
         $exceptionClass = null;
 
-        try {
-            $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.indexnow.timeout_seconds', 10)))
-                ->asJson()
-                ->post($endpoint, [
-                    'host' => $host,
-                    'key' => $key,
-                    'keyLocation' => $keyLocation,
-                    'urlList' => [$canonicalUrl],
-                ]);
-
-            $httpStatus = $response->status();
-            $accepted = $response->successful();
-        } catch (Throwable $exception) {
-            $exceptionClass = $exception::class;
-        }
+        $submission = $this->submitToChannel((string) $item->channel, $canonicalUrl);
+        $httpStatus = $submission['http_status'];
+        $accepted = $submission['accepted'];
+        $exceptionClass = $submission['exception_class'];
 
         $submissionStatus = $this->statusNormalizer->normalize($accepted ? 'accepted' : 'failed');
         $executionState = $accepted ? 'submitted' : 'submit_failed';
@@ -116,7 +101,7 @@ final class SearchChannelQueueLiveSubmissionExecutor
         $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'live_submission_response', [
             'channel' => (string) $item->channel,
             'url_hash' => (string) $item->url_hash,
-            'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+            'endpoint_host' => $submission['endpoint_host'],
             'http_status' => $httpStatus,
             'submission_status' => $submissionStatus,
             'exception_class' => $exceptionClass,
@@ -222,19 +207,130 @@ final class SearchChannelQueueLiveSubmissionExecutor
             $issues[] = 'external_api_gate_disabled';
         }
 
-        if ((string) $item->channel === 'indexnow' && ! (bool) config('seo_intel.indexnow_live_api_enabled', false)) {
-            $issues[] = 'indexnow_live_api_disabled';
-        }
+        $channel = (string) $item->channel;
+        if ($channel === 'indexnow') {
+            if (! (bool) config('seo_intel.indexnow_live_api_enabled', false)) {
+                $issues[] = 'indexnow_live_api_disabled';
+            }
 
-        if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key')) === '') {
-            $issues[] = 'indexnow_key_missing';
-        }
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key')) === '') {
+                $issues[] = 'indexnow_key_missing';
+            }
 
-        if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location')) === '') {
-            $issues[] = 'indexnow_key_location_missing';
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location')) === '') {
+                $issues[] = 'indexnow_key_location_missing';
+            }
+        } elseif ($channel === 'baidu_push') {
+            if (! (bool) config('seo_intel.baidu_live_api_enabled', false)) {
+                $issues[] = 'baidu_live_api_disabled';
+            }
+
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.baidu.endpoint')) === '') {
+                $issues[] = 'baidu_endpoint_missing';
+            }
+
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.baidu.site')) === '') {
+                $issues[] = 'baidu_site_missing';
+            }
+
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.baidu.token')) === '') {
+                $issues[] = 'baidu_token_missing';
+            }
+        } else {
+            $issues[] = 'unsupported_live_submission_channel';
         }
 
         return $issues;
+    }
+
+    /**
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string}
+     */
+    private function submitToChannel(string $channel, string $canonicalUrl): array
+    {
+        return match ($channel) {
+            'indexnow' => $this->submitIndexNow($canonicalUrl),
+            'baidu_push' => $this->submitBaiduPush($canonicalUrl),
+            default => [
+                'accepted' => false,
+                'http_status' => null,
+                'exception_class' => null,
+                'endpoint_host' => null,
+            ],
+        };
+    }
+
+    /**
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string}
+     */
+    private function submitIndexNow(string $canonicalUrl): array
+    {
+        $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.endpoint');
+        $key = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key');
+        $keyLocation = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location');
+        $host = (string) parse_url($canonicalUrl, PHP_URL_HOST);
+
+        try {
+            $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.indexnow.timeout_seconds', 10)))
+                ->asJson()
+                ->post($endpoint, [
+                    'host' => $host,
+                    'key' => $key,
+                    'keyLocation' => $keyLocation,
+                    'urlList' => [$canonicalUrl],
+                ]);
+
+            return [
+                'accepted' => $response->successful(),
+                'http_status' => $response->status(),
+                'exception_class' => null,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'accepted' => false,
+                'http_status' => null,
+                'exception_class' => $exception::class,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+            ];
+        }
+    }
+
+    /**
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string}
+     */
+    private function submitBaiduPush(string $canonicalUrl): array
+    {
+        $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.baidu.endpoint');
+        $site = (string) config('seo_intel.search_channel_queue.live_submission.baidu.site');
+        $token = (string) config('seo_intel.search_channel_queue.live_submission.baidu.token');
+        $endpointWithQuery = $endpoint.'?'.http_build_query([
+            'site' => $site,
+            'token' => $token,
+        ]);
+
+        try {
+            $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.baidu.timeout_seconds', 10)))
+                ->withBody($canonicalUrl, 'text/plain')
+                ->post($endpointWithQuery);
+
+            $body = $response->json();
+            $accepted = $response->successful() && (int) data_get(is_array($body) ? $body : [], 'success', 0) >= 1;
+
+            return [
+                'accepted' => $accepted,
+                'http_status' => $response->status(),
+                'exception_class' => null,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'accepted' => false,
+                'http_status' => null,
+                'exception_class' => $exception::class,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+            ];
+        }
     }
 
     /**

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -219,7 +219,7 @@ return [
         'purchase_truth_source' => 'backend_orders_payment_benefits',
     ],
     'baidu_enabled' => env('SEO_INTEL_BAIDU_ENABLED', false),
-    'baidu_live_api_enabled' => false,
+    'baidu_live_api_enabled' => env('SEO_INTEL_BAIDU_LIVE_API_ENABLED', false),
     'indexnow_enabled' => env('SEO_INTEL_INDEXNOW_ENABLED', false),
     'indexnow_live_api_enabled' => env('SEO_INTEL_INDEXNOW_LIVE_API_ENABLED', false),
     'baidu_source_engine' => 'baidu',
@@ -316,9 +316,16 @@ return [
             'external_api_calls_enabled' => env('SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED', false),
             'allowed_channels' => [
                 'indexnow',
+                'baidu_push',
             ],
             'allowed_hosts' => [
                 'fermatmind.com',
+            ],
+            'baidu' => [
+                'endpoint' => env('SEO_INTEL_BAIDU_PUSH_ENDPOINT', 'https://data.zz.baidu.com/urls'),
+                'site' => env('SEO_INTEL_BAIDU_SITE'),
+                'token' => env('SEO_INTEL_BAIDU_PUSH_TOKEN'),
+                'timeout_seconds' => env('SEO_INTEL_BAIDU_PUSH_TIMEOUT_SECONDS', 10),
             ],
             'indexnow' => [
                 'endpoint' => env('SEO_INTEL_INDEXNOW_ENDPOINT', 'https://api.indexnow.org/indexnow'),

--- a/backend/docs/seo/generated/search-channel-live-02-executor.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-executor.v1.json
@@ -12,7 +12,8 @@
   "raw_secret_output_allowed": false,
   "sitemap_llms_behavior_changed": false,
   "supported_live_channels": [
-    "indexnow"
+    "indexnow",
+    "baidu_push"
   ],
   "allowed_hosts": [
     "fermatmind.com"
@@ -22,7 +23,10 @@
     "SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED",
     "SEO_INTEL_INDEXNOW_LIVE_API_ENABLED",
     "SEO_INTEL_INDEXNOW_KEY",
-    "SEO_INTEL_INDEXNOW_KEY_LOCATION"
+    "SEO_INTEL_INDEXNOW_KEY_LOCATION",
+    "SEO_INTEL_BAIDU_LIVE_API_ENABLED",
+    "SEO_INTEL_BAIDU_SITE",
+    "SEO_INTEL_BAIDU_PUSH_TOKEN"
   ],
   "approval_phrase_template": "I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item <id> channel <channel> URL <canonical_url>.",
   "required_queue_item_state": {

--- a/backend/docs/seo/search-channel-live-02-executor.md
+++ b/backend/docs/seo/search-channel-live-02-executor.md
@@ -10,7 +10,7 @@ submission by itself.
 
 - Command: `seo-intel:search-channel-submit`
 - Scope: exactly one existing queue item selected by `--queue-item-id`
-- Supported live channel in this task: `indexnow`
+- Supported live channels in this task: `indexnow`, `baidu_push`
 - Allowed host in this task: `fermatmind.com`
 - Default mode: blocked unless every live gate is explicitly enabled
 - Scheduler: not registered
@@ -40,14 +40,24 @@ I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item <id> 
 
 ## Required Gates
 
-Actual live submission requires all of these gates:
+Actual live submission requires these shared gates:
 
 - `SEO_INTEL_SEARCH_CHANNEL_LIVE_SUBMISSION_ENABLED=true`
 - `SEO_INTEL_SEARCH_CHANNEL_EXTERNAL_API_CALLS_ENABLED=true`
+- The exact human approval phrase is supplied
+
+IndexNow additionally requires:
+
 - `SEO_INTEL_INDEXNOW_LIVE_API_ENABLED=true`
 - `SEO_INTEL_INDEXNOW_KEY` is present
 - `SEO_INTEL_INDEXNOW_KEY_LOCATION` is present
-- The exact human approval phrase is supplied
+
+Baidu push additionally requires:
+
+- `SEO_INTEL_BAIDU_LIVE_API_ENABLED=true`
+- `SEO_INTEL_BAIDU_SITE` is present
+- `SEO_INTEL_BAIDU_PUSH_TOKEN` is present
+- `SEO_INTEL_BAIDU_PUSH_ENDPOINT` defaults to `https://data.zz.baidu.com/urls`
 
 Default config keeps these gates disabled or empty.
 
@@ -64,12 +74,17 @@ The executor rejects the item unless it is:
 - `source_authority` is backend-approved
 - HTTPS URL under an allowed host
 
-After an accepted IndexNow response, the executor sets:
+After an accepted IndexNow or Baidu push response, the executor sets:
 
 - `approval_state=approved`
 - `execution_state=submitted`
 - `approved_by=<actor>`
 - `approved_at=<timestamp>`
+
+Baidu push sends exactly one canonical URL as `text/plain` to the configured
+endpoint with `site` and `token` query parameters. A Baidu response is accepted
+only when the HTTP response is successful and the JSON `success` count is at
+least 1.
 
 Failed provider calls are recorded as `execution_state=submit_failed`.
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
@@ -30,8 +30,11 @@ final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
             'seo_intel.indexnow_live_api_enabled' => false,
             'seo_intel.search_channel_queue.live_submission.enabled' => false,
             'seo_intel.search_channel_queue.live_submission.external_api_calls_enabled' => false,
-            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow'],
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow', 'baidu_push'],
             'seo_intel.search_channel_queue.live_submission.allowed_hosts' => ['fermatmind.com'],
+            'seo_intel.search_channel_queue.live_submission.baidu.endpoint' => 'https://data.zz.baidu.test/urls',
+            'seo_intel.search_channel_queue.live_submission.baidu.site' => null,
+            'seo_intel.search_channel_queue.live_submission.baidu.token' => null,
             'seo_intel.search_channel_queue.live_submission.indexnow.endpoint' => 'https://api.indexnow.test/indexnow',
             'seo_intel.search_channel_queue.live_submission.indexnow.key' => null,
             'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => null,
@@ -78,6 +81,47 @@ final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
     }
 
     #[Test]
+    public function baidu_dry_run_outputs_exact_phrase_without_external_call_or_writes(): void
+    {
+        Http::fake();
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice';
+        $queueItemId = $this->seedQueueItem([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_type' => 'article',
+            'entity_id' => 'article:37',
+            'source_authority' => 'backend_cms',
+            'source_table' => 'cms_articles',
+            'channel' => 'baidu_push',
+        ]);
+
+        [$exitCode, $payload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertSame(
+            'I explicitly approve SEARCH-CHANNEL-LIVE-02 live submission for queue item '.$queueItemId.' channel baidu_push URL '.$canonicalUrl.'.',
+            $payload['approval_phrase'] ?? null,
+        );
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['search_submission_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->first();
+        $this->assertSame('pending', $item->approval_state);
+        $this->assertSame('dry_run_ready', $item->execution_state);
+        $this->assertNull($item->approved_by);
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
     public function live_submission_requires_exact_phrase_and_all_gates(): void
     {
         Http::fake();
@@ -97,6 +141,43 @@ final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
         $this->assertContains('indexnow_live_api_disabled', $payload['issues'] ?? []);
         $this->assertContains('indexnow_key_missing', $payload['issues'] ?? []);
         $this->assertContains('indexnow_key_location_missing', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function baidu_live_submission_requires_baidu_specific_gates(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice',
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_type' => 'article',
+            'entity_id' => 'article:37',
+            'source_authority' => 'backend_cms',
+            'source_table' => 'cms_articles',
+            'channel' => 'baidu_push',
+        ]);
+
+        [$exitCode, $payload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => 'wrong approval phrase',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('approval_phrase_mismatch', $payload['issues'] ?? []);
+        $this->assertContains('live_submission_gate_disabled', $payload['issues'] ?? []);
+        $this->assertContains('external_api_gate_disabled', $payload['issues'] ?? []);
+        $this->assertContains('baidu_live_api_disabled', $payload['issues'] ?? []);
+        $this->assertContains('baidu_site_missing', $payload['issues'] ?? []);
+        $this->assertContains('baidu_token_missing', $payload['issues'] ?? []);
+        $this->assertNotContains('indexnow_live_api_disabled', $payload['issues'] ?? []);
+        $this->assertNotContains('indexnow_key_missing', $payload['issues'] ?? []);
+        $this->assertNotContains('indexnow_key_location_missing', $payload['issues'] ?? []);
         $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
         $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
         Http::assertNothingSent();
@@ -182,6 +263,99 @@ final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
     }
 
     #[Test]
+    public function approved_baidu_submission_updates_queue_and_logs_sanitized_events(): void
+    {
+        config([
+            'seo_intel.baidu_live_api_enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.external_api_calls_enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.baidu.endpoint' => 'https://data.zz.baidu.test/urls',
+            'seo_intel.search_channel_queue.live_submission.baidu.site' => 'https://fermatmind.com',
+            'seo_intel.search_channel_queue.live_submission.baidu.token' => 'secret-baidu-token',
+        ]);
+
+        Http::fake([
+            'data.zz.baidu.test/*' => Http::response(['success' => 1, 'remain' => 99], 200),
+        ]);
+
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice';
+        $queueItemId = $this->seedQueueItem([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_type' => 'article',
+            'entity_id' => 'article:37',
+            'source_authority' => 'backend_cms',
+            'source_table' => 'cms_articles',
+            'channel' => 'baidu_push',
+        ]);
+        $approvalPhrase = app(SearchChannelQueueLiveSubmissionExecutor::class)
+            ->approvalPhrase($queueItemId, 'baidu_push', $canonicalUrl);
+
+        [$exitCode, $payload, $rawOutput] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['external_calls_attempted'] ?? false));
+        $this->assertTrue((bool) ($payload['search_submission_attempted'] ?? false));
+        $this->assertSame('accepted', $payload['submission_status'] ?? null);
+        $this->assertSame('submitted', $payload['execution_state'] ?? null);
+        $this->assertSame(200, $payload['http_status'] ?? null);
+        $this->assertStringNotContainsString('secret-baidu-token', $rawOutput);
+
+        Http::assertSent(function (Request $request) use ($canonicalUrl): bool {
+            $query = [];
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+            return $request->method() === 'POST'
+                && parse_url($request->url(), PHP_URL_HOST) === 'data.zz.baidu.test'
+                && $query['site'] === 'https://fermatmind.com'
+                && $query['token'] === 'secret-baidu-token'
+                && $request->body() === $canonicalUrl;
+        });
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->first();
+        $this->assertSame('approved', $item->approval_state);
+        $this->assertSame('submitted', $item->execution_state);
+        $this->assertSame('seo-ops@example.com', $item->approved_by);
+        $this->assertNotNull($item->approved_at);
+
+        $events = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_events')
+            ->where('queue_item_id', $queueItemId)
+            ->orderBy('id')
+            ->get();
+
+        $this->assertSame(['live_submission_approved', 'live_submission_response'], $events->pluck('event_type')->all());
+        $this->assertSame('operator', $events[0]->actor_type);
+        $this->assertSame('seo-ops@example.com', $events[0]->actor_id);
+        $this->assertSame('system', $events[1]->actor_type);
+
+        foreach ($events as $event) {
+            $this->assertStringNotContainsString('secret-baidu-token', (string) $event->event_payload);
+            $this->assertStringNotContainsString($canonicalUrl, (string) $event->event_payload);
+        }
+
+        [$secondExitCode, $secondPayload] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $secondExitCode);
+        $this->assertSame('blocked', $secondPayload['status'] ?? null);
+        $this->assertContains('approval_state_not_pending', $secondPayload['issues'] ?? []);
+        $this->assertContains('execution_state_not_dry_run_ready', $secondPayload['issues'] ?? []);
+        Http::assertSentCount(1);
+    }
+
+    #[Test]
     public function unsafe_queue_item_is_rejected_without_writes_or_external_calls(): void
     {
         Http::fake();
@@ -224,8 +398,12 @@ final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
         $this->assertTrue((bool) ($artifact['atomic_single_item_claim_required'] ?? false));
         $this->assertFalse((bool) ($artifact['raw_secret_output_allowed'] ?? true));
         $this->assertContains('indexnow', $artifact['supported_live_channels'] ?? []);
+        $this->assertContains('baidu_push', $artifact['supported_live_channels'] ?? []);
         $this->assertContains('fermatmind.com', $artifact['allowed_hosts'] ?? []);
         $this->assertContains('SEO_INTEL_INDEXNOW_LIVE_API_ENABLED', $artifact['required_env_gates'] ?? []);
+        $this->assertContains('SEO_INTEL_BAIDU_LIVE_API_ENABLED', $artifact['required_env_gates'] ?? []);
+        $this->assertContains('SEO_INTEL_BAIDU_SITE', $artifact['required_env_gates'] ?? []);
+        $this->assertContains('SEO_INTEL_BAIDU_PUSH_TOKEN', $artifact['required_env_gates'] ?? []);
         $this->assertSame('dry_run_ready', data_get($artifact, 'required_queue_item_state.execution_state'));
         $this->assertTrue((bool) data_get($artifact, 'protected_boundaries.no_full_url_in_audit_event_payload'));
         $this->assertTrue((bool) data_get($artifact, 'protected_boundaries.single_item_idempotency_guard'));


### PR DESCRIPTION
## What changed
- Added guarded `baidu_push` support to the single-item Search Channel live submission executor.
- Added Baidu-specific live gates: `SEO_INTEL_BAIDU_LIVE_API_ENABLED`, `SEO_INTEL_BAIDU_SITE`, and `SEO_INTEL_BAIDU_PUSH_TOKEN`.
- Kept live submission disabled by default and external API calls behind the existing shared live gates.
- Added Baidu dry-run, gate-failure, accepted fake-submission, secret-sanitization, and idempotency tests.
- Updated the Search Channel live executor contract docs and generated safety artifact.

## Why
Chinese article Search Channel readiness needs a safe Baidu live push adapter path before any operator-approved live submission can be considered. This PR only adds the adapter and gates; it does not perform or authorize any live submission.

## Validation
```bash
cd backend && php artisan test --filter=SeoIntelSearchChannelLiveSubmissionExecutorTest --no-ansi
cd backend && php artisan test --filter=SeoIntelBaiduIndexNowCollectorsTest --no-ansi
python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-executor.v1.json >/dev/null && git diff --check
```

## Intentionally deferred
- No CMS mutation.
- No Baidu/GSC/IndexNow/Search Channel live submission.
- No scheduler enablement.
- No production deploy.
- No sitemap/llms/indexability changes.
- No secret values committed or printed.
