### PR TITLE
CAREER-FULL-PARITY-07: chore(career): warm en zh career detail caches

### DIFF
--- a/backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
+++ b/backend/app/Console/Commands/CareerWarmPublicAuthorityCache.php
@@ -11,6 +11,8 @@ final class CareerWarmPublicAuthorityCache extends Command
 {
     protected $signature = 'career:warm-public-authority-cache
         {--job-detail-slugs= : Comma-separated career job slugs for per-locale detail cache warm}
+        {--job-detail-manifest= : JSON manifest/report file used to derive per-locale career job slugs}
+        {--job-detail-manifest-source=auto : Slug source in the manifest: auto, items, candidate_slugs, controlled_import_manifest.candidate_slugs, slugs}
         {--job-detail-locales=zh-CN : Comma-separated public locales for detail cache warm}
         {--forget-job-detail : Forget targeted job detail caches before warming them}
         {--job-detail-only : Warm only targeted job detail caches}
@@ -21,11 +23,16 @@ final class CareerWarmPublicAuthorityCache extends Command
     public function handle(PublicCareerAuthorityResponseCache $cache): int
     {
         try {
-            $jobDetailSlugs = $this->csvOption('job-detail-slugs');
+            $manifestPath = trim((string) $this->option('job-detail-manifest'));
+            $manifestSource = trim((string) $this->option('job-detail-manifest-source'));
+            $jobDetailSlugs = array_values(array_unique(array_merge(
+                $this->csvOption('job-detail-slugs'),
+                $manifestPath === '' ? [] : $this->slugsFromManifest($manifestPath, $manifestSource === '' ? 'auto' : $manifestSource),
+            )));
             $jobDetailLocales = $this->csvOption('job-detail-locales');
             $jobDetailOnly = (bool) $this->option('job-detail-only');
             if ($jobDetailOnly && $jobDetailSlugs === []) {
-                $this->error('--job-detail-only requires --job-detail-slugs.');
+                $this->error('--job-detail-only requires --job-detail-slugs or --job-detail-manifest.');
 
                 return self::FAILURE;
             }
@@ -37,27 +44,46 @@ final class CareerWarmPublicAuthorityCache extends Command
             };
             $summary = $jobDetailOnly ? [] : $cache->warm($reporter);
             if ($jobDetailSlugs !== []) {
+                $locales = $jobDetailLocales === [] ? ['zh-CN'] : $jobDetailLocales;
                 $summary = array_merge(
                     $summary,
                     $cache->warmJobDetailPayloads(
                         $jobDetailSlugs,
-                        $jobDetailLocales === [] ? ['zh-CN'] : $jobDetailLocales,
+                        $locales,
                         (bool) $this->option('forget-job-detail'),
                         $reporter,
                     ),
                 );
+                $jobDetailReport = $this->jobDetailReport(
+                    $summary,
+                    $jobDetailSlugs,
+                    $locales,
+                    $manifestPath === '' ? null : $manifestPath,
+                    $manifestPath === '' ? null : ($manifestSource === '' ? 'auto' : $manifestSource),
+                );
+            } else {
+                $jobDetailReport = null;
             }
 
             if ((bool) $this->option('json')) {
                 $this->line((string) json_encode([
                     'status' => 'warmed',
                     'entries' => $summary,
+                    'job_detail_refresh' => $jobDetailReport,
                 ], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_PRETTY_PRINT));
 
                 return self::SUCCESS;
             }
 
             $this->line('status=warmed');
+            if ($jobDetailReport !== null) {
+                $this->line(sprintf(
+                    'job_detail_refresh slug_count=%d locale_count=%d expected_cache_entries=%d',
+                    (int) $jobDetailReport['slug_count'],
+                    (int) $jobDetailReport['locale_count'],
+                    (int) $jobDetailReport['expected_cache_entries'],
+                ));
+            }
             foreach ($summary as $name => $entry) {
                 $this->line(sprintf(
                     '%s cache_key=%s member_count=%d',
@@ -89,5 +115,123 @@ final class CareerWarmPublicAuthorityCache extends Command
             static fn (string $value): string => trim($value),
             explode(',', $raw),
         ), static fn (string $value): bool => $value !== '')));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugsFromManifest(string $path, string $source): array
+    {
+        if (! is_file($path)) {
+            throw new \InvalidArgumentException(sprintf('Job detail manifest not found: %s', $path));
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true, 512, JSON_THROW_ON_ERROR);
+        if (! is_array($decoded)) {
+            throw new \InvalidArgumentException('Job detail manifest must decode to a JSON object or array.');
+        }
+
+        $sources = match ($source) {
+            'auto' => [
+                ['items'],
+                ['controlled_import_manifest', 'candidate_slugs'],
+                ['candidate_slugs'],
+                ['slugs'],
+            ],
+            'items' => [['items']],
+            'candidate_slugs' => [['candidate_slugs']],
+            'controlled_import_manifest.candidate_slugs' => [['controlled_import_manifest', 'candidate_slugs']],
+            'slugs' => [['slugs']],
+            default => throw new \InvalidArgumentException(sprintf('Unsupported --job-detail-manifest-source value: %s', $source)),
+        };
+
+        foreach ($sources as $segments) {
+            $value = $this->arrayPath($decoded, $segments);
+            $slugs = $this->slugListFromValue($value);
+            if ($slugs !== []) {
+                return $slugs;
+            }
+        }
+
+        throw new \InvalidArgumentException(sprintf(
+            'No job detail slugs found in manifest %s using source %s.',
+            $path,
+            $source,
+        ));
+    }
+
+    /**
+     * @param  array<string, mixed>  $data
+     * @param  list<string>  $segments
+     */
+    private function arrayPath(array $data, array $segments): mixed
+    {
+        $value = $data;
+        foreach ($segments as $segment) {
+            if (! is_array($value) || ! array_key_exists($segment, $value)) {
+                return null;
+            }
+
+            $value = $value[$segment];
+        }
+
+        return $value;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function slugListFromValue(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        $slugs = [];
+        foreach ($value as $item) {
+            $slug = is_array($item) ? ($item['slug'] ?? null) : $item;
+            if (! is_string($slug)) {
+                continue;
+            }
+
+            $slug = trim($slug);
+            if ($slug !== '') {
+                $slugs[] = $slug;
+            }
+        }
+
+        return array_values(array_unique($slugs));
+    }
+
+    /**
+     * @param  array<string, array<string, mixed>>  $summary
+     * @param  list<string>  $slugs
+     * @param  list<string>  $locales
+     * @return array<string, mixed>
+     */
+    private function jobDetailReport(array $summary, array $slugs, array $locales, ?string $manifestPath, ?string $manifestSource): array
+    {
+        $entries = array_filter(
+            $summary,
+            static fn (array $entry): bool => ($entry['slug'] ?? null) !== null && ($entry['locale'] ?? null) !== null,
+        );
+        $statusCounts = [];
+        foreach ($entries as $entry) {
+            $status = (string) ($entry['status'] ?? 'unknown');
+            $statusCounts[$status] = ($statusCounts[$status] ?? 0) + 1;
+        }
+        ksort($statusCounts);
+
+        return [
+            'manifest_path' => $manifestPath,
+            'manifest_source' => $manifestSource,
+            'slug_count' => count($slugs),
+            'locales' => $locales,
+            'locale_count' => count($locales),
+            'expected_cache_entries' => count($slugs) * count($locales),
+            'observed_cache_entries' => count($entries),
+            'status_counts' => $statusCounts,
+            'forget_first' => (bool) $this->option('forget-job-detail'),
+        ];
     }
 }

--- a/backend/docs/career/generated/career-full-parity-07-cache-convergence-readiness.json
+++ b/backend/docs/career/generated/career-full-parity-07-cache-convergence-readiness.json
@@ -1,0 +1,62 @@
+{
+  "pr_id": "CAREER-FULL-PARITY-07",
+  "title": "CAREER-FULL-PARITY-07: chore(career): warm en zh career detail caches",
+  "generated_at": "2026-06-11T17:06:37Z",
+  "read_only": true,
+  "writes_database": false,
+  "cms_mutation": false,
+  "cache_mutation_executed": false,
+  "publish_allowed": false,
+  "deploy_allowed": false,
+  "source_manifest": {
+    "path": "backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json",
+    "slug_source": "items",
+    "slug_count": 1046,
+    "slug_list_sha256": "8065a0fec905af75c6524035a012928fb458c0f9cdc6d1d4b72483ee2ee06def",
+    "first_slug": "accountants-and-auditors",
+    "last_slug": "zoologists-and-wildlife-biologists"
+  },
+  "cache_convergence_plan": {
+    "target_locales": [
+      "en",
+      "zh-CN"
+    ],
+    "expected_cache_entries": 2092,
+    "cache_key_template": "career:public-authority:job-detail:v1:{slug}:{locale}",
+    "forget_before_warm": true,
+    "manifest_command": "php backend/artisan career:warm-public-authority-cache --job-detail-manifest=backend/docs/career/generated/career-full-parity-02-root-cause-manifest.json --job-detail-manifest-source=items --job-detail-locales=en,zh-CN --forget-job-detail --job-detail-only --json",
+    "chunked_fallback": "Use --job-detail-slugs=<chunk_slugs_csv> --job-detail-locales=en,zh-CN --forget-job-detail --job-detail-only --json when an operator wants smaller production batches."
+  },
+  "command_contract": {
+    "manifest_sources_supported": [
+      "auto",
+      "items",
+      "candidate_slugs",
+      "controlled_import_manifest.candidate_slugs",
+      "slugs"
+    ],
+    "json_report_fields": [
+      "job_detail_refresh.manifest_path",
+      "job_detail_refresh.manifest_source",
+      "job_detail_refresh.slug_count",
+      "job_detail_refresh.locales",
+      "job_detail_refresh.expected_cache_entries",
+      "job_detail_refresh.observed_cache_entries",
+      "job_detail_refresh.status_counts",
+      "job_detail_refresh.forget_first"
+    ],
+    "status_boundary": "Per-entry warm results keep invalid_slug and missing as entry statuses instead of aborting the whole manifest refresh."
+  },
+  "required_operator_boundary": {
+    "production_execution_requires_explicit_approval": true,
+    "approval_phrase_template": "I explicitly approve production career job detail cache forget/warm for 1046 slugs across en,zh-CN using career-full-parity-02 root-cause manifest SHA 8065a0fec905af75c6524035a012928fb458c0f9cdc6d1d4b72483ee2ee06def; run the manifest command exactly; no database writes, no CMS mutation, no publish, no deploy.",
+    "not_approved_in_this_pr": true
+  },
+  "acceptance": {
+    "full_cache_target_defined": true,
+    "en_zh_locales_supported": true,
+    "manifest_input_supported": true,
+    "missing_cache_reportable": true,
+    "production_cache_mutation_performed": false
+  }
+}

--- a/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
+++ b/backend/tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php
@@ -111,12 +111,65 @@ final class CareerWarmPublicAuthorityCacheCommandTest extends TestCase
         $this->assertFalse(Cache::has($cacheKey));
     }
 
+    public function test_command_can_warm_job_detail_caches_from_manifest_for_multiple_locales(): void
+    {
+        $manifestPath = tempnam(sys_get_temp_dir(), 'career-job-detail-manifest-');
+        $this->assertIsString($manifestPath);
+        file_put_contents($manifestPath, json_encode([
+            'items' => [
+                ['slug' => 'missing-career'],
+                ['slug' => 'another-missing-career'],
+                ['slug' => 'missing-career'],
+                ['slug' => ''],
+            ],
+        ], JSON_THROW_ON_ERROR));
+
+        foreach (['missing-career', 'another-missing-career'] as $slug) {
+            foreach (['en', 'zh-CN'] as $locale) {
+                Cache::forever(PublicCareerAuthorityResponseCache::JOB_DETAIL_CACHE_KEY_PREFIX.':'.$slug.':'.$locale, ['stale' => true]);
+            }
+        }
+
+        try {
+            $exitCode = Artisan::call('career:warm-public-authority-cache', [
+                '--job-detail-manifest' => $manifestPath,
+                '--job-detail-manifest-source' => 'items',
+                '--job-detail-locales' => 'en,zh-CN',
+                '--forget-job-detail' => true,
+                '--job-detail-only' => true,
+                '--json' => true,
+            ]);
+
+            $report = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+            $this->assertSame(0, $exitCode);
+            $this->assertSame('warmed', $report['status']);
+            $this->assertSame(2, $report['job_detail_refresh']['slug_count']);
+            $this->assertSame(['en', 'zh-CN'], $report['job_detail_refresh']['locales']);
+            $this->assertSame(4, $report['job_detail_refresh']['expected_cache_entries']);
+            $this->assertSame(4, $report['job_detail_refresh']['observed_cache_entries']);
+            $this->assertSame(['missing' => 4], $report['job_detail_refresh']['status_counts']);
+            $this->assertSame($manifestPath, $report['job_detail_refresh']['manifest_path']);
+            $this->assertSame('items', $report['job_detail_refresh']['manifest_source']);
+            $this->assertArrayHasKey('job_detail_en_missing-career', $report['entries']);
+            $this->assertArrayHasKey('job_detail_zh_cn_another-missing-career', $report['entries']);
+
+            foreach (['missing-career', 'another-missing-career'] as $slug) {
+                foreach (['en', 'zh-CN'] as $locale) {
+                    $this->assertFalse(Cache::has(PublicCareerAuthorityResponseCache::JOB_DETAIL_CACHE_KEY_PREFIX.':'.$slug.':'.$locale));
+                }
+            }
+        } finally {
+            @unlink($manifestPath);
+        }
+    }
+
     public function test_job_detail_only_requires_target_slugs(): void
     {
         $this->artisan('career:warm-public-authority-cache', [
             '--job-detail-only' => true,
         ])
-            ->expectsOutput('--job-detail-only requires --job-detail-slugs.')
+            ->expectsOutput('--job-detail-only requires --job-detail-slugs or --job-detail-manifest.')
             ->assertExitCode(1);
     }
 }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53851,7 +53851,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-06",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "merged",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-06: fix(career): align en display asset runtime bundle selection",
     "depends_on": [
@@ -53887,16 +53887,20 @@
         "evidence": "Changed files are confined to manifest-allowed Career service, Career feature test, generated career report, and docs/codex state paths."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2047 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2047 checks passed and GitHub reports the PR merged."
+      },
+      "merge": {
+        "status": "pass",
+        "evidence": "PR #2047 merged at 2026-06-11T16:59:02Z; origin/main contains merge commit 44d408217803886c85b21f1cfff55d6ce34e56fc."
       }
     },
     "failure_reason": null,
     "commit_sha": "7646ed55",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2047",
-    "merged_at": null,
-    "remote_branch_deleted": false,
-    "local_cleanup_executed": false,
+    "merged_at": "2026-06-11T16:59:02Z",
+    "remote_branch_deleted": true,
+    "local_cleanup_executed": true,
     "transitions": [
       {
         "at": "2026-06-11T13:00:17Z",
@@ -53917,6 +53921,11 @@
         "at": "2026-06-11T16:53:10Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2047 from codex/career-full-parity-06 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-11T17:06:37Z",
+        "status": "merged",
+        "note": "Reconciled CAREER-FULL-PARITY-06 after PR #2047 merge and post-merge cleanup."
       }
     ]
   },
@@ -53924,7 +53933,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-07",
     "base": "origin/main",
-    "status": "pending_dependency",
+    "status": "local_checks_passed",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-07: chore(career): warm en zh career detail caches",
     "depends_on": [
@@ -53936,8 +53945,29 @@
         "evidence": "User explicitly authorized adding and executing CAREER-FULL-PARITY-01 through CAREER-FULL-PARITY-10 and allowed fap-api docs/codex metadata updates."
       },
       "dependency": {
-        "status": "pending",
-        "evidence": "Waiting for CAREER-FULL-PARITY-06 to merge before implementation."
+        "status": "pass",
+        "evidence": "CAREER-FULL-PARITY-06 PR #2047 is merged and origin/main contains merge commit 44d408217803886c85b21f1cfff55d6ce34e56fc."
+      },
+      "implementation": {
+        "status": "pass",
+        "evidence": "Career warm public authority cache command now accepts job detail manifests, supports items/candidate/slugs sources, reports EN/ZH cache convergence summary fields, and generated CAREER-FULL-PARITY-07 readiness report for 1046 slugs across en and zh-CN without executing production cache mutation."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console tests/Feature/Career --no-ansi",
+          "cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerWarmPublicAuthorityCache.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "python3 -m json.tool backend/docs/career/generated/career-full-parity-07-cache-convergence-readiness.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check"
+        ],
+        "evidence": "Required local checks passed: focused cache command test passed with 6 warnings / 65 assertions; Feature/Console + Feature/Career suite passed with 708 warnings / 39042 assertions; Pint, JSON, YAML, and diff checks passed."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Changed files are confined to manifest-allowed console command, console feature test, generated career report, and docs/codex state paths."
       }
     },
     "failure_reason": null,
@@ -53951,6 +53981,16 @@
         "at": "2026-06-11T13:00:17Z",
         "status": "pending_dependency",
         "note": "Initialized from explicit CAREER-FULL-PARITY train authorization; implementation deferred until dependencies merge."
+      },
+      {
+        "at": "2026-06-11T17:06:37Z",
+        "status": "in_progress",
+        "note": "Started CAREER-FULL-PARITY-07 from latest origin/main after PR06 cleanup."
+      },
+      {
+        "at": "2026-06-11T17:10:50Z",
+        "status": "local_checks_passed",
+        "note": "Implementation and required local checks passed; ready for scope validation, commit, push, and PR creation."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53933,7 +53933,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-07",
     "base": "origin/main",
-    "status": "pr_open_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-07: chore(career): warm en zh career detail caches",
     "depends_on": [
@@ -53970,12 +53970,16 @@
         "evidence": "Changed files are confined to manifest-allowed console command, console feature test, generated career report, and docs/codex state paths."
       },
       "github": {
-        "status": "pending",
-        "evidence": "PR #2048 opened; waiting for GitHub checks."
+        "status": "pass",
+        "evidence": "PR #2048 GitHub checks passed: hygiene, supply-chain, content-pack-build-validate, Semgrep, verify-bigfive, verify-mbti-legacy, and verify-mbti-v2."
+      },
+      "merge_readiness": {
+        "status": "pass",
+        "evidence": "PR #2048 is OPEN, mergeStateStatus CLEAN, not draft, and changed files remain within the declared CAREER-FULL-PARITY-07 scope."
       }
     },
     "failure_reason": null,
-    "commit_sha": "cd633892",
+    "commit_sha": "f37b7883",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2048",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -54000,6 +54004,11 @@
         "at": "2026-06-11T17:13:35Z",
         "status": "pr_open_checks_pending",
         "note": "Opened PR #2048 from codex/career-full-parity-07 after local validation and scope validation passed."
+      },
+      {
+        "at": "2026-06-11T17:20:10Z",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed and merge preflight scope validation is clean for PR #2048."
       }
     ]
   },

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -53933,7 +53933,7 @@
     "repo": "fap-api",
     "branch": "codex/career-full-parity-07",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_open_checks_pending",
     "train_scope": "career_full_parity",
     "title": "CAREER-FULL-PARITY-07: chore(career): warm en zh career detail caches",
     "depends_on": [
@@ -53968,11 +53968,15 @@
       "scope": {
         "status": "pass",
         "evidence": "Changed files are confined to manifest-allowed console command, console feature test, generated career report, and docs/codex state paths."
+      },
+      "github": {
+        "status": "pending",
+        "evidence": "PR #2048 opened; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "cd633892",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2048",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -53991,6 +53995,11 @@
         "at": "2026-06-11T17:10:50Z",
         "status": "local_checks_passed",
         "note": "Implementation and required local checks passed; ready for scope validation, commit, push, and PR creation."
+      },
+      {
+        "at": "2026-06-11T17:13:35Z",
+        "status": "pr_open_checks_pending",
+        "note": "Opened PR #2048 from codex/career-full-parity-07 after local validation and scope validation passed."
       }
     ]
   },


### PR DESCRIPTION
## What changed
- Extended `career:warm-public-authority-cache` to derive job detail cache targets from JSON manifests/reports.
- Added EN/ZH cache convergence JSON reporting for slug count, locales, expected entries, observed entries, and per-status counts.
- Added a read-only CAREER-FULL-PARITY-07 readiness report for 1046 career job slugs across `en` and `zh-CN`.

## Why
- After controlled imports and module normalization, production needs a repeatable manifest-driven way to forget/warm all career job detail caches across both public locales.
- The command now supports full 1046 convergence while keeping production execution behind explicit operator approval.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console tests/Feature/Career --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerWarmPublicAuthorityCache.php tests/Feature/Console/CareerWarmPublicAuthorityCacheCommandTest.php`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `python3 -m json.tool backend/docs/career/generated/career-full-parity-07-cache-convergence-readiness.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`

## Intentionally deferred
- No production cache forget/warm was executed in this PR.
- No database writes, CMS mutation, content import, publish, deploy, sitemap, or llms changes.

## Repository rule impact
- Career job public detail remains backend-authoritative. This PR only adds backend cache operations/reporting for the existing authority layer and does not introduce frontend or CMS fallback content.