### PR TITLE
PERSONALITY-DETAIL-CONTENT-COVERAGE-01: test(personality): lock variant detail content coverage

### DIFF
--- a/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+++ b/backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
@@ -709,6 +709,77 @@ final class PersonalityPublicApiTest extends TestCase
             ->assertJsonPath('error_code', 'NOT_FOUND');
     }
 
+    public function test_committed_baseline_covers_all_public_variant_detail_pages(): void
+    {
+        $this->artisan('personality:import-local-baseline', [
+            '--status' => 'published',
+            '--upsert' => true,
+            '--source-dir' => base_path('../content_baselines/personality'),
+        ])
+            ->expectsOutputToContain('profiles_found=32')
+            ->expectsOutputToContain('variants_found=64')
+            ->expectsOutputToContain('variant_will_create=64')
+            ->assertExitCode(0);
+
+        $checkedRoutes = [];
+
+        foreach (['en', 'zh-CN'] as $locale) {
+            $directory = $this->getJson(sprintf(
+                '/api/v0.5/personality?locale=%s&include_variants=1&per_page=100',
+                rawurlencode($locale),
+            ));
+
+            $directory->assertOk()
+                ->assertJsonPath('pagination.total', 32)
+                ->assertJsonCount(32, 'items');
+
+            foreach ($directory->json('items') as $item) {
+                $routeSlug = (string) ($item['public_route_slug'] ?? $item['slug'] ?? '');
+                $runtimeTypeCode = (string) ($item['runtime_type_code'] ?? '');
+
+                $detail = $this->getJson(sprintf(
+                    '/api/v0.5/personality/%s?locale=%s',
+                    rawurlencode($routeSlug),
+                    rawurlencode($locale),
+                ));
+
+                $detail->assertOk()
+                    ->assertJsonPath('profile.type_code', (string) ($item['base_type_code'] ?? ''))
+                    ->assertJsonPath('mbti_public_projection_v1.runtime_type_code', $runtimeTypeCode);
+
+                $sections = $detail->json('sections');
+                self::assertIsArray($sections, $runtimeTypeCode.' sections should be an array.');
+                self::assertNotEmpty($sections, $runtimeTypeCode.' should not render the frontend empty-content fallback.');
+
+                $bodyText = collect($sections)
+                    ->map(static fn (array $section): string => trim(implode(' ', array_filter([
+                        (string) ($section['title'] ?? ''),
+                        (string) ($section['body_md'] ?? ''),
+                    ]))))
+                    ->filter(static fn (string $value): bool => $value !== '')
+                    ->implode("\n");
+
+                self::assertGreaterThan(
+                    200,
+                    mb_strlen($bodyText),
+                    $runtimeTypeCode.' should expose substantive public detail body text.',
+                );
+                self::assertStringNotContainsString('内容暂未同步', $bodyText);
+                self::assertStringNotContainsString('content is not yet synchronized', strtolower($bodyText));
+
+                $checkedRoutes[] = $locale.':'.$routeSlug;
+
+                if ($locale === 'zh-CN' && $runtimeTypeCode === 'ENTJ-T') {
+                    self::assertStringContainsString('带着自检系统的战略指挥官', $bodyText);
+                    self::assertStringContainsString('职业的天花板往往不在硬实力', $bodyText);
+                }
+            }
+        }
+
+        self::assertCount(64, $checkedRoutes);
+        self::assertContains('zh-CN:entj-t', $checkedRoutes);
+    }
+
     /**
      * @param  array<string, mixed>  $overrides
      */

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-11T18:32:00Z",
+  "updated_at": "2026-06-13T23:58:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54268,6 +54268,70 @@
         "at": "2026-06-11T13:00:17Z",
         "status": "pending_dependency",
         "note": "Initialized from explicit CAREER-FULL-PARITY train authorization; implementation deferred until dependencies merge."
+      }
+    ]
+  },
+  "PERSONALITY-DETAIL-CONTENT-COVERAGE-01": {
+    "repo": "fap-api",
+    "branch": "codex/personality-detail-content-coverage-01",
+    "base": "origin/main",
+    "status": "local_checks_passed",
+    "train_scope": "personality_seo",
+    "title": "PERSONALITY-DETAIL-CONTENT-COVERAGE-01: test(personality): lock variant detail content coverage",
+    "depends_on": [
+      "PERSONALITY-SEO-CURRENT-AUDIT-01"
+    ],
+    "checks": {
+      "authorization": {
+        "status": "pass",
+        "evidence": "User explicitly authorized updating fap-api docs/codex/pr-train.yaml and docs/codex/pr-train-state.json to add PERSONALITY-DETAIL-CONTENT-COVERAGE-01, then execute it."
+      },
+      "dependency": {
+        "status": "pass",
+        "evidence": "PERSONALITY-SEO-CURRENT-AUDIT-01 merged in fap-web PR #1133; origin/main contains merge commit 185df2cccfa6df158770ed4db12f17245308bd9c."
+      },
+      "implementation": {
+        "status": "pass",
+        "evidence": "Added a backend public API contract that imports committed MBTI personality baselines, asserts en and zh-CN variant directories each expose 32 A/T summaries, requests all 64 public detail routes, and verifies each route exposes substantive backend-authored sections. The contract explicitly locks zh-CN ENTJ-T body text from the committed baseline."
+      },
+      "local": {
+        "status": "pass",
+        "commands": [
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter committed_baseline_covers --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --no-ansi",
+          "cd backend && ./vendor/bin/pint --test tests/Feature/V0_5/PersonalityPublicApiTest.php",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/... php artisan migrate --force --no-ansi",
+          "cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter Personality --no-ansi",
+          "cd backend && bash scripts/ci_verify_mbti.sh",
+          "python3 -m json.tool docs/codex/pr-train-state.json >/dev/null",
+          "ruby -e \"require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'\"",
+          "git diff --check",
+          "scope validation"
+        ],
+        "evidence": "Focused committed-baseline coverage test passed with 526 assertions; full PersonalityPublicApiTest passed 12 tests / 700 assertions; Pint passed for the changed test file; route list showed the 4 personality routes; sqlite migrate passed; php artisan test --filter Personality passed 84 tests / 5462 assertions; bash scripts/ci_verify_mbti.sh exited 0 including personality full-32 authority gate OK; JSON/YAML/diff/scope checks passed."
+      },
+      "scope": {
+        "status": "pass",
+        "evidence": "Branch diff is confined to backend/tests/Feature/V0_5/PersonalityPublicApiTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. Untracked Article updater files and generated seo-ops directories were left unstaged and out of scope."
+      }
+    },
+    "failure_reason": null,
+    "commit_sha": null,
+    "pr_url": null,
+    "merged_at": null,
+    "remote_branch_deleted": false,
+    "local_cleanup_executed": false,
+    "transitions": [
+      {
+        "at": "2026-06-13T23:35:00+08:00",
+        "status": "in_progress",
+        "note": "Initialized from explicit fap-api manifest/state authorization and started the scoped backend content coverage contract."
+      },
+      {
+        "at": "2026-06-13T23:58:00+08:00",
+        "status": "local_checks_passed",
+        "note": "Implemented and validated backend personality detail coverage contract. Validation included focused and full PersonalityPublicApiTest, Personality filter, Pint, route list, sqlite migrate, ci_verify_mbti, JSON/YAML parse, git diff check, and scope validation."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-13T23:58:00+08:00",
+  "updated_at": "2026-06-14T00:05:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -54275,7 +54275,7 @@
     "repo": "fap-api",
     "branch": "codex/personality-detail-content-coverage-01",
     "base": "origin/main",
-    "status": "local_checks_passed",
+    "status": "pr_open_github_checks_pending",
     "train_scope": "personality_seo",
     "title": "PERSONALITY-DETAIL-CONTENT-COVERAGE-01: test(personality): lock variant detail content coverage",
     "depends_on": [
@@ -54314,11 +54314,16 @@
       "scope": {
         "status": "pass",
         "evidence": "Branch diff is confined to backend/tests/Feature/V0_5/PersonalityPublicApiTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. Untracked Article updater files and generated seo-ops directories were left unstaged and out of scope."
+      },
+      "github": {
+        "status": "pending",
+        "head_sha": "1b09124c67f238e4f70d0c942f07ffc7988e757d",
+        "evidence": "PR #2074 opened after local checks passed; waiting for GitHub checks."
       }
     },
     "failure_reason": null,
-    "commit_sha": null,
-    "pr_url": null,
+    "commit_sha": "1b09124c67f238e4f70d0c942f07ffc7988e757d",
+    "pr_url": "https://github.com/fermatmind/fap-api/pull/2074",
     "merged_at": null,
     "remote_branch_deleted": false,
     "local_cleanup_executed": false,
@@ -54332,6 +54337,11 @@
         "at": "2026-06-13T23:58:00+08:00",
         "status": "local_checks_passed",
         "note": "Implemented and validated backend personality detail coverage contract. Validation included focused and full PersonalityPublicApiTest, Personality filter, Pint, route list, sqlite migrate, ci_verify_mbti, JSON/YAML parse, git diff check, and scope validation."
+      },
+      {
+        "at": "2026-06-14T00:05:00+08:00",
+        "status": "pr_open_github_checks_pending",
+        "note": "Pushed commit 1b09124c and opened PR #2074; GitHub checks are pending."
       }
     ]
   }

--- a/docs/codex/pr-train-state.json
+++ b/docs/codex/pr-train-state.json
@@ -1,6 +1,6 @@
 {
   "train_id": "email-first-result-access",
-  "updated_at": "2026-06-14T00:05:00+08:00",
+  "updated_at": "2026-06-14T00:12:00+08:00",
   "FREEMIUM-LOCALE-POLICY-SCAN-01": {
     "repo": "fap-api",
     "branch": "codex/freemium-locale-policy-scan-01",
@@ -48100,7 +48100,7 @@
     "repo": "fap-api",
     "branch": "codex/daily-giving-redacted-public-proof-01",
     "base": "main",
-    "status": "pr_open_github_checks_pending",
+    "status": "ready_to_merge",
     "train_scope": "window_7_public_benefit_trust_gate",
     "title": "docs(benefit): gate DailyGiving redacted public proof",
     "depends_on": [
@@ -54316,13 +54316,24 @@
         "evidence": "Branch diff is confined to backend/tests/Feature/V0_5/PersonalityPublicApiTest.php, docs/codex/pr-train.yaml, and docs/codex/pr-train-state.json. Untracked Article updater files and generated seo-ops directories were left unstaged and out of scope."
       },
       "github": {
-        "status": "pending",
-        "head_sha": "1b09124c67f238e4f70d0c942f07ffc7988e757d",
-        "evidence": "PR #2074 opened after local checks passed; waiting for GitHub checks."
+        "status": "pass",
+        "head_sha": "95bd7dc4e8bb2c93a04691e264336b0f85c839a0",
+        "checks": [
+          "hygiene",
+          "supply-chain",
+          "content-pack-build-validate",
+          "verify-mbti-legacy",
+          "verify-mbti-v2",
+          "verify-bigfive",
+          "Semgrep blocking secrets",
+          "semgrep sarif non-blocking upload",
+          "Semgrep OSS"
+        ],
+        "evidence": "PR #2074 GitHub checks passed at head 95bd7dc4 and mergeStateStatus was CLEAN."
       }
     },
     "failure_reason": null,
-    "commit_sha": "1b09124c67f238e4f70d0c942f07ffc7988e757d",
+    "commit_sha": "95bd7dc4e8bb2c93a04691e264336b0f85c839a0",
     "pr_url": "https://github.com/fermatmind/fap-api/pull/2074",
     "merged_at": null,
     "remote_branch_deleted": false,
@@ -54342,6 +54353,11 @@
         "at": "2026-06-14T00:05:00+08:00",
         "status": "pr_open_github_checks_pending",
         "note": "Pushed commit 1b09124c and opened PR #2074; GitHub checks are pending."
+      },
+      {
+        "at": "2026-06-14T00:12:00+08:00",
+        "status": "ready_to_merge",
+        "note": "GitHub checks passed for PR #2074 at head 95bd7dc4 and mergeStateStatus was CLEAN; recording ready_to_merge before merge."
       }
     ]
   }

--- a/docs/codex/pr-train.yaml
+++ b/docs/codex/pr-train.yaml
@@ -24819,3 +24819,40 @@ prs:
     publish_allowed: false
     deploy_allowed: false
     content_authority: backend
+
+  - id: PERSONALITY-DETAIL-CONTENT-COVERAGE-01
+    repo: fap-api
+    depends_on:
+      - PERSONALITY-SEO-CURRENT-AUDIT-01
+    branch: codex/personality-detail-content-coverage-01
+    title: "PERSONALITY-DETAIL-CONTENT-COVERAGE-01: test(personality): lock variant detail content coverage"
+    train_scope: personality_seo
+    status: user_authorized
+    scope:
+      - Add backend coverage for committed MBTI personality baseline import into public variant detail pages.
+      - Prove /zh/personality/entj-t has substantive backend-authored body content after baseline import.
+      - Prove all 64 en/zh A/T public detail routes expose non-empty sections so frontend does not need an empty-content fallback.
+    allowed_paths:
+      - backend/tests/Feature/V0_5/PersonalityPublicApiTest.php
+      - docs/codex/pr-train.yaml
+      - docs/codex/pr-train-state.json
+    do_not:
+      - Modify fap-web.
+      - Add FAQ, A/T difference sections, title metadata, comparison pages, sitemap changes, or llms changes.
+      - Move personality editorial authority into frontend code or local frontend fallback content.
+      - Mutate production CMS data or publish state.
+    validation:
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter committed_baseline_covers --no-ansi
+      - cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --no-ansi
+      - cd backend && ./vendor/bin/pint --test tests/Feature/V0_5/PersonalityPublicApiTest.php
+      - python3 -m json.tool docs/codex/pr-train-state.json >/dev/null
+      - ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"
+      - git diff --check
+    merge_policy: { github_checks_required: true, squash: true, auto_merge: true }
+    production_write_execution: false
+    database_mutation: false
+    cms_mutation: false
+    api_runtime_change: false
+    publish_allowed: false
+    deploy_allowed: false
+    content_authority: backend


### PR DESCRIPTION
## What changed
- Added `PERSONALITY-DETAIL-CONTENT-COVERAGE-01` to the fap-api PR train manifest and state ledger.
- Added a backend public API coverage contract that imports the committed MBTI personality baseline, validates both en and zh-CN variant directories return 32 A/T entries, and requests all 64 public A/T detail routes.
- Locked `/zh/personality/entj-t` coverage by asserting real committed Chinese ENTJ-T body text is present after baseline import.

## Why
The fap-web SEO audit identified zh ENTJ-T as a hard content coverage risk. This backend PR keeps personality content authority in fap-api and prevents future regressions where A/T detail pages can reach the frontend with no substantive backend sections.

## Validation
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --filter committed_baseline_covers --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test tests/Feature/V0_5/PersonalityPublicApiTest.php --no-ansi`
- `cd backend && ./vendor/bin/pint --test tests/Feature/V0_5/PersonalityPublicApiTest.php`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan route:list --path=api/v0.5/personality --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=/tmp/... php artisan migrate --force --no-ansi`
- `cd backend && APP_ENV=testing DB_CONNECTION=sqlite DB_DATABASE=':memory:' php artisan test --filter Personality --no-ansi`
- `cd backend && bash scripts/ci_verify_mbti.sh`
- `python3 -m json.tool docs/codex/pr-train-state.json >/dev/null`
- `ruby -e "require 'yaml'; YAML.load_file('docs/codex/pr-train.yaml'); puts 'yaml ok'"`
- `git diff --check`
- scope validation: branch diff limited to the declared 3 files

## Intentionally deferred
- No fap-web changes.
- No FAQ, FAQPage JSON-LD, A/T difference sections, SEO title/metadata rewrite, comparison pages, sitemap, or llms changes.
- No production CMS mutation, import execution, publish action, or deploy.

## Repository Rule Impact
- Content authority remains backend/CMS/public API authoritative.
- This PR adds backend contract coverage only; it does not move personality editorial content into frontend code or add frontend fallback content.
