### PR TITLE
feat(cms): add inline article image URL replacer

### DIFF
--- a/backend/app/Console/Commands/ArticleReplaceInlineImageUrl.php
+++ b/backend/app/Console/Commands/ArticleReplaceInlineImageUrl.php
@@ -1,0 +1,128 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Services\Cms\ArticleInlineImageUrlReplacer;
+use Illuminate\Console\Command;
+use RuntimeException;
+use Throwable;
+
+final class ArticleReplaceInlineImageUrl extends Command
+{
+    protected $signature = 'articles:replace-inline-image-url
+        {--article-ids= : Comma-separated article IDs to lock and update}
+        {--translation-group-id= : Expected translation_group_id lock}
+        {--old-url= : Exact inline image URL or URL fragment to replace}
+        {--new-url= : Exact inline image URL or URL fragment to write}
+        {--dry-run : Validate and plan without writing DB rows}
+        {--execute : Apply the inline image URL replacement; omitted by default for dry-run safety}
+        {--json : Emit a JSON summary}
+        {--no-publish : Required execute-mode hold: do not publish}
+        {--no-schema : Required execute-mode hold: do not modify schema gates}
+        {--no-hreflang : Required execute-mode hold: do not modify hreflang gates}
+        {--no-search : Required execute-mode hold: do not submit search channels}
+        {--no-sitemap-llms-change : Required execute-mode hold: do not modify sitemap/llms eligibility}';
+
+    protected $description = 'Safely replace one inline Markdown image URL in locked published CMS articles.';
+
+    public function handle(ArticleInlineImageUrlReplacer $replacer): int
+    {
+        try {
+            $summary = $replacer->run($this->optionsPayload());
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function optionsPayload(): array
+    {
+        return [
+            'article_ids' => (string) $this->option('article-ids'),
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'old_url' => (string) $this->option('old-url'),
+            'new_url' => (string) $this->option('new-url'),
+            'dry_run' => (bool) $this->option('dry-run'),
+            'execute' => (bool) $this->option('execute'),
+            'json' => (bool) $this->option('json'),
+            'no_publish' => (bool) $this->option('no-publish'),
+            'no_schema' => (bool) $this->option('no-schema'),
+            'no_hreflang' => (bool) $this->option('no-hreflang'),
+            'no_search' => (bool) $this->option('no-search'),
+            'no_sitemap_llms_change' => (bool) $this->option('no-sitemap-llms-change'),
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('translation_group_id='.(string) ($summary['translation_group_id'] ?? ''));
+        $this->line('article_ids='.implode(',', array_map('strval', (array) ($summary['article_ids'] ?? []))));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+
+        foreach ((array) ($summary['errors'] ?? []) as $error) {
+            if (is_array($error)) {
+                $this->line('validation_error='.$this->issueLine($error));
+            }
+        }
+    }
+
+    /**
+     * @param  array<string,mixed>  $issue
+     */
+    private function issueLine(array $issue): string
+    {
+        return sprintf(
+            '%s:%s:%s',
+            (string) ($issue['field'] ?? 'unknown'),
+            (string) ($issue['code'] ?? 'unknown'),
+            (string) ($issue['message'] ?? '')
+        );
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => ! (bool) $this->option('execute'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'article_ids' => [],
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'old_url' => (string) $this->option('old-url'),
+            'new_url' => (string) $this->option('new-url'),
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+}

--- a/backend/app/Console/Kernel.php
+++ b/backend/app/Console/Kernel.php
@@ -8,6 +8,7 @@ use App\Console\Commands\ArticleCoverPropagationSmoke;
 use App\Console\Commands\ArticleImportEditorialPackage;
 use App\Console\Commands\ArticleImportSeoContentPackageDraft;
 use App\Console\Commands\ArticlePublishControlled;
+use App\Console\Commands\ArticleReplaceInlineImageUrl;
 use App\Console\Commands\ArticleUpdateImageMetadata;
 use App\Console\Commands\Big5AttemptPurge;
 // ✅ 显式注册（更稳，避免自动扫描失效/缓存导致找不到）
@@ -328,6 +329,7 @@ class Kernel extends ConsoleKernel
         ArticleImportSeoContentPackageDraft::class,
         ArticleCoverPropagationSmoke::class,
         ArticlePublishControlled::class,
+        ArticleReplaceInlineImageUrl::class,
         ArticleUpdateImageMetadata::class,
         MediaAssetsImportSeoImageBundle::class,
     ];

--- a/backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php
+++ b/backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php
@@ -1,0 +1,562 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Services\Cms;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Support\Facades\DB;
+
+final class ArticleInlineImageUrlReplacer
+{
+    private const SAFETY_FLAGS = [
+        'no_publish',
+        'no_schema',
+        'no_hreflang',
+        'no_search',
+        'no_sitemap_llms_change',
+    ];
+
+    private const PRIVATE_MARKERS = [
+        '/result',
+        '/results',
+        '/orders',
+        '/order',
+        '/share',
+        '/pay',
+        '/payment',
+        '/history',
+        '/take',
+        'result_id',
+        'order_id',
+        'payment_id',
+        'report_id',
+        'user_id',
+        'token',
+    ];
+
+    /**
+     * @param  array<string,mixed>  $options
+     * @return array<string,mixed>
+     */
+    public function run(array $options): array
+    {
+        $execute = (bool) ($options['execute'] ?? false);
+        $dryRun = ! $execute;
+        $errors = [];
+        $warnings = [];
+        $articleIds = $this->articleIds((string) ($options['article_ids'] ?? ''), $errors);
+        $translationGroupId = trim((string) ($options['translation_group_id'] ?? ''));
+        $oldUrl = trim((string) ($options['old_url'] ?? ''));
+        $newUrl = trim((string) ($options['new_url'] ?? ''));
+
+        if ($translationGroupId === '') {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_required', 'Expected translation_group_id is required.');
+        }
+
+        if ((bool) ($options['dry_run'] ?? false) && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+
+        if ($execute) {
+            foreach (self::SAFETY_FLAGS as $flag) {
+                if ((bool) ($options[$flag] ?? false) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+        }
+
+        $this->validateUrlFragment($oldUrl, 'old_url', $errors, allowExistingLegacy: true);
+        $this->validateUrlFragment($newUrl, 'new_url', $errors, allowExistingLegacy: false);
+
+        if ($oldUrl !== '' && $newUrl !== '' && $oldUrl === $newUrl) {
+            $errors[] = $this->issue('new_url', 'replacement_url_same_as_old', 'The replacement URL must differ from the old URL.');
+        }
+
+        $articles = $this->resolveArticles($articleIds);
+        $this->validateArticleLock($articles, $articleIds, $translationGroupId, $errors);
+
+        $plans = [];
+        foreach ($articles as $article) {
+            $plans[] = $this->planArticle($article, $oldUrl, $newUrl, $errors);
+        }
+
+        $before = array_map(static fn (array $plan): array => $plan['before'], $plans);
+        $after = array_map(static fn (array $plan): array => $plan['after'], $plans);
+
+        $protectedDiffs = $this->protectedDiffs($before, $after);
+        if ($protectedDiffs !== []) {
+            $errors[] = $this->issue('protected_fields', 'protected_field_would_change', 'Planned update would change a protected article field.', [
+                'diffs' => $protectedDiffs,
+            ]);
+        }
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleIds, $translationGroupId, $oldUrl, $newUrl, $before, $after, $plans, $errors, $warnings);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_replace_inline_image_url', $articleIds, $translationGroupId, $oldUrl, $newUrl, $before, $after, $plans, [], $warnings);
+        }
+
+        DB::transaction(function () use ($plans): void {
+            foreach ($plans as $plan) {
+                $this->applyPlan($plan);
+            }
+        });
+
+        $freshArticles = $this->resolveArticles($articleIds);
+        $afterWritePlans = [];
+        foreach ($freshArticles as $article) {
+            $afterWritePlans[] = $this->planArticle($article, $oldUrl, $newUrl, $warnings, postWriteSnapshot: true);
+        }
+
+        $afterWrite = array_map(static fn (array $plan): array => $plan['before'], $afterWritePlans);
+
+        return $this->summary(true, false, 'replaced_inline_image_url', $articleIds, $translationGroupId, $oldUrl, $newUrl, $before, $afterWrite, $plans, [], $warnings);
+    }
+
+    /**
+     * @param  list<int>  $ids
+     * @return list<Article>
+     */
+    private function resolveArticles(array $ids): array
+    {
+        if ($ids === []) {
+            return [];
+        }
+
+        /** @var list<Article> $articles */
+        $articles = Article::query()
+            ->withoutGlobalScopes()
+            ->with([
+                'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            ])
+            ->whereIn('id', $ids)
+            ->get()
+            ->sortBy(static fn (Article $article): int => array_search((int) $article->id, $ids, true))
+            ->values()
+            ->all();
+
+        return $articles;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateArticleLock(array $articles, array $articleIds, string $translationGroupId, array &$errors): void
+    {
+        $foundIds = array_map(static fn (Article $article): int => (int) $article->id, $articles);
+        foreach ($articleIds as $id) {
+            if (! in_array($id, $foundIds, true)) {
+                $errors[] = $this->issue('article_ids', 'article_not_found', 'Requested article id was not found.', ['article_id' => $id]);
+            }
+        }
+
+        foreach ($articles as $article) {
+            if ((string) $article->translation_group_id !== $translationGroupId) {
+                $errors[] = $this->issue('article.'.$article->id.'.translation_group_id', 'translation_group_id_mismatch', 'Article translation_group_id does not match expected lock.', [
+                    'article_id' => (int) $article->id,
+                    'actual' => (string) $article->translation_group_id,
+                ]);
+            }
+
+            if ((string) $article->status !== 'published' || ! (bool) $article->is_public || ! (int) $article->published_revision_id) {
+                $errors[] = $this->issue('article.'.$article->id.'.status', 'article_not_published_public', 'Inline image replacement is limited to published public articles with a published revision.', [
+                    'article_id' => (int) $article->id,
+                ]);
+            }
+
+            if (! $article->seoMeta instanceof ArticleSeoMeta) {
+                $errors[] = $this->issue('article.'.$article->id.'.seo_meta', 'article_seo_meta_missing', 'Article SEO meta row is required so canonical/schema/hreflang locks can be verified.', [
+                    'article_id' => (int) $article->id,
+                ]);
+
+                continue;
+            }
+
+            $canonical = trim((string) $article->seoMeta->canonical_url);
+            if ($canonical === '' || str_starts_with($canonical, '/ops/') || str_contains($canonical, '/article-preview/')) {
+                $errors[] = $this->issue('article.'.$article->id.'.canonical_url', 'canonical_url_invalid', 'Article canonical URL must be present and public canonical.', [
+                    'article_id' => (int) $article->id,
+                    'canonical_url' => $canonical,
+                ]);
+            }
+
+            if (! $article->workingRevision instanceof ArticleTranslationRevision || ! $article->publishedRevision instanceof ArticleTranslationRevision) {
+                $errors[] = $this->issue('article.'.$article->id.'.revision', 'current_revision_missing', 'Both working and published revisions are required for inline image replacement.', [
+                    'article_id' => (int) $article->id,
+                ]);
+            }
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateUrlFragment(string $value, string $field, array &$errors, bool $allowExistingLegacy): void
+    {
+        if ($value === '') {
+            $errors[] = $this->issue($field, 'url_required', 'Both old and new image URLs or URL fragments are required.');
+
+            return;
+        }
+
+        if (str_contains($value, '__CMS_MEDIA_LIBRARY_PLACEHOLDER__') || str_contains($value, '{{')) {
+            $errors[] = $this->issue($field, 'placeholder_not_allowed', 'Image URL replacement values must not contain placeholders.');
+        }
+
+        $normalized = strtolower($value);
+        foreach (self::PRIVATE_MARKERS as $marker) {
+            if (str_contains($normalized, strtolower($marker))) {
+                $errors[] = $this->issue($field, 'private_url_marker_not_allowed', 'Image URL replacement values must not contain private route or sensitive query markers.', [
+                    'marker' => $marker,
+                ]);
+            }
+        }
+
+        if (preg_match('/^https?:\/\//i', $value)) {
+            if (! preg_match('/^https:\/\/(?:api|assets)\.fermatmind\.com\//i', $value)) {
+                $errors[] = $this->issue($field, 'public_media_url_invalid', 'Absolute image URLs must use the FermatMind public media hosts.');
+            }
+
+            return;
+        }
+
+        if (str_contains($value, '://')) {
+            $errors[] = $this->issue($field, 'public_media_url_invalid', 'Image URL replacement value must be an HTTPS FermatMind media URL or a relative media URL fragment.');
+        }
+
+        if (! $allowExistingLegacy && str_contains($normalized, 'articleriasecexplanationcoverv1')) {
+            $errors[] = $this->issue($field, 'legacy_image_url_not_allowed_for_replacement', 'Replacement URL must not point to the legacy RIASEC fallback image.');
+        }
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return array<string,mixed>
+     */
+    private function planArticle(Article $article, string $oldUrl, string $newUrl, array &$errors, bool $postWriteSnapshot = false): array
+    {
+        $article->loadMissing([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ]);
+
+        $before = $this->snapshot($article);
+        $after = $before;
+        $surfaces = [];
+
+        $articleContent = (string) $article->content_md;
+        $articleReplacement = $this->replaceExactlyOnce($articleContent, $oldUrl, $newUrl);
+        $surfaces['article.content_md'] = [
+            'replacement_count' => $articleReplacement['count'],
+            'before_sha256' => hash('sha256', $articleContent),
+            'after_sha256' => hash('sha256', $articleReplacement['content']),
+            'diff' => $this->inlineDiff($articleContent, $articleReplacement['content'], $oldUrl, $newUrl),
+        ];
+
+        if (! $postWriteSnapshot && $articleReplacement['count'] !== 1) {
+            $errors[] = $this->issue('article.'.$article->id.'.content_md', 'inline_image_replacement_count_not_one', 'Article content_md must contain exactly one old inline image URL occurrence.', [
+                'article_id' => (int) $article->id,
+                'replacement_count' => $articleReplacement['count'],
+            ]);
+        }
+
+        foreach (['workingRevision', 'publishedRevision'] as $relationName) {
+            $revision = $article->{$relationName};
+            if (! $revision instanceof ArticleTranslationRevision) {
+                continue;
+            }
+
+            $content = (string) $revision->content_md;
+            $replacement = $this->replaceExactlyOnce($content, $oldUrl, $newUrl);
+            $surfaceKey = $relationName.'.content_md';
+            $surfaces[$surfaceKey] = [
+                'revision_id' => (int) $revision->id,
+                'replacement_count' => $replacement['count'],
+                'before_sha256' => hash('sha256', $content),
+                'after_sha256' => hash('sha256', $replacement['content']),
+                'diff' => $this->inlineDiff($content, $replacement['content'], $oldUrl, $newUrl),
+            ];
+
+            if (! $postWriteSnapshot && $replacement['count'] !== 1) {
+                $errors[] = $this->issue('article.'.$article->id.'.'.$surfaceKey, 'inline_image_replacement_count_not_one', 'Current revision content_md must contain exactly one old inline image URL occurrence.', [
+                    'article_id' => (int) $article->id,
+                    'revision_id' => (int) $revision->id,
+                    'surface' => $surfaceKey,
+                    'replacement_count' => $replacement['count'],
+                ]);
+            }
+        }
+
+        $after['content_md_sha256'] = hash('sha256', $articleReplacement['content']);
+        $after['source_version_hash'] = Article::sourceVersionHashFromPayload([
+            'locale' => $article->locale,
+            'title' => $article->title,
+            'excerpt' => $article->excerpt,
+            'content_md' => $articleReplacement['content'],
+            'content_html' => $article->content_html,
+            'cover_image_alt' => $article->cover_image_alt,
+            'related_test_slug' => $article->related_test_slug,
+            'voice' => $article->voice,
+            'voice_order' => $article->voice_order,
+        ]);
+
+        return [
+            'article_id' => (int) $article->id,
+            'article' => $article,
+            'before' => $before,
+            'after' => $after,
+            'replacement_content_md' => $articleReplacement['content'],
+            'surfaces' => $surfaces,
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $plan
+     */
+    private function applyPlan(array $plan): void
+    {
+        /** @var Article $article */
+        $article = $plan['article'];
+        $contentMd = (string) $plan['replacement_content_md'];
+
+        $article->forceFill([
+            'content_md' => $contentMd,
+        ])->saveQuietly();
+        $article->refresh();
+
+        $revisionIds = array_values(array_unique(array_filter([
+            (int) $article->working_revision_id,
+            (int) $article->published_revision_id,
+        ])));
+
+        ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->where('article_id', (int) $article->id)
+            ->whereIn('id', $revisionIds)
+            ->update([
+                'content_md' => $contentMd,
+                'source_version_hash' => $article->source_version_hash,
+                'translated_from_version_hash' => $article->translated_from_version_hash,
+            ]);
+    }
+
+    /**
+     * @return array{content:string,count:int}
+     */
+    private function replaceExactlyOnce(string $content, string $oldUrl, string $newUrl): array
+    {
+        $count = $oldUrl === '' ? 0 : substr_count($content, $oldUrl);
+
+        return [
+            'content' => $count === 1 ? str_replace($oldUrl, $newUrl, $content) : $content,
+            'count' => $count,
+        ];
+    }
+
+    /**
+     * @return array<string,string|null>
+     */
+    private function inlineDiff(string $before, string $after, string $oldUrl, string $newUrl): array
+    {
+        return [
+            'before_line' => $this->firstLineContaining($before, $oldUrl),
+            'after_line' => $this->firstLineContaining($after, $newUrl),
+        ];
+    }
+
+    private function firstLineContaining(string $content, string $needle): ?string
+    {
+        if ($needle === '') {
+            return null;
+        }
+
+        foreach (preg_split('/\R/', $content) ?: [] as $line) {
+            if (str_contains((string) $line, $needle)) {
+                return mb_substr((string) $line, 0, 500);
+            }
+        }
+
+        return null;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function snapshot(Article $article): array
+    {
+        $article->loadMissing([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+            'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ]);
+        $seoMeta = $article->seoMeta;
+
+        return [
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'slug' => (string) $article->slug,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'title' => (string) $article->title,
+            'excerpt_sha256' => hash('sha256', (string) $article->excerpt),
+            'content_md_sha256' => hash('sha256', (string) $article->content_md),
+            'content_html_sha256' => hash('sha256', (string) $article->content_html),
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'canonical_url' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->canonical_url : null,
+            'robots' => $seoMeta instanceof ArticleSeoMeta ? (string) $seoMeta->robots : null,
+            'seo_is_indexable' => $seoMeta instanceof ArticleSeoMeta ? (bool) $seoMeta->is_indexable : null,
+            'schema_json_sha256' => $seoMeta instanceof ArticleSeoMeta ? hash('sha256', (string) json_encode($seoMeta->schema_json, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)) : null,
+            'cover_image_url' => $article->cover_image_url,
+            'cover_image_variants_sha256' => hash('sha256', (string) json_encode($article->cover_image_variants, JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)),
+            'og_image_url' => $seoMeta instanceof ArticleSeoMeta ? $seoMeta->og_image_url : null,
+            'revision_count' => ArticleTranslationRevision::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->count(),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $before
+     * @param  list<array<string,mixed>>  $after
+     * @return list<array<string,mixed>>
+     */
+    private function protectedDiffs(array $before, array $after): array
+    {
+        $protectedFields = [
+            'locale',
+            'slug',
+            'translation_group_id',
+            'title',
+            'excerpt_sha256',
+            'content_html_sha256',
+            'status',
+            'is_public',
+            'is_indexable',
+            'sitemap_eligible',
+            'llms_eligible',
+            'working_revision_id',
+            'published_revision_id',
+            'canonical_url',
+            'robots',
+            'seo_is_indexable',
+            'schema_json_sha256',
+            'cover_image_url',
+            'cover_image_variants_sha256',
+            'og_image_url',
+            'revision_count',
+        ];
+
+        $diffs = [];
+        foreach ($before as $index => $beforeSnapshot) {
+            $afterSnapshot = $after[$index] ?? [];
+            foreach ($protectedFields as $field) {
+                if (($beforeSnapshot[$field] ?? null) !== ($afterSnapshot[$field] ?? null)) {
+                    $diffs[] = [
+                        'article_id' => (int) ($beforeSnapshot['article_id'] ?? 0),
+                        'field' => $field,
+                    ];
+                }
+            }
+        }
+
+        return $diffs;
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @return list<int>
+     */
+    private function articleIds(string $raw, array &$errors): array
+    {
+        $ids = array_values(array_unique(array_filter(array_map(
+            static fn (string $value): int => is_numeric(trim($value)) ? (int) trim($value) : 0,
+            explode(',', $raw)
+        ), static fn (int $id): bool => $id > 0)));
+
+        if ($ids === []) {
+            $errors[] = $this->issue('article_ids', 'article_ids_required', 'At least one article id is required.');
+        }
+
+        return $ids;
+    }
+
+    /**
+     * @param  array<string,mixed>  $extra
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message, array $extra = []): array
+    {
+        return array_merge([
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ], $extra);
+    }
+
+    /**
+     * @param  list<int>  $articleIds
+     * @param  list<array<string,mixed>>  $before
+     * @param  list<array<string,mixed>>  $after
+     * @param  list<array<string,mixed>>  $plans
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, array $articleIds, string $translationGroupId, string $oldUrl, string $newUrl, array $before, array $after, array $plans, array $errors, array $warnings): array
+    {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok && ! $dryRun,
+            'article_ids' => $articleIds,
+            'articles_count' => count($articleIds),
+            'translation_group_id' => $translationGroupId,
+            'old_url' => $oldUrl,
+            'new_url' => $newUrl,
+            'updates_scope' => [
+                'article_fields' => [
+                    'content_md',
+                    'source_version_hash',
+                ],
+                'article_translation_revision_fields' => [
+                    'content_md',
+                    'source_version_hash',
+                    'translated_from_version_hash',
+                ],
+            ],
+            'protected_holds' => [
+                'no_publish' => true,
+                'no_schema' => true,
+                'no_hreflang' => true,
+                'no_search' => true,
+                'no_sitemap_llms_change' => true,
+                'no_revision_create' => true,
+                'metadata_only' => false,
+                'body_text_only_url_replacement' => true,
+            ],
+            'replacement_plan' => array_map(static fn (array $plan): array => [
+                'article_id' => $plan['article_id'],
+                'surfaces' => $plan['surfaces'],
+            ], $plans),
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+}

--- a/backend/tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php
@@ -1,0 +1,442 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Models\ArticleTranslationRevision;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ArticleReplaceInlineImageUrlCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    private const TRANSLATION_GROUP_ID = 'tg_article_career_exploration_map_2026v1';
+
+    private const OLD_FRAGMENT = 'articleriasecexplanationcoverv1/hero_1600x900.jpg';
+
+    private const NEW_FRAGMENT = 'articlecareerconfusiontestmapbody-visualv1/hero_1600x900.jpg';
+
+    private const OLD_URL = 'https://api.fermatmind.com/storage/media-library/variants/'.self::OLD_FRAGMENT;
+
+    private const NEW_URL = 'https://api.fermatmind.com/storage/media-library/variants/'.self::NEW_FRAGMENT;
+
+    public function test_default_invocation_is_dry_run_and_does_not_write(): void
+    {
+        $articles = $this->createPublishedPair();
+        $beforeHashes = $this->bodyHashes($articles);
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertSame('would_replace_inline_image_url', $payload['action']);
+        $this->assertFalse($payload['would_write']);
+
+        foreach ($articles as $article) {
+            $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+            $this->assertSame($beforeHashes[(int) $article->id], hash('sha256', (string) $fresh->content_md));
+            $this->assertStringContainsString(self::OLD_FRAGMENT, (string) $fresh->content_md);
+            $this->assertStringNotContainsString(self::NEW_FRAGMENT, (string) $fresh->content_md);
+        }
+    }
+
+    public function test_execute_replaces_one_inline_image_url_without_changing_protected_fields_or_creating_revision(): void
+    {
+        $articles = $this->createPublishedPair();
+        $before = $this->protectedSnapshots($articles);
+        $revisionCountBefore = ArticleTranslationRevision::query()->withoutGlobalScopes()->count();
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+            '--no-schema' => true,
+            '--no-hreflang' => true,
+            '--no-search' => true,
+            '--no-sitemap-llms-change' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('replaced_inline_image_url', $payload['action']);
+        $this->assertSame($revisionCountBefore, ArticleTranslationRevision::query()->withoutGlobalScopes()->count());
+
+        foreach ($articles as $article) {
+            $fresh = Article::query()
+                ->withoutGlobalScopes()
+                ->with([
+                    'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                    'workingRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                    'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                ])
+                ->findOrFail((int) $article->id);
+
+            $this->assertStringContainsString(self::NEW_FRAGMENT, (string) $fresh->content_md);
+            $this->assertStringNotContainsString(self::OLD_FRAGMENT, (string) $fresh->content_md);
+            $this->assertSame($this->bodyWithImage(self::NEW_URL, (string) $fresh->locale), (string) $fresh->content_md);
+            $this->assertSame($this->bodyWithImage(self::NEW_URL, (string) $fresh->locale), (string) $fresh->workingRevision?->content_md);
+            $this->assertSame($this->bodyWithImage(self::NEW_URL, (string) $fresh->locale), (string) $fresh->publishedRevision?->content_md);
+            $this->assertSame($before[(int) $article->id], $this->protectedSnapshot($fresh));
+        }
+    }
+
+    public function test_execute_requires_all_no_side_effect_flags(): void
+    {
+        $articles = $this->createPublishedPair();
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        foreach ($articles as $article) {
+            $fresh = Article::query()->withoutGlobalScopes()->findOrFail((int) $article->id);
+            $this->assertStringContainsString(self::OLD_FRAGMENT, (string) $fresh->content_md);
+            $this->assertStringNotContainsString(self::NEW_FRAGMENT, (string) $fresh->content_md);
+        }
+    }
+
+    public function test_translation_group_lock_rejects_wrong_articles(): void
+    {
+        $articles = $this->createPublishedPair();
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => 'tg_wrong',
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'translation_group_id_mismatch');
+    }
+
+    public function test_rejects_missing_old_image_occurrence(): void
+    {
+        $missing = $this->createPublishedPair(contentUrl: self::NEW_URL);
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($missing),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'inline_image_replacement_count_not_one');
+    }
+
+    public function test_rejects_duplicate_old_image_occurrences(): void
+    {
+        $duplicate = $this->createPublishedPair(contentUrl: self::OLD_URL."\n\n".self::OLD_URL);
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($duplicate),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'inline_image_replacement_count_not_one');
+    }
+
+    public function test_rejects_placeholder_private_or_legacy_replacement_url(): void
+    {
+        $articles = $this->createPublishedPair();
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => '__CMS_MEDIA_LIBRARY_PLACEHOLDER__',
+            '--new-url' => 'https://example.com/private/result_id/image.jpg',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'placeholder_not_allowed');
+        $this->assertErrorCode($payload, 'private_url_marker_not_allowed');
+        $this->assertErrorCode($payload, 'public_media_url_invalid');
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::OLD_FRAGMENT,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'legacy_image_url_not_allowed_for_replacement');
+        $this->assertErrorCode($payload, 'replacement_url_same_as_old');
+    }
+
+    public function test_json_output_includes_hashes_diff_and_replacement_counts(): void
+    {
+        $articles = $this->createPublishedPair();
+
+        $exitCode = Artisan::call('articles:replace-inline-image-url', [
+            '--article-ids' => $this->articleIds($articles),
+            '--translation-group-id' => self::TRANSLATION_GROUP_ID,
+            '--old-url' => self::OLD_FRAGMENT,
+            '--new-url' => self::NEW_FRAGMENT,
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertCount(2, $payload['before']);
+        $this->assertCount(2, $payload['after']);
+        $this->assertNotSame($payload['before'][0]['content_md_sha256'], $payload['after'][0]['content_md_sha256']);
+        $this->assertSame(1, $payload['replacement_plan'][0]['surfaces']['article.content_md']['replacement_count']);
+        $this->assertStringContainsString(self::OLD_FRAGMENT, $payload['replacement_plan'][0]['surfaces']['article.content_md']['diff']['before_line']);
+        $this->assertStringContainsString(self::NEW_FRAGMENT, $payload['replacement_plan'][0]['surfaces']['article.content_md']['diff']['after_line']);
+    }
+
+    /**
+     * @return list<Article>
+     */
+    private function createPublishedPair(?string $contentUrl = null): array
+    {
+        return [
+            $this->createPublishedArticle(48, 'zh-CN', 'career-confusion-test-map', '/zh/articles/career-confusion-test-map', $contentUrl ?? self::OLD_URL),
+            $this->createPublishedArticle(49, 'en', 'choose-career-using-personality-tests', '/en/articles/choose-career-using-personality-tests', $contentUrl ?? self::OLD_URL),
+        ];
+    }
+
+    private function createPublishedArticle(int $id, string $locale, string $slug, string $canonical, string $contentUrl): Article
+    {
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'id' => $id,
+            'org_id' => 0,
+            'slug' => $slug,
+            'locale' => $locale,
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'source_locale' => 'zh-CN',
+            'translation_status' => $locale === 'zh-CN' ? Article::TRANSLATION_STATUS_SOURCE : Article::TRANSLATION_STATUS_PUBLISHED,
+            'title' => $locale === 'zh-CN' ? '不知道自己适合什么职业怎么办？' : 'How to Choose a Career Using Personality Tests',
+            'excerpt' => 'A career exploration guide.',
+            'content_md' => $this->bodyWithImage($contentUrl, $locale),
+            'content_html' => '<h1>Body</h1>',
+            'cover_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articlecareerconfusiontestmapcoverv1/hero_1600x900.jpg',
+            'cover_image_alt' => 'Career exploration map showing interest, personality, and real-world validation steps',
+            'cover_image_width' => 1600,
+            'cover_image_height' => 900,
+            'cover_image_variants' => [
+                'hero' => [
+                    'url' => 'https://api.fermatmind.com/storage/media-library/variants/articlecareerconfusiontestmapcoverv1/hero_1600x900.jpg',
+                    'width' => 1600,
+                    'height' => 900,
+                ],
+            ],
+            'related_test_slug' => 'holland-career-interest-test-riasec',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now(),
+        ]);
+
+        $revision = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'source_article_id' => (int) $article->id,
+            'translation_group_id' => self::TRANSLATION_GROUP_ID,
+            'locale' => $locale,
+            'source_locale' => 'zh-CN',
+            'revision_number' => 1,
+            'revision_status' => ArticleTranslationRevision::STATUS_PUBLISHED,
+            'source_version_hash' => (string) $article->source_version_hash,
+            'translated_from_version_hash' => (string) $article->source_version_hash,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_md' => (string) $article->content_md,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'published_at' => now(),
+        ]);
+
+        $article->forceFill([
+            'working_revision_id' => (int) $revision->id,
+            'published_revision_id' => (int) $revision->id,
+        ])->saveQuietly();
+
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => $locale,
+            'seo_title' => (string) $article->title,
+            'seo_description' => (string) $article->excerpt,
+            'canonical_url' => $canonical,
+            'og_title' => (string) $article->title,
+            'og_description' => (string) $article->excerpt,
+            'og_image_url' => 'https://api.fermatmind.com/storage/media-library/variants/articlecareerconfusiontestmapcoverv1/og_1200x630.jpg',
+            'robots' => 'index,follow',
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => true,
+                    'breadcrumb_schema_enabled' => true,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => true,
+                    ],
+                ],
+            ],
+            'is_indexable' => true,
+        ]);
+
+        return $article->refresh();
+    }
+
+    private function bodyWithImage(string $url, string $locale): string
+    {
+        $lead = $locale === 'zh-CN'
+            ? '先用职业兴趣缩小方向，再用性格偏好理解工作方式。'
+            : 'Start with career interests, then use personality preferences to understand work style.';
+
+        return <<<MD
+# Body
+
+{$lead}
+
+![Career exploration map]({$url})
+
+Keep the article body text unchanged.
+MD;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     */
+    private function articleIds(array $articles): string
+    {
+        return implode(',', array_map(static fn (Article $article): string => (string) $article->id, $articles));
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @return array<int,string>
+     */
+    private function bodyHashes(array $articles): array
+    {
+        $hashes = [];
+        foreach ($articles as $article) {
+            $hashes[(int) $article->id] = hash('sha256', (string) $article->content_md);
+        }
+
+        return $hashes;
+    }
+
+    /**
+     * @param  list<Article>  $articles
+     * @return array<int,array<string,mixed>>
+     */
+    private function protectedSnapshots(array $articles): array
+    {
+        $snapshots = [];
+        foreach ($articles as $article) {
+            $snapshots[(int) $article->id] = $this->protectedSnapshot($article);
+        }
+
+        return $snapshots;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function protectedSnapshot(Article $article): array
+    {
+        $article->refresh();
+        $article->load([
+            'seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes(),
+        ]);
+
+        return [
+            'slug' => (string) $article->slug,
+            'locale' => (string) $article->locale,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'title' => (string) $article->title,
+            'excerpt' => (string) $article->excerpt,
+            'content_html' => (string) $article->content_html,
+            'cover_image_url' => (string) $article->cover_image_url,
+            'cover_image_variants' => $article->cover_image_variants,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'working_revision_id' => (int) $article->working_revision_id,
+            'published_revision_id' => (int) $article->published_revision_id,
+            'canonical_url' => (string) $article->seoMeta?->canonical_url,
+            'robots' => (string) $article->seoMeta?->robots,
+            'seo_is_indexable' => (bool) $article->seoMeta?->is_indexable,
+            'schema_json' => $article->seoMeta?->schema_json,
+            'og_image_url' => (string) $article->seoMeta?->og_image_url,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1627,6 +1627,21 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
     }
 
+    public function test_runtime_freeze_classifier_ignores_article_inline_image_url_replacer_changes(): void
+    {
+        $changed = [
+            'backend/app/Console/Commands/ArticleReplaceInlineImageUrl.php',
+            'backend/app/Console/Kernel.php',
+            'backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php',
+        ];
+        $kernelChangedLines = [
+            '+use App\\Console\\Commands\\ArticleReplaceInlineImageUrl;',
+            '+        ArticleReplaceInlineImageUrl::class,',
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', '', $kernelChangedLines));
+    }
+
     public function test_runtime_freeze_classifier_ignores_article_body_h1_guard_changes(): void
     {
         $changed = [
@@ -3013,6 +3028,10 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 continue;
             }
 
+            if ($this->isArticleInlineImageUrlReplacerFile($file)) {
+                continue;
+            }
+
             if ($this->isArticleBodyH1GuardFile($file)) {
                 continue;
             }
@@ -3626,6 +3645,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                     || $this->kernelDiffIsSeoContentPackageDraftImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsSeoImageBundleImporterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleImageMetadataUpdaterOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
+                    || $this->kernelDiffIsArticleInlineImageUrlReplacerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsControlledArticlePublishSopOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsArticleCoverPropagationSmokeOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
                     || $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly($kernelChangedLines ?? $this->kernelChangedLines($repoRoot, $baseRef))
@@ -3920,6 +3940,14 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         return in_array($file, [
             'backend/app/Console/Commands/ArticleUpdateImageMetadata.php',
             'backend/app/Services/Cms/ArticleImageMetadataUpdater.php',
+        ], true);
+    }
+
+    private function isArticleInlineImageUrlReplacerFile(string $file): bool
+    {
+        return in_array($file, [
+            'backend/app/Console/Commands/ArticleReplaceInlineImageUrl.php',
+            'backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php',
         ], true);
     }
 
@@ -5525,6 +5553,32 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/\bArticleUpdateImageMetadata\b/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsArticleInlineImageUrlReplacerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (str_contains($line, '显式注册')) {
+                continue;
+            }
+
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/\bArticleReplaceInlineImageUrl\b/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `articles:replace-inline-image-url` for locked, dry-run-first inline Markdown image URL replacement on published CMS articles.
- Added `ArticleInlineImageUrlReplacer` with article ID / translation group / canonical / revision locks, exact-one occurrence validation, before/after hashes, inline diff output, and execute-mode no-side-effect flags.
- Registered the command and added feature coverage for dry-run, execute, lock failures, bad URL inputs, replacement count blockers, and JSON output.

## Why
Career exploration map article IDs 48/49 need a narrow, auditable way to replace only the old inline body Markdown image URL with the new body visual URL without changing publish state, schema, hreflang, sitemap/llms, or search channels.

## Validation
- `php -l backend/app/Console/Commands/ArticleReplaceInlineImageUrl.php`
- `php -l backend/app/Services/Cms/ArticleInlineImageUrlReplacer.php`
- `php -l backend/tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php`
- `php artisan test tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php`
- `php artisan list | rg 'articles:replace-inline-image-url|articles:update-image-metadata'`\n- `./vendor/bin/pint app/Console/Kernel.php app/Console/Commands/ArticleReplaceInlineImageUrl.php app/Services/Cms/ArticleInlineImageUrlReplacer.php tests/Feature/Console/ArticleReplaceInlineImageUrlCommandTest.php`\n- `git diff --check`\n\n## Intentionally deferred\n- No production mutation.\n- No CMS article body update.\n- No publish/index/schema/hreflang/search/sitemap/llms changes.\n- The actual article 48/49 URL replacement requires a separate production deploy and explicit execute approval.\n\n## Repository rule impact\nThis adds a backend-authoritative CMS maintenance command for mutable editorial body image references. It does not move editorial authority to frontend code and does not introduce frontend static content or image assets.