### PR TITLE
[codex] Support career parity remaining asset repairs

### DIFF
--- a/backend/app/Console/Commands/CareerAlignCareerAuthorityBatch.php
+++ b/backend/app/Console/Commands/CareerAlignCareerAuthorityBatch.php
@@ -97,7 +97,8 @@ final class CareerAlignCareerAuthorityBatch extends Command
         {--dry-run : Validate and report without writing}
         {--force : Required to write authority Occupation and crosswalk rows}
         {--json : Emit machine-readable report}
-        {--output= : Optional report output path}';
+        {--output= : Optional report output path}
+        {--authority-correction-output= : Optional JSON output path for safe workbook/manifest correction suggestions when existing authority conflicts with workbook rows}';
 
     protected $description = 'Guarded dry-run/force alignment for career upload authority occupations and SOC/O*NET crosswalks.';
 
@@ -179,7 +180,12 @@ final class CareerAlignCareerAuthorityBatch extends Command
             $report = array_merge($report, [
                 'validated_count' => count($items),
                 'items' => $items,
-            ], $this->summarize($items));
+            ], $this->summarize($items), $this->authorityCorrectionSummary($items, $file));
+
+            $authorityCorrectionOutput = $this->writeAuthorityCorrectionOutput($report['authority_correction_manifest']);
+            if ($authorityCorrectionOutput !== null) {
+                $report['authority_correction_output'] = $authorityCorrectionOutput;
+            }
 
             if ($errors !== []) {
                 return $this->finish(array_merge($report, [
@@ -930,10 +936,114 @@ final class CareerAlignCareerAuthorityBatch extends Command
             'failed_count' => 0,
             'would_write' => false,
             'did_write' => false,
+            'authority_correction_candidate_count' => 0,
+            'authority_correction_output' => null,
+            'authority_correction_manifest' => [
+                'scope' => 'career_authority_workbook_corrections',
+                'row_count' => 0,
+                'slugs' => [],
+                'rows' => [],
+            ],
             'display_assets_created' => false,
             'release_gates_changed' => false,
             'decision' => 'fail',
         ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $items
+     * @return array{authority_correction_candidate_count:int, authority_correction_manifest:array<string,mixed>}
+     */
+    private function authorityCorrectionSummary(array $items, string $file): array
+    {
+        $rows = [];
+
+        foreach ($items as $item) {
+            $existingSoc = $this->singleCrosswalkCode($item['existing_us_soc_crosswalks'] ?? []);
+            $existingOnet = $this->singleCrosswalkCode($item['existing_onet_crosswalks'] ?? []);
+            $workbookSoc = (string) ($item['workbook_us_soc'] ?? '');
+            $workbookOnet = (string) ($item['workbook_onet'] ?? '');
+
+            $socConflicts = $existingSoc !== null && $existingSoc !== $workbookSoc;
+            $onetConflicts = $existingOnet !== null && $existingOnet !== $workbookOnet;
+            if (! $socConflicts && ! $onetConflicts) {
+                continue;
+            }
+
+            $correctedSoc = $existingSoc ?? $workbookSoc;
+            $correctedOnet = $existingOnet ?? $workbookOnet;
+            $rows[] = [
+                'slug' => (string) $item['slug'],
+                'row_number' => (int) ($item['row_number'] ?? 0),
+                'issue' => 'existing_authority_conflicts_with_workbook',
+                'safe_to_force_original_workbook' => false,
+                'safe_to_use_corrected_row_for_next_dry_run' => $this->isNormalSocCode($correctedSoc)
+                    && $this->isNormalOnetCode($correctedOnet),
+                'original_workbook_authority' => [
+                    'SOC_Code' => $workbookSoc,
+                    'O_NET_Code' => $workbookOnet,
+                ],
+                'existing_authority' => [
+                    'SOC_Code' => $existingSoc,
+                    'O_NET_Code' => $existingOnet,
+                ],
+                'corrected_workbook_row' => [
+                    'Slug' => (string) $item['slug'],
+                    'SOC_Code' => $correctedSoc,
+                    'O_NET_Code' => $correctedOnet,
+                    'EN_Title' => (string) $item['title_en'],
+                    'CN_Title' => (string) $item['title_zh'],
+                ],
+            ];
+        }
+
+        return [
+            'authority_correction_candidate_count' => count($rows),
+            'authority_correction_manifest' => [
+                'scope' => 'career_authority_workbook_corrections',
+                'source_command' => self::COMMAND_NAME,
+                'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                'row_count' => count($rows),
+                'slugs' => array_values(array_map(
+                    static fn (array $row): string => (string) $row['slug'],
+                    $rows,
+                )),
+                'policy' => [
+                    'dry_run_only' => true,
+                    'database_writes' => false,
+                    'cache_mutation' => false,
+                    'publish' => false,
+                    'next_step' => 'Regenerate or patch workbook rows with corrected_workbook_row, then rerun authority alignment dry-run before any force operation.',
+                ],
+                'rows' => $rows,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<mixed>  $crosswalks
+     */
+    private function singleCrosswalkCode(array $crosswalks): ?string
+    {
+        if (count($crosswalks) !== 1 || ! is_array($crosswalks[0] ?? null)) {
+            return null;
+        }
+
+        $code = trim((string) ($crosswalks[0]['source_code'] ?? ''));
+
+        return $code === '' ? null : $code;
+    }
+
+    /**
+     * @param  array<string, mixed>  $manifest
+     */
+    private function writeAuthorityCorrectionOutput(array $manifest): ?string
+    {
+        return CareerCliArtifactPathGuard::writeJsonOutput(
+            $this->option('authority-correction-output'),
+            $manifest,
+            '--authority-correction-output',
+        );
     }
 
     /**

--- a/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerImportSelectedDisplayAssets.php
@@ -39,6 +39,7 @@ final class CareerImportSelectedDisplayAssets extends Command
         {--manifest-chunk-index=1 : 1-based manifest candidate chunk index}
         {--dry-run : Validate and report without writing}
         {--force : Required to write selected display asset rows}
+        {--update-existing-from-manifest : Allow a manifest-authorized existing display asset to be updated from the reviewed workbook payload}
         {--json : Emit machine-readable report}
         {--output= : Optional report output path}';
 
@@ -58,6 +59,7 @@ final class CareerImportSelectedDisplayAssets extends Command
         try {
             $force = (bool) $this->option('force');
             $dryRun = (bool) $this->option('dry-run');
+            $updateExistingFromManifest = (bool) $this->option('update-existing-from-manifest');
 
             if ($force && $dryRun) {
                 return $this->finish(array_merge($report, [
@@ -69,6 +71,15 @@ final class CareerImportSelectedDisplayAssets extends Command
 
             $file = $this->requiredFile();
             $manifest = $this->optionalManifest($file);
+            if ($updateExistingFromManifest && $manifest === null) {
+                return $this->finish(array_merge($report, [
+                    'mode' => $force ? 'force' : 'dry_run',
+                    'source_file_basename' => basename($file),
+                    'source_file_sha256' => hash_file('sha256', $file) ?: null,
+                    'decision' => 'fail',
+                    'errors' => ['--update-existing-from-manifest requires --manifest.'],
+                ]), false);
+            }
             $manifestCandidateSlugs = $manifest === null ? null : $this->manifestSlugs($manifest);
             [$slugs, $manifestExecution] = $this->executionSlugs($manifest, $manifestCandidateSlugs ?? $this->requiredSlugs());
             $workbook = $this->mapper->readWorkbook($file, $slugs);
@@ -97,6 +108,8 @@ final class CareerImportSelectedDisplayAssets extends Command
             $items = [];
             $errors = [];
             $manifestRows = $manifest === null ? [] : $this->manifestRowsBySlug($manifest);
+            $manifestAllowsExistingDisplayAssets = $manifest !== null
+                && $this->manifestAllowsExistingDisplayAssets($manifest, count($slugs), $slugs);
             foreach ($slugs as $slug) {
                 $rows = $rowsBySlug[$slug] ?? [];
                 if (count($rows) !== 1) {
@@ -121,7 +134,7 @@ final class CareerImportSelectedDisplayAssets extends Command
                 );
                 if ($manifest !== null
                     && ($authority['existing_display_asset'] ?? false) === true
-                    && ! $this->manifestAllowsExistingDisplayAssets($manifest, count($slugs))) {
+                    && ! $manifestAllowsExistingDisplayAssets) {
                     $itemErrors[] = 'Manifest slug already has a selected display asset.';
                 }
                 if ($manifest !== null && $manifestRow === null) {
@@ -131,7 +144,12 @@ final class CareerImportSelectedDisplayAssets extends Command
                     $errors[] = "{$slug}: {$error}";
                 }
 
-                $items[] = $this->item($mapped, $authority, $itemErrors);
+                $items[] = $this->item(
+                    $mapped,
+                    $authority,
+                    $itemErrors,
+                    $updateExistingFromManifest && $manifestAllowsExistingDisplayAssets,
+                );
             }
 
             $summary = $this->summarize($items);
@@ -144,6 +162,7 @@ final class CareerImportSelectedDisplayAssets extends Command
                 'manifest_target_locale' => $manifest['manifest_target_locale'] ?? null,
                 'manifest_expected_delta' => $manifest['expected_delta'] ?? null,
                 'manifest_execution' => $manifestExecution,
+                'manifest_update_existing_enabled' => $updateExistingFromManifest,
                 'requested_slugs' => $slugs,
                 'total_rows' => $workbook['total_rows'],
                 'validated_count' => count($items),
@@ -567,8 +586,12 @@ final class CareerImportSelectedDisplayAssets extends Command
     /**
      * @param  array<string, mixed>  $manifest
      */
-    private function manifestAllowsExistingDisplayAssets(array $manifest, ?int $selectedCount = null): bool
+    private function manifestAllowsExistingDisplayAssets(array $manifest, ?int $selectedCount = null, array $selectedSlugs = []): bool
     {
+        if ($this->manifestAuthorizesExistingUpdates($manifest, $selectedSlugs)) {
+            return true;
+        }
+
         try {
             $current = CareerJobDisplayAsset::query()->count();
         } catch (QueryException) {
@@ -580,6 +603,33 @@ final class CareerImportSelectedDisplayAssets extends Command
         $requiredDelta = $selectedCount === null ? $expectedDelta : min($expectedDelta, $selectedCount);
 
         return $current >= ($baseline + $requiredDelta);
+    }
+
+    /**
+     * @param  list<string>  $selectedSlugs
+     */
+    private function manifestAuthorizesExistingUpdates(array $manifest, array $selectedSlugs): bool
+    {
+        if (($manifest['manifest_scope'] ?? null) !== self::ZH_DISPLAY_PARITY_SCOPE) {
+            return false;
+        }
+
+        $selectedSlugs = array_values(array_unique(array_filter(array_map(
+            static fn (string $slug): string => strtolower(trim($slug)),
+            $selectedSlugs,
+        ), static fn (string $slug): bool => $slug !== '')));
+        if ($selectedSlugs === []) {
+            return false;
+        }
+
+        $rowsBySlug = $this->manifestRowsBySlug($manifest);
+        foreach ($selectedSlugs as $slug) {
+            if (($rowsBySlug[$slug]['update_existing_display_asset'] ?? false) !== true) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     /**
@@ -762,12 +812,16 @@ final class CareerImportSelectedDisplayAssets extends Command
      * @param  list<string>  $errors
      * @return array<string, mixed>
      */
-    private function item(array $mapped, array $authority, array $errors): array
+    private function item(array $mapped, array $authority, array $errors, bool $updateExistingFromManifest = false): array
     {
         $authorityReady = ($authority['occupation_found'] ?? false) === true
             && ($authority['soc_crosswalk_valid'] ?? false) === true
             && ($authority['onet_crosswalk_valid'] ?? false) === true;
         $authorityDeferredForLocalDryRun = ($authority['authority_state'] ?? null) === 'local_dry_run_authority_deferred';
+        $existingDisplayAsset = ($authority['existing_display_asset'] ?? false) === true;
+        $wouldWrite = $errors === []
+            && ($authorityReady || $authorityDeferredForLocalDryRun)
+            && (! $existingDisplayAsset || $updateExistingFromManifest);
 
         return [
             'slug' => $mapped['slug'],
@@ -778,10 +832,9 @@ final class CareerImportSelectedDisplayAssets extends Command
             'occupation_id' => $authority['occupation_id'],
             'soc_crosswalk_valid' => $authority['soc_crosswalk_valid'],
             'onet_crosswalk_valid' => $authority['onet_crosswalk_valid'],
-            'existing_display_asset' => $authority['existing_display_asset'],
-            'would_write' => $errors === []
-                && ($authorityReady || $authorityDeferredForLocalDryRun)
-                && ($authority['existing_display_asset'] ?? false) !== true,
+            'existing_display_asset' => $existingDisplayAsset,
+            'would_update_existing_display_asset' => $wouldWrite && $existingDisplayAsset,
+            'would_write' => $wouldWrite,
             'payload_summary' => $mapped['summary'],
             'payload' => $mapped['payload'],
             'release_gates_changed' => false,
@@ -798,7 +851,10 @@ final class CareerImportSelectedDisplayAssets extends Command
     {
         return [
             'would_write_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_write'] ?? false) === true)),
-            'already_exists_count' => count(array_filter($items, static fn (array $item): bool => ($item['existing_display_asset'] ?? false) === true && ($item['errors'] ?? []) === [])),
+            'would_update_existing_count' => count(array_filter($items, static fn (array $item): bool => ($item['would_update_existing_display_asset'] ?? false) === true)),
+            'already_exists_count' => count(array_filter($items, static fn (array $item): bool => ($item['existing_display_asset'] ?? false) === true
+                && ($item['would_update_existing_display_asset'] ?? false) !== true
+                && ($item['errors'] ?? []) === [])),
             'publish_gate_blocked_count' => count(array_filter($items, static fn (array $item): bool => data_get($item, 'payload_summary.publish_gate.decision') !== 'pass')),
             'failed_count' => count(array_filter($items, static fn (array $item): bool => ($item['errors'] ?? []) !== [])),
             'created_count' => 0,
@@ -866,6 +922,7 @@ final class CareerImportSelectedDisplayAssets extends Command
             'items' => [],
             'would_write' => false,
             'would_write_count' => 0,
+            'would_update_existing_count' => 0,
             'already_exists_count' => 0,
             'publish_gate_blocked_count' => 0,
             'did_write' => false,

--- a/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
+++ b/backend/app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php
@@ -22,6 +22,7 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
     /** @var list<string> */
     private const DISPLAY_ASSET_MODULE_SUBSET_ROOT_CAUSES = [
         'zh_display_asset_present_but_module_subset',
+        'zh_missing_en_display_modules_without_public_asset_evidence',
     ];
 
     /** @var list<string> */
@@ -36,7 +37,10 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
         'dentists',
         'financial-analysts',
         'high-school-teachers',
+        'human-resources-specialists',
+        'management-analysts',
         'market-research-analysts',
+        'project-management-specialists',
         'registered-nurses',
     ];
 
@@ -327,9 +331,11 @@ final class CareerNormalizeLegacyDisplayAssets extends Command
             $rows = array_merge($rows, $payload['items']);
         }
 
-        $bucket = data_get($payload, 'root_cause_manifest.buckets.zh_display_asset_present_but_module_subset');
-        if (is_array($bucket)) {
-            $rows = array_merge($rows, $bucket);
+        foreach (self::DISPLAY_ASSET_MODULE_SUBSET_ROOT_CAUSES as $rootCause) {
+            $bucket = data_get($payload, "root_cause_manifest.buckets.{$rootCause}");
+            if (is_array($bucket)) {
+                $rows = array_merge($rows, $bucket);
+            }
         }
 
         return $rows;

--- a/backend/tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php
+++ b/backend/tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php
@@ -278,6 +278,42 @@ final class CareerAlignCareerAuthorityBatchCommandTest extends TestCase
         $this->assertStringContainsString('Duplicate existing onet_soc_2019 crosswalks found.', implode(' ', $report['errors']));
     }
 
+    #[Test]
+    public function conflicting_existing_crosswalks_can_emit_corrected_workbook_manifest_without_writing(): void
+    {
+        $slug = 'acute-care-nurses';
+        $occupation = $this->createOccupation($slug);
+        $this->createCrosswalk($occupation, 'us_soc', '29-1141');
+        $this->createCrosswalk($occupation, 'onet_soc_2019', '29-1141.01');
+        $workbook = $this->writeWorkbook([
+            $this->row($slug, soc: '29-9999', onet: '29-9999.99'),
+        ]);
+        $correctionOutput = $this->tempDir().'/authority-correction.json';
+
+        [$exitCode, $report] = $this->runAlign($workbook, $slug, [
+            '--dry-run' => true,
+            '--authority-correction-output' => $correctionOutput,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('fail', $report['decision']);
+        $this->assertFalse($report['writes_database']);
+        $this->assertSame(1, $report['authority_correction_candidate_count']);
+        $this->assertSame(realpath(dirname($correctionOutput)).'/'.basename($correctionOutput), $report['authority_correction_output']);
+        $this->assertFileExists($correctionOutput);
+
+        $manifest = json_decode((string) file_get_contents($correctionOutput), true, 512, JSON_THROW_ON_ERROR);
+        $this->assertSame('career_authority_workbook_corrections', $manifest['scope']);
+        $this->assertSame([$slug], $manifest['slugs']);
+        $this->assertSame(1, $manifest['row_count']);
+        $this->assertFalse($manifest['rows'][0]['safe_to_force_original_workbook']);
+        $this->assertTrue($manifest['rows'][0]['safe_to_use_corrected_row_for_next_dry_run']);
+        $this->assertSame('29-1141', $manifest['rows'][0]['corrected_workbook_row']['SOC_Code']);
+        $this->assertSame('29-1141.01', $manifest['rows'][0]['corrected_workbook_row']['O_NET_Code']);
+        $this->assertSame(1, Occupation::query()->count());
+        $this->assertSame(2, OccupationCrosswalk::query()->count());
+    }
+
     /**
      * @param  array<string, mixed>  $options
      * @return array{int, array<string, mixed>}

--- a/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php
@@ -359,6 +359,68 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
+    public function manifest_authorized_update_existing_rewrites_existing_display_asset(): void
+    {
+        $row = $this->row('manifest-only-career', title: 'Manifest Only Career', cnTitle: '已审核职业', soc: '15-2011', onet: '15-2011.00');
+        $occupation = $this->createAuthorityOccupation($row['Slug'], $row['SOC_Code'], $row['O_NET_Code']);
+        CareerJobDisplayAsset::query()->create([
+            'occupation_id' => $occupation->id,
+            'canonical_slug' => $row['Slug'],
+            'surface_version' => 'display.surface.v1',
+            'asset_version' => 'v4.2',
+            'template_version' => 'v4.2',
+            'asset_type' => 'career_job_public_display',
+            'asset_role' => 'formal_pilot_master',
+            'status' => 'ready_for_pilot',
+            'component_order_json' => ['hero'],
+            'page_payload_json' => ['page' => ['zh' => ['hero' => ['title' => '旧内容']], 'en' => []]],
+            'seo_payload_json' => [],
+            'sources_json' => [],
+            'structured_data_json' => [],
+            'implementation_contract_json' => [],
+            'metadata_json' => ['command' => 'legacy-import'],
+        ]);
+        $workbook = $this->writeWorkbook([$row]);
+        $manifest = $this->writeManifest(
+            $workbook,
+            [$row],
+            baselineDisplayAssets: 1,
+            manifestScope: 'career_zh_display_parity_v0.1',
+            targetLocale: 'zh-CN',
+            updateExistingDisplayAsset: true,
+        );
+
+        [$exitCode, $report] = $this->runImportWithManifest($workbook, $manifest, [
+            '--dry-run' => true,
+            '--update-existing-from-manifest' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame(1, $report['would_write_count']);
+        $this->assertSame(1, $report['would_update_existing_count']);
+        $this->assertSame(0, $report['already_exists_count']);
+
+        [$exitCode, $report] = $this->runImportWithManifest($workbook, $manifest, [
+            '--force' => true,
+            '--update-existing-from-manifest' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertTrue($report['did_write']);
+        $this->assertSame(0, $report['created_count']);
+        $this->assertSame(1, $report['updated_count']);
+        $this->assertSame(1, CareerJobDisplayAsset::query()->count());
+
+        $asset = CareerJobDisplayAsset::query()->where('canonical_slug', $row['Slug'])->firstOrFail();
+        $this->assertCount(24, $asset->component_order_json);
+        $this->assertSame('career:import-selected-display-assets', data_get($asset->metadata_json, 'command'));
+        $this->assertIsArray(data_get($asset->page_payload_json, 'page.zh'));
+        $this->assertIsArray(data_get($asset->page_payload_json, 'page.en'));
+        $this->assertNotSame('旧内容', data_get($asset->page_payload_json, 'page.zh.hero.title'));
+    }
+
+    #[Test]
     public function d5_selected_slugs_dry_run_generates_payloads_without_writing_database_rows(): void
     {
         foreach ($this->d5Rows() as $row) {
@@ -1080,8 +1142,9 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
         ?string $contentAuthority = null,
         ?bool $seoReleaseGatesUnchanged = null,
         ?string $rowHashOverride = null,
+        bool $updateExistingDisplayAsset = false,
     ): string {
-        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus, $manifestScope, $targetLocale, $reviewedChineseFields, $contentAuthority, $seoReleaseGatesUnchanged, $rowHashOverride): array {
+        $manifestRows = array_map(static function (array $row, int $index) use ($publicResolutionType, $rowStatus, $manifestScope, $targetLocale, $reviewedChineseFields, $contentAuthority, $seoReleaseGatesUnchanged, $rowHashOverride, $updateExistingDisplayAsset): array {
             $manifestRow = [
                 'row_number' => $index + 2,
                 'slug' => $row['Slug'],
@@ -1102,6 +1165,7 @@ final class CareerImportSelectedDisplayAssetsCommandTest extends TestCase
                 $manifestRow['content_authority'] = $contentAuthority ?? 'reviewed_workbook';
                 $manifestRow['reviewed_chinese_fields'] = $reviewedChineseFields ?? true;
                 $manifestRow['seo_release_gates_unchanged'] = $seoReleaseGatesUnchanged ?? true;
+                $manifestRow['update_existing_display_asset'] = $updateExistingDisplayAsset;
             }
 
             return $manifestRow;

--- a/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
+++ b/backend/tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php
@@ -243,6 +243,41 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
     }
 
     #[Test]
+    public function it_accepts_no_public_asset_evidence_root_cause_for_manifest_authorized_old_assets(): void
+    {
+        $slugs = [
+            'data-scientists',
+            'human-resources-specialists',
+            'management-analysts',
+            'project-management-specialists',
+            'registered-nurses',
+        ];
+        foreach ($slugs as $slug) {
+            $this->createModuleSubsetAsset($slug, ['source_card', 'review_validity_card']);
+        }
+
+        $exitCode = Artisan::call('career:normalize-legacy-display-assets', [
+            '--lineage-workbook' => $this->lineageWorkbook(),
+            '--module-subset-report' => $this->moduleSubsetRootCauseReport(
+                $slugs,
+                'zh_missing_en_display_modules_without_public_asset_evidence',
+            ),
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+        $report = json_decode(Artisan::output(), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode, json_encode($report, JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE));
+        $this->assertSame('pass', $report['decision']);
+        $this->assertSame('module_subset_report', $report['requested_slug_source']);
+        $this->assertSame($slugs, $report['requested_slugs']);
+        $this->assertSame(5, $report['module_subset_authorized_count']);
+        $this->assertSame(5, $report['validated_count']);
+        $this->assertSame(5, $report['would_update_count']);
+        $this->assertSame(10, $report['module_placeholders_added_count']);
+    }
+
+    #[Test]
     public function it_rejects_manual_hold_and_outside_slugs(): void
     {
         [$exitCode, $report] = $this->runNormalize('software-developers', ['--dry-run' => true]);
@@ -474,7 +509,7 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
     /**
      * @param  list<string>  $slugs
      */
-    private function moduleSubsetRootCauseReport(array $slugs): string
+    private function moduleSubsetRootCauseReport(array $slugs, string $rootCause = 'zh_display_asset_present_but_module_subset'): string
     {
         $path = tempnam(sys_get_temp_dir(), 'career-module-subset-root-cause-report-');
         $this->assertIsString($path);
@@ -482,9 +517,9 @@ final class CareerNormalizeLegacyDisplayAssetsCommandTest extends TestCase
             'validator_version' => 'career_zh_display_parity_audit_v0.4',
             'root_cause_manifest' => [
                 'buckets' => [
-                    'zh_display_asset_present_but_module_subset' => array_map(static fn (string $slug): array => [
+                    $rootCause => array_map(static fn (string $slug): array => [
                         'slug' => $slug,
-                        'root_cause' => 'zh_display_asset_present_but_module_subset',
+                        'root_cause' => $rootCause,
                     ], $slugs),
                 ],
             ],


### PR DESCRIPTION
## What changed

- Extended `career:normalize-legacy-display-assets` so the CAREER-FULL-PARITY root-cause bucket `zh_missing_en_display_modules_without_public_asset_evidence` can authorize module-subset placeholder normalization for the five remaining old display assets.
- Added `career:align-career-authority-batch --authority-correction-output=...` to emit a dry-run-only correction manifest when existing production authority conflicts with workbook SOC/O*NET rows. The command still fails the original conflicted workbook and does not broaden force behavior.
- Added `career:import-selected-display-assets --update-existing-from-manifest` so reviewed zh parity manifests can explicitly authorize updating an existing v4.2 display asset instead of leaving it stuck as `already_exists`.

## Why

The remaining career parity work has two narrow blockers: five old display assets already exist but need manifest-authorized module repair, and two runtime-shell slugs need corrected authority workbook rows before import can safely proceed. This PR adds the guarded tool support for those cases without mutating production content by itself.

## Validation

- `php artisan test tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `./vendor/bin/pint --test app/Console/Commands/CareerNormalizeLegacyDisplayAssets.php app/Console/Commands/CareerAlignCareerAuthorityBatch.php app/Console/Commands/CareerImportSelectedDisplayAssets.php tests/Feature/Console/CareerNormalizeLegacyDisplayAssetsCommandTest.php tests/Feature/Console/CareerAlignCareerAuthorityBatchCommandTest.php tests/Feature/Console/CareerImportSelectedDisplayAssetsCommandTest.php`
- `git diff --check`

The Laravel test run passed with the repo's existing warning-level `file_get_contents(...)` messages, but no failed assertions.

## Deferred

- No production import, cache mutation, publish, or deploy is performed by this PR.
- The actual five-asset update and two authority-conflict workbook correction remain controlled production operations after this PR is merged and deployed.
