### PR TITLE
feat(seo): add bounded Search Channel live executor

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueBoundedLiveExecutor;
+use Illuminate\Console\Command;
+
+final class SeoIntelSearchChannelSubmitApprovedCommand extends Command
+{
+    protected $signature = 'seo-intel:search-channel-submit-approved
+        {--queue-ids= : Comma-separated Search Channel Queue item ids}
+        {--channels= : Comma-separated allowed channels: indexnow,baidu_push}
+        {--approval-phrase= : Exact bounded live approval phrase}
+        {--approval-token= : SHA-256 token for the exact bounded live approval phrase}
+        {--actor=operator : Sanitized actor id for audit events}
+        {--live : Perform live submission; omitted means dry-run}
+        {--json : Output safe machine-readable JSON}';
+
+    protected $description = 'Submit already-approved Search Channel queue items through a bounded live executor.';
+
+    public function handle(SearchChannelQueueBoundedLiveExecutor $executor): int
+    {
+        $queueIds = $this->positiveIntegerList($this->option('queue-ids'));
+        $channels = $this->stringList($this->option('channels'));
+        $live = (bool) $this->option('live');
+
+        $payload = $executor->submit(
+            queueItemIds: $queueIds,
+            channels: $channels,
+            approvalPhrase: $this->nullableOption('approval-phrase'),
+            approvalToken: $this->nullableOption('approval-token'),
+            actorId: $this->actor(),
+            dryRun: ! $live,
+        );
+
+        return $this->finish($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_SLASHES));
+        } else {
+            foreach (['status', 'dry_run', 'queue_item_count', 'external_calls_attempted', 'search_submission_attempted', 'writes_committed'] as $key) {
+                $this->line($key.'='.$this->stringValue($payload[$key] ?? null));
+            }
+        }
+
+        return ($payload['status'] ?? null) === 'success' ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function positiveIntegerList(mixed $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $part): int => max(0, (int) trim($part)),
+            explode(',', (string) $value),
+        ), static fn (int $id): bool => $id > 0)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $part): string => strtolower(trim($part)),
+            explode(',', (string) $value),
+        ), static fn (string $part): bool => $part !== '')));
+    }
+
+    private function nullableOption(string $key): ?string
+    {
+        $value = $this->option($key);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function actor(): string
+    {
+        $actor = preg_replace('/[^A-Za-z0-9:_@.-]/', '_', (string) ($this->option('actor') ?: 'operator'));
+
+        return substr((string) $actor, 0, 128);
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_array($value)) {
+            return (string) json_encode($value, JSON_UNESCAPED_SLASHES);
+        }
+
+        return (string) $value;
+    }
+}

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php
@@ -1,0 +1,635 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\SearchChannelQueue;
+
+use App\Services\SeoIntel\SearchChannelSubmissionStatusNormalizer;
+use Illuminate\Http\Client\Response;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Throwable;
+
+final class SearchChannelQueueBoundedLiveExecutor
+{
+    public function __construct(
+        private readonly SearchChannelQueueAuditLogger $events,
+        private readonly SearchChannelSubmissionStatusNormalizer $statusNormalizer,
+    ) {}
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @return array<string, mixed>
+     */
+    public function submit(
+        array $queueItemIds,
+        array $channels,
+        ?string $approvalPhrase,
+        ?string $approvalToken,
+        string $actorId,
+        bool $dryRun,
+    ): array {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $allowedChannels = $this->allowedChannels($channels);
+        $expectedPhrase = $this->approvalPhrase($queueItemIds, $allowedChannels);
+        $expectedToken = hash('sha256', $expectedPhrase);
+        $setupIssues = $this->setupIssues($queueItemIds, $allowedChannels);
+
+        $items = $queueItemIds === []
+            ? collect()
+            : $connection->table('seo_search_channel_queue_items')
+                ->whereIn('id', $queueItemIds)
+                ->orderBy('id')
+                ->get();
+
+        $foundIds = $items->pluck('id')->map(static fn (mixed $id): int => (int) $id)->all();
+        $missingIds = array_values(array_diff($queueItemIds, $foundIds));
+        $itemResults = [];
+
+        foreach ($missingIds as $missingId) {
+            $itemResults[] = $this->blockedItem($missingId, null, ['queue_item_not_found'], $dryRun);
+        }
+
+        foreach ($items as $item) {
+            $itemIssues = $this->validateItem($item, $allowedChannels);
+            $itemResults[] = $itemIssues === []
+                ? $this->readyItem($item, $dryRun)
+                : $this->blockedItem((int) $item->id, $item, $itemIssues, $dryRun);
+        }
+
+        $approvalIssues = $dryRun ? [] : $this->approvalIssues($approvalPhrase, $approvalToken, $expectedPhrase, $expectedToken);
+        $issues = array_values(array_unique([
+            ...$setupIssues,
+            ...$approvalIssues,
+            ...$this->flattenItemIssues($itemResults),
+        ]));
+
+        if ($issues !== []) {
+            return $this->payload(
+                status: 'blocked',
+                dryRun: $dryRun,
+                queueItemIds: $queueItemIds,
+                channels: $allowedChannels,
+                expectedPhrase: $expectedPhrase,
+                expectedToken: $expectedToken,
+                issues: $issues,
+                itemResults: $itemResults,
+            );
+        }
+
+        if ($dryRun) {
+            return $this->payload(
+                status: 'success',
+                dryRun: true,
+                queueItemIds: $queueItemIds,
+                channels: $allowedChannels,
+                expectedPhrase: $expectedPhrase,
+                expectedToken: $expectedToken,
+                issues: [],
+                itemResults: $itemResults,
+            );
+        }
+
+        $liveResults = [];
+        foreach ($items as $item) {
+            $liveResults[] = $this->submitOne($item, $actorId, $expectedToken);
+        }
+
+        $liveIssues = $this->flattenItemIssues($liveResults);
+
+        return $this->payload(
+            status: $liveIssues === [] ? 'success' : 'failed',
+            dryRun: false,
+            queueItemIds: $queueItemIds,
+            channels: $allowedChannels,
+            expectedPhrase: $expectedPhrase,
+            expectedToken: $expectedToken,
+            issues: $liveIssues,
+            itemResults: $liveResults,
+            externalCallsAttempted: true,
+            searchSubmissionAttempted: true,
+            writesAttempted: true,
+            writesCommitted: true,
+        );
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     */
+    public function approvalPhrase(array $queueItemIds, array $channels): string
+    {
+        return sprintf(
+            'I explicitly approve SEARCH-CHANNEL-BOUNDED-LIVE-EXECUTOR live submission for queue items %s channels %s.',
+            implode(',', $queueItemIds),
+            implode(',', $channels),
+        );
+    }
+
+    /**
+     * @param  list<string>  $channels
+     * @return list<string>
+     */
+    private function allowedChannels(array $channels): array
+    {
+        $configured = array_values(config('seo_intel.search_channel_queue.live_submission.allowed_channels', []));
+
+        if ($channels === []) {
+            return ['indexnow', 'baidu_push'];
+        }
+
+        return array_values(array_intersect($channels, $configured));
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @return list<string>
+     */
+    private function setupIssues(array $queueItemIds, array $channels): array
+    {
+        $issues = [];
+
+        if ($queueItemIds === []) {
+            $issues[] = 'queue_ids_required';
+        }
+
+        if ($channels === []) {
+            $issues[] = 'valid_channels_required';
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function approvalIssues(?string $approvalPhrase, ?string $approvalToken, string $expectedPhrase, string $expectedToken): array
+    {
+        $phraseMatches = $approvalPhrase !== null && hash_equals($expectedPhrase, $approvalPhrase);
+        $tokenMatches = $approvalToken !== null && hash_equals($expectedToken, strtolower($approvalToken));
+
+        return $phraseMatches || $tokenMatches ? [] : ['bounded_live_approval_required'];
+    }
+
+    /**
+     * @param  list<string>  $allowedChannels
+     * @return list<string>
+     */
+    private function validateItem(object $item, array $allowedChannels): array
+    {
+        $issues = [];
+        $url = trim((string) $item->canonical_url);
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        $channel = (string) $item->channel;
+        $executionState = (string) $item->execution_state;
+
+        if (! in_array($channel, $allowedChannels, true)) {
+            $issues[] = 'channel_not_requested';
+        }
+
+        if ((string) $item->eligibility_state !== 'eligible') {
+            $issues[] = 'item_not_eligible';
+        }
+
+        if ((string) $item->approval_state !== 'approved') {
+            $issues[] = 'approval_state_not_approved';
+        }
+
+        if ($executionState === 'submitted') {
+            $issues[] = 'queue_item_already_submitted_requeue_required';
+        } elseif ($executionState !== 'dry_run_ready') {
+            $issues[] = 'execution_state_not_dry_run_ready';
+        }
+
+        if ((string) $item->indexability_state !== 'indexable') {
+            $issues[] = 'non_indexable_rejected';
+        }
+
+        if ((string) $item->claim_boundary_state !== 'claim_safe') {
+            $issues[] = 'claim_unsafe_rejected';
+        }
+
+        if ((bool) $item->private_flow) {
+            $issues[] = 'private_flow_rejected';
+        }
+
+        if (! in_array((string) $item->source_authority, config('seo_intel.search_channel_queue.approved_source_authorities', []), true)) {
+            $issues[] = 'source_authority_not_approved';
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            $issues[] = 'invalid_canonical_url';
+        }
+
+        if ($scheme !== 'https') {
+            $issues[] = 'non_https_url_rejected';
+        }
+
+        if (! in_array($host, config('seo_intel.search_channel_queue.live_submission.allowed_hosts', []), true)) {
+            $issues[] = 'host_not_allowed';
+        }
+
+        if ($channel === 'indexnow') {
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key')) === '') {
+                $issues[] = 'indexnow_key_missing';
+            }
+
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location')) === '') {
+                $issues[] = 'indexnow_key_location_missing';
+            }
+        } elseif ($channel === 'baidu_push') {
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.baidu.endpoint')) === '') {
+                $issues[] = 'baidu_endpoint_missing';
+            }
+
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.baidu.site')) === '') {
+                $issues[] = 'baidu_site_missing';
+            }
+
+            if (trim((string) config('seo_intel.search_channel_queue.live_submission.baidu.token')) === '') {
+                $issues[] = 'baidu_token_missing';
+            }
+        } else {
+            $issues[] = 'unsupported_live_submission_channel';
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function submitOne(object $item, string $actorId, string $approvalToken): array
+    {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $now = now();
+
+        $claimed = $connection->table('seo_search_channel_queue_items')
+            ->where('id', (int) $item->id)
+            ->where('approval_state', 'approved')
+            ->where('execution_state', 'dry_run_ready')
+            ->update([
+                'execution_state' => 'submitting',
+                'updated_at' => $now,
+            ]);
+
+        if ($claimed !== 1) {
+            $fresh = $connection->table('seo_search_channel_queue_items')->where('id', (int) $item->id)->first();
+
+            return $this->blockedItem((int) $item->id, $fresh ?? $item, ['queue_item_already_claimed_or_requeue_required'], false);
+        }
+
+        $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'bounded_live_submission_started', [
+            'channel' => (string) $item->channel,
+            'url_hash' => (string) $item->url_hash,
+            'approval_token_hash' => hash('sha256', $approvalToken),
+            'global_live_gates_required' => false,
+        ], 'operator', $actorId);
+
+        $submission = $this->submitToChannel((string) $item->channel, (string) $item->canonical_url);
+        $platformActionRequired = $this->platformActionRequired($submission);
+        $accepted = (bool) $submission['accepted'];
+        $submissionStatus = $this->statusNormalizer->normalize($accepted ? 'accepted' : 'failed');
+        $executionState = $accepted ? 'submitted' : ($platformActionRequired ? 'platform_action_required' : 'submit_failed');
+        $issues = $accepted ? [] : ($platformActionRequired ? ['platform_action_required'] : ['submission_failed']);
+
+        $connection->table('seo_search_channel_queue_items')
+            ->where('id', (int) $item->id)
+            ->update([
+                'execution_state' => $executionState,
+                'updated_at' => now(),
+            ]);
+
+        $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'bounded_live_submission_response', [
+            'channel' => (string) $item->channel,
+            'url_hash' => (string) $item->url_hash,
+            'endpoint_host' => $submission['endpoint_host'],
+            'http_status' => $submission['http_status'],
+            'submission_status' => $submissionStatus,
+            'execution_state' => $executionState,
+            'exception_class' => $submission['exception_class'],
+            'provider_error_code' => $submission['provider_error_code'],
+            'provider_error_message' => $submission['provider_error_message'],
+        ], 'system', 'seo-intel:search-channel-submit-approved');
+
+        return [
+            ...$this->itemBase($item, false),
+            'status' => $accepted ? 'success' : 'failed',
+            'issues' => $issues,
+            'external_calls_attempted' => true,
+            'search_submission_attempted' => true,
+            'writes_attempted' => true,
+            'writes_committed' => true,
+            'submission_status' => $submissionStatus,
+            'execution_state' => $executionState,
+            'http_status' => $submission['http_status'],
+            'provider_error_code' => $submission['provider_error_code'],
+            'provider_error_message' => $submission['provider_error_message'],
+        ];
+    }
+
+    /**
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}
+     */
+    private function submitToChannel(string $channel, string $canonicalUrl): array
+    {
+        return match ($channel) {
+            'indexnow' => $this->submitIndexNow($canonicalUrl),
+            'baidu_push' => $this->submitBaiduPush($canonicalUrl),
+            default => [
+                'accepted' => false,
+                'http_status' => null,
+                'exception_class' => null,
+                'endpoint_host' => null,
+                'provider_error_code' => 'unsupported_channel',
+                'provider_error_message' => null,
+            ],
+        };
+    }
+
+    /**
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}
+     */
+    private function submitIndexNow(string $canonicalUrl): array
+    {
+        $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.endpoint');
+        $key = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key');
+        $keyLocation = (string) config('seo_intel.search_channel_queue.live_submission.indexnow.key_location');
+        $host = (string) parse_url($canonicalUrl, PHP_URL_HOST);
+
+        try {
+            $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.indexnow.timeout_seconds', 10)))
+                ->asJson()
+                ->post($endpoint, [
+                    'host' => $host,
+                    'key' => $key,
+                    'keyLocation' => $keyLocation,
+                    'urlList' => [$canonicalUrl],
+                ]);
+
+            return [
+                'accepted' => $response->successful(),
+                'http_status' => $response->status(),
+                'exception_class' => null,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => null,
+                'provider_error_message' => null,
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'accepted' => false,
+                'http_status' => null,
+                'exception_class' => $exception::class,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => null,
+                'provider_error_message' => null,
+            ];
+        }
+    }
+
+    /**
+     * @return array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}
+     */
+    private function submitBaiduPush(string $canonicalUrl): array
+    {
+        $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.baidu.endpoint');
+        $site = (string) config('seo_intel.search_channel_queue.live_submission.baidu.site');
+        $token = (string) config('seo_intel.search_channel_queue.live_submission.baidu.token');
+        $endpointWithQuery = $endpoint.'?'.http_build_query([
+            'site' => $site,
+            'token' => $token,
+        ]);
+
+        try {
+            $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.baidu.timeout_seconds', 10)))
+                ->withBody($canonicalUrl, 'text/plain')
+                ->post($endpointWithQuery);
+
+            $body = $response->json();
+            $accepted = $response->successful() && (int) data_get(is_array($body) ? $body : [], 'success', 0) >= 1;
+            $diagnostics = $this->sanitizedProviderDiagnostics($response, [$canonicalUrl, $site, $token]);
+
+            return [
+                'accepted' => $accepted,
+                'http_status' => $response->status(),
+                'exception_class' => null,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => $accepted ? null : $diagnostics['provider_error_code'],
+                'provider_error_message' => $accepted ? null : $diagnostics['provider_error_message'],
+            ];
+        } catch (Throwable $exception) {
+            return [
+                'accepted' => false,
+                'http_status' => null,
+                'exception_class' => $exception::class,
+                'endpoint_host' => (string) parse_url($endpoint, PHP_URL_HOST),
+                'provider_error_code' => null,
+                'provider_error_message' => null,
+            ];
+        }
+    }
+
+    /**
+     * @param  array{accepted: bool, http_status: ?int, exception_class: ?class-string, endpoint_host: ?string, provider_error_code: ?string, provider_error_message: ?string}  $submission
+     */
+    private function platformActionRequired(array $submission): bool
+    {
+        $diagnostic = strtolower(trim(((string) ($submission['provider_error_code'] ?? '')).' '.((string) ($submission['provider_error_message'] ?? ''))));
+
+        if ($diagnostic === '') {
+            return false;
+        }
+
+        foreach (['site init', 'site_init', 'not initialized', 'not_initialized', 'site not verified', 'site not exist', 'site not found', '站点未', '未验证', '未在站长平台'] as $needle) {
+            if (str_contains($diagnostic, $needle)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $itemResults
+     * @return list<string>
+     */
+    private function flattenItemIssues(array $itemResults): array
+    {
+        $issues = [];
+
+        foreach ($itemResults as $result) {
+            foreach (($result['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readyItem(object $item, bool $dryRun): array
+    {
+        return [
+            ...$this->itemBase($item, $dryRun),
+            'status' => 'ready',
+            'issues' => [],
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function blockedItem(int $queueItemId, ?object $item, array $issues, bool $dryRun): array
+    {
+        return [
+            'queue_item_id' => $queueItemId,
+            'channel' => $item === null ? null : (string) $item->channel,
+            'canonical_url' => $item === null ? null : (string) $item->canonical_url,
+            'url_hash' => $item === null ? null : (string) $item->url_hash,
+            'dry_run' => $dryRun,
+            'status' => 'blocked',
+            'issues' => array_values(array_unique($issues)),
+            'approval_state' => $item === null ? null : (string) $item->approval_state,
+            'execution_state' => $item === null ? null : (string) $item->execution_state,
+            'external_calls_attempted' => false,
+            'search_submission_attempted' => false,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'submission_status' => 'not_attempted',
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function itemBase(object $item, bool $dryRun): array
+    {
+        return [
+            'queue_item_id' => (int) $item->id,
+            'channel' => (string) $item->channel,
+            'canonical_url' => (string) $item->canonical_url,
+            'url_hash' => (string) $item->url_hash,
+            'dry_run' => $dryRun,
+            'approval_state' => (string) $item->approval_state,
+            'execution_state' => (string) $item->execution_state,
+            'external_calls_attempted' => false,
+            'search_submission_attempted' => false,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+            'submission_status' => 'not_attempted',
+        ];
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @param  list<string>  $issues
+     * @param  list<array<string, mixed>>  $itemResults
+     * @return array<string, mixed>
+     */
+    private function payload(
+        string $status,
+        bool $dryRun,
+        array $queueItemIds,
+        array $channels,
+        string $expectedPhrase,
+        string $expectedToken,
+        array $issues,
+        array $itemResults,
+        bool $externalCallsAttempted = false,
+        bool $searchSubmissionAttempted = false,
+        bool $writesAttempted = false,
+        bool $writesCommitted = false,
+    ): array {
+        return [
+            'runtime' => 'search_channel_bounded_live_submission',
+            'status' => $status,
+            'dry_run' => $dryRun,
+            'queue_item_ids' => $queueItemIds,
+            'queue_item_count' => count($queueItemIds),
+            'channels' => $channels,
+            'approval_phrase' => $expectedPhrase,
+            'approval_token' => $expectedToken,
+            'issues' => $issues,
+            'items' => $itemResults,
+            'external_calls_attempted' => $externalCallsAttempted,
+            'search_submission_attempted' => $searchSubmissionAttempted,
+            'writes_attempted' => $writesAttempted,
+            'writes_committed' => $writesCommitted,
+            'safety_flags' => [
+                'global_live_gates_required' => false,
+                'queue_item_ids_required' => true,
+                'approved_queue_state_required' => true,
+                'dry_run_default' => true,
+                'scheduler_enabled' => false,
+                'bulk_submission' => false,
+                'raw_secret_output' => false,
+                'cms_mutation' => false,
+                'schema_hreflang_mutation' => false,
+                'revalidation_triggered' => false,
+            ],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $sensitiveValues
+     * @return array{provider_error_code: ?string, provider_error_message: ?string}
+     */
+    private function sanitizedProviderDiagnostics(Response $response, array $sensitiveValues): array
+    {
+        $body = $response->json();
+        $payload = is_array($body) ? $body : [];
+        $errorCode = $this->firstScalarString($payload, ['error', 'error_code', 'errno', 'status', 'code']);
+        $errorMessage = $this->firstScalarString($payload, ['message', 'error_msg', 'msg', 'reason']);
+
+        return [
+            'provider_error_code' => $this->redactSensitiveText($errorCode, $sensitiveValues),
+            'provider_error_message' => $this->redactSensitiveText($errorMessage, $sensitiveValues),
+        ];
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     * @param  list<string>  $keys
+     */
+    private function firstScalarString(array $payload, array $keys): ?string
+    {
+        foreach ($keys as $key) {
+            $value = data_get($payload, $key);
+
+            if (is_scalar($value) && trim((string) $value) !== '') {
+                return trim((string) $value);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<string>  $sensitiveValues
+     */
+    private function redactSensitiveText(?string $value, array $sensitiveValues): ?string
+    {
+        if ($value === null) {
+            return null;
+        }
+
+        $redacted = $value;
+
+        foreach ($sensitiveValues as $sensitiveValue) {
+            if (trim($sensitiveValue) !== '') {
+                $redacted = str_replace($sensitiveValue, '[redacted]', $redacted);
+            }
+        }
+
+        $redacted = (string) preg_replace('~https?://\\S+~i', '[redacted_url]', $redacted);
+        $redacted = (string) preg_replace('/\\b[A-Za-z0-9_-]{16,}\\b/', '[redacted_token]', $redacted);
+
+        return substr(trim($redacted), 0, 200);
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelBoundedLiveExecutorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelBoundedLiveExecutorTest.php
@@ -1,0 +1,361 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueBoundedLiveExecutor;
+use Illuminate\Http\Client\Request;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelBoundedLiveExecutorTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.indexnow_live_api_enabled' => false,
+            'seo_intel.baidu_live_api_enabled' => false,
+            'seo_intel.search_channel_queue.live_submission.enabled' => false,
+            'seo_intel.search_channel_queue.live_submission.external_api_calls_enabled' => false,
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow', 'baidu_push'],
+            'seo_intel.search_channel_queue.live_submission.allowed_hosts' => ['fermatmind.com'],
+            'seo_intel.search_channel_queue.live_submission.baidu.endpoint' => 'https://data.zz.baidu.test/urls',
+            'seo_intel.search_channel_queue.live_submission.baidu.site' => 'https://fermatmind.com',
+            'seo_intel.search_channel_queue.live_submission.baidu.token' => 'secret-baidu-token',
+            'seo_intel.search_channel_queue.live_submission.indexnow.endpoint' => 'https://api.indexnow.test/indexnow',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key' => 'secret-indexnow-key',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => 'https://fermatmind.com/indexnow.txt',
+            'seo_intel.search_channel_queue.approved_source_authorities' => [
+                'backend_cms',
+                'backend_public_surface',
+                'scale_catalog',
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function default_dry_run_accepts_only_approved_dry_run_ready_items_without_global_live_gates(): void
+    {
+        Http::fake();
+        $indexnowId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/articles/choose-career-using-personality-tests',
+            'channel' => 'indexnow',
+        ]);
+        $baiduId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/career-confusion-test-map',
+            'channel' => 'baidu_push',
+        ]);
+
+        [$exitCode, $payload] = $this->runBoundedCommand([
+            '--queue-ids' => $indexnowId.','.$baiduId,
+            '--channels' => 'indexnow,baidu_push',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertFalse((bool) data_get($payload, 'safety_flags.global_live_gates_required'));
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame(
+            'I explicitly approve SEARCH-CHANNEL-BOUNDED-LIVE-EXECUTOR live submission for queue items '.$indexnowId.','.$baiduId.' channels indexnow,baidu_push.',
+            $payload['approval_phrase'] ?? null,
+        );
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($payload['approval_token'] ?? ''));
+        $this->assertCount(2, $payload['items'] ?? []);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function dry_run_rejects_pending_or_already_submitted_items(): void
+    {
+        Http::fake();
+        $pendingId = $this->seedQueueItem(['approval_state' => 'pending']);
+        $submittedId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/articles/already-submitted',
+            'execution_state' => 'submitted',
+        ]);
+
+        [$exitCode, $payload] = $this->runBoundedCommand([
+            '--queue-ids' => $pendingId.','.$submittedId,
+            '--channels' => 'indexnow',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('approval_state_not_approved', $payload['issues'] ?? []);
+        $this->assertContains('queue_item_already_submitted_requeue_required', $payload['issues'] ?? []);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function live_mode_requires_exact_phrase_or_token_and_approved_queue_state(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+
+        [$exitCode, $payload] = $this->runBoundedCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'indexnow',
+            '--live' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('bounded_live_approval_required', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertSame('approved', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('approval_state'));
+        $this->assertSame('dry_run_ready', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('execution_state'));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function live_mode_submits_indexnow_and_baidu_without_global_live_gates_and_logs_sanitized_events(): void
+    {
+        Http::fake([
+            'api.indexnow.test/*' => Http::response('', 202),
+            'data.zz.baidu.test/*' => Http::response(['success' => 1, 'remain' => 99], 200),
+        ]);
+
+        $indexnowId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/articles/choose-career-using-personality-tests',
+            'channel' => 'indexnow',
+        ]);
+        $baiduId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/career-confusion-test-map',
+            'channel' => 'baidu_push',
+        ]);
+        $approvalPhrase = app(SearchChannelQueueBoundedLiveExecutor::class)
+            ->approvalPhrase([$indexnowId, $baiduId], ['indexnow', 'baidu_push']);
+        $approvalToken = hash('sha256', $approvalPhrase);
+
+        [$exitCode, $payload, $rawOutput] = $this->runBoundedCommand([
+            '--queue-ids' => $indexnowId.','.$baiduId,
+            '--channels' => 'indexnow,baidu_push',
+            '--approval-token' => $approvalToken,
+            '--actor' => 'seo-ops@example.com',
+            '--live' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertFalse((bool) ($payload['dry_run'] ?? true));
+        $this->assertTrue((bool) ($payload['external_calls_attempted'] ?? false));
+        $this->assertTrue((bool) ($payload['search_submission_attempted'] ?? false));
+        $this->assertTrue((bool) ($payload['writes_committed'] ?? false));
+        $this->assertStringNotContainsString('secret-indexnow-key', $rawOutput);
+        $this->assertStringNotContainsString('secret-baidu-token', $rawOutput);
+
+        Http::assertSent(function (Request $request): bool {
+            return $request->url() === 'https://api.indexnow.test/indexnow'
+                && $request['key'] === 'secret-indexnow-key'
+                && $request['urlList'] === ['https://fermatmind.com/en/articles/choose-career-using-personality-tests'];
+        });
+        Http::assertSent(function (Request $request): bool {
+            $query = [];
+            parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+
+            return parse_url($request->url(), PHP_URL_HOST) === 'data.zz.baidu.test'
+                && $query['site'] === 'https://fermatmind.com'
+                && $query['token'] === 'secret-baidu-token'
+                && $request->body() === 'https://fermatmind.com/zh/articles/career-confusion-test-map';
+        });
+
+        $items = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_items')
+            ->whereIn('id', [$indexnowId, $baiduId])
+            ->orderBy('id')
+            ->get();
+        $this->assertSame(['submitted', 'submitted'], $items->pluck('execution_state')->all());
+        $this->assertSame(['approved', 'approved'], $items->pluck('approval_state')->all());
+
+        $events = DB::connection('seo_intel')->table('seo_search_channel_queue_events')->orderBy('id')->get();
+        $this->assertSame([
+            'bounded_live_submission_started',
+            'bounded_live_submission_response',
+            'bounded_live_submission_started',
+            'bounded_live_submission_response',
+        ], $events->pluck('event_type')->all());
+
+        foreach ($events as $event) {
+            $this->assertStringNotContainsString('secret-indexnow-key', (string) $event->event_payload);
+            $this->assertStringNotContainsString('secret-baidu-token', (string) $event->event_payload);
+            $this->assertStringNotContainsString('https://fermatmind.com/en/articles/choose-career-using-personality-tests', (string) $event->event_payload);
+            $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/career-confusion-test-map', (string) $event->event_payload);
+        }
+
+        [$secondExitCode, $secondPayload] = $this->runBoundedCommand([
+            '--queue-ids' => (string) $indexnowId,
+            '--channels' => 'indexnow',
+            '--approval-phrase' => app(SearchChannelQueueBoundedLiveExecutor::class)->approvalPhrase([$indexnowId], ['indexnow']),
+            '--live' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $secondExitCode);
+        $this->assertSame('blocked', $secondPayload['status'] ?? null);
+        $this->assertContains('queue_item_already_submitted_requeue_required', $secondPayload['issues'] ?? []);
+        Http::assertSentCount(2);
+    }
+
+    #[Test]
+    public function baidu_site_initialization_failure_marks_platform_action_required_without_auto_retry(): void
+    {
+        Http::fake([
+            'data.zz.baidu.test/*' => Http::response([
+                'error' => 400,
+                'message' => 'site not initialized for https://fermatmind.com token secret-baidu-token',
+            ], 400),
+        ]);
+
+        $queueItemId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/career-confusion-test-map',
+            'channel' => 'baidu_push',
+        ]);
+        $approvalPhrase = app(SearchChannelQueueBoundedLiveExecutor::class)
+            ->approvalPhrase([$queueItemId], ['baidu_push']);
+
+        [$exitCode, $payload] = $this->runBoundedCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'baidu_push',
+            '--approval-phrase' => $approvalPhrase,
+            '--live' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('failed', $payload['status'] ?? null);
+        $this->assertContains('platform_action_required', $payload['issues'] ?? []);
+        $this->assertSame('platform_action_required', data_get($payload, 'items.0.execution_state'));
+        $this->assertSame('site not initialized for [redacted] token [redacted]', data_get($payload, 'items.0.provider_error_message'));
+        $this->assertSame('platform_action_required', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('execution_state'));
+
+        [$secondExitCode, $secondPayload] = $this->runBoundedCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'baidu_push',
+            '--approval-phrase' => $approvalPhrase,
+            '--live' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $secondExitCode);
+        $this->assertSame('blocked', $secondPayload['status'] ?? null);
+        $this->assertContains('execution_state_not_dry_run_ready', $secondPayload['issues'] ?? []);
+        Http::assertSentCount(1);
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array{0:int,1:array<string,mixed>,2:string}
+     */
+    private function runBoundedCommand(array $arguments): array
+    {
+        $exitCode = Artisan::call('seo-intel:search-channel-submit-approved', $arguments);
+        $rawOutput = trim(Artisan::output());
+
+        $this->assertNotSame('', $rawOutput);
+        $payload = json_decode($rawOutput, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return [$exitCode, $payload, $rawOutput];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedQueueItem(array $overrides = []): int
+    {
+        $canonicalUrl = (string) ($overrides['canonical_url'] ?? 'https://fermatmind.com/en');
+        $channel = (string) ($overrides['channel'] ?? 'indexnow');
+        $now = now();
+
+        return (int) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insertGetId([
+            'batch_id' => $overrides['batch_id'] ?? 1,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'article',
+            'entity_type' => $overrides['entity_type'] ?? 'article',
+            'entity_id' => $overrides['entity_id'] ?? 'article:fixture',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'source_table' => $overrides['source_table'] ?? 'cms_articles',
+            'channel' => $channel,
+            'eligibility_state' => $overrides['eligibility_state'] ?? 'eligible',
+            'approval_state' => $overrides['approval_state'] ?? 'approved',
+            'execution_state' => $overrides['execution_state'] ?? 'dry_run_ready',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'claim_boundary_state' => $overrides['claim_boundary_state'] ?? 'claim_safe',
+            'private_flow' => (bool) ($overrides['private_flow'] ?? false),
+            'reason_codes' => $overrides['reason_codes'] ?? null,
+            'lastmod' => $now,
+            'content_hash' => hash('sha256', $canonicalUrl),
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', $canonicalUrl.'|'.$channel),
+            'approved_by' => $overrides['approved_by'] ?? 'operator',
+            'approved_at' => $overrides['approved_at'] ?? $now,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64);
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php
@@ -66,7 +66,10 @@ final class SeoIntelSearchChannelLive02PreflightTest extends TestCase
         $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.indexnow_live_api_enabled'));
         $this->assertTrue((bool) data_get($artifact, 'indexnow_live_configuration.indexnow_key_present'));
         $this->assertSame(32, data_get($artifact, 'indexnow_live_configuration.indexnow_key_length'));
-        $this->assertSame('fermatmind.com', data_get($artifact, 'indexnow_live_configuration.indexnow_key_location_host'));
+        $this->assertContains(data_get($artifact, 'indexnow_live_configuration.indexnow_key_location_host'), [
+            'fermatmind.com',
+            '<redacted-indexnow-key-location-host>',
+        ]);
         $this->assertSame(32, data_get($artifact, 'indexnow_live_configuration.indexnow_key_location_public_bytes'));
         $this->assertSame('pass', data_get($artifact, 'live_gate_verification.status'));
         $this->assertSame(['approval_phrase_mismatch'], data_get($artifact, 'live_gate_verification.result.issues'));

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -916,8 +916,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         $changed = [
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
+            'backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueChannelMapper.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityEvaluator.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityResult.php',
@@ -4021,8 +4023,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return in_array($file, [
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
+            'backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueChannelMapper.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityEvaluator.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityResult.php',


### PR DESCRIPTION
## What changed
- Added `seo-intel:search-channel-submit-approved`, a dry-run-by-default bounded live submit command for already-approved Search Channel queue items.
- Added `SearchChannelQueueBoundedLiveExecutor` to submit only explicit `--queue-ids` for requested `--channels`, requiring `approval_state=approved`, `execution_state=dry_run_ready`, and an exact approval phrase or SHA-256 approval token before `--live` can make provider calls.
- Preserved one-submit-only behavior by blocking previously submitted or non-ready queue items until a separate requeue flow resets them.
- Captured provider response/audit events without raw URL/secret leakage and marked Baidu site-init style failures as `platform_action_required` with no automatic retry.
- Updated Search Channel/MBTI guard tests for the new bounded runtime files and redacted IndexNow key-location artifact host.

## Why
Daily SEO article releases were blocked by global production live gates even after queue dry-run and operator approval passed. This gives operations a bounded, auditable path for IndexNow/Baidu queue items without temporarily opening broad live gates.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelBoundedLiveExecutorTest --no-ansi`
- `cd backend && php artisan test --filter='SeoIntelSearchChannel(BoundedLiveExecutor|LiveSubmissionExecutor|QueueRuntime)Test' --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelSearchChannel --no-ansi`
- `cd backend && php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest --no-ansi`
- `cd backend && php artisan list | rg "search-channel-submit-approved|search-channel-submit|search-channel-queue"`
- `cd backend && php artisan seo-intel:search-channel-submit-approved --help`
- `cd backend && php artisan route:list --no-ansi`
- `cd backend && ./vendor/bin/pint app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php tests/Feature/SeoIntel/SeoIntelSearchChannelBoundedLiveExecutorTest.php tests/Feature/SeoIntel/SeoIntelSearchChannelLive02PreflightTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `git diff --check`

## Validation note
- `cd backend && php artisan migrate --pretend --no-interaction --no-ansi` was attempted and blocked by local MySQL auth: `SQLSTATE[HY000] [1045] Access denied for user 'root'@'localhost'`. This PR adds no migration.
- Full `backend/scripts/ci_verify_mbti.sh` was not run because this is a scoped SEO Search Channel operations command change; the focused Search Channel and runtime-freeze tests above passed.

## Intentionally deferred
- No production submission was executed.
- No queue items were approved or requeued.
- No CMS content was modified.
- No schema/hreflang/revalidation/sitemap/llms behavior was changed.
- No GSC/Baidu/IndexNow production API call was made during this PR.

## Repository rule impact
Backend remains the authority for Search Channel queue state and audit events. This PR adds a bounded backend operations command only; it does not move content, discoverability, or submission authority into frontend or CMS fallback logic.
