### PR TITLE
fix(cms): normalize SEO content package import JSON fields

### DIFF
--- a/backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php
+++ b/backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php
@@ -84,7 +84,7 @@ final class ArticleImportSeoContentPackageDraft extends Command
     private function emitSummary(array $summary): void
     {
         if ((bool) $this->option('json')) {
-            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
 
             return;
         }

--- a/backend/app/Services/Cms/ArticleBodyHeadingGuard.php
+++ b/backend/app/Services/Cms/ArticleBodyHeadingGuard.php
@@ -52,21 +52,18 @@ final class ArticleBodyHeadingGuard
 
     public function downgradeMarkdownH1ToH2(string $markdown): string
     {
-        $lines = preg_split("/(\r\n|\n|\r)/", $markdown, -1, PREG_SPLIT_DELIM_CAPTURE);
-        if ($lines === false || $lines === []) {
+        $lines = explode("\n", str_replace(["\r\n", "\r"], "\n", $markdown));
+        if ($lines === []) {
             return $markdown;
         }
 
-        $output = '';
+        $output = [];
         $inFence = false;
 
-        for ($index = 0; $index < count($lines); $index += 2) {
-            $line = (string) ($lines[$index] ?? '');
-            $separator = (string) ($lines[$index + 1] ?? '');
-
+        foreach ($lines as $line) {
             if (preg_match('/^\s{0,3}(```|~~~)/', $line) === 1) {
                 $inFence = ! $inFence;
-                $output .= $line.$separator;
+                $output[] = $line;
 
                 continue;
             }
@@ -79,10 +76,10 @@ final class ArticleBodyHeadingGuard
                 }
             }
 
-            $output .= $line.$separator;
+            $output[] = $line;
         }
 
-        return $output;
+        return implode("\n", $output);
     }
 
     public function downgradeHtmlH1ToH2(string $html): string

--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php
@@ -61,6 +61,7 @@ final class SeoContentPackageDraftImporter
     public function __construct(
         private readonly ArticleTranslationRevisionWorkspace $revisionWorkspace,
         private readonly ArticleBodyHeadingGuard $articleBodyHeadingGuard,
+        private readonly SeoContentPackageJsonNormalizer $jsonNormalizer,
     ) {}
 
     /**
@@ -136,6 +137,7 @@ final class SeoContentPackageDraftImporter
             $manifest = $this->readJson($packageRoot.'/manifest.json', 'manifest.json', $errors);
             $guardScans = $this->validatePackageGuardScopes($packageRoot, $errors);
             $packageItems = $this->buildPackageItems($packageRoot, $manifest, $expectedTranslationGroupId, $expectedSlugs, $errors, $warnings);
+            $this->validateJsonFieldSerialization($packageItems, $errors, $warnings);
         }
 
         $ok = $errors === [];
@@ -171,7 +173,7 @@ final class SeoContentPackageDraftImporter
         }
 
         $category = $this->resolveCategory();
-        $metadata = $this->metadata($item);
+        $metadata = $this->normalizedJsonForWrite('article.cover_image_variants', $this->metadata($item));
         $body = (string) $item['body_markdown'];
 
         $article = $existing instanceof Article ? $existing : new Article;
@@ -238,9 +240,9 @@ final class SeoContentPackageDraftImporter
                 'og_description' => (string) $item['meta_description'],
                 'og_image_url' => (string) $item['og_image_url'],
                 'robots' => 'noindex,nofollow',
-                'schema_json' => [
+                'schema_json' => $this->normalizedJsonForWrite('article_seo_meta.schema_json', [
                     'editorial_package_v1' => $metadata['editorial_package_v1'],
-                ],
+                ]),
                 'is_indexable' => false,
             ],
         );
@@ -1009,11 +1011,103 @@ final class SeoContentPackageDraftImporter
     }
 
     /**
+     * @param  list<array<string,mixed>>  $items
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     */
+    private function validateJsonFieldSerialization(array $items, array &$errors, array &$warnings): void
+    {
+        foreach ($items as $item) {
+            $metadata = $this->metadata($item);
+            foreach ($this->jsonFieldPayloads($item, $metadata) as $field => $value) {
+                $result = $this->jsonNormalizer->normalizeField($field, $value);
+                foreach ($result['warnings'] as $warning) {
+                    $warnings[] = $warning;
+                }
+                foreach ($result['errors'] as $error) {
+                    $errors[] = $error;
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $item
+     * @param  array<string,mixed>  $metadata
+     * @return array<string,mixed>
+     */
+    private function jsonFieldPayloads(
+        array $item,
+        array $metadata,
+        ?Article $article = null,
+        ?ArticleTranslationRevision $revision = null
+    ): array {
+        $articleId = $article instanceof Article ? (int) $article->id : null;
+        $workingRevisionId = $revision instanceof ArticleTranslationRevision ? (int) $revision->id : null;
+
+        return [
+            'article.cover_image_variants' => $metadata,
+            'article_seo_meta.schema_json' => [
+                'editorial_package_v1' => $metadata['editorial_package_v1'] ?? [],
+            ],
+            'article_editorial_package_import.validation_summary_json' => [
+                'source' => 'articles:import-seo-content-package-draft',
+                'working_revision_id' => $workingRevisionId,
+                'preview_url_candidate' => $articleId !== null ? '/ops/article-preview/'.$articleId : null,
+            ],
+            'article_editorial_package_import.claim_result_json' => [
+                'status' => (string) $item['claim_gate_status'],
+                'matches' => [],
+            ],
+            'article_editorial_package_import.exactness_json' => [
+                'translation_group_id' => (string) $item['translation_group_id'],
+                'canonical_url' => (string) $item['canonical_url'],
+            ],
+            'article_editorial_package_import.references_json' => ['status' => 'operator_review_required'],
+            'article_editorial_package_import.media_json' => [
+                'status' => 'complete',
+                'cover_media_asset_key' => (string) $item['cover_media_asset_key'],
+                'cover_image_url' => (string) $item['cover_image_url'],
+                'og_image_url' => (string) $item['og_image_url'],
+            ],
+            'article_editorial_package_import.graph_json' => [
+                'primary_cta' => '/tests/holland-career-interest-test-riasec',
+                'big_five_route' => '/tests/big-five-personality-test-ocean-model',
+            ],
+            'article_editorial_package_import.answer_surface_json' => ['status' => 'visible_only'],
+            'article_editorial_package_import.heading_sequence_json' => $this->headingSequence((string) $item['body_markdown']),
+            'article_editorial_package_import.missing_fields_json' => [],
+            'article_editorial_package_import.blocked_reasons_json' => [],
+        ];
+    }
+
+    private function normalizedJsonForWrite(string $field, mixed $value): mixed
+    {
+        $result = $this->jsonNormalizer->normalizeField($field, $value);
+        if ($result['errors'] !== []) {
+            $error = $result['errors'][0];
+
+            throw new RuntimeException((string) $error['field'].' '.$error['code'].': '.$error['message']);
+        }
+
+        return $result['value'];
+    }
+
+    /**
      * @param  array<string,mixed>  $item
      * @param  array<string,mixed>  $metadata
      */
     private function persistImportRecord(Article $article, ArticleTranslationRevision $revision, array $item, array $metadata): void
     {
+        $jsonFields = [];
+        foreach ($this->jsonFieldPayloads($item, $metadata, $article, $revision) as $field => $value) {
+            if (! str_starts_with($field, 'article_editorial_package_import.')) {
+                continue;
+            }
+
+            $jsonFields[Str::after($field, 'article_editorial_package_import.')] = $this->normalizedJsonForWrite($field, $value);
+        }
+
         ArticleEditorialPackageImport::query()->withoutGlobalScopes()->create([
             'org_id' => 0,
             'article_id' => (int) $article->id,
@@ -1023,37 +1117,10 @@ final class SeoContentPackageDraftImporter
             'content_track' => 'seo_content_package_mode_c',
             'status' => ArticleEditorialPackageImport::STATUS_IMPORTED,
             'intended_status' => 'draft',
-            'validation_summary_json' => [
-                'source' => 'articles:import-seo-content-package-draft',
-                'working_revision_id' => (int) $revision->id,
-                'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
-            ],
-            'claim_result_json' => [
-                'status' => (string) $item['claim_gate_status'],
-                'matches' => [],
-            ],
-            'exactness_json' => [
-                'translation_group_id' => (string) $item['translation_group_id'],
-                'canonical_url' => (string) $item['canonical_url'],
-            ],
-            'references_json' => ['status' => 'operator_review_required'],
-            'media_json' => [
-                'status' => 'complete',
-                'cover_media_asset_key' => (string) $item['cover_media_asset_key'],
-                'cover_image_url' => (string) $item['cover_image_url'],
-                'og_image_url' => (string) $item['og_image_url'],
-            ],
-            'graph_json' => [
-                'primary_cta' => '/tests/holland-career-interest-test-riasec',
-                'big_five_route' => '/tests/big-five-personality-test-ocean-model',
-            ],
-            'answer_surface_json' => ['status' => 'visible_only'],
             'body_hash' => (string) data_get($metadata, 'editorial_package_v1.body_hash'),
-            'heading_sequence_json' => $this->headingSequence((string) $item['body_markdown']),
             'references_count' => 0,
-            'missing_fields_json' => [],
-            'blocked_reasons_json' => [],
             'imported_by' => null,
+            ...$jsonFields,
         ]);
     }
 
@@ -1063,9 +1130,9 @@ final class SeoContentPackageDraftImporter
     private function headingSequence(string $body): array
     {
         $headings = [];
-        foreach (preg_split('/\R/', $body) ?: [] as $line) {
-            if (preg_match('/^(#{2,6})\s+(.+)$/', $line, $matches) === 1) {
-                $headings[] = strlen((string) $matches[1]).':'.trim((string) $matches[2]);
+        foreach (explode("\n", str_replace(["\r\n", "\r"], "\n", $body)) as $line) {
+            if (preg_match('/^(#{2,6})[ \t]+/', $line, $matches) === 1) {
+                $headings[] = strlen((string) $matches[1]).':'.trim(substr($line, strlen((string) $matches[0])));
             }
         }
 

--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageJsonNormalizer.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageJsonNormalizer.php
@@ -1,0 +1,120 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms\SeoContentPackage;
+
+use JsonException;
+
+final class SeoContentPackageJsonNormalizer
+{
+    private const JSON_FLAGS = JSON_UNESCAPED_UNICODE
+        | JSON_UNESCAPED_SLASHES
+        | JSON_INVALID_UTF8_SUBSTITUTE
+        | JSON_THROW_ON_ERROR;
+
+    /**
+     * @return array{value:mixed,warnings:list<array{field:string,code:string,message:string}>,errors:list<array{field:string,code:string,message:string}>}
+     */
+    public function normalizeField(string $field, mixed $value): array
+    {
+        $warnings = [];
+        $errors = [];
+        $this->inspect($value, $field, $warnings, $errors);
+
+        if ($errors !== []) {
+            return [
+                'value' => $value,
+                'warnings' => $warnings,
+                'errors' => $errors,
+            ];
+        }
+
+        try {
+            $encoded = json_encode($value, self::JSON_FLAGS);
+            $normalized = json_decode($encoded, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException $exception) {
+            $errors[] = $this->issue(
+                $field,
+                'json_serialization_failed',
+                'JSON field serialization failed: '.$exception->getMessage()
+            );
+
+            return [
+                'value' => $value,
+                'warnings' => $warnings,
+                'errors' => $errors,
+            ];
+        }
+
+        return [
+            'value' => $normalized,
+            'warnings' => $warnings,
+            'errors' => [],
+        ];
+    }
+
+    /**
+     * @param  list<array{field:string,code:string,message:string}>  $warnings
+     * @param  list<array{field:string,code:string,message:string}>  $errors
+     */
+    private function inspect(mixed $value, string $path, array &$warnings, array &$errors): void
+    {
+        if (is_array($value)) {
+            foreach ($value as $key => $child) {
+                $this->inspect($child, $this->childPath($path, $key), $warnings, $errors);
+            }
+
+            return;
+        }
+
+        if (is_string($value)) {
+            if (str_contains($value, "\0")) {
+                $errors[] = $this->issue($path, 'json_binary_string_found', 'Binary string content is not allowed in JSON audit fields.');
+
+                return;
+            }
+
+            if (! mb_check_encoding($value, 'UTF-8')) {
+                $warnings[] = $this->issue($path, 'json_string_utf8_normalized', 'Invalid UTF-8 was normalized for this JSON audit field; content omitted from warning.');
+            }
+
+            return;
+        }
+
+        if (is_float($value) && (! is_finite($value))) {
+            $errors[] = $this->issue($path, 'json_non_serializable_value', 'Non-finite float is not serializable as JSON.');
+
+            return;
+        }
+
+        if (is_object($value) || is_resource($value)) {
+            $errors[] = $this->issue($path, 'json_non_serializable_value', 'Non-serializable value is not allowed in JSON audit fields.');
+        }
+    }
+
+    private function childPath(string $path, int|string $key): string
+    {
+        if (is_int($key)) {
+            return $path.'['.$key.']';
+        }
+
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $key) === 1) {
+            return $path.'.'.$key;
+        }
+
+        return $path.'['.json_encode($key, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE).']';
+    }
+
+    /**
+     * @return array{field:string,code:string,message:string}
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
@@ -11,8 +11,11 @@ use App\Models\ArticleTranslationRevision;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\Artisan;
 use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Event;
 use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
 use Illuminate\Support\Str;
+use RuntimeException;
 use Tests\TestCase;
 
 final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
@@ -343,7 +346,110 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $this->assertSame(2, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
         $this->assertSame(2, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
         $this->assertSame(0, DB::table('audit_logs')->where('action', 'content_release_publish')->count());
+        foreach (['seo_search_channel_queue_items', 'seo_search_channel_queue_batches', 'seo_search_channel_queue_events'] as $table) {
+            if (Schema::hasTable($table)) {
+                $this->assertSame(0, DB::table($table)->count(), $table.' should remain empty.');
+            }
+        }
         Http::assertNothingSent();
+    }
+
+    public function test_import_serializes_multilingual_heading_sequence_with_smart_and_fullwidth_punctuation(): void
+    {
+        $package = $this->writeModeCPackage(static function (array &$files): void {
+            $files['pages/zh-CN-career-interest-vs-personality-test-differences.md'] = str_replace(
+                "## Quick answer\n",
+                "## 职业兴趣—性格“边界”：全角，标点\n\n## Quick answer\n",
+                $files['pages/zh-CN-career-interest-vs-personality-test-differences.md']
+            );
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+
+        $importLog = ArticleEditorialPackageImport::query()
+            ->withoutGlobalScopes()
+            ->where('locale', 'zh-CN')
+            ->firstOrFail();
+
+        $this->assertStringContainsString(
+            '职业兴趣—性格“边界”：全角，标点',
+            implode("\n", $importLog->heading_sequence_json)
+        );
+    }
+
+    public function test_import_normalizes_malformed_utf8_heading_sequence_with_sanitized_warning(): void
+    {
+        $malformed = (string) hex2bin('c328');
+        $package = $this->writeModeCPackage(static function (array &$files) use ($malformed): void {
+            $files['pages/en-career-interest-test-vs-personality-test.md'] = str_replace(
+                "## Quick answer\n",
+                "## Broken {$malformed} heading\n\n## Quick answer\n",
+                $files['pages/en-career-interest-test-vs-personality-test.md']
+            );
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertWarningCode($payload, 'json_string_utf8_normalized');
+
+        $importLog = ArticleEditorialPackageImport::query()
+            ->withoutGlobalScopes()
+            ->where('locale', 'en')
+            ->firstOrFail();
+
+        $this->assertContains('2:Broken �( heading', $importLog->heading_sequence_json);
+    }
+
+    public function test_malformed_utf8_in_review_context_does_not_crash_import_audit_json(): void
+    {
+        $malformed = (string) hex2bin('c328');
+        $package = $this->writeModeCPackage(static function (array &$files) use ($malformed): void {
+            $files['review/claim_gate.md'] = "claim_gate_status: not_reviewed\nreview_note: {$malformed}\n";
+        });
+
+        $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertSame(2, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_import_failure_rolls_back_all_draft_related_writes(): void
+    {
+        $package = $this->writeModeCPackage();
+
+        Event::listen('eloquent.creating: '.ArticleEditorialPackageImport::class, static function (): void {
+            throw new RuntimeException('forced import audit failure');
+        });
+
+        try {
+            $exitCode = Artisan::call('articles:import-seo-content-package-draft', $this->commandOptions($package, [
+                '--json' => true,
+            ]));
+        } finally {
+            Event::forget('eloquent.creating: '.ArticleEditorialPackageImport::class);
+        }
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertFalse($payload['ok']);
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, ArticleEditorialPackageImport::query()->withoutGlobalScopes()->count());
     }
 
     public function test_json_output_includes_article_ids_working_revision_ids_and_preview_url_candidates(): void
@@ -407,6 +513,17 @@ final class ArticleImportSeoContentPackageDraftCommandTest extends TestCase
         $this->assertContains($code, array_map(
             static fn (array $error): string => (string) ($error['code'] ?? ''),
             $payload['errors'] ?? []
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertWarningCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $warning): string => (string) ($warning['code'] ?? ''),
+            $payload['warnings'] ?? []
         ));
     }
 

--- a/backend/tests/Unit/Services/Cms/SeoContentPackageJsonNormalizerTest.php
+++ b/backend/tests/Unit/Services/Cms/SeoContentPackageJsonNormalizerTest.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Services\Cms;
+
+use App\Services\Cms\SeoContentPackage\SeoContentPackageJsonNormalizer;
+use PHPUnit\Framework\TestCase;
+
+final class SeoContentPackageJsonNormalizerTest extends TestCase
+{
+    public function test_normal_chinese_english_and_smart_punctuation_are_preserved(): void
+    {
+        $normalizer = new SeoContentPackageJsonNormalizer;
+
+        $result = $normalizer->normalizeField('heading_sequence_json', [
+            '2:职业兴趣—性格“边界”：全角，标点',
+            '2:Career interests — personality “boundaries”',
+        ]);
+
+        $this->assertSame([], $result['errors']);
+        $this->assertSame([], $result['warnings']);
+        $this->assertSame([
+            '2:职业兴趣—性格“边界”：全角，标点',
+            '2:Career interests — personality “boundaries”',
+        ], $result['value']);
+    }
+
+    public function test_malformed_utf8_is_substituted_with_sanitized_warning(): void
+    {
+        $normalizer = new SeoContentPackageJsonNormalizer;
+        $malformed = '2:Broken '.((string) hex2bin('c328')).' heading';
+
+        $result = $normalizer->normalizeField('heading_sequence_json', [$malformed]);
+
+        $this->assertSame([], $result['errors']);
+        $this->assertSame('heading_sequence_json[0]', $result['warnings'][0]['field']);
+        $this->assertSame('json_string_utf8_normalized', $result['warnings'][0]['code']);
+        $this->assertSame(['2:Broken �( heading'], $result['value']);
+    }
+
+    public function test_non_serializable_value_fails_with_field_path(): void
+    {
+        $normalizer = new SeoContentPackageJsonNormalizer;
+        $handle = fopen('php://memory', 'rb');
+        $this->assertIsResource($handle);
+
+        try {
+            $result = $normalizer->normalizeField('heading_sequence_json', [
+                ['text' => $handle],
+            ]);
+        } finally {
+            fclose($handle);
+        }
+
+        $this->assertSame('heading_sequence_json[0].text', $result['errors'][0]['field']);
+        $this->assertSame('json_non_serializable_value', $result['errors'][0]['code']);
+    }
+
+    public function test_binary_string_fails_with_field_path(): void
+    {
+        $normalizer = new SeoContentPackageJsonNormalizer;
+
+        $result = $normalizer->normalizeField('metadata_json', [
+            'payload' => "not-json\0binary",
+        ]);
+
+        $this->assertSame('metadata_json.payload', $result['errors'][0]['field']);
+        $this->assertSame('json_binary_string_found', $result['errors'][0]['code']);
+    }
+}

--- a/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/JSON_FIELD_SERIALIZATION_MATRIX.md
+++ b/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/JSON_FIELD_SERIALIZATION_MATRIX.md
@@ -1,0 +1,24 @@
+# JSON Field Serialization Matrix
+
+| Field path | Preflight | Write-time normalization | Notes |
+| --- | --- | --- | --- |
+| `article.cover_image_variants` | Yes | Yes | Includes editorial package metadata and social image metadata. |
+| `article_seo_meta.schema_json` | Yes | Yes | Keeps schema hold metadata only; no schema is enabled. |
+| `article_editorial_package_import.validation_summary_json` | Yes | Yes | Includes source, working revision id, preview candidate. |
+| `article_editorial_package_import.claim_result_json` | Yes | Yes | Preserves claim gate status. |
+| `article_editorial_package_import.exactness_json` | Yes | Yes | Includes translation group and canonical URL. |
+| `article_editorial_package_import.references_json` | Yes | Yes | Operator review required marker. |
+| `article_editorial_package_import.media_json` | Yes | Yes | Cover and OG image audit metadata. |
+| `article_editorial_package_import.graph_json` | Yes | Yes | CTA/internal route audit metadata. |
+| `article_editorial_package_import.answer_surface_json` | Yes | Yes | Visible-only FAQ/answer-surface marker. |
+| `article_editorial_package_import.heading_sequence_json` | Yes | Yes | Heading text is extracted without PCRE multibyte capture and normalized only for JSON storage. |
+| `article_editorial_package_import.missing_fields_json` | Yes | Yes | Empty list for successful import. |
+| `article_editorial_package_import.blocked_reasons_json` | Yes | Yes | Empty list for successful import. |
+
+## Error/Warning Behavior
+
+- Valid UTF-8 is preserved, including Chinese, English, em dash, smart quotes, and fullwidth punctuation.
+- Malformed UTF-8 strings in JSON audit fields are substituted with `JSON_INVALID_UTF8_SUBSTITUTE` and produce sanitized warnings with field paths.
+- Binary strings containing NUL bytes fail with `json_binary_string_found`.
+- Objects/resources and non-finite floats fail with `json_non_serializable_value`.
+- Errors include field paths such as `heading_sequence_json[0].text`.

--- a/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/NEXT_DEPLOY_AND_DRAFT_IMPORT_RERUN_INSTRUCTIONS.md
+++ b/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/NEXT_DEPLOY_AND_DRAFT_IMPORT_RERUN_INSTRUCTIONS.md
@@ -1,0 +1,39 @@
+# Next Deploy And Draft Import Rerun Instructions
+
+## After PR Merge
+
+1. Confirm the merge commit is on `origin/main`.
+2. Deploy the exact backend SHA only after operator approval.
+3. Verify production command registration:
+
+```bash
+php artisan list articles | rg "import-seo-content-package-draft"
+```
+
+## Production Dry-Run Rerun
+
+Run the already-approved package dry-run first:
+
+```bash
+php artisan articles:import-seo-content-package-draft \
+  --package=/path/to/source-package \
+  --translation-group-id=tg_article_career_interest_vs_personality_test_2026v1 \
+  --locales=zh-CN,en \
+  --dry-run \
+  --json \
+  --draft-only \
+  --no-publish \
+  --no-index \
+  --no-sitemap \
+  --no-llms \
+  --schema-hold \
+  --hreflang-hold \
+  --expected-zh-slug=career-interest-vs-personality-test-differences \
+  --expected-en-slug=career-interest-test-vs-personality-test
+```
+
+Proceed to real draft-only import only if dry-run returns `ok=true`, `errors=[]`, and the JSON serialization preflight passes.
+
+## Hard Holds
+
+Do not publish, make indexable, add sitemap eligibility, add llms eligibility, enable schema, enable hreflang, submit search channels, or trigger revalidation as part of this fix rollout.

--- a/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/TEST_REPORT.md
+++ b/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/TEST_REPORT.md
@@ -1,0 +1,28 @@
+# Test Report
+
+## Commands Run
+
+```bash
+php artisan test tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
+php artisan test tests/Unit/Services/Cms/SeoContentPackageJsonNormalizerTest.php
+php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
+./vendor/bin/pint app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php app/Services/Cms/SeoContentPackage/SeoContentPackageJsonNormalizer.php app/Console/Commands/ArticleImportSeoContentPackageDraft.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php tests/Unit/Services/Cms/SeoContentPackageJsonNormalizerTest.php
+php artisan list articles | rg "import-seo-content-package-draft"
+git diff --check
+```
+
+## Results
+
+- `ArticleImportSeoContentPackageDraftCommandTest`: 20 passed, 149 assertions.
+- `SeoContentPackageJsonNormalizerTest`: 4 passed, 12 assertions.
+- `ArticleImportEditorialPackageCommandTest`: 11 passed, 259 assertions.
+- Pint: passed for changed PHP files.
+- Command registration: `articles:import-seo-content-package-draft` is registered.
+- `git diff --check`: passed.
+
+## Not Run
+
+- No production import.
+- No production dry-run.
+- No production DB connection.
+- No CMS draft creation.

--- a/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/TRANSACTION_ROLLBACK_SAFETY_REVIEW.md
+++ b/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/TRANSACTION_ROLLBACK_SAFETY_REVIEW.md
@@ -1,0 +1,21 @@
+# Transaction Rollback Safety Review
+
+## Transaction Boundary
+
+`SeoContentPackageDraftImporter::importFromDirectory()` still wraps all article, revision, SEO meta, and import-audit writes inside one `DB::transaction`.
+
+## Failure Behavior
+
+If write-time JSON normalization or import log persistence fails, the transaction throws and rolls back. Draft-related rows are not partially retained.
+
+## Regression Coverage
+
+`ArticleImportSeoContentPackageDraftCommandTest::test_import_failure_rolls_back_all_draft_related_writes` forces `ArticleEditorialPackageImport` creation to fail after article and SEO rows would have been written. The test confirms:
+
+- `articles` count remains 0
+- `article_seo_metas` count remains 0
+- `article_editorial_package_imports` count remains 0
+
+## Safety Gates Preserved
+
+The patch does not publish, index, add sitemap eligibility, add llms eligibility, dispatch content release follow-up, enqueue search channel work, or trigger production revalidation.

--- a/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/UTF8_NORMALIZATION_FIX_DESIGN.md
+++ b/generated/seo-ops-cms-draft-writer-utf8-normalization-fix-pr-00/UTF8_NORMALIZATION_FIX_DESIGN.md
@@ -1,0 +1,31 @@
+# UTF-8 Normalization Fix Design
+
+## Scope
+
+Command: `articles:import-seo-content-package-draft`
+
+Fixes the draft-only SEO content package writer path that failed during real import when JSON-cast audit fields, especially `ArticleEditorialPackageImport.heading_sequence_json`, contained malformed UTF-8.
+
+## Root Cause
+
+Two heading-processing paths used PCRE newline or heading capture patterns that could corrupt valid multibyte heading text before JSON persistence:
+
+- `ArticleBodyHeadingGuard::downgradeMarkdownH1ToH2()`
+- `SeoContentPackageDraftImporter::headingSequence()`
+
+The importer then handed JSON-cast fields directly to Eloquent without a shared serialization preflight, so dry-run could pass while real database writes failed.
+
+## Implementation
+
+- Replaced multibyte-sensitive newline splitting with byte-safe string newline normalization in heading guard and heading sequence extraction.
+- Added `SeoContentPackageJsonNormalizer` for recursive JSON-field serialization checks.
+- Added dry-run and non-dry-run JSON serialization preflight for:
+  - `article.cover_image_variants`
+  - `article_seo_meta.schema_json`
+  - `article_editorial_package_import.*_json`
+- Added write-time normalization for the same JSON payloads before Eloquent JSON casts.
+- Added `JSON_INVALID_UTF8_SUBSTITUTE` to command JSON output so diagnostics remain printable.
+
+## User-Visible Content Policy
+
+Article body Markdown, SEO title, meta description, and visible article content are not normalized or rewritten by this patch. Normalization is scoped to JSON audit, metadata, and heading sequence fields used by the import writer.


### PR DESCRIPTION
## What changed
- Added a scoped `SeoContentPackageJsonNormalizer` for JSON audit/metadata field serialization preflight and write-time normalization.
- Fixed UTF-8 corruption in Markdown heading processing by avoiding multibyte-unsafe PCRE newline/capture paths.
- Added `JSON_INVALID_UTF8_SUBSTITUTE` to command JSON output so diagnostics remain printable.
- Expanded draft writer tests for multilingual headings, malformed UTF-8 warnings, rollback safety, and no publish/index/sitemap/llms/search side effects.
- Added required generated SEO ops reports for this task.

## Why
Production dry-run passed, but real draft-only import failed while persisting `ArticleEditorialPackageImport.heading_sequence_json` due to malformed UTF-8. The fix makes dry-run and real import share JSON serialization checks and prevents heading extraction from corrupting valid Chinese/smart punctuation text.

## Validation
```bash
php artisan test tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php
php artisan test tests/Unit/Services/Cms/SeoContentPackageJsonNormalizerTest.php
php artisan test tests/Feature/Console/ArticleImportEditorialPackageCommandTest.php
./vendor/bin/pint app/Services/Cms/ArticleBodyHeadingGuard.php app/Services/Cms/SeoContentPackage/SeoContentPackageDraftImporter.php app/Services/Cms/SeoContentPackage/SeoContentPackageJsonNormalizer.php app/Console/Commands/ArticleImportSeoContentPackageDraft.php tests/Feature/Console/ArticleImportSeoContentPackageDraftCommandTest.php tests/Unit/Services/Cms/SeoContentPackageJsonNormalizerTest.php
php artisan list articles | rg "import-seo-content-package-draft"
git diff --check
```

## Intentionally deferred
- No production import or dry-run was executed from this PR task.
- No CMS draft was created.
- No publish/index/sitemap/llms/schema/hreflang/search/revalidation behavior was enabled.
