### PR TITLE
feat(cms): add SEO content package draft-only writer

### DIFF
--- a/backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php
+++ b/backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php
@@ -1,0 +1,159 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\SeoContentPackage\SeoContentPackageDraftImporter;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+
+final class ArticleImportSeoContentPackageDraft extends Command
+{
+    protected $signature = 'articles:import-seo-content-package-draft
+        {--package= : Path to a GPT-5.5 Pro Mode C SEO content package directory}
+        {--translation-group-id= : Expected translation_group_id}
+        {--locales=zh-CN,en : Comma-separated locale list}
+        {--dry-run : Validate and plan without writing to the database}
+        {--json : Emit a JSON summary}
+        {--draft-only : Explicitly require draft-only writes}
+        {--no-publish : Explicitly forbid publish}
+        {--no-index : Explicitly forbid indexability}
+        {--no-sitemap : Explicitly forbid sitemap eligibility}
+        {--no-llms : Explicitly forbid llms eligibility}
+        {--schema-hold : Explicitly hold schema output}
+        {--hreflang-hold : Explicitly hold hreflang output}
+        {--expected-zh-slug= : Expected zh-CN article slug}
+        {--expected-en-slug= : Expected en article slug}';
+
+    protected $description = 'Validate and import a Mode C bilingual SEO content package as CMS draft-only articles.';
+
+    public function handle(SeoContentPackageDraftImporter $importer): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        try {
+            $summary = $dryRun
+                ? $importer->planFromDirectory($this->optionsPayload())
+                : $importer->importFromDirectory($this->optionsPayload());
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function optionsPayload(): array
+    {
+        $locales = array_values(array_filter(array_map(
+            static fn (string $locale): string => trim($locale),
+            explode(',', (string) $this->option('locales'))
+        ), static fn (string $locale): bool => $locale !== ''));
+
+        return [
+            'package' => (string) $this->option('package'),
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'locales' => $locales,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'json' => (bool) $this->option('json'),
+            'draft_only' => (bool) $this->option('draft-only'),
+            'no_publish' => (bool) $this->option('no-publish'),
+            'no_index' => (bool) $this->option('no-index'),
+            'no_sitemap' => (bool) $this->option('no-sitemap'),
+            'no_llms' => (bool) $this->option('no-llms'),
+            'schema_hold' => (bool) $this->option('schema-hold'),
+            'hreflang_hold' => (bool) $this->option('hreflang-hold'),
+            'expected_slugs' => [
+                'zh-CN' => (string) $this->option('expected-zh-slug'),
+                'en' => (string) $this->option('expected-en-slug'),
+            ],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('translation_group_id='.(string) ($summary['translation_group_id'] ?? ''));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+
+        foreach ((array) ($summary['articles'] ?? []) as $article) {
+            if (! is_array($article)) {
+                continue;
+            }
+
+            $this->line(sprintf(
+                'article=%s:%s:%s:article_id=%s:working_revision_id=%s:preview=%s',
+                (string) ($article['locale'] ?? ''),
+                (string) ($article['slug'] ?? ''),
+                (string) ($article['action'] ?? ''),
+                (string) ($article['article_id'] ?? ''),
+                (string) ($article['working_revision_id'] ?? ''),
+                (string) ($article['preview_url_candidate'] ?? '')
+            ));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('validation_error='.$this->issueLine($error));
+            }
+        }
+        foreach ((array) ($summary['warnings'] ?? []) as $warning) {
+            if (is_array($warning)) {
+                $this->line('validation_warning='.$this->issueLine($warning));
+            }
+        }
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+            'articles' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode(':', [
+            (string) ($issue['field'] ?? 'unknown'),
+            (string) ($issue['code'] ?? 'unknown'),
+            (string) ($issue['message'] ?? ''),
+        ]);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -6,6 +6,7 @@ use App\Console\Commands\AdminBootstrapOwner;
 use App\Console\Commands\ArchiveColdData;
 use App\Console\Commands\ArticleCoverPropagationSmoke;
 use App\Console\Commands\ArticleImportEditorialPackage;
+use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5AttemptPurge;
@@ -322,6 +323,7 @@ class Kernel extends ConsoleKernel
         EvidencePack::class,
         ExperimentGuardrailsEvaluate::class,
         ArticleImportEditorialPackage::class,
+        ArticleImportSeoContentPackageDraft::class,
         ArticleCoverPropagationSmoke::class,
         ArticlePublishControlled::class,
     ];

--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -1,0 +1,901 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms\SeoContentPackage;
+
+use App\Models\Article;
+use App\Models\ArticleCategory;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Services\Cms\ArticleBodyHeadingGuard;
+use App\Services\Cms\ArticleTranslationRevisionWorkspace;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Str;
+use RuntimeException;
+
+final class SeoContentPackageDraftImporter
+{
+    private const REQUIRED_FILES = [
+        'manifest.json',
+        'contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json',
+        'contracts/ROUTE_ALIAS_CONTRACT.json',
+        'contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json',
+        'contracts/DYNAMIC_CTA_CONTRACT.json',
+        'contracts/INTERNAL_LINK_PLAN.json',
+        'contracts/PRIVATE_URL_GUARD.json',
+        'review/claim_gate.md',
+        'review/operator_review.md',
+        'codex/qa_checklist.md',
+    ];
+
+    private const REQUIRED_FLAGS = [
+        'draft_only',
+        'no_publish',
+        'no_index',
+        'no_sitemap',
+        'no_llms',
+        'schema_hold',
+        'hreflang_hold',
+    ];
+
+    private const PRIVATE_ROUTE_PATTERN = '~(?<![A-Za-z0-9_-])/(?:result|results|orders|order|share|pay|payment|history|take)(?:/|[?#\s)"\']|$)~i';
+
+    private const SENSITIVE_QUERY_PATTERN = '/(?:[?&]|^)(?:result_id|order_id|payment_id|token|score|user_id|report_id)=/i';
+
+    public function __construct(
+        private readonly ArticleTranslationRevisionWorkspace $revisionWorkspace,
+        private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
+    ) {}
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    public function planFromDirectory(array $options): array
+    {
+        return $this->buildPlan($options);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    public function importFromDirectory(array $options): array
+    {
+        $plan = $this->buildPlan($options);
+        if (($plan['ok'] ?? false) !== true) {
+            return $plan;
+        }
+
+        $articles = [];
+        $packageItems = is_array($plan['package_items'] ?? null) ? $plan['package_items'] : [];
+
+        DB::transaction(function () use ($packageItems, &$articles): void {
+            foreach ($packageItems as $item) {
+                if (is_array($item)) {
+                    $articles[] = $this->writeDraft($item);
+                }
+            }
+        });
+
+        return array_merge($plan, [
+            'dry_run' => false,
+            'action' => $this->summaryAction($articles),
+            'would_write' => true,
+            'articles' => $articles,
+            'package_items' => [],
+        ]);
+    }
+
+    /**
+     * @param  array<string, mixed>  $options
+     * @return array<string, mixed>
+     */
+    private function buildPlan(array $options): array
+    {
+        $errors = [];
+        $warnings = [];
+        $packageRoot = $this->resolvePackageRoot((string) ($options['package'] ?? ''), $errors);
+        $expectedTranslationGroupId = trim((string) ($options['translation_group_id'] ?? ''));
+        $locales = $this->normalizeLocales($options['locales'] ?? []);
+        $expectedSlugs = is_array($options['expected_slugs'] ?? null) ? $options['expected_slugs'] : [];
+
+        $this->validateSafetyFlags($options, $errors);
+
+        if ($expectedTranslationGroupId === '') {
+            $errors[] = $this->issue('translation_group_id', 'missing_expected_translation_group_id', '--translation-group-id is required.');
+        }
+        if ($locales !== ['zh-CN', 'en']) {
+            $errors[] = $this->issue('locales', 'unsupported_locale_set', '--locales must resolve to zh-CN,en.');
+        }
+
+        $manifest = [];
+        $packageItems = [];
+        if ($packageRoot !== null) {
+            $this->validateRequiredFiles($packageRoot, $errors);
+            $manifest = $this->readJson($packageRoot.'/manifest.json', 'manifest.json', $errors);
+            $this->validateWholePackageText($packageRoot, $errors);
+            $packageItems = $this->buildPackageItems($packageRoot, $manifest, $expectedTranslationGroupId, $expectedSlugs, $errors, $warnings);
+        }
+
+        $ok = $errors === [];
+        $plannedArticles = $ok ? array_map(fn (array $item): array => $this->plannedArticle($item), $packageItems) : [];
+
+        return [
+            'ok' => $ok,
+            'dry_run' => (bool) ($options['dry_run'] ?? true),
+            'action' => $ok ? $this->summaryAction($plannedArticles) : 'will_skip',
+            'would_write' => $ok,
+            'translation_group_id' => $expectedTranslationGroupId,
+            'package_root' => $packageRoot,
+            'manifest_status' => $manifest !== [] ? 'valid_json' : 'missing_or_invalid',
+            'safety_flags' => $this->safetyFlagSnapshot($options),
+            'articles' => $plannedArticles,
+            'package_items' => $packageItems,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function writeDraft(array $item): array
+    {
+        $existing = $this->existingArticle($item);
+        if ($existing instanceof Article && $this->isPublishedOrPublic($existing)) {
+            throw new RuntimeException('Existing published/public article cannot be mutated by SEO content package draft import.');
+        }
+
+        $category = $this->resolveCategory();
+        $metadata = $this->metadata($item);
+        $body = (string) $item['body_markdown'];
+
+        $article = $existing instanceof Article ? $existing : new Article;
+        $article->forceFill([
+            'org_id' => 0,
+            'category_id' => (int) $category->id,
+            'author_name' => 'Fermat Institute',
+            'reviewer_name' => null,
+            'reading_minutes' => $this->readingMinutes($body),
+            'slug' => (string) $item['slug'],
+            'locale' => (string) $item['locale'],
+            'translation_group_id' => (string) $item['translation_group_id'],
+            'title' => (string) $item['title'],
+            'excerpt' => (string) $item['excerpt'],
+            'content_md' => $body,
+            'content_html' => null,
+            'cover_image_url' => (string) $item['cover_image_url'],
+            'cover_image_alt' => (string) $item['cover_image_alt'],
+            'cover_image_width' => (int) $item['cover_image_width'],
+            'cover_image_height' => (int) $item['cover_image_height'],
+            'cover_image_variants' => $metadata,
+            'related_test_slug' => 'holland-career-interest-test-riasec',
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => null,
+            'scheduled_at' => null,
+            'published_revision_id' => null,
+        ])->save();
+
+        $revision = $this->revisionWorkspace->saveWorkingRevision($article, [
+            'title' => (string) $item['title'],
+            'excerpt' => (string) $item['excerpt'],
+            'content_md' => $body,
+            'seo_title' => (string) $item['meta_title'],
+            'seo_description' => (string) $item['meta_description'],
+            'working_revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'status' => 'draft',
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'published_at' => null,
+            'published_revision_id' => null,
+        ])->save();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->updateOrCreate(
+            [
+                'org_id' => 0,
+                'article_id' => (int) $article->id,
+                'locale' => (string) $item['locale'],
+            ],
+            [
+                'seo_title' => (string) $item['meta_title'],
+                'seo_description' => (string) $item['meta_description'],
+                'canonical_url' => (string) $item['canonical_url'],
+                'og_title' => (string) $item['meta_title'],
+                'og_description' => (string) $item['meta_description'],
+                'og_image_url' => (string) $item['og_image_url'],
+                'robots' => 'noindex,nofollow',
+                'schema_json' => [
+                    'editorial_package_v1' => $metadata['editorial_package_v1'],
+                ],
+                'is_indexable' => false,
+            ],
+        );
+
+        $this->persistImportRecord($article, $revision, $item, $metadata);
+
+        return [
+            'locale' => (string) $item['locale'],
+            'slug' => (string) $item['slug'],
+            'action' => $existing instanceof Article ? 'updated_working_revision' : 'created_draft',
+            'article_id' => (int) $article->id,
+            'working_revision_id' => (int) $revision->id,
+            'status' => 'draft',
+            'working_revision_status' => (string) $revision->revision_status,
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $item
+     * @return array<string, mixed>
+     */
+    private function plannedArticle(array $item): array
+    {
+        $existing = $this->existingArticle($item);
+
+        return [
+            'locale' => (string) $item['locale'],
+            'slug' => (string) $item['slug'],
+            'action' => $existing instanceof Article ? 'would_update_working_revision' : 'would_create_draft',
+            'article_id' => $existing instanceof Article ? (int) $existing->id : null,
+            'working_revision_id' => null,
+            'status' => 'draft',
+            'working_revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'preview_url_candidate' => $existing instanceof Article ? '/ops/article-preview/'.(int) $existing->id : null,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function resolvePackageRoot(string $package, array &$errors): ?string
+    {
+        $path = trim($package);
+        if ($path === '') {
+            $errors[] = $this->issue('package', 'missing_package', '--package is required.');
+
+            return null;
+        }
+
+        if (! is_dir($path)) {
+            $errors[] = $this->issue('package', 'package_directory_not_found', 'Package directory not found.');
+
+            return null;
+        }
+
+        $root = realpath($path);
+        if (! is_string($root)) {
+            $errors[] = $this->issue('package', 'package_directory_unreadable', 'Package directory is unreadable.');
+
+            return null;
+        }
+
+        if (is_file($root.'/manifest.json')) {
+            return $root;
+        }
+
+        $children = glob($root.'/*/manifest.json') ?: [];
+        if (count($children) === 1) {
+            return dirname($children[0]);
+        }
+
+        $errors[] = $this->issue('manifest.json', 'manifest_not_found', 'manifest.json must exist in package root or a single child directory.');
+
+        return null;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateRequiredFiles(string $root, array &$errors): void
+    {
+        foreach (self::REQUIRED_FILES as $relativePath) {
+            if (! is_file($root.'/'.$relativePath)) {
+                $errors[] = $this->issue($relativePath, 'missing_required_file', $relativePath.' is required.');
+            }
+        }
+
+        if ((glob($root.'/pages/*.md') ?: []) === []) {
+            $errors[] = $this->issue('pages/*.md', 'missing_pages', 'At least one Markdown page is required.');
+        }
+        if ((glob($root.'/cms/CMS_FIELDS_*.json') ?: []) === []) {
+            $errors[] = $this->issue('cms/CMS_FIELDS_*.json', 'missing_cms_fields', 'CMS_FIELDS JSON files are required.');
+        }
+        if ((glob($root.'/cms/CMS_IMPORT_DRAFT_*.json') ?: []) === []) {
+            $errors[] = $this->issue('cms/CMS_IMPORT_DRAFT_*.json', 'missing_cms_import_drafts', 'CMS_IMPORT_DRAFT JSON files are required.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return array<string,mixed>
+     */
+    private function readJson(string $path, string $field, array &$errors): array
+    {
+        if (! is_file($path)) {
+            $errors[] = $this->issue($field, 'json_file_not_found', $field.' was not found.');
+
+            return [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            $errors[] = $this->issue($field, 'invalid_json', $field.' must be valid JSON.');
+
+            return [];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateWholePackageText(string $root, array &$errors): void
+    {
+        $allFiles = array_merge(
+            glob($root.'/manifest.json') ?: [],
+            glob($root.'/pages/*.md') ?: [],
+            glob($root.'/cms/*.json') ?: [],
+            glob($root.'/contracts/*') ?: [],
+            glob($root.'/review/*') ?: [],
+            glob($root.'/codex/*') ?: [],
+        );
+        $activeLinkFiles = array_merge(
+            glob($root.'/pages/*.md') ?: [],
+            glob($root.'/cms/*.json') ?: [],
+            glob($root.'/contracts/DYNAMIC_CTA_CONTRACT.json') ?: [],
+            glob($root.'/contracts/INTERNAL_LINK_PLAN.json') ?: [],
+            glob($root.'/contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json') ?: [],
+            glob($root.'/contracts/ROUTE_ALIAS_CONTRACT.json') ?: [],
+        );
+
+        $wholeText = '';
+        foreach ($allFiles as $file) {
+            if (is_file($file)) {
+                $wholeText .= "\n".(string) file_get_contents($file);
+            }
+        }
+        $activeLinkText = '';
+        foreach ($activeLinkFiles as $file) {
+            if (is_file($file)) {
+                $activeLinkText .= "\n".(string) file_get_contents($file);
+            }
+        }
+
+        if (preg_match('#/tests/big-five-personality-test(?!-ocean-model)#', $wholeText) === 1) {
+            $errors[] = $this->issue('big_five_route', 'old_big_five_route_found', 'Old Big Five route is forbidden.');
+        }
+        if (! str_contains($wholeText, '/tests/big-five-personality-test-ocean-model')) {
+            $errors[] = $this->issue('big_five_route', 'required_big_five_route_missing', 'Canonical Big Five route is required.');
+        }
+        if (str_contains($wholeText, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__')) {
+            $errors[] = $this->issue('social_image', 'media_placeholder_found', 'CMS media placeholder marker is forbidden.');
+        }
+        if (preg_match(self::PRIVATE_ROUTE_PATTERN, $activeLinkText) === 1) {
+            $errors[] = $this->issue('private_url_guard', 'private_route_found', 'Private routes are forbidden.');
+        }
+        if (preg_match(self::SENSITIVE_QUERY_PATTERN, $activeLinkText) === 1) {
+            $errors[] = $this->issue('private_url_guard', 'sensitive_query_key_found', 'Sensitive query keys are forbidden.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @param  array<string,mixed>  $expectedSlugs
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return list<array<string,mixed>>
+     */
+    private function buildPackageItems(
+        string $root,
+        array $manifest,
+        string $expectedTranslationGroupId,
+        array $expectedSlugs,
+        array &$errors,
+        array &$warnings
+    ): array {
+        $manifestTranslationGroupId = trim((string) ($manifest['translation_group_id'] ?? ''));
+        if ($manifestTranslationGroupId !== $expectedTranslationGroupId) {
+            $errors[] = $this->issue('manifest.translation_group_id', 'translation_group_id_mismatch', 'manifest translation_group_id does not match expected value.');
+        }
+
+        $items = [];
+        foreach (['zh-CN', 'en'] as $locale) {
+            $import = $this->readFirstJson($root.'/cms/CMS_IMPORT_DRAFT_'.$locale.'_*.json', 'cms import '.$locale, $errors);
+            $fields = $this->readFirstJson($root.'/cms/CMS_FIELDS_'.$locale.'_*.json', 'cms fields '.$locale, $errors);
+            $pagePath = $this->pagePathFor($root, $locale, $import, $manifest, $errors);
+            $page = $pagePath !== null ? $this->readMarkdownPage($pagePath) : ['frontmatter' => [], 'body' => ''];
+
+            $item = $this->normalizeItem($root, $locale, $manifest, $import, $fields, $page, $errors, $warnings);
+            $expectedSlug = trim((string) ($expectedSlugs[$locale] ?? ''));
+            if ($expectedSlug !== '' && (string) ($item['slug'] ?? '') !== $expectedSlug) {
+                $errors[] = $this->issue($locale.'.slug', 'expected_slug_mismatch', 'Package slug does not match expected slug.');
+            }
+
+            if ($item !== []) {
+                $items[] = $item;
+            }
+        }
+
+        return $items;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return array<string,mixed>
+     */
+    private function readFirstJson(string $pattern, string $field, array &$errors): array
+    {
+        $matches = glob($pattern) ?: [];
+        if (count($matches) !== 1) {
+            $errors[] = $this->issue($field, 'json_file_count_invalid', $field.' must resolve to exactly one JSON file.');
+
+            return [];
+        }
+
+        return $this->readJson($matches[0], $field, $errors);
+    }
+
+    /**
+     * @param  array<string,mixed>  $import
+     * @param  array<string,mixed>  $manifest
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function pagePathFor(string $root, string $locale, array $import, array $manifest, array &$errors): ?string
+    {
+        $relative = trim((string) ($import['body_markdown_file'] ?? ''));
+        if ($relative === '') {
+            foreach ((array) ($manifest['pages'] ?? []) as $page) {
+                if (is_array($page) && (string) ($page['locale'] ?? '') === $locale) {
+                    $relative = trim((string) ($page['file'] ?? ''));
+                    break;
+                }
+            }
+        }
+
+        if ($relative === '') {
+            $matches = glob($root.'/pages/'.($locale === 'zh-CN' ? 'zh-CN-*' : 'en-*').'.md') ?: [];
+            if (count($matches) === 1) {
+                return $matches[0];
+            }
+        }
+
+        $path = $relative !== '' ? $root.'/'.ltrim($relative, '/') : '';
+        if ($path === '' || ! is_file($path)) {
+            $errors[] = $this->issue($locale.'.page', 'page_file_not_found', 'Markdown page for locale was not found.');
+
+            return null;
+        }
+
+        return $path;
+    }
+
+    /**
+     * @return array{frontmatter:array<string,mixed>,body:string}
+     */
+    private function readMarkdownPage(string $path): array
+    {
+        $contents = (string) file_get_contents($path);
+        if (preg_match('/\A---\R(.*?)\R---\R(.*)\z/s', $contents, $matches) !== 1) {
+            return ['frontmatter' => [], 'body' => trim($contents)];
+        }
+
+        return [
+            'frontmatter' => $this->parseSimpleFrontmatter((string) $matches[1]),
+            'body' => trim((string) $matches[2]),
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function parseSimpleFrontmatter(string $yaml): array
+    {
+        $data = [];
+        $lines = preg_split('/\R/', $yaml) ?: [];
+        $currentKey = null;
+        foreach ($lines as $line) {
+            if (preg_match('/^([A-Za-z0-9_-]+):\s*(.*)$/', $line, $matches) === 1) {
+                $currentKey = (string) $matches[1];
+                $value = trim((string) $matches[2]);
+                $data[$currentKey] = $value === '' ? [] : $this->parseScalar($value);
+
+                continue;
+            }
+
+            if ($currentKey !== null && preg_match('/^\s*-\s*(.+)$/', $line, $matches) === 1) {
+                if (! is_array($data[$currentKey] ?? null)) {
+                    $data[$currentKey] = [];
+                }
+                $data[$currentKey][] = $this->parseScalar(trim((string) $matches[1]));
+            }
+        }
+
+        return $data;
+    }
+
+    private function parseScalar(string $value): mixed
+    {
+        return match (strtolower($value)) {
+            'true' => true,
+            'false' => false,
+            'null' => null,
+            default => trim($value, '"\''),
+        };
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @param  array<string,mixed>  $import
+     * @param  array<string,mixed>  $fields
+     * @param  array{frontmatter:array<string,mixed>,body:string}  $page
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function normalizeItem(
+        string $root,
+        string $locale,
+        array $manifest,
+        array $import,
+        array $fields,
+        array $page,
+        array &$errors,
+        array &$warnings
+    ): array {
+        $frontmatter = $page['frontmatter'];
+        $body = $this->articleBodyHeadingGuard->downgradeMarkdownH1ToH2((string) $page['body']);
+        $manifestPage = $this->manifestPage($manifest, $locale);
+        $translationGroupId = $this->firstString($import['translation_group_id'] ?? null, $fields['translation_group_id'] ?? null, $frontmatter['translation_group_id'] ?? null, $manifest['translation_group_id'] ?? null);
+        $slug = Str::slug($this->firstString($import['slug'] ?? null, $fields['slug'] ?? null, $frontmatter['slug'] ?? null, $manifestPage['slug'] ?? null));
+        $title = $this->firstString($import['title'] ?? null, $fields['title'] ?? null, $frontmatter['title'] ?? null, $manifestPage['title'] ?? null);
+        $metaTitle = $this->firstString($import['meta_title'] ?? null, $fields['meta_title'] ?? null, $frontmatter['meta_title_draft'] ?? null, $manifestPage['meta_title_draft'] ?? null, $title);
+        $metaDescription = $this->firstString($import['meta_description'] ?? null, $fields['meta_description'] ?? null, $frontmatter['meta_description_draft'] ?? null, $manifestPage['meta_description_draft'] ?? null);
+        $canonical = $this->firstString($import['canonical_url'] ?? null, $fields['canonical_url'] ?? null, $frontmatter['canonical_url_draft'] ?? null, $manifestPage['canonical_url_draft'] ?? null);
+        $claimGateStatus = $this->firstString($import['claim_gate_status'] ?? null, $fields['claim_gate_status'] ?? null, $frontmatter['claim_gate_status'] ?? null, 'not_reviewed');
+        $social = is_array($import['social_image_metadata'] ?? null) ? $import['social_image_metadata'] : (is_array($fields['social_image_metadata'] ?? null) ? $fields['social_image_metadata'] : []);
+
+        $item = [
+            'locale' => $locale,
+            'translation_group_id' => $translationGroupId,
+            'slug' => $slug,
+            'title' => $title,
+            'meta_title' => $metaTitle,
+            'meta_description' => $metaDescription,
+            'excerpt' => mb_substr($metaDescription !== '' ? $metaDescription : trim(strip_tags($body)), 0, 240),
+            'canonical_url' => $canonical,
+            'body_markdown' => $body,
+            'primary_keyword' => $fields['primary_keyword'] ?? $import['primary_keyword'] ?? $frontmatter['primary_keyword'] ?? null,
+            'secondary_keywords' => $fields['secondary_keywords'] ?? $import['secondary_keywords'] ?? $frontmatter['secondary_keywords'] ?? null,
+            'claim_gate_status' => $claimGateStatus,
+            'publish_allowed' => (bool) ($import['publish_allowed'] ?? $fields['publish_allowed'] ?? $frontmatter['publish_allowed'] ?? false),
+            'sitemap_eligible' => (bool) ($import['sitemap_eligible'] ?? $fields['sitemap_eligible'] ?? $frontmatter['sitemap_eligible'] ?? false),
+            'llms_eligible' => (bool) ($import['llms_eligible'] ?? $fields['llms_eligible'] ?? $frontmatter['llms_eligible'] ?? false),
+            'schema_eligibility' => is_array($import['schema_eligibility'] ?? null) ? $import['schema_eligibility'] : ($fields['schema_eligibility'] ?? []),
+            'cover_media_asset_key' => $this->firstString($import['cover_media_asset_key'] ?? null, $fields['cover_media_asset_key'] ?? null, $social['media_library_asset_key'] ?? null),
+            'cover_image_url' => $this->firstString($import['cover_image_url'] ?? null, $fields['cover_image_url'] ?? null, $social['cover_image_url'] ?? null),
+            'cover_image_alt' => $this->firstString($import['cover_image_alt'] ?? null, $fields['cover_image_alt'] ?? null, $social['alt_text'] ?? null),
+            'cover_image_width' => (int) ($import['cover_image_width'] ?? $fields['cover_image_width'] ?? $social['width'] ?? 0),
+            'cover_image_height' => (int) ($import['cover_image_height'] ?? $fields['cover_image_height'] ?? $social['height'] ?? 0),
+            'cover_image_variants' => is_array($import['cover_image_variants'] ?? null) ? $import['cover_image_variants'] : ($fields['cover_image_variants'] ?? []),
+            'og_image_url' => $this->firstString($import['og_image_url'] ?? null, $fields['og_image_url'] ?? null, data_get($social, 'og_1200x630_variant.url'), $social['twitter_image_url'] ?? null),
+            'twitter_image_url' => $this->firstString($import['twitter_image_url'] ?? null, $fields['twitter_image_url'] ?? null, $social['twitter_image_url'] ?? null),
+            'social_image_metadata' => $social,
+            'source_package_root' => $root,
+        ];
+
+        $this->validateItem($item, $errors, $warnings);
+
+        return $item;
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @return array<string,mixed>
+     */
+    private function manifestPage(array $manifest, string $locale): array
+    {
+        foreach ((array) ($manifest['pages'] ?? []) as $page) {
+            if (is_array($page) && (string) ($page['locale'] ?? '') === $locale) {
+                return $page;
+            }
+        }
+
+        return [];
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     */
+    private function validateItem(array $item, array &$errors, array &$warnings): void
+    {
+        $locale = (string) $item['locale'];
+        foreach (['translation_group_id', 'slug', 'title', 'meta_title', 'meta_description', 'canonical_url', 'body_markdown'] as $field) {
+            if (trim((string) ($item[$field] ?? '')) === '') {
+                $errors[] = $this->issue($locale.'.'.$field, 'missing_required_field', $field.' is required.');
+            }
+        }
+
+        if (! is_string($item['primary_keyword'] ?? null)) {
+            $errors[] = $this->issue($locale.'.primary_keyword', 'primary_keyword_not_string', 'primary_keyword must be a string.');
+        }
+        if (! is_array($item['secondary_keywords'] ?? null)) {
+            $errors[] = $this->issue($locale.'.secondary_keywords', 'secondary_keywords_not_array', 'secondary_keywords must be an array.');
+        }
+        if (! in_array((string) $item['claim_gate_status'], ['not_reviewed', 'human_review'], true)) {
+            $errors[] = $this->issue($locale.'.claim_gate_status', 'invalid_claim_gate_status', 'claim_gate_status must be not_reviewed or human_review.');
+        }
+        if ((bool) $item['publish_allowed']) {
+            $errors[] = $this->issue($locale.'.publish_allowed', 'publish_allowed_true_forbidden', 'publish_allowed must remain false.');
+        }
+        if ((bool) $item['sitemap_eligible']) {
+            $errors[] = $this->issue($locale.'.sitemap_eligible', 'sitemap_eligible_true_forbidden', 'sitemap_eligible must remain false.');
+        }
+        if ((bool) $item['llms_eligible']) {
+            $errors[] = $this->issue($locale.'.llms_eligible', 'llms_eligible_true_forbidden', 'llms_eligible must remain false.');
+        }
+        if (! str_starts_with((string) $item['canonical_url'], $locale === 'zh-CN' ? '/zh/articles/' : '/en/articles/')) {
+            $errors[] = $this->issue($locale.'.canonical_url', 'invalid_canonical_route', 'canonical_url must be a locale article route.');
+        }
+        if ((string) $item['cover_media_asset_key'] === '' || (string) $item['cover_image_url'] === '' || (string) $item['og_image_url'] === '') {
+            $errors[] = $this->issue($locale.'.social_image_metadata', 'missing_social_image_metadata', 'social image asset, cover URL, and OG URL are required.');
+        }
+        if ((int) $item['cover_image_width'] <= 0 || (int) $item['cover_image_height'] <= 0) {
+            $errors[] = $this->issue($locale.'.social_image_metadata', 'missing_social_image_dimensions', 'social image width and height are required.');
+        }
+        if (is_array($item['social_image_metadata'])
+            && isset($item['social_image_metadata']['media_library_status'])
+            && (string) $item['social_image_metadata']['media_library_status'] !== 'published') {
+            $errors[] = $this->issue($locale.'.social_image_metadata', 'social_image_not_published', 'Media Library asset must be published.');
+        }
+        if (is_array($item['social_image_metadata'])
+            && array_key_exists('is_public', $item['social_image_metadata'])
+            && (bool) $item['social_image_metadata']['is_public'] !== true) {
+            $errors[] = $this->issue($locale.'.social_image_metadata', 'social_image_not_public', 'Media Library asset must be public.');
+        }
+        if (! is_array($item['schema_eligibility'] ?? null)
+            || (bool) data_get($item, 'schema_eligibility.faq_schema', false) !== false) {
+            $errors[] = $this->issue($locale.'.schema_eligibility', 'schema_hold_not_satisfied', 'FAQ schema must remain disabled.');
+        }
+
+        if (trim((string) $item['twitter_image_url']) === '') {
+            $warnings[] = $this->issue($locale.'.twitter_image_url', 'twitter_image_reuses_og', 'Twitter image is missing and should reuse OG if needed.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     */
+    private function existingArticle(array $item): ?Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->where('translation_group_id', (string) $item['translation_group_id'])
+            ->where('locale', (string) $item['locale'])
+            ->where('slug', (string) $item['slug'])
+            ->first();
+    }
+
+    private function isPublishedOrPublic(Article $article): bool
+    {
+        return (string) $article->status === 'published'
+            || (bool) $article->is_public
+            || $article->published_revision_id !== null
+            || $article->published_at !== null;
+    }
+
+    private function resolveCategory(): ArticleCategory
+    {
+        return ArticleCategory::query()->withoutGlobalScopes()->firstOrCreate(
+            ['org_id' => 0, 'slug' => 'seo-articles'],
+            ['name' => 'SEO Articles', 'is_active' => true, 'sort_order' => 0]
+        );
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @return array<string,mixed>
+     */
+    private function metadata(array $item): array
+    {
+        $variants = is_array($item['cover_image_variants'] ?? null) ? $item['cover_image_variants'] : [];
+        $variants['editorial_package_v1'] = [
+            'source' => 'seo_content_package_mode_c',
+            'translation_group_id' => (string) $item['translation_group_id'],
+            'claim_gate_status' => (string) $item['claim_gate_status'],
+            'publish_allowed' => false,
+            'is_public' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'schema_hold' => true,
+            'hreflang_hold' => true,
+            'search_submission_allowed' => false,
+            'revalidation_allowed' => false,
+            'cover_media_asset_key' => (string) $item['cover_media_asset_key'],
+            'social_image_metadata' => $item['social_image_metadata'],
+            'body_hash' => hash('sha256', preg_replace("/\r\n?/", "\n", trim((string) $item['body_markdown'])) ?: trim((string) $item['body_markdown'])),
+        ];
+
+        return $variants;
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  array<string,mixed>  $metadata
+     */
+    private function persistImportRecord(Article $article, ArticleTranslationRevision $revision, array $item, array $metadata): void
+    {
+        ArticleEditorialPackageImport::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'slug' => (string) $item['slug'],
+            'locale' => (string) $item['locale'],
+            'title' => (string) $item['title'],
+            'content_track' => 'seo_content_package_mode_c',
+            'status' => ArticleEditorialPackageImport::STATUS_IMPORTED,
+            'intended_status' => 'draft',
+            'validation_summary_json' => [
+                'source' => 'articles:import-seo-content-package-draft',
+                'working_revision_id' => (int) $revision->id,
+                'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
+            ],
+            'claim_result_json' => [
+                'status' => (string) $item['claim_gate_status'],
+                'matches' => [],
+            ],
+            'exactness_json' => [
+                'translation_group_id' => (string) $item['translation_group_id'],
+                'canonical_url' => (string) $item['canonical_url'],
+            ],
+            'references_json' => ['status' => 'operator_review_required'],
+            'media_json' => [
+                'status' => 'complete',
+                'cover_media_asset_key' => (string) $item['cover_media_asset_key'],
+                'cover_image_url' => (string) $item['cover_image_url'],
+                'og_image_url' => (string) $item['og_image_url'],
+            ],
+            'graph_json' => [
+                'primary_cta' => '/tests/holland-career-interest-test-riasec',
+                'big_five_route' => '/tests/big-five-personality-test-ocean-model',
+            ],
+            'answer_surface_json' => ['status' => 'visible_only'],
+            'body_hash' => (string) data_get($metadata, 'editorial_package_v1.body_hash'),
+            'heading_sequence_json' => $this->headingSequence((string) $item['body_markdown']),
+            'references_count' => 0,
+            'missing_fields_json' => [],
+            'blocked_reasons_json' => [],
+            'imported_by' => null,
+        ]);
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function headingSequence(string $body): array
+    {
+        $headings = [];
+        foreach (preg_split('/\R/', $body) ?: [] as $line) {
+            if (preg_match('/^(#{2,6})\s+(.+)$/', $line, $matches) === 1) {
+                $headings[] = strlen((string) $matches[1]).':'.trim((string) $matches[2]);
+            }
+        }
+
+        return $headings;
+    }
+
+    private function readingMinutes(string $body): int
+    {
+        $characters = max(1, mb_strlen(strip_tags($body)));
+
+        return max(1, (int) ceil($characters / 700));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function normalizeLocales(mixed $value): array
+    {
+        if (! is_array($value)) {
+            return [];
+        }
+
+        return array_values(array_map(static fn (mixed $locale): string => (string) $locale, $value));
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateSafetyFlags(array $options, array &$errors): void
+    {
+        foreach (self::REQUIRED_FLAGS as $flag) {
+            if ((bool) ($options[$flag] ?? false) !== true) {
+                $errors[] = $this->issue('flags.'.$flag, 'missing_required_safety_flag', '--'.str_replace('_', '-', $flag).' is required.');
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,bool>
+     */
+    private function safetyFlagSnapshot(array $options): array
+    {
+        $snapshot = [];
+        foreach (self::REQUIRED_FLAGS as $flag) {
+            $snapshot[$flag] = (bool) ($options[$flag] ?? false);
+        }
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $articles
+     */
+    private function summaryAction(array $articles): string
+    {
+        if ($articles === []) {
+            return 'will_skip';
+        }
+
+        $actions = array_values(array_unique(array_map(
+            static fn (array $article): string => (string) ($article['action'] ?? ''),
+            $articles
+        )));
+
+        return count($actions) === 1 ? $actions[0] : 'mixed';
+    }
+
+    private function firstString(mixed ...$values): string
+    {
+        foreach ($values as $value) {
+            if (is_string($value) || is_numeric($value) || is_bool($value)) {
+                $normalized = trim((string) $value);
+                if ($normalized !== '') {
+                    return $normalized;
+                }
+            }
+        }
+
+        return '';
+    }
+
+    /**
+     * @return array{field:string,code:string,message:string}
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -1,0 +1,440 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleEditorialPackageImport;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TRANSLATION_GROUP_ID = 'tg_article_career_interest_vs_personality_test_2026v1';
+
+    public function test_dry_run_accepts_valid_bilingual_package_without_database_writes(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_create_draft', $payload['action']);
+        $this->assertCount(2, $payload['articles']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_old_big_five_alias(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json']['secondary_hub_urls'][1] = '/tests/big-five-personality-test';
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'old_big_five_route_found');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_private_url(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['pages/en-career-interest-test-vs-personality-test.md'] .= "\n\n[private](/results/abc123)\n";
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'private_route_found');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_missing_social_image_metadata(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            foreach (['zh-CN_career-interest-vs-personality-test-differences', 'en_career-interest-test-vs-personality-test'] as $suffix) {
+                $fieldsPath = 'cms/CMS_FIELDS_'.$suffix.'.json';
+                $importPath = 'cms/CMS_IMPORT_DRAFT_'.$suffix.'.json';
+                unset(
+                    $files[$fieldsPath]['cover_media_asset_key'],
+                    $files[$fieldsPath]['cover_image_url'],
+                    $files[$fieldsPath]['og_image_url'],
+                    $files[$fieldsPath]['social_image_metadata'],
+                    $files[$importPath]['cover_media_asset_key'],
+                    $files[$importPath]['cover_image_url'],
+                    $files[$importPath]['og_image_url'],
+                    $files[$importPath]['social_image_metadata']
+                );
+            }
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'missing_social_image_metadata');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_cms_media_placeholder_marker(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json']['cover_image_url'] = '__CMS_MEDIA_LIBRARY_PLACEHOLDER__';
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'media_placeholder_found');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_import_creates_draft_only_human_review_articles_without_publish_or_discoverability_release(): void
+    {
+        Http::fake();
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('created_draft', $payload['action']);
+        $this->assertCount(2, $payload['articles']);
+
+        foreach ($payload['articles'] as $articleResult) {
+            $this->assertIsInt($articleResult['article_id']);
+            $this->assertIsInt($articleResult['working_revision_id']);
+            $this->assertStringStartsWith('/ops/article-preview/', $articleResult['preview_url_candidate']);
+
+            $article = Article::query()
+                ->withoutGlobalScopes()
+                ->with(['workingRevision', 'seoMeta'])
+                ->findOrFail((int) $articleResult['article_id']);
+
+            $this->assertSame('draft', (string) $article->status);
+            $this->assertFalse((bool) $article->is_public);
+            $this->assertFalse((bool) $article->is_indexable);
+            $this->assertFalse((bool) $article->sitemap_eligible);
+            $this->assertFalse((bool) $article->llms_eligible);
+            $this->assertNull($article->published_at);
+            $this->assertNull($article->published_revision_id);
+            $this->assertSame(self::TRANSLATION_GROUP_ID, (string) $article->translation_group_id);
+
+            $this->assertInstanceOf(ArticleTranslationRevision::class, $article->workingRevision);
+            $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, (string) $article->workingRevision->revision_status);
+            $this->assertSame((int) $articleResult['working_revision_id'], (int) $article->workingRevision->id);
+
+            $this->assertInstanceOf(ArticleSeoMeta::class, $article->seoMeta);
+            $this->assertSame('noindex,nofollow', (string) $article->seoMeta->robots);
+            $this->assertFalse((bool) $article->seoMeta->is_indexable);
+            $this->assertTrue((bool) data_get($article->seoMeta->schema_json, 'editorial_package_v1.schema_hold'));
+            $this->assertTrue((bool) data_get($article->seoMeta->schema_json, 'editorial_package_v1.hreflang_hold'));
+            $this->assertFalse((bool) data_get($article->seoMeta->schema_json, 'editorial_package_v1.publish_allowed', true));
+        }
+
+        $this->assertSame(2, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(2, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+        $this->assertSame(2, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, DB::table('audit_logs')->where('action', 'content_release_publish')->count());
+        Http::assertNothingSent();
+    }
+
+    public function test_json_output_includes_article_ids_working_revision_ids_and_preview_url_candidates(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+
+        foreach ($payload['articles'] as $article) {
+            $this->assertIsInt($article['article_id']);
+            $this->assertGreaterThan(0, $article['article_id']);
+            $this->assertIsInt($article['working_revision_id']);
+            $this->assertGreaterThan(0, $article['working_revision_id']);
+            $this->assertSame('/ops/article-preview/'.$article['article_id'], $article['preview_url_candidate']);
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function commandOptions(string $package, array $overrides = []): array
+    {
+        return array_replace([
+            '--package' => $package,
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--locales' => 'zh-CN,en',
+            '--draft-only' => true,
+            '--no-publish' => true,
+            '--no-index' => true,
+            '--no-sitemap' => true,
+            '--no-llms' => true,
+            '--schema-hold' => true,
+            '--hreflang-hold' => true,
+            '--expected-zh-slug' => 'career-interest-vs-personality-test-differences',
+            '--expected-en-slug' => 'career-interest-test-vs-personality-test',
+        ], $overrides);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+    }
+
+    /**
+     * @param  callable(array<string,mixed>&):void|null  $mutate
+     */
+    private function writeModeCPackage(?callable $mutate = null): string
+    {
+        $root = sys_get_temp_dir().'/fm-mode-c-package-'.Str::random(12);
+        foreach (['pages', 'cms', 'contracts', 'review', 'codex'] as $directory) {
+            mkdir($root.'/'.$directory, 0777, true);
+        }
+
+        $files = $this->modeCFiles();
+        if ($mutate !== null) {
+            $mutate($files);
+        }
+
+        foreach ($files as $relativePath => $contents) {
+            $path = $root.'/'.$relativePath;
+            if (! is_dir(dirname($path))) {
+                mkdir(dirname($path), 0777, true);
+            }
+            file_put_contents(
+                $path,
+                is_array($contents)
+                    ? json_encode($contents, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES)
+                    : $contents
+            );
+        }
+
+        return $root;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function modeCFiles(): array
+    {
+        $social = [
+            'media_library_asset_key' => 'article.riasec.explanation.cover.v1',
+            'media_library_status' => 'published',
+            'is_public' => true,
+            'cdn_status' => 'verified',
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg',
+            'hero_variant' => [
+                'url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/hero_1600x900.jpg',
+                'width' => 1600,
+                'height' => 900,
+            ],
+            'og_1200x630_variant' => [
+                'url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg',
+                'width' => 1200,
+                'height' => 630,
+            ],
+            'twitter_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articleriasecexplanationcoverv1/og_1200x630.jpg',
+            'alt_text' => 'Career exploration notes with a RIASEC structure and decision path diagram',
+            'width' => 1672,
+            'height' => 941,
+        ];
+        $variants = [
+            'hero' => ['url' => $social['hero_variant']['url'], 'width' => 1600, 'height' => 900],
+            'og' => ['url' => $social['og_1200x630_variant']['url'], 'width' => 1200, 'height' => 630],
+        ];
+        $baseFields = [
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'status' => 'draft',
+            'publish_allowed' => false,
+            'is_indexable' => false,
+            'sitemap_eligible' => false,
+            'llms_eligible' => false,
+            'claim_gate_status' => 'not_reviewed',
+            'primary_keyword' => 'career interest test vs personality test',
+            'secondary_keywords' => ['Holland Code vs MBTI', 'career assessment vs personality assessment'],
+            'primary_hub_url' => '/tests/holland-career-interest-test-riasec',
+            'secondary_hub_urls' => ['/tests/mbti-personality-test-16-personality-types', '/tests/big-five-personality-test-ocean-model'],
+            'schema_eligibility' => ['article_schema' => 'review_required', 'faq_schema' => false, 'breadcrumb_schema' => 'review_required'],
+            'cover_media_asset_key' => 'article.riasec.explanation.cover.v1',
+            'cover_image_url' => $social['cover_image_url'],
+            'cover_image_alt' => $social['alt_text'],
+            'cover_image_width' => 1672,
+            'cover_image_height' => 941,
+            'cover_image_variants' => $variants,
+            'og_image_url' => $social['og_1200x630_variant']['url'],
+            'twitter_image_url' => $social['twitter_image_url'],
+            'social_image_metadata' => $social,
+        ];
+
+        return [
+            'manifest.json' => [
+                'package_name' => 'career-interest-test-vs-personality-test',
+                'status' => 'draft_only_not_for_publication',
+                'translation_group_id' => self::TRANSLATION_GROUP_ID,
+                'publish_allowed' => false,
+                'schema_generation_allowed' => false,
+                'hreflang_enablement_allowed' => false,
+                'pages' => [
+                    [
+                        'locale' => 'zh-CN',
+                        'title' => '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？',
+                        'slug' => 'career-interest-vs-personality-test-differences',
+                        'canonical_url_draft' => '/zh/articles/career-interest-vs-personality-test-differences',
+                        'meta_title_draft' => '职业兴趣测试与性格测试有什么区别？职业规划指南 | FermatMind',
+                        'meta_description_draft' => '找工作应该测 MBTI 还是霍兰德？本文解释职业兴趣测试与性格测试的区别。',
+                        'file' => 'pages/zh-CN-career-interest-vs-personality-test-differences.md',
+                    ],
+                    [
+                        'locale' => 'en',
+                        'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
+                        'slug' => 'career-interest-test-vs-personality-test',
+                        'canonical_url_draft' => '/en/articles/career-interest-test-vs-personality-test',
+                        'meta_title_draft' => 'Career Interest Test vs Personality Test: Which Should You Take?',
+                        'meta_description_draft' => 'Learn how Holland Code, MBTI, and Big Five answer different career exploration questions.',
+                        'file' => 'pages/en-career-interest-test-vs-personality-test.md',
+                    ],
+                ],
+            ],
+            'pages/zh-CN-career-interest-vs-personality-test-differences.md' => $this->markdownPage('zh-CN', '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？', 'career-interest-vs-personality-test-differences', '/zh/articles/career-interest-vs-personality-test-differences'),
+            'pages/en-career-interest-test-vs-personality-test.md' => $this->markdownPage('en', 'Career Interest Test vs Personality Test: Which Should You Take First?', 'career-interest-test-vs-personality-test', '/en/articles/career-interest-test-vs-personality-test'),
+            'cms/CMS_FIELDS_zh-CN_career-interest-vs-personality-test-differences.json' => array_replace($baseFields, [
+                'locale' => 'zh-CN',
+                'title' => '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？',
+                'slug' => 'career-interest-vs-personality-test-differences',
+                'canonical_url' => '/zh/articles/career-interest-vs-personality-test-differences',
+                'meta_title' => '职业兴趣测试与性格测试有什么区别？职业规划指南 | FermatMind',
+                'meta_description' => '找工作应该测 MBTI 还是霍兰德？本文解释职业兴趣测试与性格测试的区别。',
+            ]),
+            'cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json' => array_replace($baseFields, [
+                'locale' => 'en',
+                'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
+                'slug' => 'career-interest-test-vs-personality-test',
+                'canonical_url' => '/en/articles/career-interest-test-vs-personality-test',
+                'meta_title' => 'Career Interest Test vs Personality Test: Which Should You Take?',
+                'meta_description' => 'Learn how Holland Code, MBTI, and Big Five answer different career exploration questions.',
+            ]),
+            'cms/CMS_IMPORT_DRAFT_zh-CN_career-interest-vs-personality-test-differences.json' => array_replace($baseFields, [
+                'locale' => 'zh-CN',
+                'title' => '职业兴趣测试与性格测试的区别：选专业、找工作该先做哪个？',
+                'slug' => 'career-interest-vs-personality-test-differences',
+                'canonical_url' => '/zh/articles/career-interest-vs-personality-test-differences',
+                'meta_title' => '职业兴趣测试与性格测试有什么区别？职业规划指南 | FermatMind',
+                'meta_description' => '找工作应该测 MBTI 还是霍兰德？本文解释职业兴趣测试与性格测试的区别。',
+                'body_markdown_file' => 'pages/zh-CN-career-interest-vs-personality-test-differences.md',
+            ]),
+            'cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json' => array_replace($baseFields, [
+                'locale' => 'en',
+                'title' => 'Career Interest Test vs Personality Test: Which Should You Take First?',
+                'slug' => 'career-interest-test-vs-personality-test',
+                'canonical_url' => '/en/articles/career-interest-test-vs-personality-test',
+                'meta_title' => 'Career Interest Test vs Personality Test: Which Should You Take?',
+                'meta_description' => 'Learn how Holland Code, MBTI, and Big Five answer different career exploration questions.',
+                'body_markdown_file' => 'pages/en-career-interest-test-vs-personality-test.md',
+            ]),
+            'contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json' => ['routes' => ['/zh/articles/career-interest-vs-personality-test-differences', '/en/articles/career-interest-test-vs-personality-test']],
+            'contracts/ROUTE_ALIAS_CONTRACT.json' => ['canonical_big_five' => '/tests/big-five-personality-test-ocean-model'],
+            'contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json' => ['asset_key' => 'article.riasec.explanation.cover.v1', 'required' => true],
+            'contracts/DYNAMIC_CTA_CONTRACT.json' => ['primary' => '/tests/holland-career-interest-test-riasec', 'secondary' => ['/tests/mbti-personality-test-16-personality-types', '/tests/big-five-personality-test-ocean-model']],
+            'contracts/INTERNAL_LINK_PLAN.json' => ['links' => ['/tests/holland-career-interest-test-riasec', '/tests/big-five-personality-test-ocean-model']],
+            'contracts/PRIVATE_URL_GUARD.json' => ['forbidden' => ['/result', '/results', '/orders', '/order', '/share', '/pay', '/payment', '/history', '/take']],
+            'review/claim_gate.md' => "claim_gate_status: not_reviewed\n",
+            'review/operator_review.md' => "operator_review_required: true\n",
+            'codex/qa_checklist.md' => "- no publish\n- no index\n",
+        ];
+    }
+
+    private function markdownPage(string $locale, string $title, string $slug, string $canonical): string
+    {
+        return <<<MD
+---
+translation_group_id: {self::TRANSLATION_GROUP_ID}
+locale: {$locale}
+title: {$title}
+slug: {$slug}
+canonical_url_draft: {$canonical}
+primary_keyword: career interest test vs personality test
+secondary_keywords:
+  - Holland Code vs MBTI
+  - career assessment vs personality assessment
+claim_gate_status: not_reviewed
+publish_allowed: false
+sitemap_eligible: false
+llms_eligible: false
+---
+
+## Quick answer
+
+Start with a career-interest test when the question is direction, then use MBTI and Big Five as supporting lenses.
+
+## CTA
+
+[Start RIASEC](/tests/holland-career-interest-test-riasec)
+[Use Big Five](/tests/big-five-personality-test-ocean-model)
+
+## FAQ
+
+### Can a test decide my career?
+
+No. It is only one input.
+MD;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1559,6 +1559,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_content_package_draft_importer_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleImportSeoContentPackageDraft;',
+            '+        ArticleImportSeoContentPackageDraft::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -2908,6 +2923,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoContentPackageDraftImporterFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -3506,6 +3525,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 && (
                     $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleEditorialPackageDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoContentPackageDraftImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -3773,6 +3793,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Console/Commands/ArticleImportEditorialPackage.php'
             || str_starts_with($file, 'backend/app/Services/Cms/EditorialPackage/');
+    }
+
+    private function isSeoContentPackageDraftImporterFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php'
+            || str_starts_with($file, 'backend/app/Services/Cms/SeoContentPackage/');
     }
 
     private function isArticleBodyH1GuardFile(string $file): bool
@@ -5277,6 +5303,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleImportEditorialPackage\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoContentPackageDraftImporterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleImportSeoContentPackageDraft\b/u', $line) !== 1) {
                 return false;
             }
         }

--- a/generated/seo-ops-cms-draft-only-writer-pr-00/CMS_DRAFT_ONLY_WRITER_DESIGN.md
+++ b/generated/seo-ops-cms-draft-only-writer-pr-00/CMS_DRAFT_ONLY_WRITER_DESIGN.md
@@ -1,0 +1,61 @@
+# CMS Draft-Only Writer Design
+
+Task: SEO-OPS-CMS-DRAFT-ONLY-WRITER-PR-00
+
+Branch: `codex/cms-draft-only-writer-00`
+
+## Summary
+
+Added a narrow Laravel console command for GPT-5.5 Pro Mode C bilingual SEO article packages:
+
+```bash
+php artisan articles:import-seo-content-package-draft
+```
+
+The writer validates a Mode C content package and can create or update CMS Article draft working revisions only. It does not publish and does not enable discoverability surfaces.
+
+## Files Added
+
+- `backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php`
+- `backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php`
+- `backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
+
+## File Modified
+
+- `backend/app/Console/Kernel.php`
+
+## Supported Input Tree
+
+The importer requires:
+
+- `manifest.json`
+- `pages/*.md`
+- `cms/CMS_FIELDS_*.json`
+- `cms/CMS_IMPORT_DRAFT_*.json`
+- `contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json`
+- `contracts/ROUTE_ALIAS_CONTRACT.json`
+- `contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json`
+- `contracts/DYNAMIC_CTA_CONTRACT.json`
+- `contracts/INTERNAL_LINK_PLAN.json`
+- `contracts/PRIVATE_URL_GUARD.json`
+- `review/claim_gate.md`
+- `review/operator_review.md`
+- `codex/qa_checklist.md`
+
+## Draft Write Behavior
+
+Non-dry-run writes:
+
+- create or update matching Article draft by `translation_group_id + locale + slug`
+- save a human-review working revision
+- keep `status=draft`
+- keep `is_public=false`
+- keep `is_indexable=false`
+- keep `sitemap_eligible=false`
+- keep `llms_eligible=false`
+- keep `published_at=null`
+- keep `published_revision_id=null`
+- create/update `ArticleSeoMeta` with `robots=noindex,nofollow`
+- store internal package gate metadata under `editorial_package_v1`
+
+The command blocks published/public existing articles and never calls `ArticlePublishService`, `ContentReleaseAudit`, cache invalidation, ISR, or search submission paths.

--- a/generated/seo-ops-cms-draft-only-writer-pr-00/COMMAND_CAPABILITY_MATRIX.md
+++ b/generated/seo-ops-cms-draft-only-writer-pr-00/COMMAND_CAPABILITY_MATRIX.md
@@ -1,0 +1,46 @@
+# Command Capability Matrix
+
+Command:
+
+```bash
+php artisan articles:import-seo-content-package-draft
+```
+
+## Required Parameters
+
+| Requirement | Status |
+|---|---|
+| `--package=/path/to/content-package` | supported |
+| `--translation-group-id=` | supported |
+| `--locales=zh-CN,en` | supported |
+| `--dry-run` | supported |
+| `--json` | supported |
+| `--draft-only` | supported and required |
+| `--no-publish` | supported and required |
+| `--no-index` | supported and required |
+| `--no-sitemap` | supported and required |
+| `--no-llms` | supported and required |
+| `--schema-hold` | supported and required |
+| `--hreflang-hold` | supported and required |
+| `--expected-zh-slug=` | supported |
+| `--expected-en-slug=` | supported |
+
+## Output
+
+JSON output includes:
+
+- `ok`
+- `dry_run`
+- `action`
+- `would_write`
+- `translation_group_id`
+- `articles[].article_id`
+- `articles[].working_revision_id`
+- `articles[].status`
+- `articles[].locale`
+- `articles[].slug`
+- `articles[].preview_url_candidate`
+- `errors`
+- `warnings`
+
+Dry-run reports candidate actions without writing DB rows.

--- a/generated/seo-ops-cms-draft-only-writer-pr-00/NEXT_PROD_DRAFT_IMPORT_INSTRUCTIONS.md
+++ b/generated/seo-ops-cms-draft-only-writer-pr-00/NEXT_PROD_DRAFT_IMPORT_INSTRUCTIONS.md
@@ -1,0 +1,43 @@
+# Next Prod Draft Import Instructions
+
+Status: WAIT_FOR_PR_REVIEW_AND_MERGE
+
+Do not run production import from this branch before review, merge, deploy, and explicit operator approval.
+
+## After PR Merge And Deploy
+
+1. Confirm production backend revision contains this PR.
+2. Stage the operator-approved Mode C package on production through an approved read-only/write-file path.
+3. Run dry-run only:
+
+```bash
+cd /var/www/fap-api/current/backend
+php artisan articles:import-seo-content-package-draft \
+  --package=/path/to/content-package \
+  --translation-group-id=tg_article_career_interest_vs_personality_test_2026v1 \
+  --locales=zh-CN,en \
+  --dry-run \
+  --json \
+  --draft-only \
+  --no-publish \
+  --no-index \
+  --no-sitemap \
+  --no-llms \
+  --schema-hold \
+  --hreflang-hold \
+  --expected-zh-slug=career-interest-vs-personality-test-differences \
+  --expected-en-slug=career-interest-test-vs-personality-test
+```
+
+4. Proceed to non-dry-run only after explicit operator approval and dry-run `ok=true`.
+
+## Still Forbidden Until Separate Approval
+
+- production non-dry-run import
+- publish
+- make indexable
+- sitemap eligibility
+- llms eligibility
+- schema or hreflang enablement
+- Search Channel, GSC, Baidu, or IndexNow submission
+- ISR/cache revalidation

--- a/generated/seo-ops-cms-draft-only-writer-pr-00/SAFETY_GATE_REVIEW.md
+++ b/generated/seo-ops-cms-draft-only-writer-pr-00/SAFETY_GATE_REVIEW.md
@@ -1,0 +1,53 @@
+# Safety Gate Review
+
+Status: PASS_FOR_CODE_REVIEW
+
+## Preflight Gates Implemented
+
+- `manifest.json` must be valid JSON.
+- `translation_group_id` must match expected value.
+- zh-CN and en page inputs must exist.
+- `primary_keyword` must be a string.
+- `secondary_keywords` must be an array.
+- old Big Five route is rejected.
+- canonical Big Five route is required.
+- active content/import/link surfaces are scanned for private routes.
+- active content/import/link surfaces are scanned for sensitive query keys.
+- CMS media placeholder marker is rejected.
+- social image metadata is required.
+- Media Library asset metadata must be public/published when provided.
+- `claim_gate_status` must be `not_reviewed` or `human_review`.
+- schema hold is enforced by required flag and FAQ schema false.
+- hreflang hold is enforced by required flag.
+
+## Mutation Gates Implemented
+
+The writer force-sets:
+
+- `status=draft`
+- `is_public=false`
+- `is_indexable=false`
+- `sitemap_eligible=false`
+- `llms_eligible=false`
+- `published_at=null`
+- `published_revision_id=null`
+- SEO robots `noindex,nofollow`
+
+## Explicit Non-Actions
+
+The code path does not:
+
+- publish articles
+- make pages indexable
+- mark sitemap eligible
+- mark llms eligible
+- enable Article/FAQ schema output
+- enable hreflang
+- enqueue Search Channel
+- call GSC/Baidu/IndexNow
+- call content release follow-up
+- trigger cache invalidation or ISR revalidation
+
+## Residual Review Notes
+
+This PR adds the controlled writer only. It does not execute production import and does not stage any production package files.

--- a/generated/seo-ops-cms-draft-only-writer-pr-00/TEST_REPORT.md
+++ b/generated/seo-ops-cms-draft-only-writer-pr-00/TEST_REPORT.md
@@ -1,0 +1,37 @@
+# Test Report
+
+## Commands Run
+
+```bash
+php -l backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php
+php -l backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+php -l backend/app/Console/Kernel.php
+php -l backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+cd backend && php artisan list --raw | rg '^articles:import-seo-content-package-draft'
+cd backend && php artisan test tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php --no-ansi
+cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportSeoContentPackageDraft.php app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php app/Console/Kernel.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+git diff --check -- backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php backend/app/Console/Kernel.php backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+cd backend && php artisan route:list --no-ansi
+cd backend && php artisan migrate --pretend --no-interaction --no-ansi
+```
+
+## Focused Test Result
+
+`ArticleImportSeoContentPackageDraftCommandTest`: 7 tests, 88 assertions, passing.
+
+Covered:
+
+- valid bilingual package dry-run without DB writes
+- old Big Five alias rejection
+- private URL rejection
+- missing social image metadata rejection
+- media placeholder rejection
+- non-dry-run draft-only/human-review creation
+- non-dry-run no publish/public/index/sitemap/llms
+- no content-release HTTP follow-up
+- JSON output includes article IDs, working revision IDs, and preview URL candidates
+
+## Additional Checks
+
+- `php artisan route:list --no-ansi`: passed; command registration was available.
+- `php artisan migrate --pretend --no-interaction --no-ansi`: blocked by local MySQL credentials, not by this patch. Error: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)` against local database `fap_api`. This PR adds no migrations and did not connect to production.

--- a/generated/seo-ops-cms-draft-only-writer-pr-00/TEST_REPORT.md
+++ b/generated/seo-ops-cms-draft-only-writer-pr-00/TEST_REPORT.md
@@ -13,6 +13,7 @@ cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportSeoConten
 git diff --check -- backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php backend/app/Console/Kernel.php backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
 cd backend && php artisan route:list --no-ansi
 cd backend && php artisan migrate --pretend --no-interaction --no-ansi
+cd backend && php artisan test tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php --filter='runtime_paths_have_no_uncommitted_diff|seo_content_package_draft_importer' --no-ansi
 ```
 
 ## Focused Test Result
@@ -35,3 +36,4 @@ Covered:
 
 - `php artisan route:list --no-ansi`: passed; command registration was available.
 - `php artisan migrate --pretend --no-interaction --no-ansi`: blocked by local MySQL credentials, not by this patch. Error: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)` against local database `fap_api`. This PR adds no migrations and did not connect to production.
+- Big Five runtime freeze focused check: passed after classifying the SEO content package draft-only importer as a non-Big-Five runtime CMS draft writer path.


### PR DESCRIPTION
## What changed

- Added `php artisan articles:import-seo-content-package-draft` for GPT-5.5 Pro Mode C bilingual SEO content packages.
- Added package preflight validation for manifest, locale/page presence, keyword shapes, Big Five canonical route, private URL guard, sensitive query keys, media placeholder rejection, social image metadata, claim gate status, schema hold, and hreflang hold.
- Added draft-only write behavior that creates/updates unpublished Article records, working revisions, SEO metadata, and import logs without publish/release/search/revalidation side effects.
- Added focused feature tests and generated operator reports under `generated/seo-ops-cms-draft-only-writer-pr-00/`.

## Why

Ops UI does not expose the safety fields needed for this Mode C package, local DB is not CMS authority, and the existing editorial package importer does not support the required explicit no-sitemap/no-llms/claim-gate/schema-hold/hreflang-hold draft-only contract.

## Validation

- `php -l backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php`
- `php -l backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php`
- `php -l backend/app/Console/Kernel.php`
- `php -l backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
- `cd backend && php artisan list --raw | rg '^articles:import-seo-content-package-draft'`\n- `cd backend && php artisan test tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php --no-ansi`\n- `cd backend && vendor/bin/pint --test app/Console/Commands/ArticleImportSeoContentPackageDraft.php app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php app/Console/Kernel.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`\n- `git diff --check -- backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php backend/app/Console/Kernel.php backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php generated/seo-ops-cms-draft-only-writer-pr-00`\n- `cd backend && php artisan route:list --no-ansi`\n\nNote: `cd backend && php artisan migrate --pretend --no-interaction --no-ansi` was attempted and blocked by local MySQL credentials: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost' (using password: NO)` against local database `fap_api`. This PR adds no migrations and did not connect to production.\n\n## Intentionally deferred\n\n- No production import was run.\n- No real CMS draft was created.\n- No publish/index/sitemap/llms/search-channel/ISR/revalidation path was executed.\n- Schema and hreflang remain held by importer contract and are not enabled.