### PR TITLE
fix(career): derive module subset normalization slugs from parity reports

### DIFF
--- a/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
@@ -159,6 +159,9 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             $report = array_merge($report, $this->summarize($items), [
                 'mode' => $force ? 'force' : 'dry_run',
                 'requested_slugs' => $slugs,
+                'requested_slug_source' => trim((string) $this->option('slugs')) === ''
+                    ? 'module_subset_report'
+                    : 'explicit_slugs',
                 'module_subset_report' => $this->moduleSubsetReportPath(),
                 'module_subset_authorized_count' => count($moduleSubsetAllowlist),
                 'items' => $items,
@@ -230,8 +233,13 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
     private function requiredSlugs(): array
     {
         $raw = trim((string) $this->option('slugs'));
+        $moduleSubsetAllowlist = $this->moduleSubsetAllowlist();
         if ($raw === '') {
-            throw new RuntimeException('--slugs is required and must be an explicit comma-separated allowlist.');
+            if ($moduleSubsetAllowlist !== []) {
+                return $moduleSubsetAllowlist;
+            }
+
+            throw new RuntimeException('--slugs is required unless --module-subset-report provides an explicit module-subset allowlist.');
         }
 
         $parts = array_values(array_filter(array_map(
@@ -250,7 +258,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
         $unsupported = array_values(array_filter(
             $parts,
             fn (string $slug): bool => ! in_array($slug, self::AFFECTED_SLUGS, true)
-                && ! in_array($slug, $this->moduleSubsetAllowlist(), true),
+                && ! in_array($slug, $moduleSubsetAllowlist, true),
         ));
 
         if ($unsupported !== []) {
@@ -279,10 +287,9 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             throw new RuntimeException('--module-subset-report must be valid JSON.');
         }
 
-        $items = is_array($payload['items'] ?? null) ? $payload['items'] : [];
         $slugs = [];
 
-        foreach ($items as $item) {
+        foreach ($this->moduleSubsetRows($payload) as $item) {
             if (! is_array($item)) {
                 continue;
             }
@@ -296,7 +303,10 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             $slugs[] = $slug;
         }
 
-        return array_values(array_unique($slugs));
+        $slugs = array_values(array_unique($slugs));
+        sort($slugs);
+
+        return $slugs;
     }
 
     private function moduleSubsetReportPath(): ?string
@@ -304,6 +314,25 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
         $path = trim((string) $this->option('module-subset-report'));
 
         return $path === '' ? null : $path;
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @return list<mixed>
+     */
+    private function moduleSubsetRows(array $payload): array
+    {
+        $rows = [];
+        if (is_array($payload['items'] ?? null)) {
+            $rows = array_merge($rows, $payload['items']);
+        }
+
+        $bucket = data_get($payload, 'root_cause_manifest.buckets.zh_display_asset_present_but_module_subset');
+        if (is_array($bucket)) {
+            $rows = array_merge($rows, $bucket);
+        }
+
+        return $rows;
     }
 
     /**

--- a/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
@@ -166,7 +166,6 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
     public function force_adds_missing_zh_module_placeholders_only_for_report_authorized_subset_slugs(): void
     {
         $slug = 'module-subset-career';
-        $occupation = $this->createOccupation($slug);
         $missingModules = [
             'career_snapshot_primary_locale',
             'career_snapshot_secondary_locale',
@@ -182,33 +181,7 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
             'source_card',
             'review_validity_card',
         ];
-        $zhContent = array_diff_key(
-            $this->pageContentForComponentOrder('中文内容'),
-            array_flip($missingModules),
-        );
-
-        CareerJobDisplayAsset::query()->create([
-            'occupation_id' => $occupation->id,
-            'canonical_slug' => $slug,
-            'surface_version' => 'display.surface.v1',
-            'asset_version' => 'v4.2',
-            'template_version' => 'v4.2',
-            'asset_type' => 'career_job_public_display',
-            'asset_role' => 'formal_pilot_master',
-            'status' => 'ready_for_pilot',
-            'component_order_json' => $this->componentOrder(),
-            'page_payload_json' => [
-                'page' => [
-                    'en' => $this->pageContentForComponentOrder('English content'),
-                    'zh' => $zhContent,
-                ],
-            ],
-            'seo_payload_json' => ['en' => ['title' => $slug], 'zh' => ['title' => $slug]],
-            'sources_json' => ['references' => [['label' => 'Official source']]],
-            'structured_data_json' => ['faq_page' => ['en' => ['mainEntity' => []], 'zh' => ['mainEntity' => []]]],
-            'implementation_contract_json' => ['claim_permissions' => ['visible' => true]],
-            'metadata_json' => ['command' => 'legacy-import'],
-        ]);
+        $this->createModuleSubsetAsset($slug, $missingModules);
 
         [$exitCode, $report] = $this->runNormalize($slug, [
             '--force' => true,
@@ -240,6 +213,33 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
         $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
         $this->assertSame(0, $report['would_update_count']);
         $this->assertSame(0, $report['module_placeholders_added_count']);
+    }
+
+    #[Test]
+    public function it_can_derive_module_subset_slugs_from_root_cause_manifest_without_explicit_slugs(): void
+    {
+        $first = 'module-subset-a';
+        $second = 'module-subset-b';
+        $missingModules = ['source_card', 'review_validity_card'];
+        $this->createModuleSubsetAsset($first, $missingModules);
+        $this->createModuleSubsetAsset($second, ['source_card']);
+
+        $exitCode = Artisan::call('career:normalize-legacy-display-assets', [
+            '--lineage-workbook' => $this->lineageWorkbook(),
+            '--module-subset-report' => $this->moduleSubsetRootCauseReport([$second, $first]),
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('module_subset_report', $report['requested_slug_source']);
+        $this->assertSame([$first, $second], $report['requested_slugs']);
+        $this->assertSame(2, $report['module_subset_authorized_count']);
+        $this->assertSame(2, $report['validated_count']);
+        $this->assertSame(2, $report['would_update_count']);
+        $this->assertSame(3, $report['module_placeholders_added_count']);
     }
 
     #[Test]
@@ -469,6 +469,63 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
         ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
 
         return $path;
+    }
+
+    /**
+     * @param  list<string>  $slugs
+     */
+    private function moduleSubsetRootCauseReport(array $slugs): string
+    {
+        $path = tempnam(sys_get_temp_dir(), 'career-module-subset-root-cause-report-');
+        $this->assertIsString($path);
+        file_put_contents($path, json_encode([
+            'validator_version' => 'career_zh_display_parity_audit_v0.4',
+            'root_cause_manifest' => [
+                'buckets' => [
+                    'zh_display_asset_present_but_module_subset' => array_map(static fn (string $slug): array => [
+                        'slug' => $slug,
+                        'root_cause' => 'zh_display_asset_present_but_module_subset',
+                    ], $slugs),
+                ],
+            ],
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+
+        return $path;
+    }
+
+    /**
+     * @param  list<string>  $missingModules
+     */
+    private function createModuleSubsetAsset(string $slug, array $missingModules): void
+    {
+        $occupation = $this->createOccupation($slug);
+        $zhContent = array_diff_key(
+            $this->pageContentForComponentOrder('中文内容'),
+            array_flip($missingModules),
+        );
+
+        CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => $slug,
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => $this->componentOrder(),
+            'page_payload_json' => [
+                'page' => [
+                    'en' => $this->pageContentForComponentOrder('English content'),
+                    'zh' => $zhContent,
+                ],
+            ],
+            'seo_payload_json' => ['en' => ['title' => $slug], 'zh' => ['title' => $slug]],
+            'sources_json' => ['references' => [['label' => 'Official source']]],
+            'structured_data_json' => ['faq_page' => ['en' => ['mainEntity' => []], 'zh' => ['mainEntity' => []]]],
+            'implementation_contract_json' => ['claim_permissions' => ['visible' => true]],
+            'metadata_json' => ['command' => 'legacy-import'],
+        ]);
     }
 
     /**


### PR DESCRIPTION
## What changed
- Let `career:normalize-legacy-display-assets` derive its slug allowlist from `--module-subset-report` when `--slugs` is omitted.
- Support both existing `items[]` reports and final parity `root_cause_manifest.buckets.zh_display_asset_present_but_module_subset` reports.
- Add report evidence for whether slugs came from explicit CLI input or from the module-subset report.
- Add focused coverage for root-cause-manifest driven normalization.

## Why
The latest production live gate still shows 667 `zh_display_asset_present_but_module_subset` slugs. The existing normalizer could repair this class, but operating it at production scale required manually passing a very long `--slugs` list. This PR keeps the command guarded and read/dry-run friendly while making the final parity report usable as the controlled input manifest.

## Validation
- `php -l backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php`
- `php -l backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php`
- `git diff --check`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`

## Intentionally deferred
- No production import/normalization was run.
- No cache forget/warm was run.
- No sitemap, llms, indexability, frontend, or CMS publish behavior changed.
- Runtime shell and EN/ZH direction mismatches remain separate production-content convergence steps.

## Repository rule impact
Backend/CMS remains the source of truth for career content. This PR only improves a guarded backend ops command for CMS display asset normalization; it does not add frontend fallback content or mutate public content.
