### PR TITLE
fix(ops): show sitewide test KPI metrics

### DIFF
--- a/backend/app/Filament/Ops/Pages/OpsDashboard.php
+++ b/backend/app/Filament/Ops/Pages/OpsDashboard.php
@@ -74,6 +74,9 @@ class OpsDashboard extends Dashboard
             Action::make('failedJobs')
                 ->label(__('ops.dashboard.actions.failed_jobs'))
                 ->url('/ops/queue-monitor'),
+            Action::make('testKpiDaily')
+                ->label(__('ops.dashboard.actions.test_kpi_daily'))
+                ->url('/ops/test-kpi-daily?scope=global_org0'),
             Action::make('contentProbe')
                 ->label(__('ops.dashboard.actions.content_probe'))
                 ->url('/ops/content-pack-releases'),

--- a/backend/app/Filament/Ops/Pages/TestKpiDailyPage.php
+++ b/backend/app/Filament/Ops/Pages/TestKpiDailyPage.php
@@ -35,7 +35,7 @@ final class TestKpiDailyPage extends Page
 
     public string $toDate = '';
 
-    public string $scope = self::SCOPE_CURRENT_ORG;
+    public string $scope = self::SCOPE_GLOBAL_ORG0;
 
     public string $scaleCode = 'all';
 
@@ -67,7 +67,7 @@ final class TestKpiDailyPage extends Page
     {
         $this->fromDate = now()->subDays(13)->toDateString();
         $this->toDate = now()->toDateString();
-        $this->scope = $this->normalizeScope(request()->query('scope'));
+        $this->scope = $this->normalizeScope(request()->query('scope', self::SCOPE_GLOBAL_ORG0));
         $this->refreshPage();
     }
 
@@ -274,8 +274,8 @@ final class TestKpiDailyPage extends Page
         $normalized = strtolower(trim((string) $scope));
 
         return match ($normalized) {
-            'global', 'global_org0', 'org0' => self::SCOPE_GLOBAL_ORG0,
-            default => self::SCOPE_CURRENT_ORG,
+            'current', 'current_org' => self::SCOPE_CURRENT_ORG,
+            default => self::SCOPE_GLOBAL_ORG0,
         };
     }
 

--- a/backend/app/Filament/Ops/Widgets/TestKpiSummaryWidget.php
+++ b/backend/app/Filament/Ops/Widgets/TestKpiSummaryWidget.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace App\Filament\Ops\Widgets;
 
 use App\Filament\Ops\Support\OpsMetricsAccess;
-use App\Support\OrgContext;
 use App\Support\SchemaBaseline;
 use Filament\Widgets\StatsOverviewWidget as BaseWidget;
 use Filament\Widgets\StatsOverviewWidget\Stat;
@@ -15,9 +14,9 @@ final class TestKpiSummaryWidget extends BaseWidget
 {
     protected static bool $isLazy = false;
 
-    private const NO_ORG_PLACEHOLDER = '-';
+    private const GLOBAL_ORG_ID = 0;
 
-    private const EMPTY_READ_MODEL_MESSAGE = 'No analytics_test_metrics_daily rows match the current org. Run analytics:refresh-test-metrics-daily in a controlled task.';
+    private const EMPTY_READ_MODEL_MESSAGE = 'No analytics_test_metrics_daily rows match global org_id=0. Run analytics:refresh-test-metrics-daily in a controlled task.';
 
     public static function canView(): bool
     {
@@ -35,20 +34,9 @@ final class TestKpiSummaryWidget extends BaseWidget
             return [$this->emptyReadModelStat('analytics_test_metrics_daily table is missing. Run php artisan migrate first.')];
         }
 
-        $orgContext = app(OrgContext::class);
-        $orgId = max(0, (int) $orgContext->orgId());
-        if ($orgId <= 0 && $orgContext->isTenantContext()) {
-            return [
-                $this->noOrgStat(__('ops.widgets.test_success_today'), __('ops.widgets.select_org_to_view_metrics')),
-                $this->noOrgStat(__('ops.widgets.test_failures_today'), __('ops.widgets.select_org_to_view_metrics')),
-                $this->noOrgStat(__('ops.widgets.site_success_cumulative'), __('ops.widgets.select_org_to_view_metrics')),
-                $this->noOrgStat(__('ops.widgets.site_failures_cumulative'), __('ops.widgets.select_org_to_view_metrics')),
-            ];
-        }
-
         $today = now()->toDateString();
         $query = DB::table('analytics_test_metrics_daily')
-            ->where('org_id', $orgId);
+            ->where('org_id', self::GLOBAL_ORG_ID);
 
         $row = $query
             ->selectRaw('COUNT(*) as row_count')
@@ -81,13 +69,6 @@ final class TestKpiSummaryWidget extends BaseWidget
                 ->description('analytics_test_metrics_daily.failed_attempts all days')
                 ->color($cumulativeFailures > 0 ? 'warning' : 'success'),
         ];
-    }
-
-    private function noOrgStat(string $label, string $description): Stat
-    {
-        return Stat::make($label, self::NO_ORG_PLACEHOLDER)
-            ->description($description)
-            ->color('gray');
     }
 
     private function emptyReadModelStat(string $description): Stat

--- a/backend/lang/en/ops.php
+++ b/backend/lang/en/ops.php
@@ -100,6 +100,7 @@ return [
             'order_lookup' => 'Order Lookup',
             'webhook_failures' => 'Webhook Failures',
             'failed_jobs' => 'Failed Jobs',
+            'test_kpi_daily' => 'Test KPI Daily',
             'content_probe' => 'Content Probe',
             'switch_org' => 'Create/Switch Org',
         ],
@@ -188,9 +189,9 @@ return [
             ],
             'sections' => [
                 'kpis' => 'Selected Range Summary',
-                'kpis_desc' => 'Read-model totals for the current date, scale, form, locale, and org scope.',
+                'kpis_desc' => 'Read-model totals for the current date, scale, form, locale, and scope. The default scope is sitewide org_id=0.',
                 'detail' => 'Daily By-Test Detail',
-                'detail_desc' => 'One row per day, scale, scale v2, form, and locale. The table is capped at 500 rows for Ops readability.',
+                'detail_desc' => 'Daily per-test volume by day, scale, scale v2, form, and locale. The table is capped at 500 rows for Ops readability.',
                 'no_rows' => 'No daily test rows for the current scope.',
             ],
             'table' => [

--- a/backend/lang/zh_CN/ops.php
+++ b/backend/lang/zh_CN/ops.php
@@ -100,6 +100,7 @@ return [
             'order_lookup' => '订单查询',
             'webhook_failures' => 'Webhook 失败',
             'failed_jobs' => '失败任务',
+            'test_kpi_daily' => '每日测试量',
             'content_probe' => '内容探针',
             'switch_org' => '创建/切换组织',
         ],
@@ -188,9 +189,9 @@ return [
             ],
             'sections' => [
                 'kpis' => '所选范围汇总',
-                'kpis_desc' => '当前日期、量表、表单、语言和组织范围内的读模型汇总。',
+                'kpis_desc' => '当前日期、量表、表单、语言和范围内的读模型汇总，默认展示全站 org_id=0。',
                 'detail' => '每日测试明细',
-                'detail_desc' => '按日期、量表、v2 量表、表单和语言展示。为保证后台可读性，表格最多展示 500 行。',
+                'detail_desc' => '按日期、量表、v2 量表、表单和语言展示每个测试的单日次数。为保证后台可读性，表格最多展示 500 行。',
                 'no_rows' => '当前范围暂无每日测试行。',
             ],
             'table' => [

--- a/backend/tests/Feature/Ops/TestKpiDailyPageTest.php
+++ b/backend/tests/Feature/Ops/TestKpiDailyPageTest.php
@@ -38,8 +38,9 @@ final class TestKpiDailyPageTest extends TestCase
             $admin = $this->createAdminWithPermissions([PermissionNames::ADMIN_OPS_READ]);
             $selectedOrg = $this->createOrganization('Test KPI Daily Org');
 
-            $this->insertDailyMetric('2026-06-20', (int) $selectedOrg->id, 'MBTI', 'MBTI_PERSONALITY_TEST_16_TYPES', '144Q', 'zh-CN', 7, 2, 9, 10);
-            $this->insertDailyMetric('2026-06-20', (int) $selectedOrg->id, 'BIG5_OCEAN', 'BIG_FIVE_OCEAN_MODEL', 'big5-120', 'en', 11, 1, 12, 14);
+            $this->insertDailyMetric('2026-06-20', 0, 'MBTI', 'MBTI_PERSONALITY_TEST_16_TYPES', '144Q', 'zh-CN', 7, 2, 9, 10);
+            $this->insertDailyMetric('2026-06-20', 0, 'BIG5_OCEAN', 'BIG_FIVE_OCEAN_MODEL', 'big5-120', 'en', 11, 1, 12, 14);
+            $this->insertDailyMetric('2026-06-20', (int) $selectedOrg->id, 'RIASEC', 'RIASEC_HOLLAND_CAREER_INTERESTS', 'riasec-60', 'zh-CN', 100, 100, 200, 210);
 
             $this->withSession($this->opsSession($admin, $selectedOrg))
                 ->actingAs($admin, (string) config('admin.guard', 'admin'))
@@ -52,7 +53,8 @@ final class TestKpiDailyPageTest extends TestCase
                 ->assertSee('BIG5_OCEAN')
                 ->assertSee('big5-120')
                 ->assertSee('91.7%')
-                ->assertSee('21');
+                ->assertSee('21')
+                ->assertDontSee('RIASEC_HOLLAND_CAREER_INTERESTS');
         } finally {
             Carbon::setTestNow();
         }

--- a/backend/tests/Feature/Ops/TestKpiSummaryWidgetTest.php
+++ b/backend/tests/Feature/Ops/TestKpiSummaryWidgetTest.php
@@ -17,17 +17,17 @@ final class TestKpiSummaryWidgetTest extends TestCase
 {
     use RefreshDatabase;
 
-    public function test_widget_reads_today_and_cumulative_success_failure_from_test_metrics_read_model(): void
+    public function test_widget_reads_sitewide_org_zero_success_failure_regardless_of_selected_org(): void
     {
         Carbon::setTestNow('2026-06-20 10:00:00');
 
         try {
             $this->setOpsOrg(21);
 
-            $this->insertDailyMetric('2026-06-19', 21, 'MBTI', 'zh-CN', 5, 3, 8);
-            $this->insertDailyMetric('2026-06-20', 21, 'MBTI', 'zh-CN', 7, 2, 9);
-            $this->insertDailyMetric('2026-06-20', 21, 'BIG5_OCEAN', 'en', 11, 1, 12);
-            $this->insertDailyMetric('2026-06-20', 99, 'MBTI', 'zh-CN', 100, 100, 200);
+            $this->insertDailyMetric('2026-06-19', 0, 'MBTI', 'zh-CN', 5, 3, 8);
+            $this->insertDailyMetric('2026-06-20', 0, 'MBTI', 'zh-CN', 7, 2, 9);
+            $this->insertDailyMetric('2026-06-20', 0, 'BIG5_OCEAN', 'en', 11, 1, 12);
+            $this->insertDailyMetric('2026-06-20', 21, 'MBTI', 'zh-CN', 100, 100, 200);
 
             $valuesByLabel = [];
             foreach ($this->widgetStats() as $stat) {
@@ -76,7 +76,7 @@ final class TestKpiSummaryWidgetTest extends TestCase
             $this->assertSame(__('ops.widgets.test_kpi'), (string) $stats[0]->getLabel());
             $this->assertSame(__('ops.widgets.no_data'), (string) $stats[0]->getValue());
             $this->assertSame(
-                'No analytics_test_metrics_daily rows match the current org. Run analytics:refresh-test-metrics-daily in a controlled task.',
+                'No analytics_test_metrics_daily rows match global org_id=0. Run analytics:refresh-test-metrics-daily in a controlled task.',
                 (string) $stats[0]->getDescription()
             );
         } finally {


### PR DESCRIPTION
## What changed
- Make the Ops dashboard Test KPI summary widget read sitewide `analytics_test_metrics_daily` rows from `org_id=0` regardless of the selected Ops organization.
- Keep the dashboard labels as today success, today failure, site cumulative success, and site cumulative failure.
- Add a dashboard action to the existing daily per-test KPI page and default that page to global `org_id=0`, so daily per-test counts are visible without changing org context.
- Update Ops translations and feature tests for the global-summary behavior.

## Why
Production test KPI refresh writes the read model under `org_id=0`, while the Ops dashboard can be scoped to an org such as Organization 2. The homepage summary should show whole-site testing volume and not disappear when an operator selects an organization.

## Validation
- `php artisan test --filter='TestKpiSummaryWidgetTest|TestKpiDailyPageTest|OpsLocalePurityTest' --no-ansi`
- `git diff --check`
- `git diff --name-only origin/main..HEAD`

Note: `php artisan route:list --path=ops/test-kpi-daily --no-ansi` does not expose the Filament page as a plain path-filtered route in this app; the Feature test covers the actual `/ops/test-kpi-daily` GET path.

## Intentionally deferred
- No data backfill or analytics refresh command was run.
- No production deploy.
- No CMS mutation or database mutation.
- No scheduler/supervisor change.

## Repository rule impact
Ops-only backend UI/read-model display change. No content-authority, SEO route, sitemap, or public frontend ownership changes.