### PR TITLE
TEST-KPI-SCHEDULER-05: Schedule test KPI current-day refresh

### DIFF
--- a/backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php
+++ b/backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php
@@ -18,6 +18,7 @@ final class RefreshTestMetricsDailyCommand extends Command
         {--to= : Inclusive end date (Y-m-d)}
         {--scale=* : Limit refresh to one or more scale codes}
         {--org=* : Limit refresh to one or more org ids}
+        {--scheduled-current-day : Scheduler-only mode that refreshes today for all orgs and all scales}
         {--dry-run : Preview the aggregation without writing rows}
         {--confirm-write= : Required exact confirmation token for non-dry-run refresh writes}';
 
@@ -31,8 +32,14 @@ final class RefreshTestMetricsDailyCommand extends Command
 
     public function handle(): int
     {
-        $from = $this->parseDateOption((string) $this->option('from'), now()->toDateString());
-        $to = $this->parseDateOption((string) $this->option('to'), now()->toDateString());
+        $scheduledCurrentDay = (bool) $this->option('scheduled-current-day');
+        $today = now()->toDateString();
+        $from = $scheduledCurrentDay
+            ? CarbonImmutable::parse($today)->startOfDay()
+            : $this->parseDateOption((string) $this->option('from'), $today);
+        $to = $scheduledCurrentDay
+            ? CarbonImmutable::parse($today)->startOfDay()
+            : $this->parseDateOption((string) $this->option('to'), $today);
 
         if ($from->greaterThan($to)) {
             $this->error('The --from date must be on or before --to.');
@@ -40,24 +47,24 @@ final class RefreshTestMetricsDailyCommand extends Command
             return self::FAILURE;
         }
 
-        $scaleCodes = array_values(array_filter(array_map(
+        $scaleCodes = $scheduledCurrentDay ? [] : array_values(array_filter(array_map(
             static fn (mixed $value): string => strtoupper(trim((string) $value)),
             (array) $this->option('scale')
         ), static fn (string $value): bool => $value !== ''));
 
-        $orgIds = array_values(array_filter(array_map(
+        $orgIds = $scheduledCurrentDay ? [] : array_values(array_filter(array_map(
             static fn (mixed $value): int => max(0, (int) $value),
             (array) $this->option('org')
         ), static fn (int $value): bool => $value >= 0));
 
-        $dryRun = (bool) $this->option('dry-run');
+        $dryRun = $scheduledCurrentDay ? false : (bool) $this->option('dry-run');
         $beforeCount = $this->countExistingRows($from, $to, $orgIds, $scaleCodes);
 
         if (! $dryRun) {
-            $guard = $this->validateWriteGuard($from, $to, $orgIds, $scaleCodes);
+            $guard = $this->validateWriteGuard($from, $to, $orgIds, $scaleCodes, $scheduledCurrentDay);
 
             if ($guard !== null) {
-                $this->emitSummary($from, $to, $orgIds, $scaleCodes, [
+                $this->emitSummary($from, $to, $orgIds, $scaleCodes, $scheduledCurrentDay, [
                     'dry_run' => false,
                     'before_count' => $beforeCount,
                     'after_count' => $beforeCount,
@@ -77,7 +84,7 @@ final class RefreshTestMetricsDailyCommand extends Command
         $result = $this->builder->refresh($from, $to, $orgIds, $scaleCodes, $dryRun);
         $afterCount = $this->countExistingRows($from, $to, $orgIds, $scaleCodes);
 
-        $this->emitSummary($from, $to, $orgIds, $scaleCodes, [
+        $this->emitSummary($from, $to, $orgIds, $scaleCodes, $scheduledCurrentDay, [
             'dry_run' => (bool) ($result['dry_run'] ?? false),
             'before_count' => $beforeCount,
             'after_count' => $afterCount,
@@ -140,7 +147,12 @@ final class RefreshTestMetricsDailyCommand extends Command
         CarbonImmutable $to,
         array $orgIds,
         array $scaleCodes,
+        bool $scheduledCurrentDay,
     ): ?string {
+        if ($scheduledCurrentDay) {
+            return $this->validateScheduledCurrentDayGuard();
+        }
+
         if (trim((string) $this->option('from')) === '' || trim((string) $this->option('to')) === '') {
             return 'explicit_from_to_required';
         }
@@ -158,6 +170,27 @@ final class RefreshTestMetricsDailyCommand extends Command
 
         if (! hash_equals($expected, $provided)) {
             return 'confirm_write_token_mismatch';
+        }
+
+        return null;
+    }
+
+    private function validateScheduledCurrentDayGuard(): ?string
+    {
+        if (trim((string) $this->option('from')) !== '' || trim((string) $this->option('to')) !== '') {
+            return 'scheduled_current_day_disallows_manual_dates';
+        }
+
+        if ((array) $this->option('org') !== [] || (array) $this->option('scale') !== []) {
+            return 'scheduled_current_day_disallows_manual_scope';
+        }
+
+        if ((bool) $this->option('dry-run')) {
+            return 'scheduled_current_day_disallows_dry_run';
+        }
+
+        if (trim((string) $this->option('confirm-write')) !== '') {
+            return 'scheduled_current_day_disallows_confirm_write';
         }
 
         return null;
@@ -193,12 +226,14 @@ final class RefreshTestMetricsDailyCommand extends Command
         CarbonImmutable $to,
         array $orgIds,
         array $scaleCodes,
+        bool $scheduledCurrentDay,
         array $summary,
     ): void {
         $this->line('from='.$from->toDateString());
         $this->line('to='.$to->toDateString());
         $this->line('org_scope='.($orgIds === [] ? '*' : implode(',', $orgIds)));
         $this->line('scale_scope='.($scaleCodes === [] ? '*' : implode(',', $scaleCodes)));
+        $this->line('scheduled_current_day='.($scheduledCurrentDay ? '1' : '0'));
         $this->line('dry_run='.($summary['dry_run'] ? '1' : '0'));
         $this->line('before_count='.$summary['before_count']);
         $this->line('after_count='.$summary['after_count']);

--- a/backend/bootstrap/app.php
+++ b/backend/bootstrap/app.php
@@ -41,6 +41,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $schedule->command('payments:prune-events --days=90')->dailyAt('03:00')->withoutOverlapping();
         $schedule->command('email:outbox-send --limit=50')->everyMinute()->withoutOverlapping();
         $schedule->command('commerce:compensate-pending-orders --provider=alipay --include-created --only-stale --limit=10 --older-than-minutes=60')->everyTenMinutes()->withoutOverlapping();
+        $schedule->command('analytics:refresh-test-metrics-daily --scheduled-current-day')->everyFifteenMinutes()->withoutOverlapping(20);
         $schedule->command('quality:daily-summary')->dailyAt('03:20')->withoutOverlapping();
         $schedule->command('sds:psychometrics --window=last_7_days')->weeklyOn(1, '04:10')->withoutOverlapping();
         $schedule->command('eq60:psychometrics --window=last_90_days')->weeklyOn(1, '04:20')->withoutOverlapping();

--- a/backend/docs/ops/test-kpi-scheduler.md
+++ b/backend/docs/ops/test-kpi-scheduler.md
@@ -1,0 +1,53 @@
+# Test KPI Scheduler
+
+Status: active after deployment of `TEST-KPI-SCHEDULER-05`.
+
+## Runtime schedule
+
+The Laravel 11 runtime scheduler source is `backend/bootstrap/app.php`.
+
+Registered command:
+
+```bash
+php artisan analytics:refresh-test-metrics-daily --scheduled-current-day
+```
+
+Schedule:
+
+- every 15 minutes
+- `withoutOverlapping(20)`
+- current day only
+- all orgs and all scales
+- writes only to `analytics_test_metrics_daily`
+
+The scheduled mode intentionally rejects manual `--from`, `--to`, `--org`,
+`--scale`, `--dry-run`, and `--confirm-write` overrides. Historical backfills
+must continue to use the controlled manual command flow from
+`analytics:refresh-test-metrics-daily`.
+
+## Server runner
+
+Repository deploy/runbook evidence says the current production backend target
+is Aliyun and that Nginx, Supervisor, and cron point to the managed current
+release backend. Queue workers are owned by Supervisor; the Laravel scheduler
+runner is cron or an equivalent supervised `schedule:work` process that invokes
+the current release backend.
+
+Required production check after deploy:
+
+```bash
+cd <current-release>/backend
+php artisan schedule:list --json | grep analytics:refresh-test-metrics-daily
+crontab -l | grep 'schedule:run'
+supervisorctl status 'fap-queue-*'
+```
+
+The scheduler registration is not sufficient on its own. Production must have
+an active scheduler runner pointing at the managed current release backend.
+
+## Scope
+
+This scheduler refreshes the read model used by Ops KPI cards and daily detail
+views. It does not change public routes, frontend payload contracts, result
+rendering, sitemap, llms, CMS content, payment/order state machines, or queue
+worker definitions.

--- a/backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php
+++ b/backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Feature\Analytics;
 
+use Carbon\Carbon;
 use Carbon\CarbonImmutable;
 use Illuminate\Foundation\Testing\RefreshDatabase;
 use Illuminate\Support\Facades\DB;
@@ -74,6 +75,78 @@ final class RefreshTestMetricsDailyCommandTest extends TestCase
             ->expectsOutputToContain('write_guard_reason=confirm_write_token_mismatch')
             ->expectsOutputToContain('expected_confirm_write=analytics_test_metrics_daily:write:2026-06-16:2026-06-16:org=12:scale=all')
             ->assertExitCode(1);
+    }
+
+    public function test_scheduled_current_day_refreshes_today_for_all_orgs_without_manual_token(): void
+    {
+        Carbon::setTestNow('2026-06-17 10:15:00');
+
+        try {
+            $today = CarbonImmutable::parse('2026-06-17 09:00:00');
+            $yesterday = $today->subDay();
+            $success = (string) Str::uuid();
+            $failure = (string) Str::uuid();
+            $old = (string) Str::uuid();
+
+            $this->insertAttempt($success, 12, 'MBTI', 'MBTI', 'zh-CN', $today, $today->addMinutes(8));
+            $this->insertAttempt($failure, 13, 'BIG5', 'BIG5', 'en', $today->addMinutes(2), null);
+            $this->insertAttempt($old, 12, 'MBTI', 'MBTI', 'zh-CN', $yesterday, $yesterday->addMinutes(8));
+            $this->insertSubmission($success, 12, 'succeeded', $today->addMinutes(9));
+            $this->insertSubmission($failure, 13, 'failed', $today->addMinutes(10));
+            $this->insertSubmission($old, 12, 'succeeded', $yesterday->addMinutes(9));
+
+            $this->artisan('analytics:refresh-test-metrics-daily', [
+                '--scheduled-current-day' => true,
+            ])
+                ->expectsOutputToContain('from=2026-06-17')
+                ->expectsOutputToContain('to=2026-06-17')
+                ->expectsOutputToContain('org_scope=*')
+                ->expectsOutputToContain('scale_scope=*')
+                ->expectsOutputToContain('scheduled_current_day=1')
+                ->expectsOutputToContain('dry_run=0')
+                ->expectsOutputToContain('write_guard=passed')
+                ->assertExitCode(0);
+
+            $this->assertDatabaseHas('analytics_test_metrics_daily', [
+                'day' => '2026-06-17',
+                'org_id' => 12,
+                'scale_code' => 'MBTI',
+                'successful_attempts' => 1,
+                'failed_attempts' => 0,
+                'total_attempts' => 1,
+            ]);
+            $this->assertDatabaseHas('analytics_test_metrics_daily', [
+                'day' => '2026-06-17',
+                'org_id' => 13,
+                'scale_code' => 'BIG5',
+                'successful_attempts' => 0,
+                'failed_attempts' => 1,
+                'total_attempts' => 1,
+            ]);
+            $this->assertDatabaseMissing('analytics_test_metrics_daily', [
+                'day' => '2026-06-16',
+            ]);
+        } finally {
+            Carbon::setTestNow();
+        }
+    }
+
+    public function test_scheduled_current_day_blocks_manual_scope_overrides(): void
+    {
+        Carbon::setTestNow('2026-06-17 10:15:00');
+
+        try {
+            $this->artisan('analytics:refresh-test-metrics-daily', [
+                '--scheduled-current-day' => true,
+                '--org' => [12],
+            ])
+                ->expectsOutputToContain('scheduled_current_day=1')
+                ->expectsOutputToContain('write_guard=blocked')
+                ->expectsOutputToContain('write_guard_reason=scheduled_current_day_disallows_manual_scope')
+                ->assertExitCode(1);
+        } finally {
+            Carbon::setTestNow();
+        }
     }
 
     private function insertAttempt(

--- a/backend/tests/Feature/Analytics/TestMetricsSchedulerBootstrapTest.php
+++ b/backend/tests/Feature/Analytics/TestMetricsSchedulerBootstrapTest.php
@@ -1,0 +1,45 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Analytics;
+
+use Symfony\Component\Process\Process;
+use Tests\TestCase;
+
+final class TestMetricsSchedulerBootstrapTest extends TestCase
+{
+    public function test_test_metrics_current_day_refresh_is_registered_conservatively(): void
+    {
+        $events = $this->scheduleListEvents();
+        $event = collect($events)->first(
+            fn (array $event): bool => str_contains((string) ($event['command'] ?? ''), 'analytics:refresh-test-metrics-daily')
+        );
+
+        $this->assertNotNull($event, 'schedule:list did not include the test metrics daily refresh command.');
+        $command = (string) $event['command'];
+
+        $this->assertStringContainsString('analytics:refresh-test-metrics-daily', $command);
+        $this->assertStringContainsString('--scheduled-current-day', $command);
+        $this->assertStringNotContainsString('--dry-run', $command);
+        $this->assertStringNotContainsString('--from=', $command);
+        $this->assertStringNotContainsString('--to=', $command);
+        $this->assertStringNotContainsString('--confirm-write', $command);
+        $this->assertSame('*/15 * * * *', $event['expression']);
+    }
+
+    /**
+     * @return array<int,array<string,mixed>>
+     */
+    private function scheduleListEvents(): array
+    {
+        $process = new Process([PHP_BINARY, base_path('artisan'), 'schedule:list', '--json', '--no-ansi'], base_path());
+        $process->mustRun();
+
+        $decoded = json_decode($process->getOutput(), true);
+
+        $this->assertIsArray($decoded);
+
+        return $decoded;
+    }
+}

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -334,6 +334,24 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         $this->assertSame([], $this->mbtiImpactingRuntimeChanges($changed, '', ''));
     }
 
+    public function test_runtime_freeze_classifier_ignores_test_metrics_scheduler_changes(): void
+    {
+        $changed = [
+            'backend/bootstrap/app.php',
+            'backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php',
+        ];
+        $bootstrapChangedLines = [
+            "+        \$schedule->command('analytics:refresh-test-metrics-daily --scheduled-current-day')->everyFifteenMinutes()->withoutOverlapping(20);",
+        ];
+
+        $this->assertSame([], $this->mbtiImpactingRuntimeChanges(
+            changed: $changed,
+            repoRoot: '',
+            baseRef: '',
+            bootstrapAppChangedLines: $bootstrapChangedLines,
+        ));
+    }
+
     public function test_runtime_freeze_classifier_ignores_seo_conversion_daily_read_model_changes(): void
     {
         $changed = [
@@ -2885,6 +2903,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
         ?array $webRouteChangedLines = null,
         ?array $resolveOrgContextChangedLines = null,
         ?array $contentPacksIndexChangedLines = null,
+        ?array $bootstrapAppChangedLines = null,
     ): array {
         $impacting = [];
 
@@ -3649,9 +3668,23 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
                 $file === 'backend/bootstrap/app.php'
                 && $repoRoot !== ''
                 && $baseRef !== ''
-                && $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly(
-                    $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                && (
+                    $this->kernelDiffIsAlipayPendingCompensationSchedulerOnly(
+                        $bootstrapAppChangedLines ?? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                    )
+                    || $this->kernelDiffIsTestMetricsSchedulerOnly(
+                        $bootstrapAppChangedLines ?? $this->changedLinesForFile($repoRoot, $baseRef, $file)
+                    )
                 )
+            ) {
+                continue;
+            }
+
+            if (
+                $file === 'backend/bootstrap/app.php'
+                && $repoRoot === ''
+                && $baseRef === ''
+                && $this->kernelDiffIsTestMetricsSchedulerOnly($bootstrapAppChangedLines ?? [])
             ) {
                 continue;
             }
@@ -5603,6 +5636,28 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
             }
 
             if (preg_match('/commerce:compensate-pending-orders|--provider=alipay|--include-created|--only-stale|--limit=10|--older-than-minutes=60|everyTenMinutes|withoutOverlapping/u', $line) !== 1) {
+                return false;
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     * @param  list<string>  $changedLines
+     */
+    private function kernelDiffIsTestMetricsSchedulerOnly(array $changedLines): bool
+    {
+        if ($changedLines === []) {
+            return false;
+        }
+
+        foreach ($changedLines as $line) {
+            if (preg_match('/\b(MBTI|Mbti|BigFive|Big5|Prewarm|ResultPage|Report)\b/u', $line) === 1) {
+                return false;
+            }
+
+            if (preg_match('/analytics:refresh-test-metrics-daily|--scheduled-current-day|everyFifteenMinutes|withoutOverlapping\\(20\\)/u', $line) !== 1) {
                 return false;
             }
         }


### PR DESCRIPTION
## What changed
- Added `--scheduled-current-day` to `analytics:refresh-test-metrics-daily`.
- Registered `analytics:refresh-test-metrics-daily --scheduled-current-day` in the Laravel 11 scheduler every 15 minutes with `withoutOverlapping(20)`.
- Added focused command and scheduler bootstrap tests.
- Added an Ops runbook for the test KPI scheduler and production runner checks.
- Extended the Big Five runtime-freeze classifier for this narrow scheduler registration.

## Why
PR5 makes the current-day test KPI read model refresh automatically after deploy while keeping historical backfills under the existing controlled manual write flow.

## Validation
- `php -l backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php`
- `php -l backend/bootstrap/app.php`
- `php -l backend/tests/Feature/Analytics/TestMetricsSchedulerBootstrapTest.php`
- `php -l backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php`
- `php -l backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php`
- `php artisan test --filter=RefreshTestMetricsDailyCommandTest`
- `php artisan test --filter=TestMetricsSchedulerBootstrapTest`
- `php artisan test --filter=BigFiveResultPageV2CoreBodyPreviewTest`
- `php artisan schedule:list --json >/tmp/pr5-schedule-list.json`
- `php artisan route:list >/tmp/pr5-route-list.txt`
- `git diff --check -- backend/app/Console/Commands/RefreshTestMetricsDailyCommand.php backend/bootstrap/app.php backend/tests/Feature/Analytics/RefreshTestMetricsDailyCommandTest.php backend/tests/Feature/Analytics/TestMetricsSchedulerBootstrapTest.php backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php backend/docs/ops/test-kpi-scheduler.md`
- `bash backend/scripts/ci_verify_mbti.sh`

## Intentionally deferred
- PR6 frontend scale/form/locale guard.
- PR7 post-deploy read-only smoke.
- Production deployment and live scheduler-runner verification remain post-merge/deploy operations.

## Repository rule impact
This PR changes backend scheduler registration for an existing analytics read-model command and documents the server runner check. It does not add migrations, public routes, frontend fallback logic, CMS mutations, sitemap/llms changes, payment/order state changes, or queue worker definitions.