### PR TITLE
fix(cms): harden RIASEC existing article sidecars

### DIFF
--- a/backend/app/Console/Commands/ArticleCoverPropagationSmoke.php
+++ b/backend/app/Console/Commands/ArticleCoverPropagationSmoke.php
@@ -75,7 +75,10 @@ final class ArticleCoverPropagationSmoke extends Command
 
         $query = Article::query()
             ->withoutGlobalScopes()
-            ->with(['publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes()])
+            ->with([
+                'publishedRevision' => static fn ($relation) => $relation->withoutGlobalScopes(),
+                'seoMeta',
+            ])
             ->where('org_id', $this->orgId())
             ->where(static function ($targetQuery) use ($ids, $slugs): void {
                 if ($ids !== []) {
@@ -105,6 +108,7 @@ final class ArticleCoverPropagationSmoke extends Command
     {
         $errors = [];
         $expectedCover = PublicMediaUrlGuard::sanitizeNullableUrl($article->cover_image_url);
+        $expectedSocialImage = $this->expectedSocialImageUrl($article, $expectedCover);
 
         if (! $article->published_revision_id || (string) $article->status !== 'published' || ! (bool) $article->is_public) {
             $errors[] = $this->issue('article', 'article_not_publicly_readable', 'Article is not published and public.');
@@ -144,9 +148,15 @@ final class ArticleCoverPropagationSmoke extends Command
             $this->orgId()
         ));
         $this->assertSuccessfulPayload($seo, 'seo', $errors);
-        $this->assertSameCover(data_get($seo, 'json.meta.og.image'), $expectedCover, 'seo.meta.og.image', $errors);
-        $this->assertSameCover(data_get($seo, 'json.meta.twitter.image'), $expectedCover, 'seo.meta.twitter.image', $errors);
-        $this->assertJsonLdImage(data_get($seo, 'json.jsonld.image'), $expectedCover, $errors);
+        $this->assertSameImageUrl(data_get($seo, 'json.meta.og.image'), $expectedSocialImage, 'seo.meta.og.image', 'social_image_mismatch', $errors);
+        $this->assertSameImageUrl(data_get($seo, 'json.meta.twitter.image'), $expectedSocialImage, 'seo.meta.twitter.image', 'social_image_mismatch', $errors);
+        $jsonLdImageStatus = $this->articleSchemaHeld($article)
+            ? 'schema_hold_skipped'
+            : $this->assertJsonLdImage(
+                data_get($seo, 'json.jsonld.image'),
+                array_values(array_filter([$expectedCover, $expectedSocialImage])),
+                $errors
+            );
 
         $listResult = $this->findArticleInList($kernel, $article);
         if (! (bool) ($listResult['found'] ?? false)) {
@@ -160,6 +170,8 @@ final class ArticleCoverPropagationSmoke extends Command
             'slug' => (string) $article->slug,
             'locale' => (string) $article->locale,
             'cover_image_url' => $expectedCover,
+            'social_image_url' => $expectedSocialImage,
+            'jsonld_image_status' => $jsonLdImageStatus,
             'list_found' => (bool) ($listResult['found'] ?? false),
             'list_page' => $listResult['page'] ?? null,
             'ok' => $errors === [],
@@ -260,23 +272,37 @@ final class ArticleCoverPropagationSmoke extends Command
      */
     private function assertSameCover(mixed $actual, ?string $expectedCover, string $field, array &$errors): void
     {
-        if ($expectedCover === null || trim((string) $actual) !== $expectedCover) {
+        $this->assertSameImageUrl($actual, $expectedCover, $field, 'cover_url_mismatch', $errors);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function assertSameImageUrl(mixed $actual, ?string $expectedUrl, string $field, string $code, array &$errors): void
+    {
+        if ($expectedUrl === null || trim((string) $actual) !== $expectedUrl) {
             $errors[] = $this->issue($field, 'cover_url_mismatch', 'Cover URL did not propagate to expected public payload.', [
-                'expected' => $expectedCover,
+                'code' => $code,
+                'expected' => $expectedUrl,
                 'actual' => is_scalar($actual) ? (string) $actual : gettype($actual),
             ]);
         }
     }
 
     /**
+     * @param  list<string>  $acceptedImageUrls
      * @param  list<array<string,mixed>>  $errors
      */
-    private function assertJsonLdImage(mixed $image, ?string $expectedCover, array &$errors): void
+    private function assertJsonLdImage(mixed $image, array $acceptedImageUrls, array &$errors): string
     {
-        if ($expectedCover === null) {
+        if ($image === null || $image === [] || $image === '') {
+            return 'not_emitted_schema_hold';
+        }
+
+        if ($acceptedImageUrls === []) {
             $errors[] = $this->issue('seo.jsonld.image', 'jsonld_cover_missing', 'JSON-LD image cannot be verified without a public-safe cover URL.');
 
-            return;
+            return 'unverifiable';
         }
 
         $images = is_array($image) ? array_values($image) : [$image];
@@ -285,9 +311,15 @@ final class ArticleCoverPropagationSmoke extends Command
             $images
         )));
 
-        if (! in_array($expectedCover, $normalized, true)) {
-            $errors[] = $this->issue('seo.jsonld.image', 'jsonld_cover_mismatch', 'JSON-LD image does not include the article cover URL.');
+        foreach ($acceptedImageUrls as $acceptedImageUrl) {
+            if (in_array($acceptedImageUrl, $normalized, true)) {
+                return 'matched';
+            }
         }
+
+        $errors[] = $this->issue('seo.jsonld.image', 'jsonld_cover_mismatch', 'JSON-LD image does not include an accepted public article image URL.');
+
+        return 'mismatch';
     }
 
     /**
@@ -313,6 +345,35 @@ final class ArticleCoverPropagationSmoke extends Command
                 $errors[] = $this->issue($field.'.'.$variantKey.'.dimensions', 'cover_variant_dimensions_missing', 'Variant dimensions are missing.');
             }
         }
+    }
+
+    private function expectedSocialImageUrl(Article $article, ?string $expectedCover): ?string
+    {
+        $seoImage = PublicMediaUrlGuard::sanitizeNullableUrl($article->seoMeta?->og_image_url ?? null);
+        if ($seoImage !== null) {
+            return $seoImage;
+        }
+
+        $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
+        $ogVariant = $variants['og'] ?? null;
+        if (is_array($ogVariant)) {
+            $variantUrl = PublicMediaUrlGuard::sanitizeNullableUrl($ogVariant['url'] ?? null);
+            if ($variantUrl !== null) {
+                return $variantUrl;
+            }
+        }
+
+        return $expectedCover;
+    }
+
+    private function articleSchemaHeld(Article $article): bool
+    {
+        $schemaJson = $article->relationLoaded('seoMeta') ? $article->seoMeta?->schema_json : null;
+        if (! is_array($schemaJson)) {
+            return false;
+        }
+
+        return data_get($schemaJson, 'editorial_package_v1.article_schema_enabled') === false;
     }
 
     private function orgId(): int

--- a/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
+++ b/backend/app/Http/Controllers/API/V0_5/Cms/ArticleController.php
@@ -554,15 +554,15 @@ class ArticleController extends Controller
     private function editorialPackageMetadata(Article $article): array
     {
         $seoMeta = $article->relationLoaded('seoMeta') ? $article->seoMeta : null;
-        if (is_array($seoMeta?->schema_json) && is_array($seoMeta->schema_json['editorial_package_v1'] ?? null)) {
-            return $seoMeta->schema_json['editorial_package_v1'];
-        }
-
         $variants = is_array($article->cover_image_variants) ? $article->cover_image_variants : [];
-
-        return is_array($variants['editorial_package_v1'] ?? null)
+        $variantMetadata = is_array($variants['editorial_package_v1'] ?? null)
             ? $variants['editorial_package_v1']
             : [];
+        $schemaMetadata = is_array($seoMeta?->schema_json) && is_array($seoMeta->schema_json['editorial_package_v1'] ?? null)
+            ? $seoMeta->schema_json['editorial_package_v1']
+            : [];
+
+        return array_replace_recursive($variantMetadata, $schemaMetadata);
     }
 
     /**
@@ -1063,6 +1063,7 @@ class ArticleController extends Controller
             'cover_image_width' => $article->cover_image_width !== null ? (int) $article->cover_image_width : null,
             'cover_image_height' => $article->cover_image_height !== null ? (int) $article->cover_image_height : null,
             'cover_image_variants' => $this->publicCoverImageVariants($article),
+            'body_visual' => $this->publicBodyVisualPayload($article),
             'related_test_slug' => $article->related_test_slug,
             'related_test_slugs' => $this->publicRelatedTestSlugs($article),
             'test_edges' => $this->publicTestEdges($article),
@@ -1127,6 +1128,23 @@ class ArticleController extends Controller
         unset($variants['editorial_package_v1']);
 
         return $variants;
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function publicBodyVisualPayload(Article $article): ?array
+    {
+        $metadata = $this->editorialPackageMetadata($article);
+        $imageUrl = PublicMediaUrlGuard::sanitizeNullableUrl($metadata['body_visual_image_url'] ?? null);
+        if ($imageUrl === null) {
+            return null;
+        }
+
+        return [
+            'image_url' => $imageUrl,
+            'fallback_authorized' => (bool) ($metadata['body_visual_fallback_authorized'] ?? false),
+        ];
     }
 
     /**

--- a/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php
+++ b/backend/app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php
@@ -74,6 +74,8 @@ final class SeoContentPackageExistingArticleUpdater
                 ->firstOrFail();
 
             $this->assertArticleIdentity($locked, $item);
+            $createdIsolatedWorkingRevision = $this->usesPublishedRevisionAsWorkingRevision($locked);
+            $locked = $this->ensureIsolatedWorkingRevision($locked);
 
             $revision = $this->revisionWorkspace->saveWorkingRevision($locked, [
                 'title' => (string) $item['title'],
@@ -96,6 +98,7 @@ final class SeoContentPackageExistingArticleUpdater
                 'article_id' => (int) $locked->id,
                 'working_revision_id' => (int) $revision->id,
                 'published_revision_id' => $locked->published_revision_id !== null ? (int) $locked->published_revision_id : null,
+                'created_isolated_working_revision' => $createdIsolatedWorkingRevision,
                 'status' => (string) $locked->status,
                 'is_public' => (bool) $locked->is_public,
                 'is_indexable' => (bool) $locked->is_indexable,
@@ -759,6 +762,8 @@ final class SeoContentPackageExistingArticleUpdater
             'article_id' => (int) $article->id,
             'working_revision_id' => $article->working_revision_id !== null ? (int) $article->working_revision_id : null,
             'published_revision_id' => $article->published_revision_id !== null ? (int) $article->published_revision_id : null,
+            'working_revision_is_published_revision' => $this->usesPublishedRevisionAsWorkingRevision($article),
+            'will_create_isolated_working_revision' => $this->usesPublishedRevisionAsWorkingRevision($article),
             'status' => (string) $article->status,
             'is_public' => (bool) $article->is_public,
             'is_indexable' => (bool) $article->is_indexable,
@@ -768,6 +773,61 @@ final class SeoContentPackageExistingArticleUpdater
             'body_hash' => $bodyHash,
             'preview_url_candidate' => '/ops/article-preview/'.(int) $article->id,
         ];
+    }
+
+    private function usesPublishedRevisionAsWorkingRevision(Article $article): bool
+    {
+        return $article->working_revision_id !== null
+            && $article->published_revision_id !== null
+            && (int) $article->working_revision_id === (int) $article->published_revision_id;
+    }
+
+    private function ensureIsolatedWorkingRevision(Article $article): Article
+    {
+        if (! $this->usesPublishedRevisionAsWorkingRevision($article)) {
+            return $article;
+        }
+
+        $published = $article->publishedRevision instanceof ArticleTranslationRevision
+            ? $article->publishedRevision
+            : ArticleTranslationRevision::query()
+                ->withoutGlobalScopes()
+                ->whereKey((int) $article->published_revision_id)
+                ->first();
+
+        if (! $published instanceof ArticleTranslationRevision) {
+            throw new RuntimeException('Cannot isolate working revision because the published revision was not found.');
+        }
+
+        $nextRevisionNumber = ((int) ArticleTranslationRevision::query()
+            ->withoutGlobalScopes()
+            ->where('article_id', (int) $article->id)
+            ->max('revision_number')) + 1;
+
+        $working = ArticleTranslationRevision::query()->withoutGlobalScopes()->create([
+            'org_id' => (int) $published->org_id,
+            'article_id' => (int) $article->id,
+            'source_article_id' => $published->source_article_id !== null ? (int) $published->source_article_id : (int) $article->id,
+            'translation_group_id' => (string) $published->translation_group_id,
+            'locale' => (string) $published->locale,
+            'source_locale' => $published->source_locale,
+            'revision_number' => $nextRevisionNumber,
+            'revision_status' => ArticleTranslationRevision::STATUS_HUMAN_REVIEW,
+            'source_version_hash' => (string) $published->source_version_hash,
+            'translated_from_version_hash' => (string) $published->translated_from_version_hash,
+            'title' => (string) $published->title,
+            'excerpt' => $published->excerpt,
+            'content_md' => (string) $published->content_md,
+            'seo_title' => $published->seo_title,
+            'seo_description' => $published->seo_description,
+            'supersedes_revision_id' => (int) $published->id,
+        ]);
+
+        $article->forceFill(['working_revision_id' => (int) $working->id])->saveQuietly();
+        $article->setRelation('workingRevision', $working);
+        $article->setRelation('publishedRevision', $published);
+
+        return $article;
     }
 
     /**

--- a/backend/tests/Feature/Console/ArticleCoverPropagationSmokeCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleCoverPropagationSmokeCommandTest.php
@@ -35,6 +35,40 @@ final class ArticleCoverPropagationSmokeCommandTest extends TestCase
         $this->assertTrue((bool) ($payload['ok'] ?? false));
         $this->assertSame($article->id, data_get($payload, 'articles.0.article_id'));
         $this->assertTrue((bool) data_get($payload, 'articles.0.list_found'));
+        $this->assertSame('matched', data_get($payload, 'articles.0.jsonld_image_status'));
+        $this->assertSame([], data_get($payload, 'articles.0.errors'));
+    }
+
+    public function test_command_accepts_dedicated_social_image_and_schema_hold(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+
+        $article = $this->createArticleWithCover();
+        $socialImage = 'https://api.fermatmind.com/storage/media-library/variants/big-five-cover/og_1200x630.jpg';
+        $article->seoMeta?->forceFill([
+            'og_image_url' => $socialImage,
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                    ],
+                ],
+            ],
+        ])->save();
+
+        $exitCode = Artisan::call('articles:cover-smoke', [
+            '--article' => [(string) $article->id],
+            '--json' => true,
+        ]);
+
+        $payload = json_decode(Artisan::output(), true);
+
+        $this->assertSame(0, $exitCode);
+        $this->assertIsArray($payload);
+        $this->assertTrue((bool) ($payload['ok'] ?? false));
+        $this->assertSame($socialImage, data_get($payload, 'articles.0.social_image_url'));
+        $this->assertSame('schema_hold_skipped', data_get($payload, 'articles.0.jsonld_image_status'));
         $this->assertSame([], data_get($payload, 'articles.0.errors'));
     }
 

--- a/backend/tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php
@@ -49,6 +49,8 @@ final class ArticleUpdateExistingSeoContentPackageCommandTest extends TestCase
         $this->assertSame(self::ARTICLE_ID, $payload['articles'][0]['article_id']);
         $this->assertSame((int) $article->working_revision_id, (int) $payload['articles'][0]['working_revision_id']);
         $this->assertSame((int) $article->published_revision_id, (int) $payload['articles'][0]['published_revision_id']);
+        $this->assertTrue((bool) $payload['articles'][0]['working_revision_is_published_revision']);
+        $this->assertTrue((bool) $payload['articles'][0]['will_create_isolated_working_revision']);
 
         $article->refresh();
         $this->assertSame('Published RIASEC article', (string) $article->workingRevision?->title);
@@ -71,6 +73,7 @@ final class ArticleUpdateExistingSeoContentPackageCommandTest extends TestCase
         $this->assertTrue($payload['ok']);
         $this->assertFalse($payload['dry_run']);
         $this->assertSame('updated_existing_working_revision', $payload['action']);
+        $this->assertTrue((bool) data_get($payload, 'articles.0.created_isolated_working_revision'));
 
         $article = Article::query()
             ->withoutGlobalScopes()
@@ -85,8 +88,11 @@ final class ArticleUpdateExistingSeoContentPackageCommandTest extends TestCase
         $this->assertTrue((bool) $article->sitemap_eligible);
         $this->assertTrue((bool) $article->llms_eligible);
         $this->assertSame($publishedRevisionId, (int) $article->published_revision_id);
+        $this->assertNotSame($publishedRevisionId, (int) $article->working_revision_id);
         $this->assertSame('https://fermatmind.com'.self::CANONICAL, (string) $article->seoMeta?->canonical_url);
 
+        $this->assertSame('Published RIASEC article', (string) $article->publishedRevision?->title);
+        $this->assertSame(ArticleTranslationRevision::STATUS_PUBLISHED, (string) $article->publishedRevision?->revision_status);
         $this->assertSame('霍兰德职业兴趣测试是什么？RIASEC 六型如何帮助职业探索', (string) $article->workingRevision?->title);
         $this->assertSame(ArticleTranslationRevision::STATUS_HUMAN_REVIEW, (string) $article->workingRevision?->revision_status);
         $this->assertStringContainsString('## RIASEC 六型如何帮助职业探索', (string) $article->workingRevision?->content_md);

--- a/backend/tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
@@ -82,6 +82,16 @@ final class ArticleUpdateImageMetadataCommandTest extends TestCase
 
             $this->assertSame($before[(int) $article->id], $this->protectedSnapshot($fresh));
         }
+
+        $publicPayload = $this->getJson('/api/v0.5/articles/career-confusion-test-map?locale=zh-CN&org_id=0')
+            ->assertOk()
+            ->json('article');
+        $this->assertSame(
+            'https://assets.fermatmind.com/articles/career-map/body_1600x900.jpg',
+            data_get($publicPayload, 'body_visual.image_url')
+        );
+        $this->assertFalse((bool) data_get($publicPayload, 'body_visual.fallback_authorized'));
+        $this->assertArrayNotHasKey('editorial_package_v1', (array) data_get($publicPayload, 'cover_image_variants', []));
     }
 
     public function test_execute_requires_all_no_side_effect_flags(): void


### PR DESCRIPTION
## What changed
- Hardened the existing-article SEO content package updater so it creates an isolated working revision when working_revision_id equals published_revision_id, leaving the published revision published and publicly readable.
- Exposed only a safe public body_visual payload from article editorial image metadata while continuing to strip editorial_package_v1 from public cover variants.
- Updated articles:cover-smoke to accept dedicated OG/social images and schema-held article JSON-LD instead of requiring the hero cover image everywhere.

## Why
This closes the RIASEC sidecars from the existing article update release: article 40 can no longer have its published revision downgraded to human_review, body visuals imported through image metadata can be consumed by public clients, and the cover smoke no longer blocks on the intentional 1200x630 OG/schema hold setup.

## Validation
- composer install --no-interaction --prefer-dist
- php artisan test --filter='ArticleUpdateExistingSeoContentPackageCommandTest|ArticleCoverPropagationSmokeCommandTest|ArticleUpdateImageMetadataCommandTest'
- DB_CONNECTION=sqlite DB_DATABASE=':memory:' APP_ENV=testing php artisan migrate --pretend
- php artisan route:list --path=api/v0.5/articles
- ./vendor/bin/pint --test app/Console/Commands/ArticleCoverPropagationSmoke.php app/Http/Controllers/API/V0_5/Cms/ArticleController.php app/Services/Cms/SeoContentPackage/SeoContentPackageExistingArticleUpdater.php tests/Feature/Console/ArticleCoverPropagationSmokeCommandTest.php tests/Feature/Console/ArticleUpdateExistingSeoContentPackageCommandTest.php tests/Feature/Console/ArticleUpdateImageMetadataCommandTest.php
- git diff --check
- Chrome read-only live check: /zh/articles/riasec-holland-career-interest-test-explained returned readable content, JSON-LD count 0, hreflang count 0.

## Intentionally not done
- No deployment.
- No CMS production write.
- No search submission.
- No sitemap or llms changes.
- No frontend revalidation.
- No HTML JSON-LD or hreflang output changes.

## Repository rule impact
Article content remains backend/CMS authoritative. This PR only hardens backend writer behavior, public API projection, and smoke validation assumptions.