### PR TITLE
feat(seo): add Search Channel queue approval command

### DIFF
--- a/backend/app/Console/Commands/SeoIntelSearchChannelApproveCommand.php
+++ b/backend/app/Console/Commands/SeoIntelSearchChannelApproveCommand.php
@@ -1,0 +1,111 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueApprovalExecutor;
+use Illuminate\Console\Command;
+
+final class SeoIntelSearchChannelApproveCommand extends Command
+{
+    protected $signature = 'seo-intel:search-channel-approve
+        {--queue-ids= : Comma-separated Search Channel Queue item ids}
+        {--channels= : Comma-separated allowed channels: indexnow,baidu_push}
+        {--approval-phrase= : Exact bounded queue approval phrase}
+        {--approval-token= : SHA-256 token for the exact bounded queue approval phrase}
+        {--actor=operator : Sanitized actor id for audit events}
+        {--approve : Commit approval; omitted means dry-run}
+        {--json : Output safe machine-readable JSON}';
+
+    protected $description = 'Approve bounded Search Channel queue items for the draft-safe live executor.';
+
+    public function handle(SearchChannelQueueApprovalExecutor $executor): int
+    {
+        $queueIds = $this->positiveIntegerList($this->option('queue-ids'));
+        $channels = $this->stringList($this->option('channels'));
+        $approve = (bool) $this->option('approve');
+
+        $payload = $executor->approve(
+            queueItemIds: $queueIds,
+            channels: $channels,
+            approvalPhrase: $this->nullableOption('approval-phrase'),
+            approvalToken: $this->nullableOption('approval-token'),
+            actorId: $this->actor(),
+            dryRun: ! $approve,
+        );
+
+        return $this->finish($payload);
+    }
+
+    /**
+     * @param  array<string, mixed>  $payload
+     */
+    private function finish(array $payload): int
+    {
+        if ((bool) $this->option('json')) {
+            $this->line((string) json_encode($payload, JSON_UNESCAPED_SLASHES));
+        } else {
+            foreach (['status', 'dry_run', 'queue_item_count', 'writes_committed'] as $key) {
+                $this->line($key.'='.$this->stringValue($payload[$key] ?? null));
+            }
+        }
+
+        return ($payload['status'] ?? null) === 'success' ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return list<int>
+     */
+    private function positiveIntegerList(mixed $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $part): int => max(0, (int) trim($part)),
+            explode(',', (string) $value),
+        ), static fn (int $id): bool => $id > 0)));
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function stringList(mixed $value): array
+    {
+        return array_values(array_unique(array_filter(array_map(
+            static fn (string $part): string => strtolower(trim($part)),
+            explode(',', (string) $value),
+        ), static fn (string $part): bool => $part !== '')));
+    }
+
+    private function nullableOption(string $key): ?string
+    {
+        $value = $this->option($key);
+
+        if ($value === null) {
+            return null;
+        }
+
+        $value = trim((string) $value);
+
+        return $value === '' ? null : $value;
+    }
+
+    private function actor(): string
+    {
+        $actor = preg_replace('/[^A-Za-z0-9:_@.-]/', '_', (string) ($this->option('actor') ?: 'operator'));
+
+        return substr((string) $actor, 0, 128);
+    }
+
+    private function stringValue(mixed $value): string
+    {
+        if (is_bool($value)) {
+            return $value ? '1' : '0';
+        }
+
+        if (is_array($value)) {
+            return (string) json_encode($value, JSON_UNESCAPED_SLASHES);
+        }
+
+        return (string) $value;
+    }
+}

--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueApprovalExecutor.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueApprovalExecutor.php
@@ -1,0 +1,388 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\SeoIntel\SearchChannelQueue;
+
+use Illuminate\Support\Facades\DB;
+
+final class SearchChannelQueueApprovalExecutor
+{
+    public function __construct(
+        private readonly SearchChannelQueueAuditLogger $events,
+    ) {}
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @return array<string, mixed>
+     */
+    public function approve(
+        array $queueItemIds,
+        array $channels,
+        ?string $approvalPhrase,
+        ?string $approvalToken,
+        string $actorId,
+        bool $dryRun,
+    ): array {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $allowedChannels = $this->allowedChannels($channels);
+        $expectedPhrase = $this->approvalPhrase($queueItemIds, $allowedChannels);
+        $expectedToken = hash('sha256', $expectedPhrase);
+        $setupIssues = $this->setupIssues($queueItemIds, $allowedChannels);
+
+        $items = $queueItemIds === []
+            ? collect()
+            : $connection->table('seo_search_channel_queue_items')
+                ->whereIn('id', $queueItemIds)
+                ->orderBy('id')
+                ->get();
+
+        $foundIds = $items->pluck('id')->map(static fn (mixed $id): int => (int) $id)->all();
+        $missingIds = array_values(array_diff($queueItemIds, $foundIds));
+        $itemResults = [];
+
+        foreach ($missingIds as $missingId) {
+            $itemResults[] = $this->blockedItem($missingId, null, ['queue_item_not_found'], $dryRun);
+        }
+
+        foreach ($items as $item) {
+            $itemIssues = $this->validateItem($item, $allowedChannels);
+            $itemResults[] = $itemIssues === []
+                ? $this->readyItem($item, $dryRun)
+                : $this->blockedItem((int) $item->id, $item, $itemIssues, $dryRun);
+        }
+
+        $approvalIssues = $dryRun ? [] : $this->approvalIssues($approvalPhrase, $approvalToken, $expectedPhrase, $expectedToken);
+        $issues = array_values(array_unique([
+            ...$setupIssues,
+            ...$approvalIssues,
+            ...$this->flattenItemIssues($itemResults),
+        ]));
+
+        if ($issues !== []) {
+            return $this->payload(
+                status: 'blocked',
+                dryRun: $dryRun,
+                queueItemIds: $queueItemIds,
+                channels: $allowedChannels,
+                expectedPhrase: $expectedPhrase,
+                expectedToken: $expectedToken,
+                issues: $issues,
+                itemResults: $itemResults,
+            );
+        }
+
+        if ($dryRun) {
+            return $this->payload(
+                status: 'success',
+                dryRun: true,
+                queueItemIds: $queueItemIds,
+                channels: $allowedChannels,
+                expectedPhrase: $expectedPhrase,
+                expectedToken: $expectedToken,
+                issues: [],
+                itemResults: $itemResults,
+            );
+        }
+
+        $approvedResults = [];
+        foreach ($items as $item) {
+            $approvedResults[] = $this->approveOne($item, $actorId, $expectedToken);
+        }
+
+        $approveIssues = $this->flattenItemIssues($approvedResults);
+
+        return $this->payload(
+            status: $approveIssues === [] ? 'success' : 'failed',
+            dryRun: false,
+            queueItemIds: $queueItemIds,
+            channels: $allowedChannels,
+            expectedPhrase: $expectedPhrase,
+            expectedToken: $expectedToken,
+            issues: $approveIssues,
+            itemResults: $approvedResults,
+            writesAttempted: true,
+            writesCommitted: $approveIssues === [],
+        );
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     */
+    public function approvalPhrase(array $queueItemIds, array $channels): string
+    {
+        return sprintf(
+            'I explicitly approve SEARCH-CHANNEL-QUEUE-APPROVE approval for queue items %s channels %s.',
+            implode(',', $queueItemIds),
+            implode(',', $channels),
+        );
+    }
+
+    /**
+     * @param  list<string>  $channels
+     * @return list<string>
+     */
+    private function allowedChannels(array $channels): array
+    {
+        $configured = array_values(config('seo_intel.search_channel_queue.live_submission.allowed_channels', []));
+
+        if ($channels === []) {
+            return ['indexnow', 'baidu_push'];
+        }
+
+        return array_values(array_intersect($channels, $configured));
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @return list<string>
+     */
+    private function setupIssues(array $queueItemIds, array $channels): array
+    {
+        $issues = [];
+
+        if ($queueItemIds === []) {
+            $issues[] = 'queue_ids_required';
+        }
+
+        if ($channels === []) {
+            $issues[] = 'valid_channels_required';
+        }
+
+        return $issues;
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function approvalIssues(?string $approvalPhrase, ?string $approvalToken, string $expectedPhrase, string $expectedToken): array
+    {
+        $phraseMatches = $approvalPhrase !== null && hash_equals($expectedPhrase, $approvalPhrase);
+        $tokenMatches = $approvalToken !== null && hash_equals($expectedToken, strtolower($approvalToken));
+
+        return $phraseMatches || $tokenMatches ? [] : ['bounded_queue_approval_required'];
+    }
+
+    /**
+     * @param  list<string>  $allowedChannels
+     * @return list<string>
+     */
+    private function validateItem(object $item, array $allowedChannels): array
+    {
+        $issues = [];
+        $url = trim((string) $item->canonical_url);
+        $host = strtolower((string) parse_url($url, PHP_URL_HOST));
+        $scheme = strtolower((string) parse_url($url, PHP_URL_SCHEME));
+        $channel = (string) $item->channel;
+
+        if (! in_array($channel, $allowedChannels, true)) {
+            $issues[] = 'channel_not_requested';
+        }
+
+        if ((string) $item->eligibility_state !== 'eligible') {
+            $issues[] = 'item_not_eligible';
+        }
+
+        if ((string) $item->approval_state !== 'pending') {
+            $issues[] = 'approval_state_not_pending';
+        }
+
+        if ((string) $item->execution_state !== 'dry_run_ready') {
+            $issues[] = 'execution_state_not_dry_run_ready';
+        }
+
+        if ((string) $item->indexability_state !== 'indexable') {
+            $issues[] = 'non_indexable_rejected';
+        }
+
+        if ((string) $item->claim_boundary_state !== 'claim_safe') {
+            $issues[] = 'claim_unsafe_rejected';
+        }
+
+        if ((bool) $item->private_flow) {
+            $issues[] = 'private_flow_rejected';
+        }
+
+        if (! in_array((string) $item->source_authority, config('seo_intel.search_channel_queue.approved_source_authorities', []), true)) {
+            $issues[] = 'source_authority_not_approved';
+        }
+
+        if (filter_var($url, FILTER_VALIDATE_URL) === false) {
+            $issues[] = 'invalid_canonical_url';
+        }
+
+        if ($scheme !== 'https') {
+            $issues[] = 'non_https_url_rejected';
+        }
+
+        if (! in_array($host, config('seo_intel.search_channel_queue.live_submission.allowed_hosts', []), true)) {
+            $issues[] = 'host_not_allowed';
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function approveOne(object $item, string $actorId, string $approvalToken): array
+    {
+        $connection = DB::connection((string) config('seo_intel.connection', 'seo_intel'));
+        $now = now();
+
+        $claimed = $connection->table('seo_search_channel_queue_items')
+            ->where('id', (int) $item->id)
+            ->where('approval_state', 'pending')
+            ->where('execution_state', 'dry_run_ready')
+            ->update([
+                'approval_state' => 'approved',
+                'approved_by' => $actorId,
+                'approved_at' => $now,
+                'updated_at' => $now,
+            ]);
+
+        if ($claimed !== 1) {
+            $fresh = $connection->table('seo_search_channel_queue_items')->where('id', (int) $item->id)->first();
+
+            return $this->blockedItem((int) $item->id, $fresh ?? $item, ['queue_item_already_claimed_or_requeue_required'], false);
+        }
+
+        $this->events->log($connection, (int) $item->id, is_numeric($item->batch_id) ? (int) $item->batch_id : null, 'search_channel_queue_approved', [
+            'channel' => (string) $item->channel,
+            'url_hash' => (string) $item->url_hash,
+            'approval_token_hash' => hash('sha256', $approvalToken),
+            'bounded_approval' => true,
+        ], 'operator', $actorId);
+
+        return [
+            ...$this->itemBase($item, false),
+            'status' => 'approved',
+            'issues' => [],
+            'approval_state' => 'approved',
+            'approved_by' => $actorId,
+            'approved_at' => $now->toJSON(),
+            'writes_attempted' => true,
+            'writes_committed' => true,
+        ];
+    }
+
+    /**
+     * @param  list<array<string, mixed>>  $itemResults
+     * @return list<string>
+     */
+    private function flattenItemIssues(array $itemResults): array
+    {
+        $issues = [];
+
+        foreach ($itemResults as $result) {
+            foreach (($result['issues'] ?? []) as $issue) {
+                $issues[] = (string) $issue;
+            }
+        }
+
+        return array_values(array_unique($issues));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function readyItem(object $item, bool $dryRun): array
+    {
+        return [
+            ...$this->itemBase($item, $dryRun),
+            'status' => 'ready_for_approval',
+            'issues' => [],
+        ];
+    }
+
+    /**
+     * @param  list<string>  $issues
+     * @return array<string, mixed>
+     */
+    private function blockedItem(int $queueItemId, ?object $item, array $issues, bool $dryRun): array
+    {
+        return [
+            'queue_item_id' => $queueItemId,
+            'channel' => $item === null ? null : (string) $item->channel,
+            'canonical_url' => $item === null ? null : (string) $item->canonical_url,
+            'url_hash' => $item === null ? null : (string) $item->url_hash,
+            'dry_run' => $dryRun,
+            'status' => 'blocked',
+            'issues' => array_values(array_unique($issues)),
+            'approval_state' => $item === null ? null : (string) $item->approval_state,
+            'execution_state' => $item === null ? null : (string) $item->execution_state,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+        ];
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    private function itemBase(object $item, bool $dryRun): array
+    {
+        return [
+            'queue_item_id' => (int) $item->id,
+            'channel' => (string) $item->channel,
+            'canonical_url' => (string) $item->canonical_url,
+            'url_hash' => (string) $item->url_hash,
+            'dry_run' => $dryRun,
+            'approval_state' => (string) $item->approval_state,
+            'execution_state' => (string) $item->execution_state,
+            'writes_attempted' => false,
+            'writes_committed' => false,
+        ];
+    }
+
+    /**
+     * @param  list<int>  $queueItemIds
+     * @param  list<string>  $channels
+     * @param  list<string>  $issues
+     * @param  list<array<string, mixed>>  $itemResults
+     * @return array<string, mixed>
+     */
+    private function payload(
+        string $status,
+        bool $dryRun,
+        array $queueItemIds,
+        array $channels,
+        string $expectedPhrase,
+        string $expectedToken,
+        array $issues,
+        array $itemResults,
+        bool $writesAttempted = false,
+        bool $writesCommitted = false,
+    ): array {
+        return [
+            'runtime' => 'search_channel_queue_approval',
+            'status' => $status,
+            'dry_run' => $dryRun,
+            'queue_item_ids' => $queueItemIds,
+            'queue_item_count' => count($queueItemIds),
+            'channels' => $channels,
+            'approval_phrase' => $expectedPhrase,
+            'approval_token' => $expectedToken,
+            'issues' => $issues,
+            'items' => $itemResults,
+            'external_calls_attempted' => false,
+            'search_submission_attempted' => false,
+            'writes_attempted' => $writesAttempted,
+            'writes_committed' => $writesCommitted,
+            'safety_flags' => [
+                'queue_item_ids_required' => true,
+                'pending_queue_state_required' => true,
+                'dry_run_default' => true,
+                'scheduler_enabled' => false,
+                'external_calls_attempted' => false,
+                'search_submission_attempted' => false,
+                'raw_secret_output' => false,
+                'cms_mutation' => false,
+                'schema_hreflang_mutation' => false,
+                'revalidation_triggered' => false,
+            ],
+        ];
+    }
+}

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelApproveCommandTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelApproveCommandTest.php
@@ -1,0 +1,317 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\SeoIntel;
+
+use App\Services\SeoIntel\SearchChannelQueue\SearchChannelQueueApprovalExecutor;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Http;
+use Illuminate\Support\Facades\Schema;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+final class SeoIntelSearchChannelApproveCommandTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        config([
+            'database.connections.seo_intel' => [
+                'driver' => 'sqlite',
+                'database' => ':memory:',
+                'prefix' => '',
+                'foreign_key_constraints' => false,
+            ],
+            'seo_intel.connection' => 'seo_intel',
+            'seo_intel.search_channel_queue.live_submission.allowed_channels' => ['indexnow', 'baidu_push'],
+            'seo_intel.search_channel_queue.live_submission.allowed_hosts' => ['fermatmind.com'],
+            'seo_intel.search_channel_queue.live_submission.baidu.endpoint' => 'https://data.zz.baidu.test/urls',
+            'seo_intel.search_channel_queue.live_submission.baidu.site' => 'https://fermatmind.com',
+            'seo_intel.search_channel_queue.live_submission.baidu.token' => 'secret-baidu-token',
+            'seo_intel.search_channel_queue.live_submission.indexnow.endpoint' => 'https://api.indexnow.test/indexnow',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key' => 'secret-indexnow-key',
+            'seo_intel.search_channel_queue.live_submission.indexnow.key_location' => 'https://fermatmind.com/indexnow.txt',
+            'seo_intel.search_channel_queue.approved_source_authorities' => [
+                'backend_cms',
+                'backend_public_surface',
+                'scale_catalog',
+            ],
+        ]);
+
+        DB::purge('seo_intel');
+        $this->createSeoIntelTables();
+    }
+
+    #[Test]
+    public function default_dry_run_accepts_pending_dry_run_ready_items_without_writes_or_external_calls(): void
+    {
+        Http::fake();
+        $indexnowId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/articles/choose-career-using-personality-tests',
+            'channel' => 'indexnow',
+        ]);
+        $baiduId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/career-confusion-test-map',
+            'channel' => 'baidu_push',
+        ]);
+
+        [$exitCode, $payload] = $this->runApproveCommand([
+            '--queue-ids' => $indexnowId.','.$baiduId,
+            '--channels' => 'indexnow,baidu_push',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertSame(
+            'I explicitly approve SEARCH-CHANNEL-QUEUE-APPROVE approval for queue items '.$indexnowId.','.$baiduId.' channels indexnow,baidu_push.',
+            $payload['approval_phrase'] ?? null,
+        );
+        $this->assertMatchesRegularExpression('/^[a-f0-9]{64}$/', (string) ($payload['approval_token'] ?? ''));
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertSame('pending', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $indexnowId)->value('approval_state'));
+        $this->assertSame(0, DB::connection('seo_intel')->table('seo_search_channel_queue_events')->count());
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function approve_mode_requires_exact_phrase_or_token(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+
+        [$exitCode, $payload] = $this->runApproveCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'indexnow',
+            '--approve' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('bounded_queue_approval_required', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        $this->assertSame('pending', DB::connection('seo_intel')->table('seo_search_channel_queue_items')->where('id', $queueItemId)->value('approval_state'));
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function approve_mode_marks_items_approved_and_logs_sanitized_events(): void
+    {
+        Http::fake();
+        $indexnowId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/articles/choose-career-using-personality-tests',
+            'channel' => 'indexnow',
+        ]);
+        $baiduId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/zh/articles/career-confusion-test-map',
+            'channel' => 'baidu_push',
+        ]);
+        $approvalPhrase = app(SearchChannelQueueApprovalExecutor::class)
+            ->approvalPhrase([$indexnowId, $baiduId], ['indexnow', 'baidu_push']);
+
+        [$exitCode, $payload, $rawOutput] = $this->runApproveCommand([
+            '--queue-ids' => $indexnowId.','.$baiduId,
+            '--channels' => 'indexnow,baidu_push',
+            '--approval-phrase' => $approvalPhrase,
+            '--actor' => 'seo-ops@example.com',
+            '--approve' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertFalse((bool) ($payload['dry_run'] ?? true));
+        $this->assertTrue((bool) ($payload['writes_committed'] ?? false));
+        $this->assertFalse((bool) ($payload['external_calls_attempted'] ?? true));
+        $this->assertFalse((bool) ($payload['search_submission_attempted'] ?? true));
+        $this->assertStringNotContainsString('secret-indexnow-key', $rawOutput);
+        $this->assertStringNotContainsString('secret-baidu-token', $rawOutput);
+
+        $items = DB::connection('seo_intel')
+            ->table('seo_search_channel_queue_items')
+            ->whereIn('id', [$indexnowId, $baiduId])
+            ->orderBy('id')
+            ->get();
+        $this->assertSame(['approved', 'approved'], $items->pluck('approval_state')->all());
+        $this->assertSame(['dry_run_ready', 'dry_run_ready'], $items->pluck('execution_state')->all());
+        $this->assertSame(['seo-ops@example.com', 'seo-ops@example.com'], $items->pluck('approved_by')->all());
+        $this->assertNotNull($items[0]->approved_at);
+        $this->assertNotNull($items[1]->approved_at);
+
+        $events = DB::connection('seo_intel')->table('seo_search_channel_queue_events')->orderBy('id')->get();
+        $this->assertSame(['search_channel_queue_approved', 'search_channel_queue_approved'], $events->pluck('event_type')->all());
+
+        foreach ($events as $event) {
+            $this->assertStringNotContainsString('secret-indexnow-key', (string) $event->event_payload);
+            $this->assertStringNotContainsString('secret-baidu-token', (string) $event->event_payload);
+            $this->assertStringNotContainsString('https://fermatmind.com/en/articles/choose-career-using-personality-tests', (string) $event->event_payload);
+            $this->assertStringNotContainsString('https://fermatmind.com/zh/articles/career-confusion-test-map', (string) $event->event_payload);
+        }
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function approved_items_are_accepted_by_bounded_live_executor_dry_run(): void
+    {
+        Http::fake();
+        $queueItemId = $this->seedQueueItem();
+        $approvalToken = hash('sha256', app(SearchChannelQueueApprovalExecutor::class)->approvalPhrase([$queueItemId], ['indexnow']));
+
+        [$approveExitCode, $approvePayload] = $this->runApproveCommand([
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'indexnow',
+            '--approval-token' => $approvalToken,
+            '--approve' => true,
+            '--json' => true,
+        ]);
+
+        $this->assertSame(0, $approveExitCode);
+        $this->assertSame('success', $approvePayload['status'] ?? null);
+
+        $exitCode = Artisan::call('seo-intel:search-channel-submit-approved', [
+            '--queue-ids' => (string) $queueItemId,
+            '--channels' => 'indexnow',
+            '--json' => true,
+        ]);
+        $payload = json_decode(trim(Artisan::output()), true, 512, JSON_THROW_ON_ERROR);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertSame('success', $payload['status'] ?? null);
+        $this->assertTrue((bool) ($payload['dry_run'] ?? false));
+        $this->assertSame([], $payload['issues'] ?? null);
+        Http::assertNothingSent();
+    }
+
+    #[Test]
+    public function command_rejects_already_approved_private_or_non_indexable_items(): void
+    {
+        Http::fake();
+        $approvedId = $this->seedQueueItem([
+            'approval_state' => 'approved',
+            'approved_by' => 'operator',
+            'approved_at' => now(),
+        ]);
+        $privateId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/private-flow',
+            'private_flow' => true,
+        ]);
+        $noindexId = $this->seedQueueItem([
+            'canonical_url' => 'https://fermatmind.com/en/noindex',
+            'indexability_state' => 'noindex',
+        ]);
+
+        [$exitCode, $payload] = $this->runApproveCommand([
+            '--queue-ids' => $approvedId.','.$privateId.','.$noindexId,
+            '--channels' => 'indexnow',
+            '--json' => true,
+        ]);
+
+        $this->assertSame(1, $exitCode);
+        $this->assertSame('blocked', $payload['status'] ?? null);
+        $this->assertContains('approval_state_not_pending', $payload['issues'] ?? []);
+        $this->assertContains('private_flow_rejected', $payload['issues'] ?? []);
+        $this->assertContains('non_indexable_rejected', $payload['issues'] ?? []);
+        $this->assertFalse((bool) ($payload['writes_committed'] ?? true));
+        Http::assertNothingSent();
+    }
+
+    /**
+     * @param  array<string, mixed>  $arguments
+     * @return array{0:int,1:array<string,mixed>,2:string}
+     */
+    private function runApproveCommand(array $arguments): array
+    {
+        $exitCode = Artisan::call('seo-intel:search-channel-approve', $arguments);
+        $rawOutput = trim(Artisan::output());
+
+        $this->assertNotSame('', $rawOutput);
+        $payload = json_decode($rawOutput, true, 512, JSON_THROW_ON_ERROR);
+        $this->assertIsArray($payload);
+
+        return [$exitCode, $payload, $rawOutput];
+    }
+
+    /**
+     * @param  array<string, mixed>  $overrides
+     */
+    private function seedQueueItem(array $overrides = []): int
+    {
+        $canonicalUrl = (string) ($overrides['canonical_url'] ?? 'https://fermatmind.com/en/articles/search-channel-fixture');
+        $channel = (string) ($overrides['channel'] ?? 'indexnow');
+        $now = now();
+
+        return (int) DB::connection('seo_intel')->table('seo_search_channel_queue_items')->insertGetId([
+            'batch_id' => $overrides['batch_id'] ?? 1,
+            'canonical_url' => $canonicalUrl,
+            'locale' => $overrides['locale'] ?? 'en',
+            'page_entity_type' => $overrides['page_entity_type'] ?? 'article',
+            'entity_type' => $overrides['entity_type'] ?? 'article',
+            'entity_id' => $overrides['entity_id'] ?? 'article:fixture',
+            'source_authority' => $overrides['source_authority'] ?? 'backend_cms',
+            'source_table' => $overrides['source_table'] ?? 'cms_articles',
+            'channel' => $channel,
+            'eligibility_state' => $overrides['eligibility_state'] ?? 'eligible',
+            'approval_state' => $overrides['approval_state'] ?? 'pending',
+            'execution_state' => $overrides['execution_state'] ?? 'dry_run_ready',
+            'indexability_state' => $overrides['indexability_state'] ?? 'indexable',
+            'claim_boundary_state' => $overrides['claim_boundary_state'] ?? 'claim_safe',
+            'private_flow' => (bool) ($overrides['private_flow'] ?? false),
+            'reason_codes' => $overrides['reason_codes'] ?? null,
+            'lastmod' => $now,
+            'content_hash' => hash('sha256', $canonicalUrl),
+            'url_hash' => hash('sha256', $canonicalUrl),
+            'idempotency_key' => hash('sha256', $canonicalUrl.'|'.$channel),
+            'approved_by' => $overrides['approved_by'] ?? null,
+            'approved_at' => $overrides['approved_at'] ?? null,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ]);
+    }
+
+    private function createSeoIntelTables(): void
+    {
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_items', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->text('canonical_url');
+            $table->string('locale', 16);
+            $table->string('page_entity_type', 64);
+            $table->string('entity_type', 64)->nullable();
+            $table->string('entity_id', 255)->nullable();
+            $table->string('source_authority', 64);
+            $table->string('source_table', 128)->nullable();
+            $table->string('channel', 64);
+            $table->string('eligibility_state', 64)->default('eligible');
+            $table->string('approval_state', 64)->default('pending');
+            $table->string('execution_state', 64)->default('dry_run_ready');
+            $table->string('indexability_state', 64);
+            $table->string('claim_boundary_state', 64)->default('claim_safe');
+            $table->boolean('private_flow')->default(false);
+            $table->json('reason_codes')->nullable();
+            $table->timestamp('lastmod')->nullable();
+            $table->char('content_hash', 64)->nullable();
+            $table->char('url_hash', 64);
+            $table->char('idempotency_key', 64);
+            $table->string('approved_by', 128)->nullable();
+            $table->timestamp('approved_at')->nullable();
+            $table->timestamps();
+        });
+
+        Schema::connection('seo_intel')->create('seo_search_channel_queue_events', function ($table): void {
+            $table->id();
+            $table->unsignedBigInteger('queue_item_id')->nullable();
+            $table->unsignedBigInteger('batch_id')->nullable();
+            $table->string('event_type', 96);
+            $table->json('event_payload')->nullable();
+            $table->string('actor_type', 64)->default('system');
+            $table->string('actor_id', 128)->nullable();
+            $table->timestamp('created_at')->useCurrent();
+        });
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -915,10 +915,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files(): void
     {
         $changed = [
+            'backend/app/Console/Commands/SeoIntelSearchChannelApproveCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueApprovalExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueChannelMapper.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityEvaluator.php',
@@ -4022,10 +4024,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isSeoIntelSearchChannelQueueRuntimeFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/SeoIntelSearchChannelApproveCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelQueueCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitApprovedCommand.php',
             'backend/app/Console/Commands/SeoIntelSearchChannelSubmitCommand.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueAuditLogger.php',
+            'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueApprovalExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueChannelMapper.php',
             'backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueEligibilityEvaluator.php',


### PR DESCRIPTION
## What changed
- Added `seo-intel:search-channel-approve` for bounded approval of explicit Search Channel queue item IDs.
- Added `SearchChannelQueueApprovalExecutor` to validate pending, dry-run-ready, indexable, claim-safe queue items before approval.
- Approval defaults to dry-run; `--approve` requires the exact phrase or SHA-256 approval token and writes only `approval_state`, `approved_by`, `approved_at`, `updated_at` plus an audit event.
- Extended the Search Channel runtime freeze allowlist and added focused feature coverage.

## Why
Daily SEO releases need a stable official path to move reviewed Search Channel queue items from `pending` to `approved` before the bounded live executor submits IndexNow or Baidu. This avoids manual DB edits and avoids temporary global live gate changes.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelApproveCommandTest --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelSearchChannelBoundedLiveExecutorTest --no-ansi`
- `cd backend && php artisan test --filter=test_runtime_freeze_classifier_ignores_seo_intel_search_channel_queue_runtime_files --no-ansi`
- `cd backend && ./vendor/bin/pint --dirty`
- `git diff --check`
- `cd backend && php artisan list --format=txt | rg "seo-intel:search-channel-(approve|submit-approved|submit|queue)"`

## Intentionally deferred
- No production queue approval was executed.
- No live IndexNow or Baidu submission was executed.
- No CMS, schema, hreflang, sitemap, llms, revalidation, or Search Console behavior changed.
