### PR TITLE
fix(ops): mark article draft previews as private no-store

### DIFF
--- a/backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php
+++ b/backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php
@@ -83,7 +83,7 @@ final class ArticleDraftPreviewController extends Controller
         return response($html, 200, [
             'Content-Type' => 'text/html; charset=UTF-8',
             'X-Robots-Tag' => 'noindex, noarchive, nosnippet',
-            'Cache-Control' => 'no-store',
+            'Cache-Control' => 'no-store, private',
             'Referrer-Policy' => 'no-referrer',
         ]);
     }

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -1136,16 +1136,16 @@
         },
         {
             "name": "filament/actions",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/actions.git",
-                "reference": "f8ea2b015b12c00522f1d6a7bcb9453b5f08beb1"
+                "reference": "3cb3e1f9094ed3b4bc102616966c365138c908bc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/actions/zipball/f8ea2b015b12c00522f1d6a7bcb9453b5f08beb1",
-                "reference": "f8ea2b015b12c00522f1d6a7bcb9453b5f08beb1",
+                "url": "https://api.github.com/repos/filamentphp/actions/zipball/3cb3e1f9094ed3b4bc102616966c365138c908bc",
+                "reference": "3cb3e1f9094ed3b4bc102616966c365138c908bc",
                 "shasum": ""
             },
             "require": {
@@ -1185,20 +1185,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:29:27+00:00"
+            "time": "2026-02-07T21:52:11+00:00"
         },
         {
             "name": "filament/filament",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/panels.git",
-                "reference": "790e3c163e93f5746beea88b93d38673424984b6"
+                "reference": "073e41c0abe78bc2cfcde3a186a40cbed328a6a7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/panels/zipball/790e3c163e93f5746beea88b93d38673424984b6",
-                "reference": "790e3c163e93f5746beea88b93d38673424984b6",
+                "url": "https://api.github.com/repos/filamentphp/panels/zipball/073e41c0abe78bc2cfcde3a186a40cbed328a6a7",
+                "reference": "073e41c0abe78bc2cfcde3a186a40cbed328a6a7",
                 "shasum": ""
             },
             "require": {
@@ -1250,20 +1250,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:29:34+00:00"
+            "time": "2026-05-21T17:50:14+00:00"
         },
         {
             "name": "filament/forms",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/forms.git",
-                "reference": "f708ce490cff3770071d18e9ea678eb4b7c65c58"
+                "reference": "67b6dc4cef99d2a9eda916a4202f63985b54ccf2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/forms/zipball/f708ce490cff3770071d18e9ea678eb4b7c65c58",
-                "reference": "f708ce490cff3770071d18e9ea678eb4b7c65c58",
+                "url": "https://api.github.com/repos/filamentphp/forms/zipball/67b6dc4cef99d2a9eda916a4202f63985b54ccf2",
+                "reference": "67b6dc4cef99d2a9eda916a4202f63985b54ccf2",
                 "shasum": ""
             },
             "require": {
@@ -1306,20 +1306,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:29:33+00:00"
+            "time": "2026-05-21T17:51:59+00:00"
         },
         {
             "name": "filament/infolists",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/infolists.git",
-                "reference": "ac7fc1c8acc651c6c793696f0772747791c91155"
+                "reference": "9cef7bf9f46756a8adf762ced62952e8c239b840"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/ac7fc1c8acc651c6c793696f0772747791c91155",
-                "reference": "ac7fc1c8acc651c6c793696f0772747791c91155",
+                "url": "https://api.github.com/repos/filamentphp/infolists/zipball/9cef7bf9f46756a8adf762ced62952e8c239b840",
+                "reference": "9cef7bf9f46756a8adf762ced62952e8c239b840",
                 "shasum": ""
             },
             "require": {
@@ -1357,11 +1357,11 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:28:31+00:00"
+            "time": "2026-02-07T21:51:54+00:00"
         },
         {
             "name": "filament/notifications",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/notifications.git",
@@ -1413,16 +1413,16 @@
         },
         {
             "name": "filament/support",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/support.git",
-                "reference": "c37f4b9045a7c514974e12562b5a41813860b505"
+                "reference": "493bd79d4f4ae7b9256c317af742354318a6f4e0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/support/zipball/c37f4b9045a7c514974e12562b5a41813860b505",
-                "reference": "c37f4b9045a7c514974e12562b5a41813860b505",
+                "url": "https://api.github.com/repos/filamentphp/support/zipball/493bd79d4f4ae7b9256c317af742354318a6f4e0",
+                "reference": "493bd79d4f4ae7b9256c317af742354318a6f4e0",
                 "shasum": ""
             },
             "require": {
@@ -1468,20 +1468,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-09T09:01:14+00:00"
+            "time": "2026-02-07T21:51:58+00:00"
         },
         {
             "name": "filament/tables",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/tables.git",
-                "reference": "c88d17248827b3fbca09db53d563498d29c6b180"
+                "reference": "6665aa5cc1bfaccd6c1de31b9c64a6f5ee54d937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/tables/zipball/c88d17248827b3fbca09db53d563498d29c6b180",
-                "reference": "c88d17248827b3fbca09db53d563498d29c6b180",
+                "url": "https://api.github.com/repos/filamentphp/tables/zipball/6665aa5cc1bfaccd6c1de31b9c64a6f5ee54d937",
+                "reference": "6665aa5cc1bfaccd6c1de31b9c64a6f5ee54d937",
                 "shasum": ""
             },
             "require": {
@@ -1520,20 +1520,20 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:29:37+00:00"
+            "time": "2026-05-20T15:37:01+00:00"
         },
         {
             "name": "filament/widgets",
-            "version": "v3.3.47",
+            "version": "v3.3.52",
             "source": {
                 "type": "git",
                 "url": "https://github.com/filamentphp/widgets.git",
-                "reference": "2bf59fd94007b69c22c161f7a4749ea19560e03e"
+                "reference": "f58ff26e81ca2557205e3111e1d9d05c258cc206"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/2bf59fd94007b69c22c161f7a4749ea19560e03e",
-                "reference": "2bf59fd94007b69c22c161f7a4749ea19560e03e",
+                "url": "https://api.github.com/repos/filamentphp/widgets/zipball/f58ff26e81ca2557205e3111e1d9d05c258cc206",
+                "reference": "f58ff26e81ca2557205e3111e1d9d05c258cc206",
                 "shasum": ""
             },
             "require": {
@@ -1564,7 +1564,7 @@
                 "issues": "https://github.com/filamentphp/filament/issues",
                 "source": "https://github.com/filamentphp/filament"
             },
-            "time": "2026-01-01T16:29:32+00:00"
+            "time": "2026-02-07T21:51:58+00:00"
         },
         {
             "name": "fruitcake/php-cors",
@@ -1910,16 +1910,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "2.9.0",
+            "version": "2.10.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884"
+                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/7d0ed42f28e42d61352a7a79de682e5e67fec884",
-                "reference": "7d0ed42f28e42d61352a7a79de682e5e67fec884",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
+                "reference": "a1bbdc172f32a25fe999965b65b6e71fd87da9ed",
                 "shasum": ""
             },
             "require": {
@@ -1934,9 +1934,9 @@
             },
             "require-dev": {
                 "bamarni/composer-bin-plugin": "^1.8.2",
-                "http-interop/http-factory-tests": "0.9.0",
+                "http-interop/http-factory-tests": "1.1.0",
                 "jshttp/mime-db": "1.54.0.1",
-                "phpunit/phpunit": "^8.5.44 || ^9.6.25"
+                "phpunit/phpunit": "^8.5.52 || ^9.6.34"
             },
             "suggest": {
                 "laminas/laminas-httphandlerrunner": "Emit PSR-7 responses"
@@ -2007,7 +2007,7 @@
             ],
             "support": {
                 "issues": "https://github.com/guzzle/psr7/issues",
-                "source": "https://github.com/guzzle/psr7/tree/2.9.0"
+                "source": "https://github.com/guzzle/psr7/tree/2.10.2"
             },
             "funding": [
                 {
@@ -2023,7 +2023,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-10T16:41:02+00:00"
+            "time": "2026-05-25T22:58:15+00:00"
         },
         {
             "name": "guzzlehttp/uri-template",

--- a/backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+++ b/backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
@@ -58,6 +58,7 @@ final class ArticleDraftPreviewRouteTest extends TestCase
             ->assertDontSee('rel=\"canonical\"', false)
             ->assertDontSee('rel=\"alternate\"', false);
         $this->assertStringContainsString('no-store', (string) $response->headers->get('Cache-Control'));
+        $this->assertStringContainsString('private', (string) $response->headers->get('Cache-Control'));
 
         $article->refresh();
         $this->assertSame('draft', $article->status);
@@ -79,6 +80,16 @@ final class ArticleDraftPreviewRouteTest extends TestCase
             ->get('/ops/article-preview/'.$article->id)
             ->assertForbidden()
             ->assertJsonPath('message', 'admin_content_read_required');
+    }
+
+    public function test_preview_route_requires_authenticated_ops_session(): void
+    {
+        $article = $this->createDraftArticle();
+
+        $this
+            ->get('/ops/article-preview/'.$article->id)
+            ->assertUnauthorized()
+            ->assertJsonPath('message', 'admin_token_missing');
     }
 
     public function test_article_workspace_builds_ops_preview_url_instead_of_public_canonical_url(): void
@@ -119,7 +130,7 @@ final class ArticleDraftPreviewRouteTest extends TestCase
             'revision_status' => ArticleTranslationRevision::STATUS_MACHINE_DRAFT,
             'title' => 'Working Revision Preview Title',
             'excerpt' => 'Working revision excerpt.',
-            'content_md' => "## Body\\n\\nDraft body with /result/abc123?token=abc123 private link.",
+            'content_md' => '## Body\\n\\nDraft body with /result/abc123?token=abc123 private link.',
             'seo_title' => 'Revision SEO Title',
             'seo_description' => 'Revision SEO description.',
         ]);

--- a/generated/seo-ops-article-preview-cache-control-private-pr-00/NEXT_DEPLOY_AND_PREVIEW_QA_RERUN_INSTRUCTIONS.md
+++ b/generated/seo-ops-article-preview-cache-control-private-pr-00/NEXT_DEPLOY_AND_PREVIEW_QA_RERUN_INSTRUCTIONS.md
@@ -1,0 +1,21 @@
+# Next Deploy And Preview QA Rerun Instructions
+
+After this PR is merged:
+
+1. Run backend deploy readiness for the merge commit.
+2. Deploy the exact merged SHA only after explicit operator approval.
+3. Do not publish or mutate CMS during deploy readiness or deploy.
+4. After production deploy, rerun `SEO-OPS-NEW-BILINGUAL-ARTICLE-PAIR-PREVIEW-QA-00` for:
+   - zh article_id: 46
+   - en article_id: 47
+5. Confirm production preview response now has `Cache-Control: no-store, private`.
+6. Proceed to operator publish review only if preview QA returns `GO_FOR_OPERATOR_PUBLISH_REVIEW`.
+
+Still forbidden before separate explicit approval:
+- publish
+- indexable
+- sitemap eligible
+- llms eligible
+- schema/hreflang enablement
+- GSC/Baidu/IndexNow/Search Channel submission
+- ISR/revalidation/cache invalidation outside normal backend deploy behavior

--- a/generated/seo-ops-article-preview-cache-control-private-pr-00/PREVIEW_CACHE_CONTROL_FIX_REPORT.md
+++ b/generated/seo-ops-article-preview-cache-control-private-pr-00/PREVIEW_CACHE_CONTROL_FIX_REPORT.md
@@ -1,0 +1,24 @@
+# Preview Cache-Control Fix Report
+
+Decision: READY_FOR_PR
+
+Scope:
+- fap-api only.
+- No CMS mutation.
+- No draft import.
+- No publish/index/sitemap/llms/search/revalidation changes.
+
+Change implemented:
+- Updated `ArticleDraftPreviewController` response header for `/ops/article-preview/{article}` from `Cache-Control: no-store` to `Cache-Control: no-store, private`.
+
+Files changed:
+- `backend/app/Http/Controllers/Ops/ArticleDraftPreviewController.php`
+- `backend/tests/Feature/Ops/ArticleDraftPreviewRouteTest.php`
+
+Safety notes:
+- `X-Robots-Tag` remains `noindex, noarchive, nosnippet`.
+- Preview response still renders no canonical link tag.
+- Preview response still renders no hreflang/alternate tag.
+- Preview response still renders no JSON-LD/schema.
+- Route remains behind Ops/admin middleware.
+- Public canonical article routes are not touched.

--- a/generated/seo-ops-article-preview-cache-control-private-pr-00/PREVIEW_HEADER_CONTRACT_CHECK.md
+++ b/generated/seo-ops-article-preview-cache-control-private-pr-00/PREVIEW_HEADER_CONTRACT_CHECK.md
@@ -1,0 +1,15 @@
+# Preview Header Contract Check
+
+| Contract | Result | Evidence |
+|---|---:|---|
+| Authenticated article draft preview returns 200 | PASS | `ArticleDraftPreviewRouteTest` authenticated case passes |
+| `X-Robots-Tag` includes `noindex` | PASS | Exact assertion remains `noindex, noarchive, nosnippet` |
+| `X-Robots-Tag` includes `noarchive` | PASS | Exact assertion remains `noindex, noarchive, nosnippet` |
+| `X-Robots-Tag` includes `nosnippet` | PASS | Exact assertion remains `noindex, noarchive, nosnippet` |
+| `Cache-Control` includes `no-store` | PASS | Existing assertion retained |
+| `Cache-Control` includes `private` | PASS | New assertion added |
+| No canonical link | PASS | Existing `assertDontSee('rel="canonical"')` retained |
+| No hreflang/alternate | PASS | Existing `assertDontSee('rel="alternate"')` retained |
+| No JSON-LD/schema | PASS | Existing `assertDontSee('application/ld+json')` retained |
+| Unauthenticated preview remains blocked | PASS | New 401 `admin_token_missing` test added |
+| Public canonical route unaffected | PASS | No public route/controller/model/publish code changed |

--- a/generated/seo-ops-article-preview-cache-control-private-pr-00/TEST_REPORT.md
+++ b/generated/seo-ops-article-preview-cache-control-private-pr-00/TEST_REPORT.md
@@ -41,3 +41,34 @@ git diff --check
 
 Result:
 - PASS: no whitespace errors.
+
+## CI supply-chain rerun fix
+
+GitHub `supply-chain` failed on `composer audit --locked` because new advisories affected the locked versions of `filament/tables` and `guzzlehttp/psr7`.
+
+Remediation command:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+composer update filament/filament filament/actions filament/forms filament/infolists filament/notifications filament/support filament/tables filament/widgets guzzlehttp/psr7 --with filament/filament:3.3.52 --with guzzlehttp/psr7:2.10.2
+```
+
+Packages updated in `composer.lock`:
+- `filament/*` panel components: `v3.3.47` -> `v3.3.52`
+- `guzzlehttp/psr7`: `2.9.0` -> `2.10.2`
+
+Post-fix validation:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+composer validate --strict
+composer audit --locked --no-interaction --ignore-unreachable
+php artisan test tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --path=ops/article-preview
+```
+
+Result:
+- PASS: `composer.json` valid.
+- PASS: no security vulnerability advisories found.
+- PASS: article draft preview route tests remain green.
+- PASS: Ops article preview route remains registered when Ops panel is enabled.

--- a/generated/seo-ops-article-preview-cache-control-private-pr-00/TEST_REPORT.md
+++ b/generated/seo-ops-article-preview-cache-control-private-pr-00/TEST_REPORT.md
@@ -1,0 +1,43 @@
+# Test Report
+
+Commands run:
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+```
+
+Result:
+- PASS: 4 tests, 26 assertions.
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+./vendor/bin/pint app/Http/Controllers/Ops/ArticleDraftPreviewController.php tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+```
+
+Result:
+- PASS: Pint completed; one single-quote style fix applied in the test file.
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+php artisan test tests/Feature/Ops/ArticleDraftPreviewRouteTest.php
+```
+
+Result after Pint:
+- PASS: 4 tests, 26 assertions.
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api/backend
+FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --path=ops/article-preview
+```
+
+Result:
+- PASS: `GET|HEAD ops/article-preview/{article}` registered as `ops.articles.preview` when Ops panel is enabled.
+
+```bash
+cd /Users/rainie/Desktop/GitHub/fap-api
+git diff --check
+```
+
+Result:
+- PASS: no whitespace errors.


### PR DESCRIPTION
## What changed
- Updated Ops article draft preview responses to send `Cache-Control: no-store, private`.
- Kept `X-Robots-Tag: noindex, noarchive, nosnippet` unchanged.
- Extended `ArticleDraftPreviewRouteTest` to assert `private` and unauthenticated preview blocking.
- Added scoped SEO-OPS reports under `generated/seo-ops-article-preview-cache-control-private-pr-00/`.

## Why
`SEO-OPS-NEW-BILINGUAL-ARTICLE-PAIR-PREVIEW-QA-00` blocked operator publish review because production preview responses only had `Cache-Control: no-store`. The preview QA contract requires both `no-store` and `private`.

## Validation
- `cd backend && php artisan test tests/Feature/Ops/ArticleDraftPreviewRouteTest.php`
- `cd backend && ./vendor/bin/pint app/Http/Controllers/Ops/ArticleDraftPreviewController.php tests/Feature/Ops/ArticleDraftPreviewRouteTest.php`
- `cd backend && php artisan test tests/Feature/Ops/ArticleDraftPreviewRouteTest.php`
- `cd backend && FAP_ADMIN_PANEL_ENABLED=true php artisan route:list --path=ops/article-preview`
- `git diff --check`
- `git diff --cached --check`

## Intentionally deferred
- No CMS mutation.
- No draft import.
- No publish/index/sitemap/llms/search-channel changes.
- No production deploy.
- No ISR/revalidation/cache invalidation.
