### PR TITLE
TEST-KPI-READMODEL-01: Add test metrics daily read model

### DIFF
--- a/backend/app/Services/Analytics/TestMetricsDailyBuilder.php
+++ b/backend/app/Services/Analytics/TestMetricsDailyBuilder.php
@@ -1,0 +1,533 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Analytics;
+
+use App\Support\SchemaBaseline;
+use Carbon\CarbonImmutable;
+use Illuminate\Database\Query\Builder as QueryBuilder;
+use Illuminate\Support\Facades\DB;
+
+final class TestMetricsDailyBuilder
+{
+    private const SUCCESS_STATES = [
+        'succeeded',
+        'success',
+        'ready',
+        'completed',
+    ];
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array{
+     *     rows:list<array<string,mixed>>,
+     *     attempted_rows:int,
+     *     org_scope:list<int>,
+     *     scale_scope:list<string>,
+     *     from:string,
+     *     to:string
+     * }
+     */
+    public function build(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+    ): array {
+        $fromAt = CarbonImmutable::parse($from)->startOfDay();
+        $toAt = CarbonImmutable::parse($to)->endOfDay();
+        $normalizedOrgIds = $this->normalizeOrgIds($orgIds);
+        $normalizedScaleCodes = $this->normalizeScaleCodes($scaleCodes);
+
+        $started = $this->collectStartedEntries($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes);
+        $successful = $this->collectSuccessfulEntries($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes);
+        $failed = $this->collectFailedEntries($fromAt, $toAt, $normalizedOrgIds, $normalizedScaleCodes);
+
+        $attemptIds = $this->candidateAttemptIds($started, $successful, $failed);
+        $dimensions = $this->loadAttemptDimensions($attemptIds, $normalizedOrgIds, $normalizedScaleCodes);
+        $rows = $this->aggregateRows($started, $successful, $failed, $dimensions);
+
+        return [
+            'rows' => array_values($rows),
+            'attempted_rows' => count($rows),
+            'org_scope' => $normalizedOrgIds,
+            'scale_scope' => $normalizedScaleCodes,
+            'from' => $fromAt->toDateString(),
+            'to' => $toAt->toDateString(),
+        ];
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array{
+     *     rows:list<array<string,mixed>>,
+     *     attempted_rows:int,
+     *     deleted_rows:int,
+     *     upserted_rows:int,
+     *     org_scope:list<int>,
+     *     scale_scope:list<string>,
+     *     from:string,
+     *     to:string,
+     *     dry_run:bool
+     * }
+     */
+    public function refresh(
+        \DateTimeInterface $from,
+        \DateTimeInterface $to,
+        array $orgIds = [],
+        array $scaleCodes = [],
+        bool $dryRun = false,
+    ): array {
+        $payload = $this->build($from, $to, $orgIds, $scaleCodes);
+        $rows = $payload['rows'];
+        $deletedRows = 0;
+        $upsertedRows = 0;
+
+        if (! $dryRun) {
+            DB::transaction(function () use ($payload, $rows, &$deletedRows, &$upsertedRows): void {
+                $deletedRows = $this->deleteScope(
+                    $payload['from'],
+                    $payload['to'],
+                    $payload['org_scope'],
+                    $payload['scale_scope']
+                );
+
+                if ($rows === []) {
+                    return;
+                }
+
+                DB::table('analytics_test_metrics_daily')->upsert(
+                    $rows,
+                    ['day', 'org_id', 'scale_code', 'scale_code_v2', 'form_code', 'locale'],
+                    [
+                        'scale_uid',
+                        'started_attempts',
+                        'successful_attempts',
+                        'failed_attempts',
+                        'total_attempts',
+                        'last_refreshed_at',
+                        'updated_at',
+                    ]
+                );
+
+                $upsertedRows = count($rows);
+            });
+        }
+
+        return $payload + [
+            'deleted_rows' => $deletedRows,
+            'upserted_rows' => $upsertedRows,
+            'dry_run' => $dryRun,
+        ];
+    }
+
+    /**
+     * @param  list<array{attempt_id:string,day:string}>  ...$entryLists
+     * @return list<string>
+     */
+    private function candidateAttemptIds(array ...$entryLists): array
+    {
+        $attemptIds = [];
+        foreach ($entryLists as $entries) {
+            foreach ($entries as $entry) {
+                $attemptId = trim((string) ($entry['attempt_id'] ?? ''));
+                if ($attemptId !== '') {
+                    $attemptIds[$attemptId] = true;
+                }
+            }
+        }
+
+        return array_keys($attemptIds);
+    }
+
+    /**
+     * @param  list<string>  $attemptIds
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return array<string,array{org_id:int,scale_code:string,scale_code_v2:string,scale_uid:string,form_code:string,locale:string}>
+     */
+    private function loadAttemptDimensions(array $attemptIds, array $orgIds, array $scaleCodes): array
+    {
+        if ($attemptIds === [] || ! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $query = DB::table('attempts')
+            ->whereIn('id', $attemptIds)
+            ->select(['id', 'org_id', 'scale_code']);
+
+        $this->applyOrgFilter($query, 'attempts', $orgIds);
+        $this->applyScaleFilter($query, 'attempts', $scaleCodes);
+
+        if (SchemaBaseline::hasColumn('attempts', 'scale_code_v2')) {
+            $query->addSelect('scale_code_v2');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'scale_uid')) {
+            $query->addSelect('scale_uid');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'form_code')) {
+            $query->addSelect('form_code');
+        }
+        if (SchemaBaseline::hasColumn('attempts', 'locale')) {
+            $query->addSelect('locale');
+        }
+
+        $dimensions = [];
+        foreach ($query->get() as $row) {
+            $attemptId = trim((string) ($row->id ?? ''));
+            if ($attemptId === '') {
+                continue;
+            }
+
+            $scaleCode = $this->normalizeDimension($row->scale_code ?? null, 'unknown');
+            $scaleCodeV2 = $this->normalizeDimension($row->scale_code_v2 ?? null, '');
+
+            $dimensions[$attemptId] = [
+                'org_id' => max(0, (int) ($row->org_id ?? 0)),
+                'scale_code' => $scaleCode,
+                'scale_code_v2' => $scaleCodeV2,
+                'scale_uid' => $this->normalizeDimension($row->scale_uid ?? null, ''),
+                'form_code' => $this->normalizeDimension($row->form_code ?? null, ''),
+                'locale' => $this->normalizeLocale($row->locale ?? null),
+            ];
+        }
+
+        return $dimensions;
+    }
+
+    /**
+     * @param  list<array{attempt_id:string,day:string}>  $started
+     * @param  list<array{attempt_id:string,day:string}>  $successful
+     * @param  list<array{attempt_id:string,day:string}>  $failed
+     * @param  array<string,array{org_id:int,scale_code:string,scale_code_v2:string,scale_uid:string,form_code:string,locale:string}>  $dimensions
+     * @return array<string,array<string,mixed>>
+     */
+    private function aggregateRows(array $started, array $successful, array $failed, array $dimensions): array
+    {
+        $rows = [];
+
+        $this->incrementRows($rows, $started, $dimensions, 'started_attempts');
+        $this->incrementRows($rows, $successful, $dimensions, 'successful_attempts');
+        $this->incrementRows($rows, $failed, $dimensions, 'failed_attempts');
+
+        $now = now();
+        foreach ($rows as &$row) {
+            $row['total_attempts'] = (int) $row['successful_attempts'] + (int) $row['failed_attempts'];
+            $row['last_refreshed_at'] = $now;
+            $row['created_at'] = $now;
+            $row['updated_at'] = $now;
+        }
+        unset($row);
+
+        ksort($rows);
+
+        return $rows;
+    }
+
+    /**
+     * @param  array<string,array<string,mixed>>  $rows
+     * @param  list<array{attempt_id:string,day:string}>  $entries
+     * @param  array<string,array{org_id:int,scale_code:string,scale_code_v2:string,scale_uid:string,form_code:string,locale:string}>  $dimensions
+     */
+    private function incrementRows(array &$rows, array $entries, array $dimensions, string $metric): void
+    {
+        foreach ($entries as $entry) {
+            $attemptId = trim((string) ($entry['attempt_id'] ?? ''));
+            $day = trim((string) ($entry['day'] ?? ''));
+            if ($attemptId === '' || $day === '' || ! isset($dimensions[$attemptId])) {
+                continue;
+            }
+
+            $dimension = $dimensions[$attemptId];
+            $key = implode('|', [
+                $day,
+                (string) $dimension['org_id'],
+                $dimension['scale_code'],
+                $dimension['scale_code_v2'],
+                $dimension['form_code'],
+                $dimension['locale'],
+            ]);
+
+            if (! isset($rows[$key])) {
+                $rows[$key] = [
+                    'day' => $day,
+                    'org_id' => $dimension['org_id'],
+                    'scale_code' => $dimension['scale_code'],
+                    'scale_code_v2' => $dimension['scale_code_v2'],
+                    'scale_uid' => $dimension['scale_uid'],
+                    'form_code' => $dimension['form_code'],
+                    'locale' => $dimension['locale'],
+                    'started_attempts' => 0,
+                    'successful_attempts' => 0,
+                    'failed_attempts' => 0,
+                    'total_attempts' => 0,
+                ];
+            }
+
+            $rows[$key][$metric] = (int) $rows[$key][$metric] + 1;
+        }
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return list<array{attempt_id:string,day:string}>
+     */
+    private function collectStartedEntries(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $scaleCodes
+    ): array {
+        if (! SchemaBaseline::hasTable('attempts')) {
+            return [];
+        }
+
+        $timeColumn = SchemaBaseline::hasColumn('attempts', 'started_at') ? 'started_at' : 'created_at';
+        $query = DB::table('attempts')
+            ->whereBetween($timeColumn, [$fromAt, $toAt])
+            ->select(['id as attempt_id', $timeColumn.' as metric_at']);
+
+        $this->applyOrgFilter($query, 'attempts', $orgIds);
+        $this->applyScaleFilter($query, 'attempts', $scaleCodes);
+
+        return $this->entriesFromRows($query->get());
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return list<array{attempt_id:string,day:string}>
+     */
+    private function collectSuccessfulEntries(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $scaleCodes
+    ): array {
+        $entries = [];
+
+        if (SchemaBaseline::hasTable('attempts') && SchemaBaseline::hasColumn('attempts', 'submitted_at')) {
+            $query = DB::table('attempts')
+                ->whereBetween('submitted_at', [$fromAt, $toAt])
+                ->select(['id as attempt_id', 'submitted_at as metric_at']);
+            $this->applyOrgFilter($query, 'attempts', $orgIds);
+            $this->applyScaleFilter($query, 'attempts', $scaleCodes);
+            $entries = $this->mergeDistinctEntries($entries, $this->entriesFromRows($query->get()));
+        }
+
+        if (SchemaBaseline::hasTable('attempt_submissions')) {
+            $timeExpression = 'COALESCE(attempt_submissions.finished_at, attempt_submissions.updated_at, attempt_submissions.created_at)';
+            $query = DB::table('attempt_submissions')
+                ->join('attempts', 'attempts.id', '=', 'attempt_submissions.attempt_id')
+                ->whereIn('attempt_submissions.state', self::SUCCESS_STATES)
+                ->whereBetween(DB::raw($timeExpression), [$fromAt, $toAt])
+                ->select([
+                    'attempt_submissions.attempt_id as attempt_id',
+                    DB::raw($timeExpression.' as metric_at'),
+                ]);
+            $this->applyOrgFilter($query, 'attempt_submissions', $orgIds);
+            $this->applyScaleFilter($query, 'attempts', $scaleCodes);
+            $entries = $this->mergeDistinctEntries($entries, $this->entriesFromRows($query->get()));
+        }
+
+        if (SchemaBaseline::hasTable('results')) {
+            $timeColumn = SchemaBaseline::hasColumn('results', 'computed_at') ? 'computed_at' : 'created_at';
+            $query = DB::table('results')
+                ->join('attempts', 'attempts.id', '=', 'results.attempt_id')
+                ->whereBetween('results.'.$timeColumn, [$fromAt, $toAt])
+                ->select([
+                    'results.attempt_id as attempt_id',
+                    'results.'.$timeColumn.' as metric_at',
+                ]);
+            $this->applyOrgFilter($query, 'results', $orgIds);
+            $this->applyScaleFilter($query, 'attempts', $scaleCodes);
+            $entries = $this->mergeDistinctEntries($entries, $this->entriesFromRows($query->get()));
+        }
+
+        return $entries;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @return list<array{attempt_id:string,day:string}>
+     */
+    private function collectFailedEntries(
+        CarbonImmutable $fromAt,
+        CarbonImmutable $toAt,
+        array $orgIds,
+        array $scaleCodes
+    ): array {
+        if (! SchemaBaseline::hasTable('attempt_submissions')) {
+            return [];
+        }
+
+        $timeExpression = 'COALESCE(attempt_submissions.finished_at, attempt_submissions.updated_at, attempt_submissions.created_at)';
+        $query = DB::table('attempt_submissions')
+            ->join('attempts', 'attempts.id', '=', 'attempt_submissions.attempt_id')
+            ->where('attempt_submissions.state', 'failed')
+            ->whereBetween(DB::raw($timeExpression), [$fromAt, $toAt])
+            ->select([
+                'attempt_submissions.attempt_id as attempt_id',
+                DB::raw($timeExpression.' as metric_at'),
+            ]);
+
+        $this->applyOrgFilter($query, 'attempt_submissions', $orgIds);
+        $this->applyScaleFilter($query, 'attempts', $scaleCodes);
+
+        return $this->entriesFromRows($query->get());
+    }
+
+    /**
+     * @param  iterable<object>  $rows
+     * @return list<array{attempt_id:string,day:string}>
+     */
+    private function entriesFromRows(iterable $rows): array
+    {
+        $entries = [];
+        foreach ($rows as $row) {
+            $attemptId = trim((string) ($row->attempt_id ?? ''));
+            $metricAt = $row->metric_at ?? null;
+            if ($attemptId === '' || $metricAt === null) {
+                continue;
+            }
+
+            $day = CarbonImmutable::parse($metricAt)->toDateString();
+            $entries[$attemptId.'|'.$day] = [
+                'attempt_id' => $attemptId,
+                'day' => $day,
+            ];
+        }
+
+        return array_values($entries);
+    }
+
+    /**
+     * @param  list<array{attempt_id:string,day:string}>  $current
+     * @param  list<array{attempt_id:string,day:string}>  $incoming
+     * @return list<array{attempt_id:string,day:string}>
+     */
+    private function mergeDistinctEntries(array $current, array $incoming): array
+    {
+        $merged = [];
+        foreach (array_merge($current, $incoming) as $entry) {
+            $attemptId = trim((string) ($entry['attempt_id'] ?? ''));
+            $day = trim((string) ($entry['day'] ?? ''));
+            if ($attemptId !== '' && $day !== '') {
+                $merged[$attemptId.'|'.$day] = [
+                    'attempt_id' => $attemptId,
+                    'day' => $day,
+                ];
+            }
+        }
+
+        return array_values($merged);
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     */
+    private function applyOrgFilter(QueryBuilder $query, string $table, array $orgIds): void
+    {
+        if ($orgIds !== [] && SchemaBaseline::hasColumn($table, 'org_id')) {
+            $query->whereIn($table.'.org_id', $orgIds);
+        }
+    }
+
+    /**
+     * @param  list<string>  $scaleCodes
+     */
+    private function applyScaleFilter(QueryBuilder $query, string $table, array $scaleCodes): void
+    {
+        if ($scaleCodes === []) {
+            return;
+        }
+
+        $query->where(function (QueryBuilder $nested) use ($table, $scaleCodes): void {
+            if (SchemaBaseline::hasColumn($table, 'scale_code')) {
+                $nested->orWhereIn(DB::raw('UPPER('.$table.'.scale_code)'), $scaleCodes);
+            }
+            if (SchemaBaseline::hasColumn($table, 'scale_code_v2')) {
+                $nested->orWhereIn(DB::raw('UPPER('.$table.'.scale_code_v2)'), $scaleCodes);
+            }
+        });
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function deleteScope(string $from, string $to, array $orgIds, array $scaleCodes): int
+    {
+        if (! SchemaBaseline::hasTable('analytics_test_metrics_daily')) {
+            return 0;
+        }
+
+        $query = DB::table('analytics_test_metrics_daily')->whereBetween('day', [$from, $to]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        if ($scaleCodes !== []) {
+            $query->where(function (QueryBuilder $nested) use ($scaleCodes): void {
+                $nested->whereIn(DB::raw('UPPER(scale_code)'), $scaleCodes)
+                    ->orWhereIn(DB::raw('UPPER(scale_code_v2)'), $scaleCodes);
+            });
+        }
+
+        return $query->delete();
+    }
+
+    /**
+     * @param  list<int|string>  $orgIds
+     * @return list<int>
+     */
+    private function normalizeOrgIds(array $orgIds): array
+    {
+        $normalized = [];
+        foreach ($orgIds as $orgId) {
+            $value = (int) $orgId;
+            if ($value >= 0) {
+                $normalized[$value] = $value;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    /**
+     * @param  list<string>  $scaleCodes
+     * @return list<string>
+     */
+    private function normalizeScaleCodes(array $scaleCodes): array
+    {
+        $normalized = [];
+        foreach ($scaleCodes as $scaleCode) {
+            $value = strtoupper(trim((string) $scaleCode));
+            if ($value !== '') {
+                $normalized[$value] = $value;
+            }
+        }
+
+        return array_values($normalized);
+    }
+
+    private function normalizeDimension(mixed $value, string $fallback): string
+    {
+        $normalized = trim((string) ($value ?? ''));
+
+        return $normalized !== '' ? $normalized : $fallback;
+    }
+
+    private function normalizeLocale(mixed $value): string
+    {
+        $normalized = trim((string) ($value ?? ''));
+
+        return $normalized !== '' ? $normalized : 'unknown';
+    }
+}

--- a/backend/database/migrations/2026_06_13_180000_create_analytics_test_metrics_daily_table.php
+++ b/backend/database/migrations/2026_06_13_180000_create_analytics_test_metrics_daily_table.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+use App\Support\Database\SchemaIndex;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private const TABLE = 'analytics_test_metrics_daily';
+
+    public function up(): void
+    {
+        if (! Schema::hasTable(self::TABLE)) {
+            Schema::create(self::TABLE, function (Blueprint $table): void {
+                $table->date('day');
+                $table->unsignedBigInteger('org_id')->default(0);
+                $table->string('scale_code', 64)->default('unknown');
+                $table->string('scale_code_v2', 64)->default('');
+                $table->char('scale_uid', 36)->default('');
+                $table->string('form_code', 64)->default('');
+                $table->string('locale', 16)->default('unknown');
+
+                $table->unsignedInteger('started_attempts')->default(0);
+                $table->unsignedInteger('successful_attempts')->default(0);
+                $table->unsignedInteger('failed_attempts')->default(0);
+                $table->unsignedInteger('total_attempts')->default(0);
+
+                $table->timestamp('last_refreshed_at')->nullable();
+                $table->timestamps();
+            });
+        } else {
+            Schema::table(self::TABLE, function (Blueprint $table): void {
+                if (! Schema::hasColumn(self::TABLE, 'day')) {
+                    $table->date('day')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'org_id')) {
+                    $table->unsignedBigInteger('org_id')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'scale_code')) {
+                    $table->string('scale_code', 64)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'scale_code_v2')) {
+                    $table->string('scale_code_v2', 64)->default('');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'scale_uid')) {
+                    $table->char('scale_uid', 36)->default('');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'form_code')) {
+                    $table->string('form_code', 64)->default('');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'locale')) {
+                    $table->string('locale', 16)->default('unknown');
+                }
+                if (! Schema::hasColumn(self::TABLE, 'started_attempts')) {
+                    $table->unsignedInteger('started_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'successful_attempts')) {
+                    $table->unsignedInteger('successful_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'failed_attempts')) {
+                    $table->unsignedInteger('failed_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'total_attempts')) {
+                    $table->unsignedInteger('total_attempts')->default(0);
+                }
+                if (! Schema::hasColumn(self::TABLE, 'last_refreshed_at')) {
+                    $table->timestamp('last_refreshed_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'created_at')) {
+                    $table->timestamp('created_at')->nullable();
+                }
+                if (! Schema::hasColumn(self::TABLE, 'updated_at')) {
+                    $table->timestamp('updated_at')->nullable();
+                }
+            });
+        }
+
+        $this->ensureUnique(
+            ['day', 'org_id', 'scale_code', 'scale_code_v2', 'form_code', 'locale'],
+            'analytics_test_metrics_daily_unique'
+        );
+        $this->ensureIndex(['org_id', 'day'], 'analytics_test_metrics_daily_org_day_idx');
+        $this->ensureIndex(
+            ['org_id', 'scale_code', 'scale_code_v2', 'form_code', 'day'],
+            'analytics_test_metrics_daily_scope_day_idx'
+        );
+    }
+
+    public function down(): void
+    {
+        // forward-only migration: rollback disabled to prevent analytics data loss.
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureUnique(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->unique($columns, $indexName);
+        });
+    }
+
+    /**
+     * @param  array<int,string>  $columns
+     */
+    private function ensureIndex(array $columns, string $indexName): void
+    {
+        if (! Schema::hasTable(self::TABLE) || SchemaIndex::indexExists(self::TABLE, $indexName)) {
+            return;
+        }
+
+        Schema::table(self::TABLE, function (Blueprint $table) use ($columns, $indexName): void {
+            $table->index($columns, $indexName);
+        });
+    }
+};

--- a/backend/tests/Feature/Analytics/TestMetricsDailyBuilderTest.php
+++ b/backend/tests/Feature/Analytics/TestMetricsDailyBuilderTest.php
@@ -1,0 +1,144 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use App\Services\Analytics\TestMetricsDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class TestMetricsDailyBuilderTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_builder_aggregates_daily_success_failure_and_started_counts_by_test_scope(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-13 09:00:00');
+        $mbtiSuccess = (string) Str::uuid();
+        $mbtiFailure = (string) Str::uuid();
+        $bigFiveSuccess = (string) Str::uuid();
+
+        $this->insertAttempt($mbtiSuccess, 7, 'MBTI', 'MBTI', 'zh-CN', $day, $day->addMinutes(8));
+        $this->insertAttempt($mbtiFailure, 7, 'MBTI', 'MBTI', 'zh-CN', $day->addMinutes(2), null);
+        $this->insertAttempt($bigFiveSuccess, 7, 'BIG5_OCEAN', 'BIG_FIVE_OCEAN_MODEL', 'en', $day->addMinutes(3), $day->addMinutes(14));
+
+        $this->insertSubmission($mbtiSuccess, 7, 'succeeded', $day->addMinutes(9));
+        $this->insertSubmission($mbtiFailure, 7, 'failed', $day->addMinutes(10));
+        $this->insertSubmission($mbtiFailure, 7, 'failed', $day->addMinutes(11));
+        $this->insertSubmission($bigFiveSuccess, 7, 'completed', $day->addMinutes(15));
+
+        $payload = app(TestMetricsDailyBuilder::class)->build($day, $day, [7]);
+        $rows = collect($payload['rows'])->keyBy('scale_code');
+
+        $mbti = $rows->get('MBTI');
+        $bigFive = $rows->get('BIG5_OCEAN');
+
+        $this->assertNotNull($mbti);
+        $this->assertSame('2026-06-13', $mbti['day']);
+        $this->assertSame(2, (int) $mbti['started_attempts']);
+        $this->assertSame(1, (int) $mbti['successful_attempts']);
+        $this->assertSame(1, (int) $mbti['failed_attempts']);
+        $this->assertSame(2, (int) $mbti['total_attempts']);
+        $this->assertSame('zh-CN', $mbti['locale']);
+
+        $this->assertNotNull($bigFive);
+        $this->assertSame(1, (int) $bigFive['started_attempts']);
+        $this->assertSame(1, (int) $bigFive['successful_attempts']);
+        $this->assertSame(0, (int) $bigFive['failed_attempts']);
+        $this->assertSame(1, (int) $bigFive['total_attempts']);
+        $this->assertSame('BIG_FIVE_OCEAN_MODEL', $bigFive['scale_code_v2']);
+    }
+
+    public function test_refresh_upserts_and_replaces_the_requested_scope(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-14 09:00:00');
+        $attemptId = (string) Str::uuid();
+
+        $this->insertAttempt($attemptId, 9, 'ENNEAGRAM', 'ENNEAGRAM_PERSONALITY_TEST', 'en', $day, $day->addMinutes(20));
+        $this->insertSubmission($attemptId, 9, 'succeeded', $day->addMinutes(21));
+
+        $builder = app(TestMetricsDailyBuilder::class);
+        $first = $builder->refresh($day, $day, [9], [], false);
+        $second = $builder->refresh($day, $day, [9], [], false);
+
+        $this->assertSame(1, (int) $first['upserted_rows']);
+        $this->assertSame(1, (int) $second['deleted_rows']);
+        $this->assertSame(1, (int) $second['upserted_rows']);
+
+        $this->assertDatabaseHas('analytics_test_metrics_daily', [
+            'day' => '2026-06-14',
+            'org_id' => 9,
+            'scale_code' => 'ENNEAGRAM',
+            'successful_attempts' => 1,
+            'failed_attempts' => 0,
+            'total_attempts' => 1,
+        ]);
+    }
+
+    private function insertAttempt(
+        string $attemptId,
+        int $orgId,
+        string $scaleCode,
+        string $scaleCodeV2,
+        string $locale,
+        CarbonImmutable $startedAt,
+        ?CarbonImmutable $submittedAt
+    ): void {
+        $row = [
+            'id' => $attemptId,
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => $orgId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'question_count' => 100,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/test-metrics',
+            'locale' => $locale,
+            'started_at' => $startedAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $startedAt,
+            'updated_at' => $submittedAt ?? $startedAt,
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = $scaleCodeV2;
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = (string) Str::uuid();
+        }
+
+        DB::table('attempts')->insert($row);
+    }
+
+    private function insertSubmission(string $attemptId, int $orgId, string $state, CarbonImmutable $finishedAt): void
+    {
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => 'actor_'.$attemptId,
+            'dedupe_key' => 'dedupe_'.$attemptId.'_'.$state.'_'.$finishedAt->timestamp,
+            'mode' => 'async',
+            'state' => $state,
+            'error_code' => $state === 'failed' ? 'SCORING_FAILED' : null,
+            'error_message' => $state === 'failed' ? 'fixture failure' : null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => json_encode(['ok' => $state !== 'failed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'started_at' => $finishedAt->subMinute(),
+            'finished_at' => $finishedAt,
+            'created_at' => $finishedAt->subMinute(),
+            'updated_at' => $finishedAt,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -2469,6 +2469,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_test_metrics_daily_read_model_changes(): void
+    {
+        $changed = [
+            'backend/app/Services/Analytics/TestMetricsDailyBuilder.php',
+            'backend/database/migrations/2026_06_13_180000_create_analytics_test_metrics_daily_table.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_payment_unlock_attribution_diagnostics(): void
     {
         $changed = [
@@ -3374,6 +3384,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if ($this->isAnalyticsFunnelOpsReadModelFile($file)) {
+                continue;
+            }
+
+            if ($this->isTestMetricsDailyReadModelFile($file)) {
                 continue;
             }
 
@@ -5141,6 +5155,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Filament/Ops/Pages/FunnelConversionPage.php',
             'backend/app/Filament/Ops/Widgets/FunnelWidget.php',
+        ], true);
+    }
+
+    private function isTestMetricsDailyReadModelFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Services/Analytics/TestMetricsDailyBuilder.php',
+            'backend/database/migrations/2026_06_13_180000_create_analytics_test_metrics_daily_table.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added analytics_test_metrics_daily as the backend read model for test KPI counts.
- Added TestMetricsDailyBuilder to aggregate started, successful, failed, and total attempts by day, org, scale, form, and locale.
- Added focused feature coverage for daily aggregation, failure de-duplication, and scoped refresh upserts.
- Added a Big Five runtime-freeze classifier allowlist test for this Ops analytics read model so the existing gate keeps blocking real Big Five runtime drift without blocking non-runtime analytics storage.

## Why
Ops needs backend-authoritative daily and cumulative test metrics for current and future tests. This PR establishes the storage and builder layer only; UI and scheduling are intentionally separate PRs.

## Validation
- php artisan test --filter=TestMetricsDailyBuilderTest
- php artisan test --filter=AnalyticsFunnelDailyBuilderTest
- php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest
- php artisan route:list
- DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan migrate --pretend --no-interaction
- bash scripts/ci_verify_mbti.sh
- git diff --check -- backend/database/migrations/2026_06_13_180000_create_analytics_test_metrics_daily_table.php backend/app/Services/Analytics/TestMetricsDailyBuilder.php backend/tests/Feature/Analytics/TestMetricsDailyBuilderTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php

Note: plain php artisan migrate --pretend hit local MySQL root access denial on this machine, so migration validation was rerun with SQLite in-memory and the full CI migration chain passed.

## Intentionally deferred
- TEST-KPI-REFRESH-COMMAND-02: artisan refresh/backfill command.
- TEST-KPI-OPS-SUMMARY-03: Ops dashboard summary cards.
- TEST-KPI-OPS-DAILY-BY-TEST-04: per-test daily volume Ops view.
- TEST-KPI-SCHEDULER-05: scheduled production refresh.
- TEST-KPI-FRONTEND-CONTRACT-06: frontend telemetry/identity guard.
- TEST-KPI-POST-DEPLOY-SMOKE-07: production read-only smoke.

## Repository rule impact
Backend remains the authority for operational test metrics. No frontend, CMS content, route, sitemap, llms, or public SEO behavior changed.