### PR TITLE
feat(cms): add article image metadata updater

### DIFF
--- a/backend/app/Console/Commands/ArticleUpdateImageMetadata.php
+++ b/backend/app/Console/Commands/ArticleUpdateImageMetadata.php
@@ -1,0 +1,124 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ArticleImageMetadataUpdater;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+
+final class ArticleUpdateImageMetadata extends Command
+{
+    protected $signature = 'articles:update-image-metadata
+        {--article-ids= : Comma-separated article IDs to lock and update}
+        {--translation-group-id= : Expected translation_group_id lock}
+        {--resolved-metadata= : Path to resolved image metadata JSON}
+        {--dry-run : Validate and plan without writing DB rows}
+        {--execute : Apply the image metadata update; omitted by default for dry-run safety}
+        {--json : Emit a JSON summary}
+        {--no-publish : Required execute-mode hold: do not publish}
+        {--no-schema : Required execute-mode hold: do not modify schema gates}
+        {--no-hreflang : Required execute-mode hold: do not modify hreflang gates}
+        {--no-search : Required execute-mode hold: do not submit search channels}
+        {--no-sitemap-llms-change : Required execute-mode hold: do not modify sitemap/llms eligibility}';
+
+    protected $description = 'Safely update published CMS article image metadata from resolved Media Library metadata.';
+
+    public function handle(ArticleImageMetadataUpdater $updater): int
+    {
+        try {
+            $summary = $updater->run($this->optionsPayload());
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        return [
+            'article_ids' => (string) $this->option('article-ids'),
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'resolved_metadata' => (string) $this->option('resolved-metadata'),
+            'dry_run' => (bool) $this->option('dry-run'),
+            'execute' => (bool) $this->option('execute'),
+            'json' => (bool) $this->option('json'),
+            'no_publish' => (bool) $this->option('no-publish'),
+            'no_schema' => (bool) $this->option('no-schema'),
+            'no_hreflang' => (bool) $this->option('no-hreflang'),
+            'no_search' => (bool) $this->option('no-search'),
+            'no_sitemap_llms_change' => (bool) $this->option('no-sitemap-llms-change'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('translation_group_id='.(string) ($summary['translation_group_id'] ?? ''));
+        $this->line('article_ids='.implode(',', array_map('strval', (array) ($summary['article_ids'] ?? []))));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('validation_error='.$this->issueLine($error));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return sprintf(
+            '%s:%s:%s',
+            (string) ($issue['field'] ?? 'unknown'),
+            (string) ($issue['code'] ?? 'unknown'),
+            (string) ($issue['message'] ?? '')
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => ! (bool) $this->option('execute'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'article_ids' => [],
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use App\Console\Commands\ArticleCoverPropagationSmoke;
 use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
+use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
 use App\Console\Commands\Big5PsychometricsReport;
@@ -327,6 +328,7 @@ class Kernel extends ConsoleKernel
         ArticleImportSeoContentPackageDraft::class,
         ArticleCoverPropagationSmoke::class,
         ArticlePublishControlled::class,
+        ArticleUpdateImageMetadata::class,
         MediaAssetsImportSeoImageBundle::class,
     ];
 

--- a/backend/app/Services/Cms/ArticleImageMetadataUpdater.php
+++ b/backend/app/Services/Cms/ArticleImageMetadataUpdater.php
@@ -1,0 +1,494 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use App\Support\PublicMediaUrlGuard;
+use Illuminate\Support\Facades\DB;
+
+final class ArticleImageMetadataUpdater
+{
+    private const REQUIRED_VARIANTS = ['hero', 'card', 'thumbnail', 'og', 'preload'];
+
+    private const SAFETY_FLAGS = [
+        'no_publish',
+        'no_schema',
+        'no_hreflang',
+        'no_search',
+        'no_sitemap_llms_change',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options): array
+    {
+        $execute = (bool) ($options['execute'] ?? false);
+        $dryRun = ! $execute;
+        $errors = [];
+        $warnings = [];
+        $articleIds = $this->articleIds((string) ($options['article_ids'] ?? ''), $errors);
+        $translationGroupId = trim((string) ($options['translation_group_id'] ?? ''));
+        $metadataPath = trim((string) ($options['resolved_metadata'] ?? ''));
+
+        if ($translationGroupId === '') {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_required', 'Expected translation_group_id is required.');
+        }
+
+        if ((bool) ($options['dry_run'] ?? false) && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+
+        if ($execute) {
+            foreach (self::SAFETY_FLAGS as $flag) {
+                if ((bool) ($options[$flag] ?? false) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+        }
+
+        $metadata = $this->readResolvedMetadata($metadataPath, $errors);
+        $normalized = $this->normalizeResolvedMetadata($metadata, $errors);
+        $articles = $this->resolveArticles($articleIds);
+        $this->validateArticleLock($articles, $articleIds, $translationGroupId, $errors);
+
+        $before = array_map(fn (Article $article): array => $this->snapshot($article), $articles);
+        $after = [];
+        foreach ($articles as $article) {
+            $after[] = $this->plannedSnapshot($article, $normalized);
+        }
+
+        $protectedDiffs = $this->protectedDiffs($before, $after);
+        if ($protectedDiffs !== []) {
+            $errors[] = $this->issue('protected_fields', 'protected_field_would_change', 'Planned update would change a protected article field.', [
+                'diffs' => $protectedDiffs,
+            ]);
+        }
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleIds, $translationGroupId, $metadataPath, $before, $after, $errors, $warnings);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_update_image_metadata', $articleIds, $translationGroupId, $metadataPath, $before, $after, [], $warnings);
+        }
+
+        DB::transaction(function () use ($articles, $normalized): void {
+            foreach ($articles as $article) {
+                $this->applyMetadata($article, $normalized);
+            }
+        });
+
+        $fresh = $this->resolveArticles($articleIds);
+        $afterWrite = array_map(fn (Article $article): array => $this->snapshot($article), $fresh);
+
+        return $this->summary(true, false, 'updated_image_metadata', $articleIds, $translationGroupId, $metadataPath, $before, $afterWrite, [], $warnings);
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<Article>
+     */
+    private function resolveArticles(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        /** @var list<Article> $articles */
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->with(['seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes()])
+            ->whereIn('id', $ids)
+            ->get()
+            ->sortBy(static fn (Article $article): int => array_search((int) $article->id, $ids, true))
+            ->values()
+            ->all();
+
+        return $articles;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateArticleLock(array $articles, array $articleIds, string $translationGroupId, array &$errors): void
+    {
+        $foundIds = array_map(static fn (Article $article): int => (int) $article->id, $articles);
+        foreach ($articleIds as $id) {
+            if (! in_array($id, $foundIds, true)) {
+                $errors[] = $this->issue('article_ids', 'article_not_found', 'Requested article id was not found.', ['article_id' => $id]);
+            }
+        }
+
+        foreach ($articles as $article) {
+            if ((string) $article->translation_group_id !== $translationGroupId) {
+                $errors[] = $this->issue('article.'.$article->id.'.translation_group_id', 'translation_group_id_mismatch', 'Article translation_group_id does not match expected lock.', [
+                    'article_id' => (int) $article->id,
+                    'actual' => (string) $article->translation_group_id,
+                ]);
+            }
+
+            if ((string) $article->status !== 'published' || ! (bool) $article->is_public || ! (int) $article->published_revision_id) {
+                $errors[] = $this->issue('article.'.$article->id.'.status', 'article_not_published_public', 'Image metadata updates are limited to published public articles with a published revision.', [
+                    'article_id' => (int) $article->id,
+                ]);
+            }
+
+            if (! $article->seoMeta instanceof ArticleSeoMeta) {
+                $errors[] = $this->issue('article.'.$article->id.'.seo_meta', 'article_seo_meta_missing', 'Article SEO meta row is required so canonical/schema/hreflang locks can be verified.', [
+                    'article_id' => (int) $article->id,
+                ]);
+
+                continue;
+            }
+
+            $canonical = trim((string) $article->seoMeta->canonical_url);
+            if ($canonical === '' || str_starts_with($canonical, '/ops/') || str_contains($canonical, '/article-preview/')) {
+                $errors[] = $this->issue('article.'.$article->id.'.canonical_url', 'canonical_url_invalid', 'Article canonical URL must be present and public canonical.', [
+                    'article_id' => (int) $article->id,
+                    'canonical_url' => $canonical,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $metadata
+     * @param  list<array<string,mixed>>  $errors
+     * @return array<string,mixed>
+     */
+    private function normalizeResolvedMetadata(array $metadata, array &$errors): array
+    {
+        if ($this->containsPlaceholder($metadata)) {
+            $errors[] = $this->issue('resolved_metadata', 'placeholder_not_allowed', 'Resolved metadata must not contain CMS media placeholders.');
+        }
+
+        $coverUrl = $this->publicUrl($metadata['cover_image_url'] ?? null, 'cover_image_url', $errors);
+        $ogUrl = $this->publicUrl($metadata['og_image_url'] ?? null, 'og_image_url', $errors);
+        $twitterUrl = $this->publicUrl($metadata['twitter_image_url'] ?? ($metadata['og_image_url'] ?? null), 'twitter_image_url', $errors);
+        $bodyVisualUrl = $this->optionalPublicUrl($metadata['body_visual_image_url'] ?? null, 'body_visual_image_url', $errors);
+
+        $alt = trim((string) ($metadata['cover_image_alt'] ?? ''));
+        if ($alt === '' || mb_strlen($alt) > 255) {
+            $errors[] = $this->issue('cover_image_alt', 'cover_image_alt_invalid', 'cover_image_alt is required and must be <=255 characters.');
+        }
+
+        $width = (int) ($metadata['cover_image_width'] ?? 0);
+        $height = (int) ($metadata['cover_image_height'] ?? 0);
+        if ($width <= 0 || $height <= 0) {
+            $errors[] = $this->issue('cover_dimensions', 'cover_dimensions_invalid', 'cover_image_width and cover_image_height must be positive integers.');
+        }
+
+        $variants = is_array($metadata['cover_image_variants'] ?? null) ? $metadata['cover_image_variants'] : [];
+        foreach (self::REQUIRED_VARIANTS as $variantKey) {
+            $variant = $variants[$variantKey] ?? null;
+            if (! is_array($variant)) {
+                $errors[] = $this->issue('cover_image_variants.'.$variantKey, 'cover_variant_missing', 'Required cover image variant is missing.', [
+                    'variant' => $variantKey,
+                ]);
+
+                continue;
+            }
+
+            $variantUrl = $this->publicUrl($variant['url'] ?? null, 'cover_image_variants.'.$variantKey.'.url', $errors);
+            $variants[$variantKey]['url'] = $variantUrl;
+            $variants[$variantKey]['width'] = (int) ($variant['width'] ?? 0);
+            $variants[$variantKey]['height'] = (int) ($variant['height'] ?? 0);
+            if ((int) $variants[$variantKey]['width'] <= 0 || (int) $variants[$variantKey]['height'] <= 0) {
+                $errors[] = $this->issue('cover_image_variants.'.$variantKey, 'cover_variant_dimensions_invalid', 'Variant width and height must be positive integers.', [
+                    'variant' => $variantKey,
+                ]);
+            }
+        }
+
+        $coverMediaAssetKey = trim((string) ($metadata['cover_media_asset_key'] ?? ''));
+        if ($coverMediaAssetKey === '') {
+            $errors[] = $this->issue('cover_media_asset_key', 'cover_media_asset_key_required', 'cover_media_asset_key is required.');
+        }
+
+        $variants['editorial_package_v1'] = [
+            'cover_media_asset_key' => $coverMediaAssetKey,
+            'social_image_metadata' => is_array($metadata['social_image_metadata'] ?? null) ? $metadata['social_image_metadata'] : [],
+            'body_visual_asset_key' => trim((string) ($metadata['body_visual_asset_key'] ?? '')),
+            'body_visual_image_url' => $bodyVisualUrl,
+            'body_visual_fallback_authorized' => (bool) ($metadata['body_visual_fallback_authorized'] ?? false),
+            'image_metadata_updated_by' => 'articles:update-image-metadata',
+        ];
+
+        return [
+            'cover_media_asset_key' => $coverMediaAssetKey,
+            'cover_image_url' => $coverUrl,
+            'cover_image_alt' => $alt,
+            'cover_image_width' => $width,
+            'cover_image_height' => $height,
+            'cover_image_variants' => $variants,
+            'og_image_url' => $ogUrl,
+            'twitter_image_url' => $twitterUrl,
+            'body_visual_image_url' => $bodyVisualUrl,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $normalized
+     */
+    private function applyMetadata(Article $article, array $normalized): void
+    {
+        $article->forceFill([
+            'cover_image_url' => $normalized['cover_image_url'],
+            'cover_image_alt' => $normalized['cover_image_alt'],
+            'cover_image_width' => $normalized['cover_image_width'],
+            'cover_image_height' => $normalized['cover_image_height'],
+            'cover_image_variants' => $normalized['cover_image_variants'],
+        ])->saveQuietly();
+
+        /** @var ArticleSeoMeta $seoMeta */
+        $seoMeta = $article->seoMeta;
+        $seoMeta->forceFill([
+            'og_image_url' => $normalized['og_image_url'],
+        ])->saveQuietly();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $article->loadMissing(['seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes()]);
+        $seoMeta = $article->seoMeta;
+
+        return [
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'slug' => (string) $article->slug,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'title' => (string) $article->title,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'canonical_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null,
+            'robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'seo_is_indexable' => $seoMeta instanceof ArticleSeoMeta ? (bool) $seoMeta->is_indexable : null,
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)) : null,
+            'cover_image_url' => $article->cover_image_url,
+            'cover_image_alt' => $article->cover_image_alt,
+            'cover_image_width' => $article->cover_image_width,
+            'cover_image_height' => $article->cover_image_height,
+            'cover_image_variants' => $article->cover_image_variants,
+            'og_image_url' => $seoMeta instanceof ArticleSeoMeta ? $seoMeta->og_image_url : null,
+            'revision_count' => ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->count(),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $normalized
+     * @return array<string,mixed>
+     */
+    private function plannedSnapshot(Article $article, array $normalized): array
+    {
+        $snapshot = $this->snapshot($article);
+        $snapshot['cover_image_url'] = $normalized['cover_image_url'];
+        $snapshot['cover_image_alt'] = $normalized['cover_image_alt'];
+        $snapshot['cover_image_width'] = $normalized['cover_image_width'];
+        $snapshot['cover_image_height'] = $normalized['cover_image_height'];
+        $snapshot['cover_image_variants'] = $normalized['cover_image_variants'];
+        $snapshot['og_image_url'] = $normalized['og_image_url'];
+
+        return $snapshot;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $before
+     * @param  list<array<string,mixed>>  $after
+     * @return list<array<string,mixed>>
+     */
+    private function protectedDiffs(array $before, array $after): array
+    {
+        $protectedFields = [
+            'locale',
+            'slug',
+            'translation_group_id',
+            'title',
+            'status',
+            'is_public',
+            'is_indexable',
+            'sitemap_eligible',
+            'llms_eligible',
+            'working_revision_id',
+            'published_revision_id',
+            'canonical_url',
+            'robots',
+            'seo_is_indexable',
+            'schema_json_sha256',
+            'revision_count',
+        ];
+
+        $diffs = [];
+        foreach ($before as $index => $beforeSnapshot) {
+            $afterSnapshot = $after[$index] ?? [];
+            foreach ($protectedFields as $field) {
+                if (($beforeSnapshot[$field] ?? null) !== ($afterSnapshot[$field] ?? null)) {
+                    $diffs[] = [
+                        'article_id' => (int) ($beforeSnapshot['article_id'] ?? 0),
+                        'field' => $field,
+                    ];
+                }
+            }
+        }
+
+        return $diffs;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<int>
+     */
+    private function articleIds(string $raw, array &$errors): array
+    {
+        $ids = array_values(array_unique(array_filter(array_map(
+            static fn (string $value): int => is_numeric(trim($value)) ? (int) trim($value) : 0,
+            explode(',', $raw)
+        ), static fn (int $id): bool => $id > 0)));
+
+        if ($ids === []) {
+            $errors[] = $this->issue('article_ids', 'article_ids_required', 'At least one article id is required.');
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return array<string,mixed>
+     */
+    private function readResolvedMetadata(string $path, array &$errors): array
+    {
+        if ($path === '' || ! is_file($path)) {
+            $errors[] = $this->issue('resolved_metadata', 'resolved_metadata_file_missing', 'Resolved image metadata JSON file is required.');
+
+            return [];
+        }
+
+        $decoded = json_decode((string) file_get_contents($path), true);
+        if (! is_array($decoded) || array_is_list($decoded)) {
+            $errors[] = $this->issue('resolved_metadata', 'resolved_metadata_json_invalid', 'Resolved image metadata must be a JSON object.');
+
+            return [];
+        }
+
+        return $decoded;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function publicUrl(mixed $value, string $field, array &$errors): ?string
+    {
+        $url = PublicMediaUrlGuard::sanitizeNullableUrl($value);
+        if ($url === null || mb_strlen($url) > 255) {
+            $errors[] = $this->issue($field, 'public_media_url_invalid', 'Image URL must be a public HTTPS Media Library/CDN URL <=255 characters.');
+        }
+
+        return $url;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function optionalPublicUrl(mixed $value, string $field, array &$errors): ?string
+    {
+        if (trim((string) $value) === '') {
+            return null;
+        }
+
+        return $this->publicUrl($value, $field, $errors);
+    }
+
+    private function containsPlaceholder(mixed $value): bool
+    {
+        if (is_string($value)) {
+            return str_contains($value, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__') || str_contains($value, '{{');
+        }
+
+        if (! is_array($value)) {
+            return false;
+        }
+
+        foreach ($value as $nested) {
+            if ($this->containsPlaceholder($nested)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    /**
+     * @param  array<string,mixed>  $extra
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $extra = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $extra);
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $before
+     * @param  list<array<string,mixed>>  $after
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, array $articleIds, string $translationGroupId, string $metadataPath, array $before, array $after, array $errors, array $warnings): array
+    {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok && ! $dryRun,
+            'article_ids' => $articleIds,
+            'articles_count' => count($articleIds),
+            'translation_group_id' => $translationGroupId,
+            'resolved_metadata' => $metadataPath,
+            'updates_scope' => [
+                'article_fields' => [
+                    'cover_image_url',
+                    'cover_image_alt',
+                    'cover_image_width',
+                    'cover_image_height',
+                    'cover_image_variants',
+                ],
+                'article_seo_meta_fields' => [
+                    'og_image_url',
+                ],
+            ],
+            'protected_holds' => [
+                'no_publish' => true,
+                'no_schema' => true,
+                'no_hreflang' => true,
+                'no_search' => true,
+                'no_sitemap_llms_change' => true,
+                'no_revision_create' => true,
+            ],
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
@@ -1,0 +1,426 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Illuminate\Support\Str;
+use Tests\TestCase;
+
+final class ArticleUpdateImageMetadataCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TRANSLATION_GROUP_ID = 'tg_article_image_metadata_update_2026v1';
+
+    public function test_default_invocation_is_dry_run_and_does_not_write(): void
+    {
+        $articles = $this->createPublishedPair();
+        $metadata = $this->writeResolvedMetadata();
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resolved-metadata' => $metadata,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_update_image_metadata', $payload['action']);
+        $this->assertFalse($payload['would_write']);
+
+        foreach ($articles as $article) {
+            $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+            $this->assertSame('https://assets.fermatmind.com/articles/old/hero.jpg', (string) $fresh->cover_image_url);
+            $this->assertSame('https://assets.fermatmind.com/articles/old/og.jpg', (string) $fresh->seoMeta?->og_image_url);
+        }
+    }
+
+    public function test_execute_updates_only_image_metadata_and_does_not_create_revision_or_change_holds(): void
+    {
+        $articles = $this->createPublishedPair();
+        $metadata = $this->writeResolvedMetadata();
+        $before = $this->protectedSnapshots($articles);
+        $revisionCountBefore = ArticleTranslationRevision::query()->withoutGlobalScopes()->count();
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resolved-metadata' => $metadata,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+            '--no-schema' => true,
+            '--no-hreflang' => true,
+            '--no-search' => true,
+            '--no-sitemap-llms-change' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('updated_image_metadata', $payload['action']);
+        $this->assertSame($revisionCountBefore, ArticleTranslationRevision::query()->withoutGlobalScopes()->count());
+
+        foreach ($articles as $article) {
+            $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+            $this->assertSame('https://assets.fermatmind.com/articles/career-map/hero_1600x900.jpg', (string) $fresh->cover_image_url);
+            $this->assertSame('Career exploration map showing interest, personality, and real-world validation steps', (string) $fresh->cover_image_alt);
+            $this->assertSame(1600, (int) $fresh->cover_image_width);
+            $this->assertSame(900, (int) $fresh->cover_image_height);
+            $this->assertSame('https://assets.fermatmind.com/articles/career-map/og_1200x630.jpg', (string) $fresh->seoMeta?->og_image_url);
+            $this->assertSame('article.career.exploration.map.cover.v1', (string) data_get($fresh->cover_image_variants, 'editorial_package_v1.cover_media_asset_key'));
+
+            $this->assertSame($before[(int) $article->id], $this->protectedSnapshot($fresh));
+        }
+    }
+
+    public function test_execute_requires_all_no_side_effect_flags(): void
+    {
+        $articles = $this->createPublishedPair();
+        $metadata = $this->writeResolvedMetadata();
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resolved-metadata' => $metadata,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        foreach ($articles as $article) {
+            $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+            $this->assertSame('https://assets.fermatmind.com/articles/old/hero.jpg', (string) $fresh->cover_image_url);
+        }
+    }
+
+    public function test_translation_group_lock_rejects_wrong_articles(): void
+    {
+        $articles = $this->createPublishedPair();
+        $metadata = $this->writeResolvedMetadata();
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => 'tg_wrong',
+            '--resolved-metadata' => $metadata,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'translation_group_id_mismatch');
+    }
+
+    public function test_rejects_missing_resolved_metadata_file(): void
+    {
+        $articles = $this->createPublishedPair();
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resolved-metadata' => sys_get_temp_dir().'/missing-'.Str::random(8).'.json',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'resolved_metadata_file_missing');
+    }
+
+    public function test_rejects_placeholder_or_private_image_url(): void
+    {
+        $articles = $this->createPublishedPair();
+        $metadata = $this->writeResolvedMetadata(static function (array &$payload): void {
+            $payload['cover_image_url'] = '__CMS_MEDIA_LIBRARY_PLACEHOLDER__';
+            $payload['og_image_url'] = 'https://example.com/private/og.jpg';
+        });
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resolved-metadata' => $metadata,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'placeholder_not_allowed');
+        $this->assertErrorCode($payload, 'public_media_url_invalid');
+    }
+
+    public function test_json_output_includes_before_after_snapshots(): void
+    {
+        $articles = $this->createPublishedPair();
+        $metadata = $this->writeResolvedMetadata();
+
+        $exitCode = Artisan::call('articles:update-image-metadata', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--resolved-metadata' => $metadata,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(2, $payload['before']);
+        $this->assertCount(2, $payload['after']);
+        $this->assertSame('https://assets.fermatmind.com/articles/old/hero.jpg', $payload['before'][0]['cover_image_url']);
+        $this->assertSame('https://assets.fermatmind.com/articles/career-map/hero_1600x900.jpg', $payload['after'][0]['cover_image_url']);
+        $this->assertSame($payload['before'][0]['schema_json_sha256'], $payload['after'][0]['schema_json_sha256']);
+    }
+
+    /**
+     * @return list<Article>
+     */
+    private function createPublishedPair(): array
+    {
+        return [
+            $this->createPublishedArticle(48, 'zh-CN', 'career-confusion-test-map', '/zh/articles/career-confusion-test-map'),
+            $this->createPublishedArticle(49, 'en', 'choose-career-using-personality-tests', '/en/articles/choose-career-using-personality-tests'),
+        ];
+    }
+
+    private function createPublishedArticle(int $id, string $locale, string $slug, string $canonical): Article
+    {
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'id' => $id,
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'source_locale' => 'zh-CN',
+            'translation_status' => $locale === 'zh-CN' ? Article::TRANSLATION_STATUS_SOURCE : Article::TRANSLATION_STATUS_PUBLISHED,
+            'title' => $locale === 'zh-CN' ? '不知道自己适合什么职业怎么办？' : 'How to Choose a Career Using Personality Tests',
+            'excerpt' => 'A career exploration guide.',
+            'content_md' => '# Body',
+            'content_html' => '<h1>Body</h1>',
+            'cover_image_url' => 'https://assets.fermatmind.com/articles/old/hero.jpg',
+            'cover_image_alt' => 'Old cover',
+            'cover_image_width' => 1200,
+            'cover_image_height' => 630,
+            'cover_image_variants' => [
+                'hero' => [
+                    'url' => 'https://assets.fermatmind.com/articles/old/hero.jpg',
+                    'width' => 1200,
+                    'height' => 630,
+                ],
+            ],
+            'related_test_slug' => 'holland-career-interest-test-riasec',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now(),
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'locale' => $locale,
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => now(),
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->saveQuietly();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => $canonical,
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://assets.fermatmind.com/articles/old/og.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->refresh();
+    }
+
+    /**
+     * @param  callable(array<string,mixed>&):void|null  $mutate
+     */
+    private function writeResolvedMetadata(?callable $mutate = null): string
+    {
+        $path = sys_get_temp_dir().'/fm-resolved-image-metadata-'.Str::random(12).'.json';
+        $payload = [
+            'cover_media_asset_key' => 'article.career.exploration.map.cover.v1',
+            'cover_image_url' => 'https://assets.fermatmind.com/articles/career-map/hero_1600x900.jpg',
+            'cover_image_alt' => 'Career exploration map showing interest, personality, and real-world validation steps',
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'cover_image_variants' => [
+                'hero' => [
+                    'url' => 'https://assets.fermatmind.com/articles/career-map/hero_1600x900.jpg',
+                    'width' => 1600,
+                    'height' => 900,
+                    'mime_type' => 'image/jpeg',
+                ],
+                'card' => [
+                    'url' => 'https://assets.fermatmind.com/articles/career-map/card_800x450.jpg',
+                    'width' => 800,
+                    'height' => 450,
+                    'mime_type' => 'image/jpeg',
+                ],
+                'thumbnail' => [
+                    'url' => 'https://assets.fermatmind.com/articles/career-map/thumbnail_400x225.jpg',
+                    'width' => 400,
+                    'height' => 225,
+                    'mime_type' => 'image/jpeg',
+                ],
+                'og' => [
+                    'url' => 'https://assets.fermatmind.com/articles/career-map/og_1200x630.jpg',
+                    'width' => 1200,
+                    'height' => 630,
+                    'mime_type' => 'image/jpeg',
+                ],
+                'preload' => [
+                    'url' => 'https://assets.fermatmind.com/articles/career-map/preload_64x36.jpg',
+                    'width' => 64,
+                    'height' => 36,
+                    'mime_type' => 'image/jpeg',
+                ],
+            ],
+            'og_image_url' => 'https://assets.fermatmind.com/articles/career-map/og_1200x630.jpg',
+            'twitter_image_url' => 'https://assets.fermatmind.com/articles/career-map/og_1200x630.jpg',
+            'social_image_metadata' => [
+                'media_library_asset_key' => 'article.career.exploration.map.cover.v1',
+                'media_library_status' => 'published',
+                'media_library_is_public' => true,
+                'asset_provenance' => 'gpt_generated_for_fermatmind',
+            ],
+            'body_visual_asset_key' => 'article.career.exploration.map.body.v1',
+            'body_visual_image_url' => 'https://assets.fermatmind.com/articles/career-map/body_1600x900.jpg',
+            'body_visual_fallback_authorized' => false,
+        ];
+
+        if ($mutate !== null) {
+            $mutate($payload);
+        }
+
+        file_put_contents($path, json_encode($payload, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES));
+
+        return $path;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     */
+    private function articleIds(array $articles): string
+    {
+        return implode(',', array_map(static fn (Article $article): string => (string) $article->id, $articles));
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @return array<int,array<string,mixed>>
+     */
+    private function protectedSnapshots(array $articles): array
+    {
+        $snapshots = [];
+        foreach ($articles as $article) {
+            $snapshots[(int) $article->id] = $this->protectedSnapshot($article);
+        }
+
+        return $snapshots;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function protectedSnapshot(Article $article): array
+    {
+        $article->refresh();
+        $article->load('seoMeta');
+
+        return [
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'content_html' => (string) $article->content_html,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'canonical_url' => (string) $article->seoMeta?->canonical_url,
+            'robots' => (string) $article->seoMeta?->robots,
+            'seo_is_indexable' => (bool) $article->seoMeta?->is_indexable,
+            'schema_json' => $article->seoMeta?->schema_json,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1593,6 +1593,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_image_metadata_updater_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleUpdateImageMetadata.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/ArticleImageMetadataUpdater.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleUpdateImageMetadata;',
+            '+        ArticleUpdateImageMetadata::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -2960,6 +2975,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleImageMetadataUpdaterFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -3564,6 +3583,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsArticleEditorialPackageDraftGateOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoContentPackageDraftImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoImageBundleImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsArticleImageMetadataUpdaterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -3843,6 +3863,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     {
         return $file === 'backend/app/Console/Commands/MediaAssetsImportSeoImageBundle.php'
             || str_starts_with($file, 'backend/app/Services/Cms/SeoImageBundle/');
+    }
+
+    private function isArticleImageMetadataUpdaterFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticleUpdateImageMetadata.php',
+            'backend/app/Services/Cms/ArticleImageMetadataUpdater.php',
+        ], true);
     }
 
     private function isArticleBodyH1GuardFile(string $file): bool
@@ -5407,6 +5435,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bMediaAssetsImportSeoImageBundle\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsArticleImageMetadataUpdaterOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleUpdateImageMetadata\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `articles:update-image-metadata` as a production-safe CMS image metadata updater.
- Added `ArticleImageMetadataUpdater` to lock article IDs, translation group, canonical, status, revision IDs, schema/hreflang/search/sitemap holds, and resolved Media Library metadata before writes.
- Registered the command and added runtime-freeze allowlisting for this CMS ops tool.
- Added feature coverage for dry-run default, execute safety flags, identity lock failures, placeholder/private URL rejection, before/after snapshots, and no revision creation.

## Why
Daily SEO image replacement needs a narrow backend path that updates only article image metadata after Media Library import. This avoids ad hoc CMS mutations, publish/search/schema/hreflang side effects, and repeated manual blockers.

## Validation
- `composer install --no-interaction --prefer-dist`
- `php artisan test --filter ArticleUpdateImageMetadataCommandTest`
- `php artisan test --filter test_runtime_freeze_classifier_ignores_article_image_metadata_updater_changes`
- `php artisan test --filter MediaAssetsImportSeoImageBundleCommandTest`
- `php artisan list | rg 'articles:update-image-metadata'`
- `php artisan route:list --except-vendor`
- `php artisan migrate --pretend --no-interaction`
- `./vendor/bin/pint app/Console/Commands/ArticleUpdateImageMetadata.php app/Services/Cms/ArticleImageMetadataUpdater.php tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php app/Console/Kernel.php`
- `git diff --check`

## Intentionally deferred
- No production image metadata update was executed.
- No CMS publish, revision creation, schema/hreflang mutation, sitemap/llms mutation, search submission, or revalidation.
- No fap-web changes.