### PR TITLE
PERSONALITY-LIST-VARIANTS-01: expose variant directory list

### DIFF
--- a/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php
@@ -42,21 +42,40 @@ class PersonalityController extends Controller
             return $validated;
         }
 
-        $paginator = $this->personalityProfileService->listPublicProfiles(
-            $validated['org_id'],
-            $validated['scale_code'],
-            $validated['locale'],
-            $validated['page'],
-            $validated['per_page'],
-        );
-
         $items = [];
-        foreach ($paginator->items() as $profile) {
-            if (! $profile instanceof PersonalityProfile) {
-                continue;
-            }
 
-            $items[] = $this->profileListPayload($profile);
+        if ($validated['include_variants']) {
+            $paginator = $this->personalityProfileService->listPublicProfileVariants(
+                $validated['org_id'],
+                $validated['scale_code'],
+                $validated['locale'],
+                $validated['page'],
+                $validated['per_page'],
+            );
+
+            foreach ($paginator->items() as $variant) {
+                if (! $variant instanceof PersonalityProfileVariant) {
+                    continue;
+                }
+
+                $items[] = $this->variantListPayload($variant);
+            }
+        } else {
+            $paginator = $this->personalityProfileService->listPublicProfiles(
+                $validated['org_id'],
+                $validated['scale_code'],
+                $validated['locale'],
+                $validated['page'],
+                $validated['per_page'],
+            );
+
+            foreach ($paginator->items() as $profile) {
+                if (! $profile instanceof PersonalityProfile) {
+                    continue;
+                }
+
+                $items[] = $this->profileListPayload($profile);
+            }
         }
 
         return response()->json([
@@ -539,6 +558,50 @@ class PersonalityController extends Controller
     /**
      * @return array<string, mixed>
      */
+    private function variantListPayload(PersonalityProfileVariant $variant): array
+    {
+        $profile = $variant->profile;
+        if (! $profile instanceof PersonalityProfile) {
+            return [];
+        }
+
+        $projection = $this->personalityProfileService->buildPublicProjection($profile, $variant);
+        $runtimeTypeCode = strtoupper(trim((string) ($variant->runtime_type_code ?? '')));
+        $canonicalTypeCode = strtoupper(trim((string) ($variant->canonical_type_code ?: $profile->canonical_type_code ?: $profile->type_code)));
+        $routeSlug = strtolower($runtimeTypeCode);
+
+        return array_merge([
+            'id' => (int) $variant->id,
+            'variant_id' => (int) $variant->id,
+            'profile_id' => (int) $profile->id,
+            'org_id' => (int) $profile->org_id,
+            'scale_code' => (string) $profile->scale_code,
+            'type_code' => $runtimeTypeCode,
+            'base_type_code' => $canonicalTypeCode,
+            'runtime_type_code' => $runtimeTypeCode,
+            'variant_code' => (string) $variant->variant_code,
+            'slug' => $routeSlug,
+            'base_slug' => (string) $profile->slug,
+            'locale' => (string) $profile->locale,
+            'title' => (string) $profile->title,
+            'subtitle' => $profile->subtitle,
+            'excerpt' => $profile->excerpt,
+            'hero_image_url' => PublicMediaUrlGuard::sanitizeNullableUrl($profile->hero_image_url),
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => (bool) $profile->is_indexable,
+            'published_at' => $variant->published_at?->toISOString(),
+            'updated_at' => $variant->updated_at?->toISOString(),
+            'seo_meta' => $this->variantSeoMetaSummaryPayload($profile, $variant),
+            'display_type' => data_get($projection, 'display_type'),
+            'public_route_slug' => data_get($projection, 'public_route_slug', $routeSlug),
+            'public_route_type' => data_get($projection, '_meta.public_route_type', '32-type'),
+        ], $this->personalityProfileService->publicCanonicalFields($profile, $variant));
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
     private function profileDetailPayload(PersonalityProfile $profile, ?PersonalityProfileVariant $variant = null): array
     {
         return array_merge([
@@ -703,7 +766,27 @@ class PersonalityController extends Controller
     }
 
     /**
-     * @return array{org_id:int,scale_code:string,locale:string,page:int,per_page:int}|JsonResponse
+     * @return array<string, mixed>|null
+     */
+    private function variantSeoMetaSummaryPayload(
+        PersonalityProfile $profile,
+        PersonalityProfileVariant $variant
+    ): ?array {
+        $profileSeoMeta = $profile->seoMeta;
+        $variantSeoMeta = $variant->seoMeta;
+
+        if (! $profileSeoMeta instanceof PersonalityProfileSeoMeta && ! $variantSeoMeta instanceof PersonalityProfileVariantSeoMeta) {
+            return null;
+        }
+
+        return [
+            'seo_title' => $variantSeoMeta?->seo_title ?? $profileSeoMeta?->seo_title,
+            'seo_description' => $variantSeoMeta?->seo_description ?? $profileSeoMeta?->seo_description,
+        ];
+    }
+
+    /**
+     * @return array{org_id:int,scale_code:string,locale:string,page:int,per_page:int,include_variants:bool}|JsonResponse
      */
     private function validateListQuery(Request $request): array|JsonResponse
     {
@@ -713,6 +796,7 @@ class PersonalityController extends Controller
             'locale' => ['required', 'in:en,zh-CN'],
             'page' => ['nullable', 'integer', 'min:1'],
             'per_page' => ['nullable', 'integer', 'min:1', 'max:100'],
+            'include_variants' => ['nullable', 'in:0,1'],
         ]);
 
         if ($validator->fails()) {
@@ -727,6 +811,7 @@ class PersonalityController extends Controller
             'locale' => (string) $validated['locale'],
             'page' => (int) ($validated['page'] ?? 1),
             'per_page' => (int) ($validated['per_page'] ?? 20),
+            'include_variants' => filter_var($validated['include_variants'] ?? false, FILTER_VALIDATE_BOOLEAN),
         ];
     }
 

--- a/backend/app/Services/Cms/PersonalityProfileService.php
+++ b/backend/app/Services/Cms/PersonalityProfileService.php
@@ -40,6 +40,47 @@ final class PersonalityProfileService
             ->paginate($perPage, ['*'], 'page', $page);
     }
 
+    public function listPublicProfileVariants(
+        int $orgId,
+        string $scaleCode,
+        string $locale,
+        int $page = 1,
+        int $perPage = 100
+    ): LengthAwarePaginator {
+        return PersonalityProfileVariant::query()
+            ->withoutGlobalScopes()
+            ->where('org_id', max(0, $orgId))
+            ->where('is_published', true)
+            ->where(static function (Builder $query): void {
+                $query->whereNull('published_at')
+                    ->orWhere('published_at', '<=', now());
+            })
+            ->whereHas('profile', function (Builder $query) use ($orgId, $scaleCode, $locale): void {
+                $query->withoutGlobalScopes()
+                    ->where('org_id', max(0, $orgId))
+                    ->where('scale_code', $this->normalizeScaleCode($scaleCode))
+                    ->whereIn('type_code', PersonalityProfile::TYPE_CODES)
+                    ->forLocale($this->normalizeLocale($locale))
+                    ->publishedPublic()
+                    ->where(static function (Builder $nested): void {
+                        $nested->whereNull('published_at')
+                            ->orWhere('published_at', '<=', now());
+                    });
+            })
+            ->with([
+                'profile' => static function ($query): void {
+                    $query->withoutGlobalScopes()
+                        ->with('seoMeta');
+                },
+                'seoMeta',
+            ])
+            ->orderBy('canonical_type_code')
+            ->orderByRaw("case when variant_code = 'A' then 0 when variant_code = 'T' then 1 else 9 end")
+            ->orderBy('runtime_type_code')
+            ->orderBy('id')
+            ->paginate($perPage, ['*'], 'page', $page);
+    }
+
     public function getPublicProfileByType(
         string $typeLookup,
         int $orgId,

--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -134,6 +134,207 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('items.0.title', 'INTJ Org 7');
     }
 
+    public function test_list_defaults_to_base_profiles_even_when_variants_exist(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'hero_image_url' => 'https://assets.fermatmind.com/static/personality/type-icons/intj.png',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createVariant($profile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariant($profile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/personality?locale=en')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonCount(1, 'items')
+            ->assertJsonPath('items.0.type_code', 'INTJ')
+            ->assertJsonPath('items.0.slug', 'intj')
+            ->assertJsonPath('items.0.hero_image_url', 'https://assets.fermatmind.com/static/personality/type-icons/intj.png')
+            ->assertJsonMissingPath('items.0.runtime_type_code')
+            ->assertJsonMissingPath('items.0.variant_code');
+    }
+
+    public function test_list_can_return_backend_authoritative_variant_directory(): void
+    {
+        $profile = $this->createProfile([
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'title' => 'INTJ - Architect',
+            'type_name' => 'Architect',
+            'nickname' => 'Systems builder',
+            'rarity_text' => 'About 2%',
+            'keywords_json' => ['strategy', 'independence'],
+            'hero_summary_md' => 'Base hero summary',
+            'hero_image_url' => 'https://assets.fermatmind.com/static/personality/type-icons/intj.png',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+            'schema_version' => PersonalityProfile::SCHEMA_VERSION_V2,
+        ]);
+        $this->createSeoMeta($profile, [
+            'seo_title' => 'Base INTJ title',
+            'seo_description' => 'Base INTJ description',
+        ]);
+        $assertive = $this->createVariant($profile, [
+            'variant_code' => 'A',
+            'runtime_type_code' => 'INTJ-A',
+            'type_name' => 'Architect Assertive',
+            'nickname' => 'Assertive strategist',
+            'rarity_text' => 'About 3%',
+            'keywords_json' => ['assertive', 'strategy'],
+            'hero_summary_md' => 'Assertive hero summary',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariantSeoMeta($assertive, [
+            'seo_title' => 'INTJ-A title',
+            'seo_description' => 'INTJ-A description',
+        ]);
+        $this->createVariant($profile, [
+            'variant_code' => 'T',
+            'runtime_type_code' => 'INTJ-T',
+            'type_name' => 'Architect Turbulent',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $draftProfile = $this->createProfile([
+            'type_code' => 'ENTP',
+            'slug' => 'entp',
+            'title' => 'ENTP draft',
+            'status' => 'draft',
+            'is_public' => true,
+        ]);
+        $this->createVariant($draftProfile, [
+            'canonical_type_code' => 'ENTP',
+            'variant_code' => 'A',
+            'runtime_type_code' => 'ENTP-A',
+            'is_published' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $response = $this->getJson('/api/v0.5/personality?locale=en&include_variants=1');
+
+        $response->assertOk()
+            ->assertJsonPath('ok', true)
+            ->assertJsonPath('pagination.total', 2)
+            ->assertJsonCount(2, 'items')
+            ->assertJsonPath('items.0.type_code', 'INTJ-A')
+            ->assertJsonPath('items.0.runtime_type_code', 'INTJ-A')
+            ->assertJsonPath('items.0.base_type_code', 'INTJ')
+            ->assertJsonPath('items.0.canonical_type_code', 'INTJ')
+            ->assertJsonPath('items.0.variant_code', 'A')
+            ->assertJsonPath('items.0.slug', 'intj-a')
+            ->assertJsonPath('items.0.base_slug', 'intj')
+            ->assertJsonPath('items.0.display_type', 'INTJ-A')
+            ->assertJsonPath('items.0.public_route_slug', 'intj-a')
+            ->assertJsonPath('items.0.public_route_type', '32-type')
+            ->assertJsonPath('items.0.type_name', 'Architect Assertive')
+            ->assertJsonPath('items.0.nickname', 'Assertive strategist')
+            ->assertJsonPath('items.0.rarity', 'About 3%')
+            ->assertJsonPath('items.0.keywords.0', 'assertive')
+            ->assertJsonPath('items.0.hero_summary', 'Assertive hero summary')
+            ->assertJsonPath('items.0.hero_image_url', 'https://assets.fermatmind.com/static/personality/type-icons/intj.png')
+            ->assertJsonPath('items.0.seo_meta.seo_title', 'INTJ-A title')
+            ->assertJsonPath('items.1.type_code', 'INTJ-T')
+            ->assertJsonPath('items.1.slug', 'intj-t');
+
+        self::assertNotContains('ENTP-A', collect($response->json('items'))->pluck('runtime_type_code')->all());
+    }
+
+    public function test_variant_directory_respects_locale_org_and_publication_time(): void
+    {
+        $enProfile = $this->createProfile([
+            'org_id' => 0,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $zhProfile = $this->createProfile([
+            'org_id' => 0,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'zh-CN',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+        $orgProfile = $this->createProfile([
+            'org_id' => 7,
+            'type_code' => 'INTJ',
+            'slug' => 'intj',
+            'locale' => 'en',
+            'status' => 'published',
+            'is_public' => true,
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->createVariant($enProfile, [
+            'runtime_type_code' => 'INTJ-A',
+            'variant_code' => 'A',
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariant($enProfile, [
+            'runtime_type_code' => 'INTJ-T',
+            'variant_code' => 'T',
+            'published_at' => now()->addHour(),
+        ]);
+        $this->createVariant($zhProfile, [
+            'runtime_type_code' => 'INTJ-T',
+            'variant_code' => 'T',
+            'published_at' => now()->subMinute(),
+        ]);
+        $this->createVariant($orgProfile, [
+            'runtime_type_code' => 'INTJ-T',
+            'variant_code' => 'T',
+            'published_at' => now()->subMinute(),
+        ]);
+
+        $this->getJson('/api/v0.5/personality?locale=en&include_variants=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.runtime_type_code', 'INTJ-A');
+
+        $this->getJson('/api/v0.5/personality?locale=zh-CN&include_variants=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.runtime_type_code', 'INTJ-T')
+            ->assertJsonPath('items.0.locale', 'zh-CN');
+
+        $this->getJson('/api/v0.5/personality?locale=en&org_id=7&include_variants=1')
+            ->assertOk()
+            ->assertJsonPath('pagination.total', 1)
+            ->assertJsonPath('items.0.org_id', 7)
+            ->assertJsonPath('items.0.runtime_type_code', 'INTJ-T');
+    }
+
+    public function test_variant_directory_requires_explicit_zero_or_one_flag(): void
+    {
+        $this->getJson('/api/v0.5/personality?locale=en&include_variants=true')
+            ->assertStatus(422)
+            ->assertJsonPath('ok', false)
+            ->assertJsonPath('error_code', 'INVALID_ARGUMENT');
+    }
+
     public function test_detail_returns_profile_sections_and_seo_meta(): void
     {
         config(['app.frontend_url' => 'https://www.fermatmind.com']);

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -240,6 +240,16 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_personality_public_directory_changes(): void
+    {
+        $changed = [
+            'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
+            'backend/app/Services/Cms/PersonalityProfileService.php',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
+    }
+
     public function test_runtime_freeze_classifier_ignores_mbti_personality_variant_seo_metadata_refresh_files(): void
     {
         $changed = [
@@ -2874,6 +2884,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isPersonalityPublicDirectoryFile($file)) {
+                continue;
+            }
+
             if ($this->isMbtiPersonalityVariantSeoMetadataRefreshFile($file)) {
                 continue;
             }
@@ -3662,6 +3676,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
             'backend/app/PersonalityCms/DesktopClone/PersonalityDesktopCloneAssetSlotSupport.php',
             'backend/app/Services/Experiments/ExperimentAssigner.php',
+        ], true);
+    }
+
+    private function isPersonalityPublicDirectoryFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php',
+            'backend/app/Services/Cms/PersonalityProfileService.php',
         ], true);
     }
 


### PR DESCRIPTION
## What changed
- Added explicit `include_variants=1` support to `GET /api/v0.5/personality`.
- Added a backend-authored 32-entry variant directory summary shape with `type_code`/`runtime_type_code` like `INTJ-A`, `slug` like `intj-a`, and base identifiers preserved as `base_type_code`/`canonical_type_code`.
- Added feature coverage that default list behavior remains the 16 base profiles, while the opt-in variant directory filters by published/public base profile, locale, org, and variant publication time.

## Why
The personality hub should consume backend-authoritative variant directory entries instead of inferring A/T routes or summary content in fap-web.

## Validation
- `php -l backend/app/Services/Cms/PersonalityProfileService.php`
- `php -l backend/app/Http/Controllers/API/V0_5/Cms/PersonalityController.php`
- `php -l backend/tests/Feature/V0_5/PersonalityPublicApiTest.php`
- `cd backend && php artisan test --filter=PersonalityPublicApiTest --no-ansi`
- `cd backend && ./vendor/bin/pint --test app/Services/Cms/PersonalityProfileService.php app/Http/Controllers/API/V0_5/Cms/PersonalityController.php tests/Feature/V0_5/PersonalityPublicApiTest.php`
- `cd backend && php artisan route:list --path=api/v0.5/personality --no-ansi`
- `git diff --check`

## Intentionally deferred
- No fap-web changes.
- No 32-entry hub rendering changes.
- No new media assets or 32 distinct image set.
- No frontend inference fallback for variants.

## Repository rule impact
Personality variant directory authority remains backend/API-owned; fap-web must consume this public API contract rather than deriving public variant content locally.