### PR TITLE
fix(career): avoid product schema substring false positives

### DIFF
--- a/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
+++ b/backend/app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php
@@ -875,11 +875,39 @@ final class CareerSelectedDisplayAssetMapper
             $text = $this->encodedText($occupation);
             $this->expect(is_array($occupation), "{$label} must parse as Occupation JSON.", $errors);
             $this->expect(trim((string) ($occupation['occupationalCategory'] ?? $occupation['occupationCategory'] ?? '')) !== '', "{$label} must include occupationalCategory.", $errors);
-            $this->expect(! str_contains($text, 'product'), "{$label} must not include Product schema.", $errors);
+            $this->expect(! $this->containsProductSchema($occupation), "{$label} must not include Product schema.", $errors);
             $this->expect(! str_contains($text, 'ai exposure') && ! str_contains($text, 'ai_exposure'), "{$label} must not include AI Exposure.", $errors);
             $this->expect(! str_contains($text, 'industry_proxy'), "{$label} must not include CN industry proxy wage.", $errors);
             $this->expect(! str_contains($text, 'job posting sample') && ! str_contains($text, '招聘样本'), "{$label} must not include job posting sample terms.", $errors);
         }
+    }
+
+    private function containsProductSchema(mixed $value): bool
+    {
+        if (! is_array($value)) {
+            return false;
+        }
+
+        $type = $value['@type'] ?? null;
+        if (is_string($type) && strtolower($type) === 'product') {
+            return true;
+        }
+
+        if (is_array($type)) {
+            foreach ($type as $entry) {
+                if (is_string($entry) && strtolower($entry) === 'product') {
+                    return true;
+                }
+            }
+        }
+
+        foreach ($value as $child) {
+            if ($this->containsProductSchema($child)) {
+                return true;
+            }
+        }
+
+        return false;
     }
 
     /**

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -971,7 +971,7 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
-    public function biomedical_engineers_product_substring_blocker_is_rejected_if_reintroduced(): void
+    public function biomedical_engineers_product_word_in_description_does_not_block_import(): void
     {
         $this->createAuthorityOccupation('biomedical-engineers', '17-2031', '17-2031.00');
         $row = $this->row(
@@ -992,10 +992,10 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
 
         [$exitCode, $report] = $this->runImport($workbook, 'biomedical-engineers');
 
-        $this->assertSame(1, $exitCode);
-        $this->assertStringContainsString(
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertStringNotContainsString(
             'EN_Occupation_Schema_JSON must not include Product schema.',
-            implode(' ', $report['errors']),
+            implode(' ', $report['errors'] ?? []),
         );
     }
 

--- a/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
+++ b/backend/tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php
@@ -201,7 +201,7 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
         }
     }
 
-    public function test_biomedical_engineers_rejects_product_substring_if_reintroduced(): void
+    public function test_biomedical_engineers_allows_product_word_in_occupation_description(): void
     {
         $row = $this->row(
             'biomedical-engineers',
@@ -220,7 +220,7 @@ final class CareerSelectedDisplayAssetMapperTest extends TestCase
 
         $result = app(CareerSelectedDisplayAssetMapper::class)->mapRow($row);
 
-        $this->assertStringContainsString(
+        $this->assertStringNotContainsString(
             'EN_Occupation_Schema_JSON must not include Product schema.',
             implode(' ', $result['errors']),
         );


### PR DESCRIPTION
## What changed
- Narrowed career display asset Product schema validation to real JSON-LD `@type: Product` nodes, including nested objects and `@type` arrays.
- Allowed normal occupation descriptions to contain ordinary words like `product`, `products`, or `product design`.
- Updated unit and command-level regression tests for the biomedical engineers case while keeping true Product schema rejection covered.

## Why
The CAREER-FULL-PARITY 131 runtime-shell dry-run showed 49 clean repaired workbook rows were blocked because descriptions contained ordinary `product` wording. The repaired workbook has `@type: Occupation`; the importer was over-broadly scanning encoded text for the substring `product`.

## Validation commands
- `composer install --no-interaction --prefer-dist`
- `php artisan test tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php` (passes; existing warning output remains in these test files)
- `php <<'PHP' ...` local 131 repaired-workbook mapper smoke: `rows=131`, `product_schema_errors=0`
- `./vendor/bin/pint --test app/Services/Career/Import/CareerSelectedDisplayAssetMapper.php tests/Unit/Services/Career/CareerSelectedDisplayAssetMapperTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `git diff --check`

## Intentionally deferred
- No production import, cache mutation, publish, or deploy.
- The 129 safe crosswalk force is deferred until after this PR is merged/deployed and separately approved.
- The 2 crosswalk conflicts remain manual review items: `diesel-service-technicians-and-mechanics`, `medical-scientists`.

## Repository rule impact
This keeps backend/CMS import validation as the authority layer. No content ownership, public SEO release gates, sitemap, llms, or frontend behavior changes.
