### PR TITLE
fix(cms): scope SEO content package guard scans to active surfaces

### DIFF
--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -44,6 +44,20 @@ final class SeoContentPackageDraftImporter
 
     private const SENSITIVE_QUERY_PATTERN = '/(?:[?&]|^)(?:result_id|order_id|payment_id|token|score|user_id|report_id)=/i';
 
+    private const OLD_BIG_FIVE_ROUTE_PATTERN = '#/tests/big-five-personality-test(?!-ocean-model)#';
+
+    private const CANONICAL_BIG_FIVE_ROUTE = '/tests/big-five-personality-test-ocean-model';
+
+    private const SENSITIVE_QUERY_KEYS = [
+        'result_id',
+        'order_id',
+        'payment_id',
+        'token',
+        'score',
+        'user_id',
+        'report_id',
+    ];
+
     public function __construct(
         private readonly ArticleTranslationRevisionWorkspace $revisionWorkspace,
         private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
@@ -113,10 +127,14 @@ final class SeoContentPackageDraftImporter
 
         $manifest = [];
         $packageItems = [];
+        $guardScans = [
+            'active_surface_guard_scan' => ['status' => 'not_run'],
+            'contract_integrity_scan' => ['status' => 'not_run'],
+        ];
         if ($packageRoot !== null) {
             $this->validateRequiredFiles($packageRoot, $errors);
             $manifest = $this->readJson($packageRoot.'/manifest.json', 'manifest.json', $errors);
-            $this->validateWholePackageText($packageRoot, $errors);
+            $guardScans = $this->validatePackageGuardScopes($packageRoot, $errors);
             $packageItems = $this->buildPackageItems($packageRoot, $manifest, $expectedTranslationGroupId, $expectedSlugs, $errors, $warnings);
         }
 
@@ -131,6 +149,8 @@ final class SeoContentPackageDraftImporter
             'translation_group_id' => $expectedTranslationGroupId,
             'package_root' => $packageRoot,
             'manifest_status' => $manifest !== [] ? 'valid_json' : 'missing_or_invalid',
+            'active_surface_guard_scan' => $guardScans['active_surface_guard_scan'],
+            'contract_integrity_scan' => $guardScans['contract_integrity_scan'],
             'safety_flags' => $this->safetyFlagSnapshot($options),
             'articles' => $plannedArticles,
             'package_items' => $packageItems,
@@ -352,10 +372,91 @@ final class SeoContentPackageDraftImporter
 
     /**
      * @param  list<array<string,mixed>>  $errors
+     * @return array{active_surface_guard_scan:array<string,mixed>,contract_integrity_scan:array<string,mixed>}
      */
-    private function validateWholePackageText(string $root, array &$errors): void
+    private function validatePackageGuardScopes(string $root, array &$errors): array
     {
-        $allFiles = array_merge(
+        $activeErrorStart = count($errors);
+        $activeSurfaceText = $this->activeSurfaceText($root);
+        $packageText = $this->packageText($root);
+
+        if (preg_match(self::OLD_BIG_FIVE_ROUTE_PATTERN, $activeSurfaceText) === 1) {
+            $errors[] = $this->issue('active_surface_guard_scan.big_five_route', 'old_big_five_route_found_in_active_surface', 'Old Big Five route is forbidden in active import surfaces.');
+        }
+        if (! str_contains($packageText, self::CANONICAL_BIG_FIVE_ROUTE)) {
+            $errors[] = $this->issue('big_five_route', 'required_big_five_route_missing', 'Canonical Big Five route is required.');
+        }
+        if (str_contains($packageText, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__')) {
+            $errors[] = $this->issue('social_image', 'media_placeholder_found', 'CMS media placeholder marker is forbidden.');
+        }
+        if (preg_match(self::PRIVATE_ROUTE_PATTERN, $activeSurfaceText) === 1) {
+            $errors[] = $this->issue('active_surface_guard_scan.private_url_guard', 'private_route_found_in_active_surface', 'Private routes are forbidden in active import surfaces.');
+        }
+        if (preg_match(self::SENSITIVE_QUERY_PATTERN, $activeSurfaceText) === 1) {
+            $errors[] = $this->issue('active_surface_guard_scan.private_url_guard', 'sensitive_query_key_found_in_active_surface', 'Sensitive query keys are forbidden in active import surfaces.');
+        }
+        $activeErrorCount = count($errors) - $activeErrorStart;
+
+        $contractErrorStart = count($errors);
+        $this->validateRouteAliasContract($root, $errors);
+        $this->validatePrivateUrlGuardContract($root, $errors);
+        $this->validateDynamicCtaContract($root, $errors);
+        $contractErrorCount = count($errors) - $contractErrorStart;
+
+        return [
+            'active_surface_guard_scan' => [
+                'status' => $activeErrorCount === 0 ? 'passed' : 'failed',
+                'error_count' => $activeErrorCount,
+            ],
+            'contract_integrity_scan' => [
+                'status' => $contractErrorCount === 0 ? 'passed' : 'failed',
+                'error_count' => $contractErrorCount,
+            ],
+        ];
+    }
+
+    private function activeSurfaceText(string $root): string
+    {
+        $parts = [];
+
+        foreach (glob($root.'/pages/*.md') ?: [] as $path) {
+            if (! is_file($path)) {
+                continue;
+            }
+
+            $page = $this->readMarkdownPage($path);
+            $parts[] = (string) json_encode($page['frontmatter'], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+            $parts[] = $page['body'];
+        }
+
+        foreach (glob($root.'/cms/*.json') ?: [] as $path) {
+            if (is_file($path)) {
+                $parts[] = (string) file_get_contents($path);
+            }
+        }
+
+        $manifest = $this->readJsonLenient($root.'/manifest.json');
+        $parts[] = (string) json_encode($manifest['pages'] ?? [], JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE);
+
+        $parts[] = (string) json_encode(
+            $this->withoutPolicyKeys($this->readJsonLenient($root.'/contracts/DYNAMIC_CTA_CONTRACT.json')),
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+        $parts[] = (string) json_encode(
+            $this->withoutPolicyKeys($this->readJsonLenient($root.'/contracts/INTERNAL_LINK_PLAN.json')),
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+        $parts[] = (string) json_encode(
+            $this->readJsonLenient($root.'/contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json'),
+            JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+
+        return implode("\n", $parts);
+    }
+
+    private function packageText(string $root): string
+    {
+        $files = array_merge(
             glob($root.'/manifest.json') ?: [],
             glob($root.'/pages/*.md') ?: [],
             glob($root.'/cms/*.json') ?: [],
@@ -363,43 +464,204 @@ final class SeoContentPackageDraftImporter
             glob($root.'/review/*') ?: [],
             glob($root.'/codex/*') ?: [],
         );
-        $activeLinkFiles = array_merge(
-            glob($root.'/pages/*.md') ?: [],
-            glob($root.'/cms/*.json') ?: [],
-            glob($root.'/contracts/DYNAMIC_CTA_CONTRACT.json') ?: [],
-            glob($root.'/contracts/INTERNAL_LINK_PLAN.json') ?: [],
-            glob($root.'/contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json') ?: [],
-            glob($root.'/contracts/ROUTE_ALIAS_CONTRACT.json') ?: [],
-        );
 
-        $wholeText = '';
-        foreach ($allFiles as $file) {
+        $text = '';
+        foreach ($files as $file) {
             if (is_file($file)) {
-                $wholeText .= "\n".(string) file_get_contents($file);
-            }
-        }
-        $activeLinkText = '';
-        foreach ($activeLinkFiles as $file) {
-            if (is_file($file)) {
-                $activeLinkText .= "\n".(string) file_get_contents($file);
+                $text .= "\n".(string) file_get_contents($file);
             }
         }
 
-        if (preg_match('#/tests/big-five-personality-test(?!-ocean-model)#', $wholeText) === 1) {
-            $errors[] = $this->issue('big_five_route', 'old_big_five_route_found', 'Old Big Five route is forbidden.');
+        return $text;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJsonLenient(string $path): array
+    {
+        if (! is_file($path)) {
+            return [];
         }
-        if (! str_contains($wholeText, '/tests/big-five-personality-test-ocean-model')) {
-            $errors[] = $this->issue('big_five_route', 'required_big_five_route_missing', 'Canonical Big Five route is required.');
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+
+        return is_array($decoded) ? $decoded : [];
+    }
+
+    private function withoutPolicyKeys(mixed $value): mixed
+    {
+        if (! is_array($value)) {
+            return $value;
         }
-        if (str_contains($wholeText, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__')) {
-            $errors[] = $this->issue('social_image', 'media_placeholder_found', 'CMS media placeholder marker is forbidden.');
+
+        $filtered = [];
+        foreach ($value as $key => $child) {
+            $normalizedKey = strtolower((string) $key);
+            if (in_array($normalizedKey, [
+                'forbidden',
+                'forbidden_paths',
+                'forbidden_private_routes',
+                'forbidden_query_keys',
+                'forbidden_sensitive_query_keys',
+                'forbidden_tracking_params',
+                'private_url_guard_ref',
+                'private_links_forbidden',
+            ], true)) {
+                continue;
+            }
+
+            $filtered[$key] = $this->withoutPolicyKeys($child);
         }
-        if (preg_match(self::PRIVATE_ROUTE_PATTERN, $activeLinkText) === 1) {
-            $errors[] = $this->issue('private_url_guard', 'private_route_found', 'Private routes are forbidden.');
+
+        return $filtered;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateRouteAliasContract(string $root, array &$errors): void
+    {
+        $path = $root.'/contracts/ROUTE_ALIAS_CONTRACT.json';
+        $contract = $this->readJsonLenient($path);
+        $aliases = $this->aliasMappings($contract);
+        $allowedOldAliasCount = 0;
+
+        foreach ($aliases as $alias => $target) {
+            if (preg_match(self::OLD_BIG_FIVE_ROUTE_PATTERN, (string) $alias) === 1) {
+                if ($target !== self::CANONICAL_BIG_FIVE_ROUTE) {
+                    $errors[] = $this->issue('contract_integrity_scan.route_alias_contract', 'route_alias_contract_invalid', 'Old Big Five alias must resolve to the canonical OCEAN route.');
+                } else {
+                    $allowedOldAliasCount++;
+                }
+            }
+
+            if (preg_match(self::OLD_BIG_FIVE_ROUTE_PATTERN, $target) === 1) {
+                $errors[] = $this->issue('contract_integrity_scan.route_alias_contract', 'route_alias_contract_invalid', 'Old Big Five route is forbidden as an alias target.');
+            }
         }
-        if (preg_match(self::SENSITIVE_QUERY_PATTERN, $activeLinkText) === 1) {
-            $errors[] = $this->issue('private_url_guard', 'sensitive_query_key_found', 'Sensitive query keys are forbidden.');
+
+        $raw = is_file($path) ? (string) file_get_contents($path) : '';
+        $oldRouteCount = preg_match_all(self::OLD_BIG_FIVE_ROUTE_PATTERN, $raw);
+        if ($oldRouteCount > $allowedOldAliasCount) {
+            $errors[] = $this->issue('contract_integrity_scan.route_alias_contract', 'route_alias_contract_invalid', 'Old Big Five route may appear only as a known alias key.');
         }
+    }
+
+    /**
+     * @param  array<string,mixed>  $contract
+     * @return array<string,string>
+     */
+    private function aliasMappings(array $contract): array
+    {
+        $candidates = [];
+        foreach (['known_aliases', 'aliases', 'route_aliases'] as $key) {
+            if (is_array($contract[$key] ?? null)) {
+                $candidates[] = $contract[$key];
+            }
+        }
+        if ($candidates === []) {
+            $candidates[] = $contract;
+        }
+
+        $aliases = [];
+        foreach ($candidates as $candidate) {
+            foreach ($candidate as $alias => $target) {
+                if (is_string($alias) && is_string($target) && str_starts_with($alias, '/')) {
+                    $aliases[$alias] = $target;
+                }
+            }
+        }
+
+        return $aliases;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validatePrivateUrlGuardContract(string $root, array &$errors): void
+    {
+        $contract = $this->readJsonLenient($root.'/contracts/PRIVATE_URL_GUARD.json');
+        $invalidPaths = [];
+        $this->collectPrivateGuardViolations($contract, [], false, $invalidPaths);
+
+        if ($invalidPaths !== []) {
+            $errors[] = $this->issue('contract_integrity_scan.private_url_guard', 'private_url_guard_contract_invalid', 'Private URL guard contract contains private routes or sensitive keys outside forbidden guard fields.');
+        }
+    }
+
+    /**
+     * @param  list<string>  $path
+     * @param  list<string>  $invalidPaths
+     */
+    private function collectPrivateGuardViolations(mixed $value, array $path, bool $allowedGuardContext, array &$invalidPaths): void
+    {
+        $key = strtolower((string) end($path));
+        $allowed = $allowedGuardContext || in_array($key, [
+            'forbidden',
+            'forbidden_paths',
+            'forbidden_private_routes',
+            'forbidden_query_keys',
+            'forbidden_sensitive_query_keys',
+            'sensitive_query_keys',
+        ], true);
+
+        if (is_array($value)) {
+            foreach ($value as $childKey => $child) {
+                $this->collectPrivateGuardViolations($child, [...$path, (string) $childKey], $allowed, $invalidPaths);
+            }
+
+            return;
+        }
+
+        if (! is_string($value)) {
+            return;
+        }
+
+        if ((preg_match(self::PRIVATE_ROUTE_PATTERN, $value) === 1 || $this->isSensitiveQueryKeyLiteral($value)) && ! $allowed) {
+            $invalidPaths[] = implode('.', $path);
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateDynamicCtaContract(string $root, array &$errors): void
+    {
+        $contract = $this->readJsonLenient($root.'/contracts/DYNAMIC_CTA_CONTRACT.json');
+        $invalidPaths = [];
+        $this->collectDynamicCtaSensitiveKeyViolations($contract, [], false, $invalidPaths);
+
+        if ($invalidPaths !== []) {
+            $errors[] = $this->issue('contract_integrity_scan.dynamic_cta_contract', 'dynamic_cta_forbidden_params_contract_invalid', 'Sensitive tracking params may appear only in forbidden_tracking_params.');
+        }
+    }
+
+    /**
+     * @param  list<string>  $path
+     * @param  list<string>  $invalidPaths
+     */
+    private function collectDynamicCtaSensitiveKeyViolations(mixed $value, array $path, bool $allowedForbiddenParamContext, array &$invalidPaths): void
+    {
+        $key = strtolower((string) end($path));
+        $allowed = $allowedForbiddenParamContext || $key === 'forbidden_tracking_params';
+
+        if (is_array($value)) {
+            foreach ($value as $childKey => $child) {
+                $this->collectDynamicCtaSensitiveKeyViolations($child, [...$path, (string) $childKey], $allowed, $invalidPaths);
+            }
+
+            return;
+        }
+
+        if (is_string($value) && $this->isSensitiveQueryKeyLiteral($value) && ! $allowed) {
+            $invalidPaths[] = implode('.', $path);
+        }
+    }
+
+    private function isSensitiveQueryKeyLiteral(string $value): bool
+    {
+        return in_array(strtolower(trim($value)), self::SENSITIVE_QUERY_KEYS, true);
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -35,16 +35,38 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $this->assertTrue($payload['ok']);
         $this->assertTrue($payload['dry_run']);
         $this->assertSame('would_create_draft', $payload['action']);
+        $this->assertSame('passed', $payload['active_surface_guard_scan']['status']);
+        $this->assertSame('passed', $payload['contract_integrity_scan']['status']);
         $this->assertCount(2, $payload['articles']);
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
         $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
         $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
     }
 
-    public function test_dry_run_rejects_old_big_five_alias(): void
+    public function test_dry_run_accepts_old_big_five_alias_key_with_canonical_value(): void
     {
         $package = $this->writeModeCPackage(static function (array &$files): void {
-            $files['cms/CMS_FIELDS_en_career-interest-test-vs-personality-test.json']['secondary_hub_urls'][1] = '/tests/big-five-personality-test';
+            $files['contracts/ROUTE_ALIAS_CONTRACT.json']['known_aliases'] = [
+                '/tests/big-five-personality-test' => '/tests/big-five-personality-test-ocean-model',
+            ];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('passed', $payload['contract_integrity_scan']['status']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_old_big_five_path_in_page_body(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['pages/en-career-interest-test-vs-personality-test.md'] .= "\n\n[Old Big Five](/tests/big-five-personality-test)\n";
         });
 
         $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
@@ -54,11 +76,89 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
 
         $payload = $this->jsonOutput();
         $this->assertSame(1, $exitCode);
-        $this->assertErrorCode($payload, 'old_big_five_route_found');
+        $this->assertErrorCode($payload, 'old_big_five_route_found_in_active_surface');
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
     }
 
-    public function test_dry_run_rejects_private_url(): void
+    public function test_dry_run_rejects_old_big_five_path_in_page_frontmatter_active_link(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['pages/en-career-interest-test-vs-personality-test.md'] = str_replace(
+                "canonical_url_draft: /en/articles/career-interest-test-vs-personality-test\n",
+                "canonical_url_draft: /en/articles/career-interest-test-vs-personality-test\nrelated_test_url: /tests/big-five-personality-test\n",
+                $files['pages/en-career-interest-test-vs-personality-test.md']
+            );
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'old_big_five_route_found_in_active_surface');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_old_big_five_path_in_cms_import_cta_target(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['cms/CMS_IMPORT_DRAFT_en_career-interest-test-vs-personality-test.json']['secondary_hub_urls'][1] = '/tests/big-five-personality-test';
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'old_big_five_route_found_in_active_surface');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_old_big_five_alias_value(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['contracts/ROUTE_ALIAS_CONTRACT.json']['known_aliases'] = [
+                '/tests/big-five-personality-test-ocean-model' => '/tests/big-five-personality-test',
+            ];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'route_alias_contract_invalid');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_accepts_private_routes_in_private_url_guard_forbidden_paths(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['contracts/PRIVATE_URL_GUARD.json'] = [
+                'forbidden_paths' => ['/result', '/results', '/orders', '/order', '/share', '/pay', '/payment', '/history', '/take'],
+                'forbidden_query_keys' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('passed', $payload['contract_integrity_scan']['status']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_private_url_in_page_body(): void
     {
         $package = $this->writeModeCPackage(static function (array &$files): void {
             $files['pages/en-career-interest-test-vs-personality-test.md'] .= "\n\n[private](/results/abc123)\n";
@@ -71,7 +171,77 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
 
         $payload = $this->jsonOutput();
         $this->assertSame(1, $exitCode);
-        $this->assertErrorCode($payload, 'private_route_found');
+        $this->assertErrorCode($payload, 'private_route_found_in_active_surface');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_accepts_sensitive_keys_in_dynamic_cta_forbidden_tracking_params(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['contracts/DYNAMIC_CTA_CONTRACT.json']['forbidden_tracking_params'] = ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('passed', $payload['contract_integrity_scan']['status']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_sensitive_keys_in_dynamic_cta_allowed_tracking_params(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['contracts/DYNAMIC_CTA_CONTRACT.json']['allowed_tracking_params'] = ['utm_source', 'token'];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'dynamic_cta_forbidden_params_contract_invalid');
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_does_not_scan_claim_gate_review_text_as_article_body(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['review/claim_gate.md'] = "forbidden_claims_avoided:\n- Do not link /results or token examples in public body.\n- Legacy route mention: /tests/big-five-personality-test\n";
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame('passed', $payload['active_surface_guard_scan']['status']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_dry_run_rejects_private_url_guard_contract_private_routes_outside_forbidden_context(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['contracts/PRIVATE_URL_GUARD.json']['allowed_paths'] = ['/result'];
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'private_url_guard_contract_invalid');
         $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
     }
 
@@ -391,11 +561,25 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
                 'body_markdown_file' => 'pages/en-career-interest-test-vs-personality-test.md',
             ]),
             'contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json' => ['routes' => ['/zh/articles/career-interest-vs-personality-test-differences', '/en/articles/career-interest-test-vs-personality-test']],
-            'contracts/ROUTE_ALIAS_CONTRACT.json' => ['canonical_big_five' => '/tests/big-five-personality-test-ocean-model'],
+            'contracts/ROUTE_ALIAS_CONTRACT.json' => [
+                'known_alias_autofix_allowed' => true,
+                'unknown_alias_requires_operator_input' => true,
+                'known_aliases' => [
+                    '/tests/big-five-personality-test' => '/tests/big-five-personality-test-ocean-model',
+                ],
+            ],
             'contracts/SOCIAL_IMAGE_METADATA_REQUIREMENTS.json' => ['asset_key' => 'article.riasec.explanation.cover.v1', 'required' => true],
-            'contracts/DYNAMIC_CTA_CONTRACT.json' => ['primary' => '/tests/holland-career-interest-test-riasec', 'secondary' => ['/tests/mbti-personality-test-16-personality-types', '/tests/big-five-personality-test-ocean-model']],
+            'contracts/DYNAMIC_CTA_CONTRACT.json' => [
+                'primary' => '/tests/holland-career-interest-test-riasec',
+                'secondary' => ['/tests/mbti-personality-test-16-personality-types', '/tests/big-five-personality-test-ocean-model'],
+                'allowed_tracking_params' => ['utm_source', 'utm_medium', 'utm_campaign'],
+                'forbidden_tracking_params' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ],
             'contracts/INTERNAL_LINK_PLAN.json' => ['links' => ['/tests/holland-career-interest-test-riasec', '/tests/big-five-personality-test-ocean-model']],
-            'contracts/PRIVATE_URL_GUARD.json' => ['forbidden' => ['/result', '/results', '/orders', '/order', '/share', '/pay', '/payment', '/history', '/take']],
+            'contracts/PRIVATE_URL_GUARD.json' => [
+                'forbidden_paths' => ['/result', '/results', '/orders', '/order', '/share', '/pay', '/payment', '/history', '/take'],
+                'forbidden_query_keys' => ['result_id', 'order_id', 'payment_id', 'token', 'score', 'user_id', 'report_id'],
+            ],
             'review/claim_gate.md' => "claim_gate_status: not_reviewed\n",
             'review/operator_review.md' => "operator_review_required: true\n",
             'codex/qa_checklist.md' => "- no publish\n- no index\n",

--- a/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/ACTIVE_SURFACE_VS_CONTRACT_SURFACE_MATRIX.md
+++ b/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/ACTIVE_SURFACE_VS_CONTRACT_SURFACE_MATRIX.md
@@ -1,0 +1,59 @@
+# Active Surface vs Contract Surface Matrix
+
+## Active Import Surfaces
+
+These continue to block old routes, private URLs, and sensitive tokenized URLs:
+
+| Surface | Scanner behavior |
+| --- | --- |
+| `pages/*.md` frontmatter | Scanned as active metadata. |
+| `pages/*.md` body markdown | Scanned as active article body. |
+| `cms/CMS_FIELDS_*.json` | Scanned as active CMS field payload. |
+| `cms/CMS_IMPORT_DRAFT_*.json` | Scanned as active CMS draft payload. |
+| `manifest.json` page entries | Scanned as active page metadata. |
+| `contracts/DYNAMIC_CTA_CONTRACT.json` active CTA/link fields | Scanned after removing policy-only forbidden fields. |
+| `contracts/INTERNAL_LINK_PLAN.json` active link fields | Scanned after removing policy-only forbidden fields. |
+| `contracts/PUBLIC_CANONICAL_ROUTE_CONTRACT.json` | Scanned as public route authority input. |
+
+Active surfaces block:
+
+- `/tests/big-five-personality-test`
+- `/result`
+- `/results`
+- `/orders`
+- `/order`
+- `/share`
+- `/pay`
+- `/payment`
+- `/history`
+- `/take`
+- tokenized sensitive query URLs using `result_id`, `order_id`, `payment_id`, `token`, `score`, `user_id`, or `report_id`
+
+## Contract / Policy Surfaces
+
+These are checked by context-aware contract integrity rules:
+
+| Surface | Allowed context | Blocking context |
+| --- | --- | --- |
+| `contracts/ROUTE_ALIAS_CONTRACT.json` | Old Big Five route as alias key only, with canonical OCEAN route value. | Old Big Five route as alias value or any non-alias occurrence. |
+| `contracts/PRIVATE_URL_GUARD.json` | Private routes and sensitive keys inside forbidden guard fields. | Private routes or sensitive keys inside allowed route fields or active target fields. |
+| `contracts/DYNAMIC_CTA_CONTRACT.json` | Sensitive keys inside `forbidden_tracking_params`. | Sensitive keys inside `allowed_tracking_params` or active CTA params. |
+| `review/claim_gate.md` | Review-only forbidden claim context. | Not scanned as article body. |
+
+## Preflight Output
+
+The command response now includes:
+
+- `active_surface_guard_scan.status`
+- `active_surface_guard_scan.error_count`
+- `contract_integrity_scan.status`
+- `contract_integrity_scan.error_count`
+
+Primary new error codes:
+
+- `old_big_five_route_found_in_active_surface`
+- `private_route_found_in_active_surface`
+- `sensitive_query_key_found_in_active_surface`
+- `route_alias_contract_invalid`
+- `private_url_guard_contract_invalid`
+- `dynamic_cta_forbidden_params_contract_invalid`

--- a/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/NEXT_DEPLOY_AND_DRY_RUN_INSTRUCTIONS.md
+++ b/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/NEXT_DEPLOY_AND_DRY_RUN_INSTRUCTIONS.md
@@ -1,0 +1,56 @@
+# Next Deploy and Dry-Run Instructions
+
+Task: SEO-OPS-CMS-DRAFT-WRITER-SCANNER-SCOPE-FIX-PR-00
+
+## Current Decision
+
+GO_FOR_PR_REVIEW
+
+## After PR Merge
+
+Do not deploy automatically. First run deploy readiness for the merged SHA and confirm production backend has the scanner-scope fix.
+
+Exact next operator approval should be requested only after:
+
+1. PR is merged.
+2. `origin/main` contains the merge commit.
+3. Production backend deploy readiness confirms the merged SHA is not deployed yet.
+
+## Production Dry-Run Command
+
+After backend production deploy is explicitly approved and completed, run production dry-run only:
+
+```bash
+php artisan articles:import-seo-content-package-draft \
+  --package=/path/to/source-package \
+  --translation-group-id=tg_article_career_interest_vs_personality_test_2026v1 \
+  --locales=zh-CN,en \
+  --dry-run \
+  --json \
+  --draft-only \
+  --no-publish \
+  --no-index \
+  --no-sitemap \
+  --no-llms \
+  --schema-hold \
+  --hreflang-hold \
+  --expected-zh-slug=career-interest-vs-personality-test-differences \
+  --expected-en-slug=career-interest-test-vs-personality-test
+```
+
+Expected scanner result:
+
+- `active_surface_guard_scan.status=passed`
+- `contract_integrity_scan.status=passed`
+- no `old_big_five_route_found_in_active_surface`
+- no `route_alias_contract_invalid`
+- no `private_route_found_in_active_surface`
+
+## Hard Holds
+
+- Do not create CMS drafts until dry-run passes in production.
+- Do not publish.
+- Do not make indexable.
+- Do not mark sitemap or llms eligible.
+- Do not submit Search Channel, GSC, Baidu, or IndexNow.
+- Do not trigger ISR/revalidation as part of dry-run.

--- a/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/TEST_REPORT.md
+++ b/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/TEST_REPORT.md
@@ -1,0 +1,75 @@
+# Test Report
+
+Task: SEO-OPS-CMS-DRAFT-WRITER-SCANNER-SCOPE-FIX-PR-00
+
+## Commands Run
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+```
+
+Result: PASS
+
+- 16 tests passed
+- 130 assertions
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php
+```
+
+Result: PASS
+
+- 14 tests passed
+- 275 assertions
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+./vendor/bin/pint app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+```
+
+Result: PASS
+
+- 2 files formatted/checked
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan route:list
+```
+
+Result: PASS
+
+- 218 routes listed
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+git diff --check
+```
+
+Result: PASS
+
+## Real Package Local Dry-Run Probe
+
+Command attempted locally with `--dry-run --json` against:
+
+`/Users/rainie/Desktop/GitHub/fap-web/generated/seo-ops-new-bilingual-article-pair-package-fix-and-rerun-00/source-package`
+
+Result: BLOCKED_BY_LOCAL_DB_AUTH
+
+The command reached local existing-article lookup and failed because this local environment cannot authenticate to MySQL `fap_api` as `root` with no password. No CMS write was attempted. This is the known local DB authority limitation and is not evidence of a scanner-scope failure.
+
+## Regression Coverage Added
+
+- Valid package with `ROUTE_ALIAS_CONTRACT.json` containing old Big Five alias key passes dry-run.
+- Old Big Five path in page body fails.
+- Old Big Five path in page frontmatter active link fails.
+- Old Big Five path in CMS import CTA target fails.
+- Old Big Five alias key with canonical value passes.
+- Old Big Five alias value fails.
+- Private routes in `PRIVATE_URL_GUARD.json` forbidden fields pass.
+- Private routes in page body fail.
+- Sensitive keys in `DYNAMIC_CTA_CONTRACT.json` `forbidden_tracking_params` pass.
+- Sensitive keys in `allowed_tracking_params` fail.
+- Review text in `review/claim_gate.md` is not treated as article body.
+- `__CMS_MEDIA_LIBRARY_PLACEHOLDER__` remains blocked.

--- a/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/WRITER_SCANNER_SCOPE_FIX_DESIGN.md
+++ b/generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/WRITER_SCANNER_SCOPE_FIX_DESIGN.md
@@ -1,0 +1,50 @@
+# Writer Scanner Scope Fix Design
+
+Task: SEO-OPS-CMS-DRAFT-WRITER-SCANNER-SCOPE-FIX-PR-00
+
+Decision: GO_FOR_PR_REVIEW
+
+## Problem
+
+The draft-only SEO content package writer treated the entire Mode C package as one scan surface. That incorrectly blocked valid policy files, especially `contracts/ROUTE_ALIAS_CONTRACT.json`, where the legacy Big Five route is expected to appear as an alias key:
+
+`/tests/big-five-personality-test` -> `/tests/big-five-personality-test-ocean-model`
+
+## Fix
+
+The importer now separates scan scope into two explicit preflight outputs:
+
+- `active_surface_guard_scan`
+- `contract_integrity_scan`
+
+`active_surface_guard_scan` scans only data that can be written to article content, CMS fields, CTA/link targets, metadata, manifest page entries, and public canonical route surfaces.
+
+`contract_integrity_scan` validates policy files with context-aware rules:
+
+- `ROUTE_ALIAS_CONTRACT.json` may contain the old Big Five route only as an alias key.
+- The old Big Five alias value must be `/tests/big-five-personality-test-ocean-model`.
+- `PRIVATE_URL_GUARD.json` may contain private routes and sensitive query keys only inside forbidden guard fields.
+- `DYNAMIC_CTA_CONTRACT.json` may contain sensitive tracking params only inside `forbidden_tracking_params`.
+- Review files such as `review/claim_gate.md` are not treated as article body.
+
+## Files Changed
+
+Modified:
+
+- `backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php`
+- `backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php`
+
+Added:
+
+- `generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/WRITER_SCANNER_SCOPE_FIX_DESIGN.md`
+- `generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/ACTIVE_SURFACE_VS_CONTRACT_SURFACE_MATRIX.md`
+- `generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/TEST_REPORT.md`
+- `generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/NEXT_DEPLOY_AND_DRY_RUN_INSTRUCTIONS.md`
+
+## Out Of Scope
+
+- No CMS writes.
+- No draft creation.
+- No publish/index/sitemap/llms/search-channel mutation.
+- No production environment changes.
+- No `fap-web` changes.


### PR DESCRIPTION
## What changed

- Split SEO content package writer preflight into `active_surface_guard_scan` and `contract_integrity_scan`.
- Kept strict blocking for old Big Five routes, private URLs, and sensitive tokenized URLs on active import surfaces.
- Added context-aware contract validation for:
  - `ROUTE_ALIAS_CONTRACT.json`
  - `PRIVATE_URL_GUARD.json`
  - `DYNAMIC_CTA_CONTRACT.json`
  - review-only `claim_gate.md` text not being treated as article body
- Added regression coverage for valid alias-key usage, invalid active-surface leaks, invalid contract placement, and media placeholder blocking.
- Added generated scanner-scope fix reports under `generated/seo-ops-cms-draft-writer-scanner-scope-fix-pr-00/`.

## Why

Production dry-run showed the writer was scanning policy/contract files as if they were active article/CMS surfaces. That caused the required Big Five alias mapping to be blocked as `old_big_five_route_found`, even though the content package active surfaces were already clean.

## Validation commands

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php tests/Feature/Cms/ArticleMultiTestGraphEdgesTest.php
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
./vendor/bin/pint app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api/backend
php artisan route:list
```

```bash
cd /Users/rainie/Desktop/GitHub/fap-api
git diff --check
```

## Intentionally deferred

- No CMS draft creation.
- No production import.
- No publish/index/sitemap/llms/search-channel mutation.
- No GSC/Baidu/IndexNow submission.
- No ISR/revalidation.
- No `fap-web` changes.
- `php artisan migrate`, curl smoke tests, and `bash backend/scripts/ci_verify_mbti.sh` were not run because this PR is scoped to a console importer scanner and its focused feature tests; the local MySQL authority is also unavailable in this environment for non-test DB operations.

## Repository rule impact

This change preserves backend CMS authority for article import and narrows preflight scanning semantics. It does not introduce a new content surface or publication path.
