### PR TITLE
fix(seo): diagnose baidu push provider failures

### DIFF
--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueLiveSubmissionExecutor.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace App\Services\SeoIntel\SearchChannelQueue;
 
 use App\Services\SeoIntel\SearchChannelSubmissionStatusNormalizer;
+use Illuminate\Http\Client\Response;
 use Illuminate\Support\Facades\DB;
 use Illuminate\Support\Facades\Http;
 use Throwable;
@@ -87,6 +88,8 @@ final class SearchChannelQueueLiveSubmissionExecutor
         $httpStatus = $submission['http_status'];
         $accepted = $submission['accepted'];
         $exceptionClass = $submission['exception_class'];
+        $providerErrorCode = $submission['provider_error_code'];
+        $providerErrorMessage = $submission['provider_error_message'];
 
         $submissionStatus = $this->statusNormalizer->normalize($accepted ? 'accepted' : 'failed');
         $executionState = $accepted ? 'submitted' : 'submit_failed';
@@ -105,6 +108,8 @@ final class SearchChannelQueueLiveSubmissionExecutor
             'http_status' => $httpStatus,
             'submission_status' => $submissionStatus,
             'exception_class' => $exceptionClass,
+            'provider_error_code' => $providerErrorCode,
+            'provider_error_message' => $providerErrorMessage,
         ], 'system', 'seo-intel:search-channel-submit');
 
         return [
@@ -118,6 +123,8 @@ final class SearchChannelQueueLiveSubmissionExecutor
             'submission_status' => $submissionStatus,
             'execution_state' => $executionState,
             'http_status' => $httpStatus,
+            'provider_error_code' => $providerErrorCode,
+            'provider_error_message' => $providerErrorMessage,
         ];
     }
 
@@ -244,7 +251,7 @@ final class SearchChannelQueueLiveSubmissionExecutor
     }
 
     /**
-     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string}
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}
      */
     private function submitToChannel(string $channel, string $canonicalUrl): array
     {
@@ -256,12 +263,14 @@ final class SearchChannelQueueLiveSubmissionExecutor
                 'http_status' => null,
                 'exception_class' => null,
                 'endpoint_host' => null,
+                'provider_error_code' => null,
+                'provider_error_message' => null,
             ],
         };
     }
 
     /**
-     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string}
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}
      */
     private function submitIndexNow(string $canonicalUrl): array
     {
@@ -285,6 +294,8 @@ final class SearchChannelQueueLiveSubmissionExecutor
                 'http_status' => $response->status(),
                 'exception_class' => null,
                 'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => null,
+                'provider_error_message' => null,
             ];
         } catch (Throwable $exception) {
             return [
@@ -292,12 +303,14 @@ final class SearchChannelQueueLiveSubmissionExecutor
                 'http_status' => null,
                 'exception_class' => $exception::class,
                 'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => null,
+                'provider_error_message' => null,
             ];
         }
     }
 
     /**
-     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string}
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}
      */
     private function submitBaiduPush(string $canonicalUrl): array
     {
@@ -316,12 +329,15 @@ final class SearchChannelQueueLiveSubmissionExecutor
 
             $body = $response->json();
             $accepted = $response->successful() && (int) data_get(is_array($body) ? $body : [], 'success', 0) >= 1;
+            $diagnostics = $this->sanitizedProviderDiagnostics($response, [$canonicalUrl, $site, $token]);
 
             return [
                 'accepted' => $accepted,
                 'http_status' => $response->status(),
                 'exception_class' => null,
                 'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => $accepted ? null : $diagnostics['provider_error_code'],
+                'provider_error_message' => $accepted ? null : $diagnostics['provider_error_message'],
             ];
         } catch (Throwable $exception) {
             return [
@@ -329,8 +345,67 @@ final class SearchChannelQueueLiveSubmissionExecutor
                 'http_status' => null,
                 'exception_class' => $exception::class,
                 'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => null,
+                'provider_error_message' => null,
             ];
         }
+    }
+
+    /**
+     * @param  list<string>  $sensitiveValues
+     * @return array{provider_error_code: ?string, provider_error_message: ?string}
+     */
+    private function sanitizedProviderDiagnostics(Response $response, array $sensitiveValues): array
+    {
+        $body = $response->json();
+        $payload = is_array($body) ? $body : [];
+        $errorCode = $this->firstScalarString($payload, ['error', 'error_code', 'errno', 'status', 'code']);
+        $errorMessage = $this->firstScalarString($payload, ['message', 'error_msg', 'msg', 'reason']);
+
+        return [
+            'provider_error_code' => $this->redactSensitiveText($errorCode, $sensitiveValues),
+            'provider_error_message' => $this->redactSensitiveText($errorMessage, $sensitiveValues),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $keys
+     */
+    private function firstScalarString(array $payload, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = data_get($payload, $key);
+
+            if (is_scalar($value) && trim((string) $value) !== '') {
+                return trim((string) $value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<string>  $sensitiveValues
+     */
+    private function redactSensitiveText(?string $value, array $sensitiveValues): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $redacted = $value;
+
+        foreach ($sensitiveValues as $sensitiveValue) {
+            if (trim($sensitiveValue) !== '') {
+                $redacted = str_replace($sensitiveValue, '[redacted]', $redacted);
+            }
+        }
+
+        $redacted = (string) preg_replace('~https?://\\S+~i', '[redacted_url]', $redacted);
+        $redacted = (string) preg_replace('/\\b[A-Za-z0-9_-]{16,}\\b/', '[redacted_token]', $redacted);
+
+        return substr(trim($redacted), 0, 200);
     }
 
     /**

--- a/backend/config/seo_intel.php
+++ b/backend/config/seo_intel.php
@@ -322,7 +322,7 @@ return [
                 'fermatmind.com',
             ],
             'baidu' => [
-                'endpoint' => env('SEO_INTEL_BAIDU_PUSH_ENDPOINT', 'https://data.zz.baidu.com/urls'),
+                'endpoint' => env('SEO_INTEL_BAIDU_PUSH_ENDPOINT', 'http://data.zz.baidu.com/urls'),
                 'site' => env('SEO_INTEL_BAIDU_SITE'),
                 'token' => env('SEO_INTEL_BAIDU_PUSH_TOKEN'),
                 'timeout_seconds' => env('SEO_INTEL_BAIDU_PUSH_TIMEOUT_SECONDS', 10),

--- a/backend/docs/seo/generated/search-channel-live-02-executor.v1.json
+++ b/backend/docs/seo/generated/search-channel-live-02-executor.v1.json
@@ -10,6 +10,7 @@
   "bulk_submission_supported": false,
   "atomic_single_item_claim_required": true,
   "raw_secret_output_allowed": false,
+  "sanitized_provider_error_diagnostics_allowed": true,
   "sitemap_llms_behavior_changed": false,
   "supported_live_channels": [
     "indexnow",
@@ -52,6 +53,7 @@
     "no_production_env_edit": true,
     "no_deploy": true,
     "no_raw_key_or_key_location_output": true,
-    "no_full_url_in_audit_event_payload": true
+    "no_full_url_in_audit_event_payload": true,
+    "provider_error_diagnostics_must_redact_secrets_and_urls": true
   }
 }

--- a/backend/docs/seo/search-channel-live-02-executor.md
+++ b/backend/docs/seo/search-channel-live-02-executor.md
@@ -57,7 +57,7 @@ Baidu push additionally requires:
 - `SEO_INTEL_BAIDU_LIVE_API_ENABLED=true`
 - `SEO_INTEL_BAIDU_SITE` is present
 - `SEO_INTEL_BAIDU_PUSH_TOKEN` is present
-- `SEO_INTEL_BAIDU_PUSH_ENDPOINT` defaults to `https://data.zz.baidu.com/urls`
+- `SEO_INTEL_BAIDU_PUSH_ENDPOINT` defaults to `http://data.zz.baidu.com/urls`
 
 Default config keeps these gates disabled or empty.
 
@@ -99,8 +99,8 @@ The executor writes only Search Channel Queue audit events:
 - `live_submission_response`
 
 Event payloads use `url_hash`, endpoint host, HTTP status, normalized submission
-status, and optional exception class. They do not contain raw keys or the full
-submitted URL.
+status, optional exception class, and sanitized provider error code/message when
+available. They do not contain raw keys or the full submitted URL.
 
 ## Deferred
 

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLiveSubmissionExecutorTest.php
@@ -356,6 +356,85 @@ final class SeoIntelSearchChannelLiveSubmissionExecutorTest extends TestCase
     }
 
     #[Test]
+    public function failed_baidu_submission_captures_sanitized_provider_diagnostics(): void
+    {
+        config([
+            'seo_intel.baidu_live_api_enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.external_api_calls_enabled' => true,
+            'seo_intel.search_channel_queue.live_submission.baidu.endpoint' => 'http://data.zz.baidu.test/urls',
+            'seo_intel.search_channel_queue.live_submission.baidu.site' => 'https://fermatmind.com',
+            'seo_intel.search_channel_queue.live_submission.baidu.token' => 'secret-baidu-token',
+        ]);
+
+        Http::fake([
+            'data.zz.baidu.test/*' => Http::response([
+                'error' => 401,
+                'message' => 'site https://fermatmind.com token secret-baidu-token rejected for https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice',
+            ], 400),
+        ]);
+
+        $canonicalUrl = 'https://fermatmind.com/zh/articles/mbti-vs-holland-career-choice';
+        $queueItemId = $this->seedQueueItem([
+            'canonical_url' => $canonicalUrl,
+            'locale' => 'zh-CN',
+            'page_entity_type' => 'article',
+            'entity_type' => 'article',
+            'entity_id' => 'article:37',
+            'source_authority' => 'backend_cms',
+            'source_table' => 'cms_articles',
+            'channel' => 'baidu_push',
+        ]);
+        $approvalPhrase = app(SearchChannelQueueLiveSubmissionExecutor::class)
+            ->approvalPhrase($queueItemId, 'baidu_push', $canonicalUrl);
+
+        [$exitCode, $payload, $rawOutput] = $this->runSubmitCommand([
+            '--queue-item-id' => $queueItemId,
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('failed', $payload['status'] ?? null);
+        $this->assertSame('failed', $payload['submission_status'] ?? null);
+        $this->assertSame('submit_failed', $payload['execution_state'] ?? null);
+        $this->assertSame(400, $payload['http_status'] ?? null);
+        $this->assertSame('401', $payload['provider_error_code'] ?? null);
+        $this->assertSame('site [redacted] token [redacted] rejected for [redacted]', $payload['provider_error_message'] ?? null);
+        $this->assertStringNotContainsString('secret-baidu-token', $rawOutput);
+
+        Http::assertSent(function (Request $request) use ($canonicalUrl): bool {
+            $query = [];
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+            return $request->method() === 'POST'
+                && parse_url($request->url(), PHP_URL_SCHEME) === 'http'
+                && parse_url($request->url(), PHP_URL_HOST) === 'data.zz.baidu.test'
+                && $query['site'] === 'https://fermatmind.com'
+                && $query['token'] === 'secret-baidu-token'
+                && $request->body() === $canonicalUrl
+                && $request->hasHeader('Content-Type', 'text/plain');
+        });
+
+        $item = DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->first();
+        $this->assertSame('approved', $item->approval_state);
+        $this->assertSame('submit_failed', $item->execution_state);
+
+        $responseEvent = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_events')
+            ->where('queue_item_id', $queueItemId)
+            ->where('event_type', 'live_submission_response')
+            ->first();
+
+        $this->assertNotNull($responseEvent);
+        $this->assertStringContainsString('"provider_error_code":"401"', (string) $responseEvent->event_payload);
+        $this->assertStringContainsString('"provider_error_message":"site [redacted] token [redacted] rejected for [redacted]"', (string) $responseEvent->event_payload);
+        $this->assertStringNotContainsString('secret-baidu-token', (string) $responseEvent->event_payload);
+        $this->assertStringNotContainsString($canonicalUrl, (string) $responseEvent->event_payload);
+    }
+
+    #[Test]
     public function unsafe_queue_item_is_rejected_without_writes_or_external_calls(): void
     {
         Http::fake();


### PR DESCRIPTION
## What changed
- Changed the default Baidu push endpoint to Baidu's documented HTTP endpoint: `http://data.zz.baidu.com/urls`.
- Added sanitized provider failure diagnostics for Baidu push responses: provider error code/message can be captured without raw tokens or full URLs.
- Kept live gates disabled by default and preserved the single-item exact-approval guard.
- Added a Baidu HTTP 400 regression test that locks request scheme, host, query params, `Content-Type: text/plain`, raw URL body shape, queue failure state, and sanitized audit payloads.
- Updated Search Channel live executor docs and generated safety artifact.

## Why
The production Baidu retry reached the provider but returned HTTP 400. The existing executor only recorded `submission_failed`, which was insufficient to distinguish site/token/quota/body errors while preserving secret-safe audit logs.

## Validation
```bash
cd backend && php artisan test --filter=SeoIntelSearchChannelLiveSubmissionExecutorTest --no-ansi
cd backend && php artisan test --filter=SeoIntelBaiduIndexNowCollectorsTest --no-ansi
python3 -m json.tool backend/docs/seo/generated/search-channel-live-02-executor.v1.json >/dev/null && git diff --check
```

## Intentionally deferred
- No production Baidu retry.
- No GSC / IndexNow submission.
- No CMS mutation.
- No sitemap / llms mutation.
- No ISR revalidation.
- No production env mutation.
- No raw token or full URL in audit event payloads.
