### PR TITLE
CAREER-FULL-PARITY-06: fix(career): align en display asset runtime bundle selection

### DIFF
--- a/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
+++ b/backend/app/Services/Career/Bundles/CareerJobDisplaySurfaceBuilder.php
@@ -116,6 +116,8 @@ final class CareerJobDisplaySurfaceBuilder
             return null;
         }
 
+        $componentOrder = $this->stripForbiddenKeys($asset->component_order_json ?? []);
+        $pageContent = $this->alignPageContentToComponentOrder($pageContent, $componentOrder);
         $claimPermissions = $this->claimPermissions($occupation, $asset, $pageContent);
         if (! $this->hasRequiredClaimPermissionKeys($claimPermissions)) {
             return null;
@@ -125,7 +127,6 @@ final class CareerJobDisplaySurfaceBuilder
             'locale' => $this->publicLocale($normalizedLocale),
             'content' => $this->stripForbiddenKeys($pageContent),
         ];
-        $componentOrder = $this->stripForbiddenKeys($asset->component_order_json ?? []);
         $sources = $this->stripForbiddenKeys($asset->sources_json ?? []);
         $structuredData = $this->stripForbiddenKeys($asset->structured_data_json ?? []);
         $implementationContract = $this->stripForbiddenKeys($asset->implementation_contract_json ?? []);
@@ -150,6 +151,34 @@ final class CareerJobDisplaySurfaceBuilder
             'structured_data_from_visible_content' => $structuredData,
             'implementation_contract' => $implementationContract,
         ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $pageContent
+     * @param  array<mixed>  $componentOrder
+     * @return array<string, mixed>
+     */
+    private function alignPageContentToComponentOrder(array $pageContent, array $componentOrder): array
+    {
+        foreach ($componentOrder as $component) {
+            if (! is_string($component) || trim($component) === '') {
+                continue;
+            }
+
+            if (array_key_exists($component, $pageContent)) {
+                continue;
+            }
+
+            $pageContent[$component] = [
+                'module_key' => $component,
+                'module_state' => 'pending_reviewed_locale_content',
+                'content_available' => false,
+                'source' => 'component_order_contract',
+                'placeholder_policy' => 'no_cross_locale_editorial_copy_generated',
+            ];
+        }
+
+        return $pageContent;
     }
 
     private function readyDisplayAsset(Occupation $occupation, string $canonicalSlug): ?CareerJobDisplayAsset

--- a/backend/docs/career/generated/career-full-parity-06-en-display-asset-runtime-alignment.json
+++ b/backend/docs/career/generated/career-full-parity-06-en-display-asset-runtime-alignment.json
@@ -1,0 +1,27 @@
+{
+  "pr_id": "CAREER-FULL-PARITY-06",
+  "validator_version": "career_full_parity_en_display_asset_runtime_alignment_v1",
+  "read_only": true,
+  "writes_database": false,
+  "cms_mutation": false,
+  "publish_allowed": false,
+  "deploy_allowed": false,
+  "api_runtime_change": true,
+  "source_report": "backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json",
+  "source_classification": "zh_has_modules_en_missing",
+  "candidate_slug_count": 106,
+  "candidate_slug_sha256": "8c0d2e50f6f4b28fd4a9e6195c579ebdbd62149dab57e0de608709e4c19fbea0",
+  "runtime_policy": {
+    "surface": "display_surface_v1.page.content",
+    "module_key_source": "career_job_display_assets.component_order_json",
+    "locale_alignment": "When a ready display asset surface is returned for any locale, missing component-order modules are represented as explicit pending_reviewed_locale_content placeholders for that requested locale.",
+    "public_copy_policy": "No cross-locale editorial copy is generated or copied.",
+    "index_strategy_changed": false
+  },
+  "expected_effect_after_deploy_and_cache_warm": {
+    "zh_has_modules_en_missing_delta": -106,
+    "sitemap_changed": false,
+    "llms_changed": false,
+    "index_strategy_changed": false
+  }
+}

--- a/backend/tests/Feature/Career/CareerJobDetailApiTest.php
+++ b/backend/tests/Feature/Career/CareerJobDetailApiTest.php
@@ -26,6 +26,33 @@ final class CareerJobDetailApiTest extends TestCase
 {
     use RefreshDatabase;
 
+    private const DISPLAY_COMPONENT_ORDER = [
+        'breadcrumb',
+        'hero',
+        'fermat_decision_card',
+        'primary_cta',
+        'career_snapshot_primary_locale',
+        'career_snapshot_secondary_locale',
+        'fit_decision_checklist',
+        'riasec_fit_block',
+        'personality_fit_block',
+        'definition_block',
+        'responsibilities_block',
+        'work_context_block',
+        'market_signal_card',
+        'adjacent_career_comparison_table',
+        'ai_impact_table',
+        'career_risk_cards',
+        'contract_project_risk_block',
+        'next_steps_block',
+        'faq_block',
+        'related_next_pages',
+        'source_card',
+        'review_validity_card',
+        'boundary_notice',
+        'final_cta',
+    ];
+
     protected function setUp(): void
     {
         parent::setUp();
@@ -463,6 +490,63 @@ final class CareerJobDetailApiTest extends TestCase
             ->assertJsonPath('display_surface_v1.claim_permissions.integrity_state', 'full');
     }
 
+    public function test_display_asset_surface_aligns_english_module_subset_to_component_order_without_copying_zh_content(): void
+    {
+        $this->configurePublicResolutionPlan([
+            ['slug' => 'english-module-subset-display-asset', 'status' => 'already_imported_validated'],
+        ]);
+
+        $occupation = $this->createDisplayAssetBackedOccupation('english-module-subset-display-asset');
+        $zhPage = $this->pageContentForDisplayComponentOrder('中文已审内容');
+        $zhPage['hero'] = ['title' => '中文完整展示资产职业'];
+        $enPage = [
+            'hero' => ['title' => 'English display asset career'],
+            'primary_cta' => ['label' => 'Start career fit test'],
+            'market_signal_card' => [
+                'salary_data_type' => 'BLS official wage evidence',
+                'body' => 'Official market signal from BLS.',
+            ],
+            'ai_impact_table' => [
+                'score_normalized' => '82',
+                'source' => 'FermatMind central score',
+            ],
+        ];
+
+        $this->createDisplayAsset($occupation, [
+            'component_order_json' => self::DISPLAY_COMPONENT_ORDER,
+            'page_payload_json' => [
+                'page' => [
+                    'zh' => $zhPage,
+                    'en' => $enPage,
+                ],
+            ],
+        ]);
+
+        $zhResponse = $this->getJson('/api/v0.5/career/jobs/english-module-subset-display-asset?locale=zh-CN')
+            ->assertOk()
+            ->assertJsonPath('display_surface_v1.page.locale', 'zh-CN');
+        $enResponse = $this->getJson('/api/v0.5/career/jobs/english-module-subset-display-asset?locale=en')
+            ->assertOk()
+            ->assertJsonPath('display_surface_v1.page.locale', 'en')
+            ->assertJsonPath('display_surface_v1.page.content.responsibilities_block.module_state', 'pending_reviewed_locale_content')
+            ->assertJsonPath('display_surface_v1.page.content.responsibilities_block.content_available', false)
+            ->assertJsonPath('display_surface_v1.page.content.responsibilities_block.placeholder_policy', 'no_cross_locale_editorial_copy_generated');
+
+        $zhContentKeys = array_keys((array) $zhResponse->json('display_surface_v1.page.content'));
+        $enContentKeys = array_keys((array) $enResponse->json('display_surface_v1.page.content'));
+        sort($zhContentKeys);
+        sort($enContentKeys);
+
+        $expected = self::DISPLAY_COMPONENT_ORDER;
+        sort($expected);
+        $this->assertSame($expected, $zhContentKeys);
+        $this->assertSame($expected, $enContentKeys);
+
+        $enDisplayContent = json_encode($enResponse->json('display_surface_v1.page.content'), JSON_THROW_ON_ERROR | JSON_UNESCAPED_UNICODE);
+        $this->assertStringNotContainsString('中文完整展示资产职业', $enDisplayContent);
+        $this->assertStringNotContainsString('中文已审内容', $enDisplayContent);
+    }
+
     public function test_runtime_published_occupation_without_display_or_docx_asset_returns_restricted_public_shell(): void
     {
         $this->configurePublicResolutionPlan([
@@ -693,5 +777,27 @@ final class CareerJobDetailApiTest extends TestCase
             'implementation_contract_json' => [],
             'metadata_json' => [],
         ], $overrides));
+    }
+
+    /**
+     * @return array<string, array<string, mixed>>
+     */
+    private function pageContentForDisplayComponentOrder(string $bodyPrefix): array
+    {
+        $content = [];
+        foreach (self::DISPLAY_COMPONENT_ORDER as $moduleKey) {
+            $content[$moduleKey] = ['body' => $bodyPrefix.': '.$moduleKey];
+        }
+
+        $content['market_signal_card'] = [
+            'salary_data_type' => 'BLS official wage evidence',
+            'body' => $bodyPrefix.': market_signal_card',
+        ];
+        $content['ai_impact_table'] = [
+            'score_normalized' => '82',
+            'source' => 'FermatMind central score',
+        ];
+
+        return $content;
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53764,7 +53764,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-05",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "merged",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-05: fix(career): normalize zh display asset module subsets",
     "depends_on": [
@@ -53805,16 +53805,20 @@
         "evidence": "Changed files are confined to manifest-allowed command, career tests, generated career report, and docs/codex state paths; the PersonalityEnsure formatter-only change is in backend/app/Console/Commands/** and was required by the manifest Pint check."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2046 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2046 merged; GitHub checks were green before squash merge."
+      },
+      "cleanup": {
+        "status": "pass",
+        "evidence": "origin/main contains merge commit e948eebb1e34740720bb412417098f1f0f2e1ebf; main fast-forwarded; remote branch deleted; local task branch/worktree cleaned."
       }
     },
     "failure_reason": null,
-    "commit_sha": "d722cc1606b1c3aa4a12d1b119a14ce8abc92af2",
+    "commit_sha": "e948eebb1e34740720bb412417098f1f0f2e1ebf",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2046",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T16:38:31Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-11T13:00:17Z",
@@ -53835,6 +53839,11 @@
         "at": "2026-06-11T16:31:26Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2046 from codex/career-full-parity-05 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-11T16:48:40Z",
+        "status": "merged",
+        "note": "Reconciled CAREER-FULL-PARITY-05 after PR #2046 merge and post-merge cleanup."
       }
     ]
   },
@@ -53842,7 +53851,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-06",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-06: fix(career): align en display asset runtime bundle selection",
     "depends_on": [
@@ -53854,8 +53863,24 @@
         "evidence": "User explicitly authorized adding and executing CAREER-FULL-PARITY-01 through CAREER-FULL-PARITY-10 and allowed fap-api docs/codex metadata updates."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-FULL-PARITY-05 to merge before implementation."
+        "status": "pass",
+        "evidence": "CAREER-FULL-PARITY-05 PR #2046 is merged and origin/main contains merge commit e948eebb1e34740720bb412417098f1f0f2e1ebf."
+      },
+      "implementation": {
+        "status": "pass",
+        "evidence": "CareerJobDisplaySurfaceBuilder now aligns returned display_surface_v1.page.content to component_order by filling missing requested-locale modules with explicit pending_reviewed_locale_content placeholders; no cross-locale editorial copy is generated. Added feature coverage and generated CAREER-FULL-PARITY-06 readiness report for 106 zh_has_modules_en_missing candidates."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career/CareerJobDetailApiTest.php --filter=display_asset_surface_aligns_english_module_subset --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career tests/Unit/Services/Career --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Services/Career tests/Feature/Career tests/Unit/Services/Career",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "Required local checks passed: Career feature/unit test suite passed with 27 passed / 15789 assertions, Pint passed across 203 files, JSON/YAML and diff checks passed."
       }
     },
     "failure_reason": null,
@@ -53869,6 +53894,16 @@
         "at": "2026-06-11T13:00:17Z",
         "status": "pending_dependency",
         "note": "Initialized from explicit CAREER-FULL-PARITY train authorization; implementation deferred until dependencies merge."
+      },
+      {
+        "at": "2026-06-11T16:48:40Z",
+        "status": "in_progress",
+        "note": "Started CAREER-FULL-PARITY-06 from latest origin/main after PR05 cleanup."
+      },
+      {
+        "at": "2026-06-11T16:51:54Z",
+        "status": "local_checks_passed",
+        "note": "Implementation and required local checks passed; ready for scope validation, commit, push, and PR creation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53851,7 +53851,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-06",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-06: fix(career): align en display asset runtime bundle selection",
     "depends_on": [
@@ -53881,11 +53881,19 @@
           "git diff --check"
         ],
         "evidence": "Required local checks passed: Career feature/unit test suite passed with 27 passed / 15789 assertions, Pint passed across 203 files, JSON/YAML and diff checks passed."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to manifest-allowed Career service, Career feature test, generated career report, and docs/codex state paths."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2047 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "7646ed55",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2047",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53904,6 +53912,11 @@
         "at": "2026-06-11T16:51:54Z",
         "status": "local_checks_passed",
         "note": "Implementation and required local checks passed; ready for scope validation, commit, push, and PR creation."
+      },
+      {
+        "at": "2026-06-11T16:53:10Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2047 from codex/career-full-parity-06 after local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Align `display_surface_v1.page.content` to the ready display asset `component_order` for the requested locale.
- Missing requested-locale modules are represented as explicit `pending_reviewed_locale_content` placeholders.
- Added feature coverage proving EN module subsets are aligned without copying ZH content.
- Added a CAREER-FULL-PARITY-06 readiness report for the 106 `zh_has_modules_en_missing` candidates.
- Reconciled CAREER-FULL-PARITY-05 merged/cleanup state in the PR train ledger.

## Why
The live parity audit found a class where ZH returned more display modules than EN. That happens when a ready display asset has a complete module contract, but the requested locale page content is a subset. The public parity gate compares `display_surface_v1.page.content` keys, so the runtime should expose the module contract consistently while keeping unreviewed copy explicit.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career/CareerJobDetailApiTest.php --filter=display_asset_surface_aligns_english_module_subset --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Career tests/Unit/Services/Career --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/Career tests/Feature/Career tests/Unit/Services/Career`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No production import, cache mutation, publish, sitemap/llms/index strategy change, or deploy is included.
- Production parity impact still requires deployment and subsequent cache convergence handled by later PRs.
