### PR TITLE
feat(cms): import SEO image asset bundles into Media Library

### DIFF
--- a/backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php
+++ b/backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php
@@ -1,0 +1,150 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\SeoImageBundle\SeoImageBundleImporter;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+
+final class MediaAssetsImportSeoImageBundle extends Command
+{
+    protected $signature = 'media-assets:import-seo-image-bundle
+        {--package= : Path to a SEO source package directory}
+        {--translation-group-id= : Expected translation_group_id}
+        {--locales=zh-CN,en : Comma-separated locale list}
+        {--dry-run : Validate and plan without writing DB, storage, or package files}
+        {--json : Emit a JSON summary}
+        {--write-resolved-package : Write a resolved package copy with CMS image metadata backfilled}
+        {--resolved-output-dir= : Safe output directory for --write-resolved-package}
+        {--expected-asset-prefix= : Expected asset_key prefix such as article.career.exploration}
+        {--allow-update-existing : Allow updating an existing Media Library asset}';
+
+    protected $description = 'Import SEO image asset bundles into Media Library and emit CMS draft image metadata.';
+
+    public function handle(SeoImageBundleImporter $importer): int
+    {
+        $dryRun = (bool) $this->option('dry-run');
+
+        try {
+            $summary = $dryRun
+                ? $importer->planFromDirectory($this->optionsPayload())
+                : $importer->importFromDirectory($this->optionsPayload());
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        $locales = array_values(array_filter(array_map(
+            static fn (string $locale): string => trim($locale),
+            explode(',', (string) $this->option('locales'))
+        ), static fn (string $locale): bool => $locale !== ''));
+
+        return [
+            'package' => (string) $this->option('package'),
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'locales' => $locales,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'json' => (bool) $this->option('json'),
+            'write_resolved_package' => (bool) $this->option('write-resolved-package'),
+            'resolved_output_dir' => (string) $this->option('resolved-output-dir'),
+            'expected_asset_prefix' => (string) $this->option('expected-asset-prefix'),
+            'allow_update_existing' => (bool) $this->option('allow-update-existing'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('translation_group_id='.(string) ($summary['translation_group_id'] ?? ''));
+        $this->line('assets_count='.(string) ($summary['assets_count'] ?? 0));
+        $this->line('would_create='.(string) ($summary['would_create'] ?? 0));
+        $this->line('would_update='.(string) ($summary['would_update'] ?? 0));
+        $this->line('would_generate_variants='.(string) ($summary['would_generate_variants'] ?? 0));
+        $this->line('would_patch_package='.(string) ($summary['would_patch_package'] ?? 0));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+
+        foreach ((array) ($summary['assets'] ?? []) as $asset) {
+            if (! is_array($asset)) {
+                continue;
+            }
+            $this->line(sprintf(
+                'asset=%s:%s:create=%s:update=%s:variants=%s',
+                (string) ($asset['role'] ?? ''),
+                (string) ($asset['asset_key'] ?? ''),
+                ($asset['would_create'] ?? false) ? '1' : '0',
+                ($asset['would_update'] ?? false) ? '1' : '0',
+                ($asset['would_generate_variants'] ?? false) ? '1' : '0'
+            ));
+        }
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('validation_error='.$this->issueLine($error));
+            }
+        }
+        foreach ((array) ($summary['warnings'] ?? []) as $warning) {
+            if (is_array($warning)) {
+                $this->line('validation_warning='.$this->issueLine($warning));
+            }
+        }
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => (bool) $this->option('dry-run'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+            'assets' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return implode(':', [
+            (string) ($issue['field'] ?? 'unknown'),
+            (string) ($issue['code'] ?? 'unknown'),
+            (string) ($issue['message'] ?? ''),
+        ]);
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,8 +8,8 @@ use App\Console\Commands\ArticleCoverPropagationSmoke;
 use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
-// ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5AttemptPurge;
+// ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
 use App\Console\Commands\Big5TelemetrySummary;
 use App\Console\Commands\CareerAlignActorsAuthorityOccupation;
@@ -108,6 +108,7 @@ use App\Console\Commands\FapValidateReport;
 use App\Console\Commands\FapWeeklyReport;
 use App\Console\Commands\MbtiPrewarm;
 use App\Console\Commands\MbtiUpgradeLegacyPartialUnlocks;
+use App\Console\Commands\MediaAssetsImportSeoImageBundle;
 use App\Console\Commands\MetricsWeeklyValidity;
 use App\Console\Commands\NormsBig5BootstrapBuild;
 use App\Console\Commands\NormsBig5DriftCheck;
@@ -326,6 +327,7 @@ class Kernel extends ConsoleKernel
         ArticleImportSeoContentPackageDraft::class,
         ArticleCoverPropagationSmoke::class,
         ArticlePublishControlled::class,
+        MediaAssetsImportSeoImageBundle::class,
     ];
 
     /**

--- a/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
+++ b/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
@@ -1,0 +1,747 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms\SeoImageBundle;
+
+use App\Models\Article;
+use App\Models\MediaAsset;
+use App\Services\Cms\MediaAssetStorageSyncService;
+use App\Services\Cms\MediaVariantGenerator;
+use App\Support\PublicMediaUrlGuard;
+use Illuminate\Http\UploadedFile;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\File;
+use RuntimeException;
+
+final class SeoImageBundleImporter
+{
+    private const MANIFEST_PATH = 'media/IMAGE_ASSET_MANIFEST.json';
+
+    private const ALLOWED_ROLES = ['cover', 'body_visual', 'og_override', 'card_override', 'thumbnail_override'];
+
+    private const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp'];
+
+    private const MAX_BYTES = 10485760;
+
+    private const RECOMMENDED_MAX_BYTES = 3145728;
+
+    public function __construct(
+        private readonly MediaVariantGenerator $variantGenerator,
+        private readonly MediaAssetStorageSyncService $syncService,
+    ) {}
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function planFromDirectory(array $options): array
+    {
+        return $this->run($options, true);
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function importFromDirectory(array $options): array
+    {
+        return $this->run($options, false);
+    }
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    private function run(array $options, bool $dryRun): array
+    {
+        $package = $this->resolvePackagePath((string) ($options['package'] ?? ''));
+        $translationGroupId = trim((string) ($options['translation_group_id'] ?? ''));
+        $expectedPrefix = trim((string) ($options['expected_asset_prefix'] ?? ''));
+        $allowUpdateExisting = (bool) ($options['allow_update_existing'] ?? false);
+        $writeResolvedPackage = (bool) ($options['write_resolved_package'] ?? false);
+        $resolvedOutputDir = trim((string) ($options['resolved_output_dir'] ?? ''));
+        $locales = $this->locales((array) ($options['locales'] ?? []));
+
+        $errors = [];
+        $warnings = [];
+        $manifestPath = $package.'/'.self::MANIFEST_PATH;
+
+        if (! is_file($manifestPath)) {
+            return $this->summary(false, $dryRun, 'will_skip', $package, $translationGroupId, [], [], [[
+                'field' => self::MANIFEST_PATH,
+                'code' => 'image_asset_manifest_missing',
+                'message' => 'media/IMAGE_ASSET_MANIFEST.json is required for SEO image bundle import.',
+            ]], []);
+        }
+
+        $manifest = $this->readJsonFile($manifestPath, self::MANIFEST_PATH);
+        if ($translationGroupId !== '' && trim((string) ($manifest['translation_group_id'] ?? '')) !== $translationGroupId) {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_mismatch', 'Manifest translation_group_id does not match expected value.');
+        }
+
+        $assets = $this->normalizeAssets($manifest, $package, $expectedPrefix, $errors, $warnings);
+        $plans = [];
+        foreach ($assets as $asset) {
+            $plans[] = $this->assetPlan($asset, $allowUpdateExisting, $errors, $warnings);
+        }
+
+        $this->duplicateRecentCoverCheck($assets, $warnings);
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $package, $translationGroupId, $plans, [], $errors, $warnings);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_import_media_assets', $package, $translationGroupId, $plans, $this->resolvedMetadataFromPlans($plans, $locales, true), [], $warnings);
+        }
+
+        $writtenPlans = [];
+        DB::transaction(function () use ($plans, &$writtenPlans): void {
+            foreach ($plans as $plan) {
+                $writtenPlans[] = $this->writeAsset($plan);
+            }
+        });
+
+        $resolved = $this->resolvedMetadataFromPlans($writtenPlans, $locales, false);
+        $resolvedPackage = null;
+        if ($writeResolvedPackage) {
+            $resolvedPackage = $this->writeResolvedPackageCopy($package, $resolved, $resolvedOutputDir, $warnings);
+        }
+
+        $summary = $this->summary(true, false, 'imported_media_assets', $package, $translationGroupId, $writtenPlans, $resolved, [], $warnings);
+        $summary['resolved_package_dir'] = $resolvedPackage;
+
+        return $summary;
+    }
+
+    private function resolvePackagePath(string $package): string
+    {
+        $candidate = trim($package);
+        if ($candidate === '') {
+            throw new RuntimeException('--package is required.');
+        }
+
+        $real = realpath($candidate);
+        if ($real === false || ! is_dir($real)) {
+            throw new RuntimeException('Package directory not found: '.$candidate);
+        }
+
+        return $real;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function readJsonFile(string $path, string $field): array
+    {
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded)) {
+            throw new RuntimeException('Invalid JSON file: '.$field);
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  array<string,mixed>  $manifest
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return list<array<string,mixed>>
+     */
+    private function normalizeAssets(array $manifest, string $package, string $expectedPrefix, array &$errors, array &$warnings): array
+    {
+        $rows = $manifest['assets'] ?? null;
+        if (! is_array($rows) || $rows === []) {
+            $errors[] = $this->issue('assets', 'assets_missing', 'Manifest assets must be a non-empty array.');
+
+            return [];
+        }
+
+        $assets = [];
+        foreach (array_values($rows) as $index => $row) {
+            $field = 'assets.'.$index;
+            if (! is_array($row)) {
+                $errors[] = $this->issue($field, 'asset_invalid', 'Asset row must be an object.');
+
+                continue;
+            }
+
+            $assetKey = strtolower(trim((string) ($row['asset_key'] ?? '')));
+            $role = trim((string) ($row['role'] ?? ''));
+            $sourceFile = ltrim(trim((string) ($row['source_file'] ?? '')), '/');
+            $altText = trim((string) ($row['alt_text'] ?? ''));
+            $path = $package.'/'.$sourceFile;
+
+            if (! preg_match('/^article\.[a-z0-9][a-z0-9.-]*\.v[0-9]+$/', $assetKey)) {
+                $errors[] = $this->issue($field.'.asset_key', 'asset_key_invalid', 'Asset key must match article.<topic>.<role>.vN.');
+            }
+            if ($expectedPrefix !== '' && ! str_starts_with($assetKey, $expectedPrefix)) {
+                $errors[] = $this->issue($field.'.asset_key', 'asset_key_prefix_mismatch', 'Asset key does not match --expected-asset-prefix.');
+            }
+            if (! in_array($role, self::ALLOWED_ROLES, true)) {
+                $errors[] = $this->issue($field.'.role', 'asset_role_invalid', 'Unsupported image asset role.');
+            }
+            if ($sourceFile === '' || str_contains($sourceFile, '..')) {
+                $errors[] = $this->issue($field.'.source_file', 'source_file_invalid', 'Source file path is missing or unsafe.');
+            }
+            if ($altText === '' || mb_strlen($altText) > 255) {
+                $errors[] = $this->issue($field.'.alt_text', 'alt_text_invalid', 'Alt text is required and must be <= 255 characters.');
+            }
+
+            $provenance = $row['provenance'] ?? null;
+            if (! is_array($provenance)) {
+                $errors[] = $this->issue($field.'.provenance', 'provenance_missing', 'Image provenance is required.');
+            } elseif (($provenance['competitor_asset'] ?? null) !== false) {
+                $errors[] = $this->issue($field.'.provenance.competitor_asset', 'competitor_asset_not_allowed', 'Competitor assets are not allowed.');
+            }
+
+            $dimensions = is_array($row['dimensions_expected'] ?? null) ? $row['dimensions_expected'] : [];
+            $expectedWidth = (int) ($dimensions['width'] ?? 0);
+            $expectedHeight = (int) ($dimensions['height'] ?? 0);
+            if ($expectedWidth <= 0 || $expectedHeight <= 0) {
+                $errors[] = $this->issue($field.'.dimensions_expected', 'dimensions_expected_invalid', 'Expected dimensions are required.');
+            }
+
+            $fileMeta = $this->validateImageFile($path, $field.'.source_file', $expectedWidth, $expectedHeight, (bool) ($dimensions['exact'] ?? false), $errors, $warnings);
+            $this->validateManifestFileConstraints($row, $fileMeta, $field, $errors);
+
+            $assets[] = [
+                'field' => $field,
+                'asset_key' => $assetKey,
+                'role' => $role,
+                'source_file' => $sourceFile,
+                'path' => $path,
+                'alt_text' => $altText,
+                'caption' => $this->nullableString($row['caption'] ?? null),
+                'credit' => $this->nullableString($row['credit'] ?? null),
+                'intended_usage' => array_values(array_filter((array) ($row['intended_usage'] ?? []), 'is_string')),
+                'provenance' => is_array($provenance) ? $provenance : [],
+                'file' => $fileMeta,
+            ];
+        }
+
+        return $assets;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function validateImageFile(string $path, string $field, int $expectedWidth, int $expectedHeight, bool $exact, array &$errors, array &$warnings): array
+    {
+        if (! is_file($path)) {
+            $errors[] = $this->issue($field, 'source_file_missing', 'Image source file does not exist.');
+
+            return [];
+        }
+
+        $extension = strtolower(pathinfo($path, PATHINFO_EXTENSION));
+        if (! in_array($extension, ['jpg', 'jpeg', 'png', 'webp'], true)) {
+            $errors[] = $this->issue($field, 'image_extension_not_allowed', 'Only jpg, jpeg, png, and webp image files are allowed.');
+        }
+        if ($extension === 'svg') {
+            $errors[] = $this->issue($field, 'svg_not_allowed', 'SVG is not allowed for SEO image bundles.');
+        }
+
+        $bytes = filesize($path);
+        if ($bytes === false) {
+            $bytes = 0;
+        }
+        if ($bytes > self::MAX_BYTES) {
+            $errors[] = $this->issue($field, 'image_file_too_large', 'Image file exceeds 10 MB.');
+        } elseif ($bytes > self::RECOMMENDED_MAX_BYTES) {
+            $warnings[] = $this->issue($field, 'image_file_above_recommended_size', 'Image file is above the recommended 3 MB daily SEO target.');
+        }
+
+        $imageSize = @getimagesize($path);
+        if (! is_array($imageSize)) {
+            $errors[] = $this->issue($field, 'image_unreadable', 'Image dimensions and MIME type could not be read.');
+
+            return ['bytes' => $bytes];
+        }
+
+        $width = (int) ($imageSize[0] ?? 0);
+        $height = (int) ($imageSize[1] ?? 0);
+        $mime = strtolower((string) ($imageSize['mime'] ?? ''));
+        if (! in_array($mime, self::ALLOWED_MIME_TYPES, true)) {
+            $errors[] = $this->issue($field, 'image_mime_not_allowed', 'Only image/jpeg, image/png, and image/webp are allowed.');
+        }
+        if ($exact && ($width !== $expectedWidth || $height !== $expectedHeight)) {
+            $errors[] = $this->issue($field, 'image_dimensions_mismatch', 'Image dimensions do not exactly match manifest dimensions.');
+        } elseif (! $exact && ($width < $expectedWidth || $height < $expectedHeight)) {
+            $errors[] = $this->issue($field, 'image_dimensions_too_small', 'Image dimensions are smaller than manifest dimensions.');
+        }
+
+        $binary = (string) file_get_contents($path);
+        if (($extension === 'webp' && str_contains($binary, 'ANMF')) || ($extension === 'png' && str_contains($binary, 'acTL'))) {
+            $errors[] = $this->issue($field, 'animated_image_not_allowed', 'Animated images are not allowed.');
+        }
+        if (str_contains($binary, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__')) {
+            $errors[] = $this->issue($field, 'placeholder_not_allowed', 'Image file contains a CMS placeholder marker.');
+        }
+
+        return [
+            'width' => $width,
+            'height' => $height,
+            'mime_type' => $mime,
+            'bytes' => $bytes,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $row
+     * @param  array<string,mixed>  $fileMeta
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateManifestFileConstraints(array $row, array $fileMeta, string $field, array &$errors): void
+    {
+        if ($fileMeta === []) {
+            return;
+        }
+
+        $allowedFormats = array_values(array_filter(array_map(
+            static fn (mixed $format): string => strtolower(trim((string) $format)),
+            (array) ($row['format_allowed'] ?? [])
+        ), static fn (string $format): bool => $format !== ''));
+        if ($allowedFormats !== [] && ! in_array((string) ($fileMeta['mime_type'] ?? ''), $allowedFormats, true)) {
+            $errors[] = $this->issue($field.'.format_allowed', 'image_mime_not_allowed_by_manifest', 'Image MIME type is not allowed by manifest format_allowed.');
+        }
+
+        $maxBytes = (int) ($row['max_bytes'] ?? self::MAX_BYTES);
+        if ($maxBytes > 0 && (int) ($fileMeta['bytes'] ?? 0) > $maxBytes) {
+            $errors[] = $this->issue($field.'.max_bytes', 'image_file_exceeds_manifest_max_bytes', 'Image file exceeds manifest max_bytes.');
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function assetPlan(array $asset, bool $allowUpdateExisting, array &$errors, array &$warnings): array
+    {
+        $existing = MediaAsset::query()
+            ->withoutGlobalScopes()
+            ->with('variants')
+            ->where('org_id', 0)
+            ->where('asset_key', $asset['asset_key'])
+            ->first();
+
+        if ($existing instanceof MediaAsset && ! $allowUpdateExisting) {
+            $errors[] = $this->issue($asset['field'].'.asset_key', 'asset_exists_update_not_allowed', 'Media asset already exists; pass --allow-update-existing to update it.');
+        }
+
+        return [
+            ...$asset,
+            'existing_asset_id' => $existing?->id,
+            'would_create' => ! $existing instanceof MediaAsset,
+            'would_update' => $existing instanceof MediaAsset,
+            'would_generate_variants' => true,
+            'would_patch_package' => true,
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $assets
+     * @param  list<array<string,mixed>>  $warnings
+     */
+    private function duplicateRecentCoverCheck(array $assets, array &$warnings): void
+    {
+        $coverKeys = array_values(array_map(
+            static fn (array $asset): string => (string) $asset['asset_key'],
+            array_filter($assets, static fn (array $asset): bool => (string) $asset['role'] === 'cover')
+        ));
+        if ($coverKeys === []) {
+            return;
+        }
+
+        $recent = Article::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', 0)
+            ->whereIn('status', ['published', 'human_review', 'draft'])
+            ->orderByDesc('published_at')
+            ->orderByDesc('id')
+            ->limit(5)
+            ->get();
+
+        foreach ($recent as $article) {
+            $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
+            $recordedKey = trim((string) data_get($variants, 'editorial_package_v1.cover_media_asset_key'));
+            foreach ($coverKeys as $coverKey) {
+                if ($recordedKey === $coverKey || str_contains((string) $article->cover_image_url, str_replace('.', '', $coverKey))) {
+                    $warnings[] = $this->issue('duplicate_recent_cover', 'duplicate_recent_cover_asset', 'A recent SEO article appears to use the same cover asset key: '.$coverKey);
+                }
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    private function writeAsset(array $plan): array
+    {
+        $asset = MediaAsset::query()
+            ->withoutGlobalScopes()
+            ->firstOrNew([
+                'org_id' => 0,
+                'asset_key' => (string) $plan['asset_key'],
+            ]);
+
+        $asset->fill([
+            'alt' => (string) $plan['alt_text'],
+            'caption' => $this->nullableString($plan['caption'] ?? null),
+            'credit' => $this->nullableString($plan['credit'] ?? null),
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+            'payload_json' => array_merge($asset->payload_json ?? [], [
+                'seo_image_bundle_v1' => [
+                    'role' => (string) $plan['role'],
+                    'source_file' => (string) $plan['source_file'],
+                    'intended_usage' => $plan['intended_usage'] ?? [],
+                    'provenance' => $plan['provenance'] ?? [],
+                ],
+            ]),
+        ]);
+        $asset->save();
+
+        $uploaded = new UploadedFile(
+            (string) $plan['path'],
+            basename((string) $plan['source_file']),
+            (string) data_get($plan, 'file.mime_type'),
+            null,
+            true
+        );
+
+        $asset = $this->syncService->syncAndVerify($this->variantGenerator->storeUploadAndGenerate($asset, $uploaded));
+        $this->assertImportedAssetIsSafe($asset);
+
+        return [
+            ...$plan,
+            'media_asset_id' => (int) $asset->id,
+            'asset' => $this->assetPayload($asset),
+            'would_create' => false,
+            'would_update' => false,
+            'would_generate_variants' => false,
+            'would_patch_package' => true,
+        ];
+    }
+
+    private function assertImportedAssetIsSafe(MediaAsset $asset): void
+    {
+        $asset->loadMissing('variants');
+        if ((string) $asset->status !== MediaAsset::STATUS_PUBLISHED || ! (bool) $asset->is_public) {
+            throw new RuntimeException('Imported media asset is not published and public: '.$asset->asset_key);
+        }
+        if ((string) $asset->cdn_status === MediaAsset::CDN_FAILED) {
+            throw new RuntimeException('Imported media asset CDN verification failed: '.$asset->asset_key);
+        }
+        if (PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $asset->path, $asset->url) === null) {
+            throw new RuntimeException('Imported media asset URL is not public-safe: '.$asset->asset_key);
+        }
+
+        $variants = $asset->variants->keyBy(fn ($variant): string => (string) $variant->variant_key);
+        foreach (MediaVariantGenerator::variantKeys() as $variantKey) {
+            $variant = $variants->get($variantKey);
+            if (! $variant) {
+                throw new RuntimeException('Imported media asset is missing variant '.$variantKey.': '.$asset->asset_key);
+            }
+            if ((string) $variant->cdn_status === MediaAsset::CDN_FAILED) {
+                throw new RuntimeException('Imported media asset variant CDN verification failed: '.$asset->asset_key.' '.$variantKey);
+            }
+            if (PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $variant->path, $variant->url) === null) {
+                throw new RuntimeException('Imported media asset variant URL is not public-safe: '.$asset->asset_key.' '.$variantKey);
+            }
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $plans
+     * @param  list<string>  $locales
+     * @return array<string,mixed>
+     */
+    private function resolvedMetadataFromPlans(array $plans, array $locales, bool $dryRun): array
+    {
+        $cover = $this->firstRolePlan($plans, 'cover');
+        $body = $this->firstRolePlan($plans, 'body_visual');
+
+        $metadata = [
+            'locales' => $locales,
+            'cover_media_asset_key' => $cover ? (string) $cover['asset_key'] : null,
+            'cover_image_url' => $cover ? $this->variantUrl($cover, 'hero', $dryRun) : null,
+            'cover_image_alt' => $cover ? (string) $cover['alt_text'] : null,
+            'cover_image_width' => $cover ? (int) data_get($cover, 'asset.width', data_get($cover, 'file.width', 0)) : null,
+            'cover_image_height' => $cover ? (int) data_get($cover, 'asset.height', data_get($cover, 'file.height', 0)) : null,
+            'cover_image_variants' => $cover ? $this->variantMap($cover) : [],
+            'og_image_url' => $this->variantUrl($this->firstRolePlan($plans, 'og_override') ?? $cover, 'og', $dryRun),
+            'twitter_image_url' => $this->variantUrl($this->firstRolePlan($plans, 'og_override') ?? $cover, 'og', $dryRun),
+            'social_image_metadata' => $cover ? $this->socialMetadata($cover, $dryRun) : [],
+            'body_visual_asset_key' => $body ? (string) $body['asset_key'] : null,
+            'body_visual_image_url' => $body ? $this->variantUrl($body, 'hero', $dryRun) : null,
+            'body_visual_fallback_authorized' => false,
+        ];
+
+        return $metadata;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $plans
+     */
+    private function firstRolePlan(array $plans, string $role): ?array
+    {
+        foreach ($plans as $plan) {
+            if ((string) ($plan['role'] ?? '') === $role) {
+                return $plan;
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>|null  $plan
+     */
+    private function variantUrl(?array $plan, string $variantKey, bool $dryRun): ?string
+    {
+        if ($plan === null) {
+            return null;
+        }
+
+        $variant = data_get($plan, 'asset.variants.'.$variantKey);
+        if (is_array($variant)) {
+            return $this->nullableString($variant['url'] ?? null);
+        }
+
+        if ($dryRun) {
+            return null;
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,array<string,mixed>>
+     */
+    private function variantMap(array $plan): array
+    {
+        $assetVariants = data_get($plan, 'asset.variants');
+        if (is_array($assetVariants)) {
+            return $assetVariants;
+        }
+
+        return [
+            'hero' => ['url' => null, 'width' => 1600, 'height' => 900, 'mime_type' => 'image/jpeg'],
+            'card' => ['url' => null, 'width' => 800, 'height' => 450, 'mime_type' => 'image/jpeg'],
+            'thumbnail' => ['url' => null, 'width' => 400, 'height' => 225, 'mime_type' => 'image/jpeg'],
+            'og' => ['url' => null, 'width' => 1200, 'height' => 630, 'mime_type' => 'image/jpeg'],
+            'preload' => ['url' => null, 'width' => 64, 'height' => 36, 'mime_type' => 'image/jpeg'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    private function socialMetadata(array $plan, bool $dryRun): array
+    {
+        return [
+            'media_library_asset_key' => (string) $plan['asset_key'],
+            'media_library_status' => 'published',
+            'media_library_is_public' => true,
+            'cover_image_url' => $this->variantUrl($plan, 'hero', $dryRun),
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'hero_variant' => $this->variantMap($plan)['hero'] ?? null,
+            'og_image_url' => $this->variantUrl($plan, 'og', $dryRun),
+            'og_image_width' => 1200,
+            'og_image_height' => 630,
+            'og_1200x630_variant' => $this->variantMap($plan)['og'] ?? null,
+            'twitter_image_url' => $this->variantUrl($plan, 'og', $dryRun),
+            'asset_provenance' => 'SEO image bundle import: '.(string) $plan['asset_key'],
+            'alt_text' => (string) $plan['alt_text'],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $asset
+     * @return array<string,mixed>
+     */
+    private function assetPayload(MediaAsset $asset): array
+    {
+        $asset->loadMissing('variants');
+        $variants = [];
+        foreach ($asset->variants as $variant) {
+            if ((string) $variant->variant_key === 'original') {
+                continue;
+            }
+            $variants[(string) $variant->variant_key] = [
+                'url' => PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $variant->path, $variant->url),
+                'width' => (int) $variant->width,
+                'height' => (int) $variant->height,
+                'mime_type' => (string) $variant->mime_type,
+            ];
+        }
+
+        return [
+            'id' => (int) $asset->id,
+            'asset_key' => (string) $asset->asset_key,
+            'url' => PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $asset->path, $asset->url),
+            'mime_type' => (string) $asset->mime_type,
+            'width' => (int) $asset->width,
+            'height' => (int) $asset->height,
+            'bytes' => (int) $asset->bytes,
+            'alt' => (string) $asset->alt,
+            'status' => (string) $asset->status,
+            'is_public' => (bool) $asset->is_public,
+            'sync_status' => (string) $asset->sync_status,
+            'cdn_status' => (string) $asset->cdn_status,
+            'variants' => $variants,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $resolved
+     * @param  list<array<string,mixed>>  $warnings
+     */
+    private function writeResolvedPackageCopy(string $package, array $resolved, string $resolvedOutputDir, array &$warnings): string
+    {
+        $output = $resolvedOutputDir !== ''
+            ? $resolvedOutputDir
+            : dirname($package).'/resolved-package';
+
+        if (realpath($output) === realpath($package)) {
+            throw new RuntimeException('Resolved output directory must not be the original package directory.');
+        }
+        if (is_dir($output)) {
+            File::deleteDirectory($output);
+        }
+        File::copyDirectory($package, $output);
+
+        foreach (glob($output.'/cms/CMS_FIELDS_*.json') ?: [] as $file) {
+            $this->patchJsonFile($file, $resolved);
+        }
+        foreach (glob($output.'/cms/CMS_IMPORT_DRAFT_*.json') ?: [] as $file) {
+            $this->patchJsonFile($file, $resolved);
+        }
+
+        if (! is_dir($output.'/cms')) {
+            $warnings[] = $this->issue('cms', 'cms_directory_missing_for_patch', 'Resolved package was copied, but cms/ directory was not present.');
+        }
+
+        return $output;
+    }
+
+    /**
+     * @param  array<string,mixed>  $resolved
+     */
+    private function patchJsonFile(string $file, array $resolved): void
+    {
+        $payload = $this->readJsonFile($file, basename($file));
+        foreach ([
+            'cover_media_asset_key',
+            'cover_image_url',
+            'cover_image_alt',
+            'cover_image_width',
+            'cover_image_height',
+            'cover_image_variants',
+            'og_image_url',
+            'twitter_image_url',
+            'social_image_metadata',
+            'body_visual_asset_key',
+            'body_visual_image_url',
+            'body_visual_fallback_authorized',
+        ] as $key) {
+            if (array_key_exists($key, $resolved) && $resolved[$key] !== null) {
+                $payload[$key] = $resolved[$key];
+            }
+        }
+
+        file_put_contents($file, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)."\n");
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $plans
+     * @param  array<string,mixed>  $resolved
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, string $package, string $translationGroupId, array $plans, array $resolved, array $errors, array $warnings): array
+    {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => ! $dryRun && $ok,
+            'package' => $package,
+            'translation_group_id' => $translationGroupId,
+            'manifest_path' => self::MANIFEST_PATH,
+            'assets_count' => count($plans),
+            'would_create' => count(array_filter($plans, static fn (array $plan): bool => (bool) ($plan['would_create'] ?? false))),
+            'would_update' => count(array_filter($plans, static fn (array $plan): bool => (bool) ($plan['would_update'] ?? false))),
+            'would_generate_variants' => count(array_filter($plans, static fn (array $plan): bool => (bool) ($plan['would_generate_variants'] ?? false))),
+            'would_patch_package' => count(array_filter($plans, static fn (array $plan): bool => (bool) ($plan['would_patch_package'] ?? false))),
+            'assets' => array_map(fn (array $plan): array => $this->safePlanPayload($plan), $plans),
+            'resolved_metadata' => $resolved,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     * @return array<string,mixed>
+     */
+    private function safePlanPayload(array $plan): array
+    {
+        return [
+            'asset_key' => (string) ($plan['asset_key'] ?? ''),
+            'role' => (string) ($plan['role'] ?? ''),
+            'source_file' => (string) ($plan['source_file'] ?? ''),
+            'alt_text' => (string) ($plan['alt_text'] ?? ''),
+            'file' => $plan['file'] ?? [],
+            'existing_asset_id' => $plan['existing_asset_id'] ?? null,
+            'media_asset_id' => $plan['media_asset_id'] ?? null,
+            'would_create' => (bool) ($plan['would_create'] ?? false),
+            'would_update' => (bool) ($plan['would_update'] ?? false),
+            'would_generate_variants' => (bool) ($plan['would_generate_variants'] ?? false),
+            'would_patch_package' => (bool) ($plan['would_patch_package'] ?? false),
+        ];
+    }
+
+    /**
+     * @return list<string>
+     */
+    private function locales(array $locales): array
+    {
+        $normalized = array_values(array_filter(array_map(
+            static fn (mixed $locale): string => trim((string) $locale),
+            $locales
+        ), static fn (string $locale): bool => $locale !== ''));
+
+        return $normalized !== [] ? $normalized : ['zh-CN', 'en'];
+    }
+
+    private function nullableString(mixed $value): ?string
+    {
+        $trimmed = trim((string) $value);
+
+        return $trimmed !== '' ? $trimmed : null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
+++ b/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
@@ -1,0 +1,413 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\MediaAsset;
+use App\Models\MediaVariant;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Facades\Storage;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TRANSLATION_GROUP_ID = 'tg_article_image_bundle_2026v1';
+
+    public function test_valid_image_manifest_dry_run_passes_without_database_or_storage_writes(): void
+    {
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_import_media_assets', $payload['action']);
+        $this->assertSame(1, $payload['would_create']);
+        $this->assertSame(1, $payload['would_generate_variants']);
+        $this->assertSame('article.daily.seo.cover.v1', $payload['resolved_metadata']['cover_media_asset_key']);
+        $this->assertSame(0, MediaAsset::query()->withoutGlobalScopes()->count());
+        $this->assertSame(0, MediaVariant::query()->count());
+        $this->assertFalse(Storage::disk('public')->exists('media-library'));
+    }
+
+    public function test_missing_manifest_fails_when_image_bundle_required(): void
+    {
+        $package = $this->writeImageBundlePackage();
+        unlink($package.'/media/IMAGE_ASSET_MANIFEST.json');
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'image_asset_manifest_missing');
+    }
+
+    public function test_missing_file_fails(): void
+    {
+        $package = $this->writeImageBundlePackage(static function (array &$manifest): void {
+            $manifest['assets'][0]['source_file'] = 'media/missing.png';
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'source_file_missing');
+    }
+
+    public function test_invalid_mime_and_svg_fail(): void
+    {
+        $package = $this->writeImageBundlePackage(static function (array &$manifest, string $root): void {
+            file_put_contents($root.'/media/cover_source_1600x900.svg', '<svg xmlns="http://www.w3.org/2000/svg"></svg>');
+            $manifest['assets'][0]['source_file'] = 'media/cover_source_1600x900.svg';
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'image_extension_not_allowed');
+        $this->assertErrorCode($payload, 'svg_not_allowed');
+    }
+
+    public function test_oversize_file_fails(): void
+    {
+        $package = $this->writeImageBundlePackage(static function (array &$manifest, string $root): void {
+            file_put_contents($root.'/media/cover_source_1600x900.png', str_repeat('x', 10485761));
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'image_file_too_large');
+    }
+
+    public function test_missing_alt_fails(): void
+    {
+        $package = $this->writeImageBundlePackage(static function (array &$manifest): void {
+            $manifest['assets'][0]['alt_text'] = '';
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'alt_text_invalid');
+    }
+
+    public function test_invalid_asset_key_fails(): void
+    {
+        $package = $this->writeImageBundlePackage(static function (array &$manifest): void {
+            $manifest['assets'][0]['asset_key'] = 'bad-key';
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'asset_key_invalid');
+    }
+
+    public function test_competitor_asset_true_fails(): void
+    {
+        $package = $this->writeImageBundlePackage(static function (array &$manifest): void {
+            $manifest['assets'][0]['provenance']['competitor_asset'] = true;
+        });
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'competitor_asset_not_allowed');
+    }
+
+    public function test_non_dry_run_creates_media_asset_and_variants_without_cms_article_mutation(): void
+    {
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('imported_media_assets', $payload['action']);
+        $this->assertSame(1, MediaAsset::query()->withoutGlobalScopes()->count());
+        $this->assertSame(6, MediaVariant::query()->count());
+        $this->assertSame(0, Article::query()->withoutGlobalScopes()->count());
+
+        $asset = MediaAsset::query()->withoutGlobalScopes()->where('asset_key', 'article.daily.seo.cover.v1')->firstOrFail();
+        $this->assertSame(MediaAsset::STATUS_PUBLISHED, (string) $asset->status);
+        $this->assertTrue((bool) $asset->is_public);
+        $this->assertSame(MediaAsset::CDN_SKIPPED, (string) $asset->cdn_status);
+        $this->assertArrayHasKey('hero', $payload['resolved_metadata']['cover_image_variants']);
+        $this->assertSame($payload['resolved_metadata']['og_image_url'], $payload['resolved_metadata']['twitter_image_url']);
+        Storage::disk('public')->assertExists((string) $asset->path);
+    }
+
+    public function test_dry_run_does_not_write_existing_asset_or_storage(): void
+    {
+        Storage::fake('public');
+        MediaAsset::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'asset_key' => 'article.daily.seo.cover.v1',
+            'disk' => 'public_static',
+            'path' => '/static/old.jpg',
+            'url' => 'https://assets.fermatmind.com/static/old.jpg',
+            'mime_type' => 'image/jpeg',
+            'width' => 1200,
+            'height' => 630,
+            'bytes' => 100,
+            'alt' => 'Old image',
+            'status' => MediaAsset::STATUS_PUBLISHED,
+            'is_public' => true,
+        ]);
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+            '--allow-update-existing' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertSame(1, $payload['would_update']);
+        $this->assertSame('Old image', (string) MediaAsset::query()->withoutGlobalScopes()->firstOrFail()->alt);
+        $this->assertSame(0, MediaVariant::query()->count());
+        $this->assertFalse(Storage::disk('public')->exists('media-library'));
+    }
+
+    public function test_duplicate_recent_cover_emits_warning(): void
+    {
+        Article::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'slug' => 'recent-article',
+            'locale' => 'en',
+            'translation_group_id' => 'tg_recent',
+            'title' => 'Recent article',
+            'excerpt' => 'Recent article',
+            'content_md' => 'Body',
+            'cover_image_url' => 'https://assets.fermatmind.com/storage/media-library/variants/articledailyseocoverv1/hero_1600x900.jpg',
+            'cover_image_alt' => 'Recent cover',
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'cover_image_variants' => [
+                'editorial_package_v1' => [
+                    'cover_media_asset_key' => 'article.daily.seo.cover.v1',
+                ],
+            ],
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'published_at' => now(),
+        ]);
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--dry-run' => true,
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertWarningCode($payload, 'duplicate_recent_cover_asset');
+    }
+
+    public function test_write_resolved_package_outputs_safe_copy_with_cms_metadata(): void
+    {
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage();
+        $output = sys_get_temp_dir().'/fm-image-bundle-resolved-'.Str::random(12);
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+            '--write-resolved-package' => true,
+            '--resolved-output-dir' => $output,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertSame($output, $payload['resolved_package_dir']);
+        $this->assertFileExists($output.'/cms/CMS_IMPORT_DRAFT_en_demo.json');
+
+        $draft = json_decode((string) file_get_contents($output.'/cms/CMS_IMPORT_DRAFT_en_demo.json'), true);
+        $this->assertSame('article.daily.seo.cover.v1', $draft['cover_media_asset_key']);
+        $this->assertSame('SEO cover image showing a structured career decision map', $draft['cover_image_alt']);
+        $this->assertArrayHasKey('hero', $draft['cover_image_variants']);
+        $this->assertSame($draft['og_image_url'], $draft['twitter_image_url']);
+
+        $original = json_decode((string) file_get_contents($package.'/cms/CMS_IMPORT_DRAFT_en_demo.json'), true);
+        $this->assertSame('__CMS_MEDIA_LIBRARY_PLACEHOLDER__', $original['cover_media_asset_key']);
+    }
+
+    /**
+     * @param  array<string,mixed>  $overrides
+     * @return array<string,mixed>
+     */
+    private function commandOptions(string $package, array $overrides = []): array
+    {
+        return array_replace([
+            '--package' => $package,
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--locales' => 'zh-CN,en',
+            '--expected-asset-prefix' => 'article.daily.seo',
+        ], $overrides);
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertWarningCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $warning): string => (string) ($warning['code'] ?? ''),
+            $payload['warnings'] ?? []
+        ));
+    }
+
+    /**
+     * @param  callable(array<string,mixed>&, string):void|null  $mutate
+     */
+    private function writeImageBundlePackage(?callable $mutate = null): string
+    {
+        $root = sys_get_temp_dir().'/fm-image-bundle-'.Str::random(12);
+        mkdir($root.'/media', 0777, true);
+        mkdir($root.'/cms', 0777, true);
+
+        $this->writePng($root.'/media/cover_source_1600x900.png', 1600, 900);
+
+        $manifest = [
+            'schema_version' => 'image_asset_manifest_v1',
+            'package_id' => 'daily-seo-demo',
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'locale_scope' => ['zh-CN', 'en'],
+            'assets' => [
+                [
+                    'asset_key' => 'article.daily.seo.cover.v1',
+                    'role' => 'cover',
+                    'source_file' => 'media/cover_source_1600x900.png',
+                    'alt_text' => 'SEO cover image showing a structured career decision map',
+                    'locale_strategy' => 'shared_for_zh_cn_and_en',
+                    'intended_usage' => ['cover', 'hero', 'card', 'thumbnail', 'og', 'twitter'],
+                    'dimensions_expected' => ['width' => 1600, 'height' => 900, 'exact' => true],
+                    'format_allowed' => ['image/jpeg', 'image/png', 'image/webp'],
+                    'max_bytes' => 10485760,
+                    'fallback_allowed' => false,
+                    'provenance' => [
+                        'source' => 'gpt_generated_for_fermatmind',
+                        'prompt_file' => 'media/IMAGE_PROMPTS.md',
+                        'competitor_asset' => false,
+                    ],
+                ],
+            ],
+            'qa_gates' => [
+                'file_exists' => true,
+                'dimensions' => true,
+                'format' => true,
+                'file_size' => true,
+                'alt_text' => true,
+                'no_competitor_image' => true,
+                'no_private_asset' => true,
+                'no_placeholder' => true,
+                'media_library_public' => true,
+                'cdn_200' => true,
+                'variants_present' => true,
+                'cms_payload_backfilled' => true,
+                'preview_rendered' => true,
+                'recent_article_card_duplicate_check' => true,
+            ],
+        ];
+
+        if ($mutate !== null) {
+            $mutate($manifest, $root);
+        }
+
+        file_put_contents($root.'/media/IMAGE_ASSET_MANIFEST.json', json_encode($manifest, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($root.'/media/IMAGE_PROMPTS.md', "# Prompt\nGenerated for FermatMind only.\n");
+        file_put_contents($root.'/cms/CMS_IMPORT_DRAFT_en_demo.json', json_encode([
+            'locale' => 'en',
+            'slug' => 'demo',
+            'cover_media_asset_key' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+            'cover_image_url' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+            'cover_image_alt' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+            'og_image_url' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+            'twitter_image_url' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+        file_put_contents($root.'/cms/CMS_FIELDS_en_demo.json', json_encode([
+            'locale' => 'en',
+            'slug' => 'demo',
+            'cover_media_asset_key' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+        ], JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $root;
+    }
+
+    private function writePng(string $path, int $width, int $height): void
+    {
+        $image = imagecreatetruecolor($width, $height);
+        imagefill($image, 0, 0, imagecolorallocate($image, 230, 247, 244));
+        imagefilledrectangle($image, 40, 40, $width - 40, $height - 40, imagecolorallocate($image, 8, 99, 116));
+        imagepng($image, $path);
+        imagedestroy($image);
+    }
+}

--- a/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
+++ b/backend/tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
@@ -42,12 +42,12 @@ final class MediaLibraryPublicApiTest extends TestCase
             '--source-dir' => '../content_baselines/media_assets',
         ])
             ->expectsOutputToContain('files_found=2')
-            ->expectsOutputToContain('assets_found=227')
-            ->expectsOutputToContain('will_create=227')
+            ->expectsOutputToContain('assets_found=230')
+            ->expectsOutputToContain('will_create=230')
             ->assertExitCode(0);
 
-        $this->assertSame(227, MediaAsset::query()->withoutGlobalScopes()->count());
-        $this->assertSame(233, MediaVariant::query()->count());
+        $this->assertSame(230, MediaAsset::query()->withoutGlobalScopes()->count());
+        $this->assertSame(239, MediaVariant::query()->count());
     }
 
     public function test_public_and_internal_api_return_media_variant_metadata(): void

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1578,6 +1578,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_seo_image_bundle_importer_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\MediaAssetsImportSeoImageBundle;',
+            '+        MediaAssetsImportSeoImageBundle::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -2931,6 +2946,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isSeoImageBundleImporterFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -3530,6 +3549,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     $this->kernelDiffIsCareerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleEditorialPackageDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoContentPackageDraftImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsSeoImageBundleImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -3803,6 +3823,12 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Console/Commands/ArticleImportSeoContentPackageDraft.php'
             || str_starts_with($file, 'backend/app/Services/Cms/SeoContentPackage/');
+    }
+
+    private function isSeoImageBundleImporterFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php'
+            || str_starts_with($file, 'backend/app/Services/Cms/SeoImageBundle/');
     }
 
     private function isArticleBodyH1GuardFile(string $file): bool
@@ -5333,6 +5359,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleImportSeoContentPackageDraft\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsSeoImageBundleImporterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bMediaAssetsImportSeoImageBundle\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## Summary
- add a production-safe media-assets:import-seo-image-bundle command for SEO content packages
- validate media/IMAGE_ASSET_MANIFEST.json and source images in dry-run without DB/storage writes
- import Media Library assets with standard variants and emit CMS draft image metadata in non-dry-run mode
- add resolved package copy/backfill support and duplicate recent cover warnings
- refresh stale Media Library baseline count expectations to current baseline truth

## Why
Daily SEO packages need a stable backend-owned path for attached image files before CMS draft import. This keeps Codex from inventing URLs or relying on repeated fallback assets.

## Validation
- cd backend && ./vendor/bin/phpunit --filter MediaAssetsImportSeoImageBundleCommandTest
- cd backend && ./vendor/bin/phpunit --filter MediaLibraryPublicApiTest
- cd backend && ./vendor/bin/phpunit --filter ArticleImportSeoContentPackageDraftCommandTest
- cd backend && php artisan list | rg 'media-assets:import-seo-image-bundle'
- cd backend && ./vendor/bin/pint app/Console/Commands/MediaAssetsImportSeoImageBundle.php app/Console/Kernel.php app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php tests/Feature/MediaLibrary/MediaLibraryPublicApiTest.php
- git diff --check

## Deferred
- no skill / Mode C rules patch in this PR
- no production image upload
- no CMS article mutation
- no publish, revalidation, schema/hreflang, sitemap/llms, or search submission

## Repository rule impact
Adds a backend-authoritative Media Library import path for SEO article image assets. Frontend and CMS content authority remain unchanged.