### PR TITLE
TEST-KPI-REFRESH-COMMAND-02: Add test metrics refresh command

### DIFF
--- a/backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php
@@ -1,0 +1,210 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Analytics\TestMetricsDailyBuilder;
+use Carbon\CarbonImmutable;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+final class RefreshTestMetricsDailyCommand extends Command
+{
+    private const MAX_WRITE_RANGE_DAYS = 31;
+
+    protected $signature = 'analytics:refresh-test-metrics-daily
+        {--from= : Inclusive start date (Y-m-d)}
+        {--to= : Inclusive end date (Y-m-d)}
+        {--scale=* : Limit refresh to one or more scale codes}
+        {--org=* : Limit refresh to one or more org ids}
+        {--dry-run : Preview the aggregation without writing rows}
+        {--confirm-write= : Required exact confirmation token for non-dry-run refresh writes}';
+
+    protected $description = 'Refresh the analytics_test_metrics_daily backend-authoritative test metrics read model.';
+
+    public function __construct(
+        private readonly TestMetricsDailyBuilder $builder,
+    ) {
+        parent::__construct();
+    }
+
+    public function handle(): int
+    {
+        $from = $this->parseDateOption((string) $this->option('from'), now()->toDateString());
+        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+
+        if ($from->greaterThan($to)) {
+            $this->error('The --from date must be on or before --to.');
+
+            return self::FAILURE;
+        }
+
+        $scaleCodes = array_values(array_filter(array_map(
+            static fn (mixed $value): string => strtoupper(trim((string) $value)),
+            (array) $this->option('scale')
+        ), static fn (string $value): bool => $value !== ''));
+
+        $orgIds = array_values(array_filter(array_map(
+            static fn (mixed $value): int => max(0, (int) $value),
+            (array) $this->option('org')
+        ), static fn (int $value): bool => $value >= 0));
+
+        $dryRun = (bool) $this->option('dry-run');
+        $beforeCount = $this->countExistingRows($from, $to, $orgIds, $scaleCodes);
+
+        if (! $dryRun) {
+            $guard = $this->validateWriteGuard($from, $to, $orgIds, $scaleCodes);
+
+            if ($guard !== null) {
+                $this->emitSummary($from, $to, $orgIds, $scaleCodes, [
+                    'dry_run' => false,
+                    'before_count' => $beforeCount,
+                    'after_count' => $beforeCount,
+                    'attempted_rows' => 0,
+                    'deleted_rows' => 0,
+                    'upserted_rows' => 0,
+                    'write_guard' => 'blocked',
+                ]);
+                $this->line('write_guard_reason='.$guard);
+                $this->line('expected_confirm_write='.$this->expectedWriteConfirmationToken($from, $to, $orgIds, $scaleCodes));
+                $this->error('Non-dry-run test metrics refresh is blocked by the controlled write guard.');
+
+                return self::FAILURE;
+            }
+        }
+
+        $result = $this->builder->refresh($from, $to, $orgIds, $scaleCodes, $dryRun);
+        $afterCount = $this->countExistingRows($from, $to, $orgIds, $scaleCodes);
+
+        $this->emitSummary($from, $to, $orgIds, $scaleCodes, [
+            'dry_run' => (bool) ($result['dry_run'] ?? false),
+            'before_count' => $beforeCount,
+            'after_count' => $afterCount,
+            'attempted_rows' => (int) ($result['attempted_rows'] ?? 0),
+            'deleted_rows' => (int) ($result['deleted_rows'] ?? 0),
+            'upserted_rows' => (int) ($result['upserted_rows'] ?? 0),
+            'write_guard' => $dryRun ? 'dry_run_no_write' : 'passed',
+        ]);
+
+        if (($result['attempted_rows'] ?? 0) === 0) {
+            $this->warn('No test metrics rows were generated for the selected scope.');
+        } else {
+            $this->info($dryRun ? 'dry-run complete' : 'refresh complete');
+        }
+
+        return self::SUCCESS;
+    }
+
+    private function parseDateOption(string $value, string $fallback): CarbonImmutable
+    {
+        $candidate = trim($value) !== '' ? trim($value) : $fallback;
+
+        return CarbonImmutable::createFromFormat('Y-m-d', $candidate)?->startOfDay()
+            ?? CarbonImmutable::parse($candidate)->startOfDay();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function countExistingRows(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+    ): int {
+        $query = DB::table('analytics_test_metrics_daily')
+            ->whereBetween('day', [$from->toDateString(), $to->toDateString()]);
+
+        if ($orgIds !== []) {
+            $query->whereIn('org_id', $orgIds);
+        }
+
+        if ($scaleCodes !== []) {
+            $query->where(function ($nested) use ($scaleCodes): void {
+                $nested->whereIn(DB::raw('UPPER(scale_code)'), $scaleCodes)
+                    ->orWhereIn(DB::raw('UPPER(scale_code_v2)'), $scaleCodes);
+            });
+        }
+
+        return (int) $query->count();
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function validateWriteGuard(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+    ): ?string {
+        if (trim((string) $this->option('from')) === '' || trim((string) $this->option('to')) === '') {
+            return 'explicit_from_to_required';
+        }
+
+        if ($orgIds === []) {
+            return 'explicit_org_scope_required';
+        }
+
+        if ($from->diffInDays($to) + 1 > self::MAX_WRITE_RANGE_DAYS) {
+            return 'date_range_exceeds_'.self::MAX_WRITE_RANGE_DAYS.'_days';
+        }
+
+        $expected = $this->expectedWriteConfirmationToken($from, $to, $orgIds, $scaleCodes);
+        $provided = trim((string) $this->option('confirm-write'));
+
+        if (! hash_equals($expected, $provided)) {
+            return 'confirm_write_token_mismatch';
+        }
+
+        return null;
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     */
+    private function expectedWriteConfirmationToken(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+    ): string {
+        return implode(':', [
+            'analytics_test_metrics_daily',
+            'write',
+            $from->toDateString(),
+            $to->toDateString(),
+            'org='.($orgIds === [] ? 'all' : implode(',', $orgIds)),
+            'scale='.($scaleCodes === [] ? 'all' : implode(',', $scaleCodes)),
+        ]);
+    }
+
+    /**
+     * @param  list<int>  $orgIds
+     * @param  list<string>  $scaleCodes
+     * @param  array{dry_run:bool,before_count:int,after_count:int,attempted_rows:int,deleted_rows:int,upserted_rows:int,write_guard:string}  $summary
+     */
+    private function emitSummary(
+        CarbonImmutable $from,
+        CarbonImmutable $to,
+        array $orgIds,
+        array $scaleCodes,
+        array $summary,
+    ): void {
+        $this->line('from='.$from->toDateString());
+        $this->line('to='.$to->toDateString());
+        $this->line('org_scope='.($orgIds === [] ? '*' : implode(',', $orgIds)));
+        $this->line('scale_scope='.($scaleCodes === [] ? '*' : implode(',', $scaleCodes)));
+        $this->line('dry_run='.($summary['dry_run'] ? '1' : '0'));
+        $this->line('before_count='.$summary['before_count']);
+        $this->line('after_count='.$summary['after_count']);
+        $this->line('attempted_rows='.$summary['attempted_rows']);
+        $this->line('deleted_rows='.$summary['deleted_rows']);
+        $this->line('upserted_rows='.$summary['upserted_rows']);
+        $this->line('write_guard='.$summary['write_guard']);
+    }
+}

--- a/backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php
@@ -1,0 +1,140 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Carbon\CarbonImmutable;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Support\Facades\Schema;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class RefreshTestMetricsDailyCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_command_supports_dry_run_and_controlled_scope_write(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-15 09:00:00');
+        $success = (string) Str::uuid();
+        $failure = (string) Str::uuid();
+
+        $this->insertAttempt($success, 12, 'MBTI', 'MBTI', 'zh-CN', $day, $day->addMinutes(8));
+        $this->insertAttempt($failure, 12, 'MBTI', 'MBTI', 'zh-CN', $day->addMinutes(2), null);
+        $this->insertSubmission($success, 12, 'succeeded', $day->addMinutes(9));
+        $this->insertSubmission($failure, 12, 'failed', $day->addMinutes(10));
+
+        $this->artisan('analytics:refresh-test-metrics-daily', [
+            '--from' => $day->toDateString(),
+            '--to' => $day->toDateString(),
+            '--org' => [12],
+            '--dry-run' => true,
+        ])
+            ->expectsOutputToContain('dry_run=1')
+            ->expectsOutputToContain('attempted_rows=1')
+            ->expectsOutputToContain('write_guard=dry_run_no_write')
+            ->assertExitCode(0);
+
+        $this->assertSame(0, DB::table('analytics_test_metrics_daily')->count());
+
+        $this->artisan('analytics:refresh-test-metrics-daily', [
+            '--from' => $day->toDateString(),
+            '--to' => $day->toDateString(),
+            '--org' => [12],
+            '--confirm-write' => 'analytics_test_metrics_daily:write:'.$day->toDateString().':'.$day->toDateString().':org=12:scale=all',
+        ])
+            ->expectsOutputToContain('dry_run=0')
+            ->expectsOutputToContain('upserted_rows=1')
+            ->expectsOutputToContain('write_guard=passed')
+            ->assertExitCode(0);
+
+        $this->assertDatabaseHas('analytics_test_metrics_daily', [
+            'day' => $day->toDateString(),
+            'org_id' => 12,
+            'scale_code' => 'MBTI',
+            'started_attempts' => 2,
+            'successful_attempts' => 1,
+            'failed_attempts' => 1,
+            'total_attempts' => 2,
+        ]);
+    }
+
+    public function test_command_blocks_unconfirmed_non_dry_run_writes(): void
+    {
+        $day = CarbonImmutable::parse('2026-06-16 09:00:00');
+
+        $this->artisan('analytics:refresh-test-metrics-daily', [
+            '--from' => $day->toDateString(),
+            '--to' => $day->toDateString(),
+            '--org' => [12],
+        ])
+            ->expectsOutputToContain('write_guard=blocked')
+            ->expectsOutputToContain('write_guard_reason=confirm_write_token_mismatch')
+            ->expectsOutputToContain('expected_confirm_write=analytics_test_metrics_daily:write:2026-06-16:2026-06-16:org=12:scale=all')
+            ->assertExitCode(1);
+    }
+
+    private function insertAttempt(
+        string $attemptId,
+        int $orgId,
+        string $scaleCode,
+        string $scaleCodeV2,
+        string $locale,
+        CarbonImmutable $startedAt,
+        ?CarbonImmutable $submittedAt
+    ): void {
+        $row = [
+            'id' => $attemptId,
+            'anon_id' => 'anon_'.substr(str_replace('-', '', $attemptId), 0, 10),
+            'user_id' => null,
+            'org_id' => $orgId,
+            'scale_code' => $scaleCode,
+            'scale_version' => 'v0.3',
+            'question_count' => 100,
+            'answers_summary_json' => json_encode(['seed' => true], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'client_platform' => 'web',
+            'client_version' => 'test',
+            'channel' => 'web',
+            'referrer' => '/tests/test-metrics',
+            'locale' => $locale,
+            'started_at' => $startedAt,
+            'submitted_at' => $submittedAt,
+            'created_at' => $startedAt,
+            'updated_at' => $submittedAt ?? $startedAt,
+        ];
+
+        if (Schema::hasColumn('attempts', 'scale_code_v2')) {
+            $row['scale_code_v2'] = $scaleCodeV2;
+        }
+
+        if (Schema::hasColumn('attempts', 'scale_uid')) {
+            $row['scale_uid'] = (string) Str::uuid();
+        }
+
+        DB::table('attempts')->insert($row);
+    }
+
+    private function insertSubmission(string $attemptId, int $orgId, string $state, CarbonImmutable $finishedAt): void
+    {
+        DB::table('attempt_submissions')->insert([
+            'id' => (string) Str::uuid(),
+            'org_id' => $orgId,
+            'attempt_id' => $attemptId,
+            'actor_user_id' => null,
+            'actor_anon_id' => 'actor_'.$attemptId,
+            'dedupe_key' => 'dedupe_'.$attemptId.'_'.$state.'_'.$finishedAt->timestamp,
+            'mode' => 'async',
+            'state' => $state,
+            'error_code' => $state === 'failed' ? 'SCORING_FAILED' : null,
+            'error_message' => $state === 'failed' ? 'fixture failure' : null,
+            'request_payload_json' => json_encode(['attempt_id' => $attemptId], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'response_payload_json' => json_encode(['ok' => $state !== 'failed'], JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES),
+            'started_at' => $finishedAt->subMinute(),
+            'finished_at' => $finishedAt,
+            'created_at' => $finishedAt->subMinute(),
+            'updated_at' => $finishedAt,
+        ]);
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -315,6 +315,15 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_test_metrics_refresh_command_guard_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_conversion_daily_read_model_changes(): void
     {
         $changed = [
@@ -3399,6 +3408,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isTestMetricsRefreshCommandFile($file)) {
+                continue;
+            }
+
             if ($this->isEq60V5ReportAssetLayerChange($file)) {
                 continue;
             }
@@ -5174,6 +5187,11 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isAnalyticsFunnelRefreshCommandFile(string $file): bool
     {
         return $file === 'backend/app/Console/Commands/RefreshAnalyticsFunnelDailyCommand.php';
+    }
+
+    private function isTestMetricsRefreshCommandFile(string $file): bool
+    {
+        return $file === 'backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php';
     }
 
     private function isSeoConversionDailyReadModelFile(string $file): bool


### PR DESCRIPTION
## What changed
- Added `analytics:refresh-test-metrics-daily` for backend-authoritative refresh/backfill of `analytics_test_metrics_daily`.
- Added dry-run support plus controlled non-dry-run write guards for explicit date/org scope, max 31-day write windows, and exact confirmation tokens.
- Added focused command coverage for dry-run, guarded writes, and blocked unconfirmed writes.
- Updated the Big Five runtime freeze classifier allowlist for this analytics command file.

## Why
This is PR 2 in the test KPI train. PR 1 introduced the read model; this PR adds the safe operator command needed to generate current-day, historical, and whole-site stats without adding UI or scheduler behavior yet.

## Validation
- `php artisan test --filter=RefreshTestMetricsDailyCommandTest`
- `php artisan test --filter=TestMetricsDailyBuilderTest`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest`
- `php artisan route:list`
- `php artisan list analytics | rg "refresh-test-metrics-daily|refresh"`
- `git diff --check -- backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `bash scripts/ci_verify_mbti.sh` reached the dependency security gate; that gate initially failed because Packagist returned HTTP/2 502 after retries.
- `bash scripts/pr78_verify.sh` passed on rerun after Packagist recovered: `total_advisories=0 high_or_critical=0 abandoned=0 ignored=0`.

## Intentionally deferred
- PR 3: Ops summary cards.
- PR 4: Ops daily-by-test detail view.
- PR 5: production scheduler/supervisor wiring.
- PR 6: frontend scale/form/locale contract guard.
- PR 7: post-deploy smoke report.

## Repository rule impact
Backend remains the statistics authority. No CMS content, public route, sitemap, llms, frontend runtime, or scheduler behavior changes are included in this PR.
