### PR TITLE
fix(seo): preserve Baidu push site query format

### DIFF
--- a/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php
+++ b/backend/app/Services/SeoIntel/SearchChannelQueue/SearchChannelQueueBoundedLiveExecutor.php
@@ -398,10 +398,7 @@ final class SearchChannelQueueBoundedLiveExecutor
         $endpoint = (string) config('seo_intel.search_channel_queue.live_submission.baidu.endpoint');
         $site = (string) config('seo_intel.search_channel_queue.live_submission.baidu.site');
         $token = (string) config('seo_intel.search_channel_queue.live_submission.baidu.token');
-        $endpointWithQuery = $endpoint.'?'.http_build_query([
-            'site' => $site,
-            'token' => $token,
-        ]);
+        $endpointWithQuery = $endpoint.'?site='.$site.'&token='.rawurlencode($token);
 
         try {
             $response = Http::timeout(max(1, (int) config('seo_intel.search_channel_queue.live_submission.baidu.timeout_seconds', 10)))

--- a/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelBoundedLiveExecutorTest.php
+++ b/backend/tests/Feature/SeoIntel/SeoIntelSearchChannelBoundedLiveExecutorTest.php
@@ -175,8 +175,11 @@ final class SeoIntelSearchChannelBoundedLiveExecutorTest extends TestCase
         Http::assertSent(function (Request $request): bool {
             $query = [];
             parse_str((string) parse_url($request->url(), PHP_URL_QUERY), $query);
+            $rawQuery = (string) parse_url($request->url(), PHP_URL_QUERY);
 
             return parse_url($request->url(), PHP_URL_HOST) === 'data.zz.baidu.test'
+                && str_contains($rawQuery, 'site=https://fermatmind.com&token=')
+                && ! str_contains($rawQuery, 'site=https%3A%2F%2Ffermatmind.com')
                 && $query['site'] === 'https://fermatmind.com'
                 && $query['token'] === 'secret-baidu-token'
                 && $request->body() === 'https://fermatmind.com/zh/articles/career-confusion-test-map';


### PR DESCRIPTION
## What changed
- Updated the bounded Search Channel Baidu push executor to preserve Baidu's raw `site=https://...` query shape while still URL-encoding the token.
- Strengthened the bounded live executor test to assert the outgoing Baidu query uses the platform-documented raw site parameter and does not encode it as `site=https%3A%2F%2F...`.

## Why
Production Baidu live push was failing with provider `site init fail` even though the Baidu platform site and token matched production config. A controlled production probe using the Baidu platform's documented raw query shape succeeded, isolating the issue to query construction rather than site verification or token configuration.

## Validation
- `cd backend && php artisan test --filter=SeoIntelSearchChannelBoundedLiveExecutorTest --no-ansi`
- `cd backend && php artisan test --filter=SeoIntelSearchChannelApproveCommandTest --no-ansi`
- `cd backend && ./vendor/bin/pint --dirty`
- `git diff --check`

## Intentionally deferred
- No production deploy in this PR.
- No CMS mutation, schema/hreflang changes, sitemap/llms changes, GSC action, or revalidation changes.
- Requeue and live Baidu push for items 28/29 should happen only after this PR is merged and deployed.
