### PR TITLE
fix(cms): add SEO meta baseline repair and media URL fallback

### DIFF
--- a/backend/app/Console/Commands/ArticleEnsureSeoMetaBaseline.php
+++ b/backend/app/Console/Commands/ArticleEnsureSeoMetaBaseline.php
@@ -1,0 +1,332 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use App\Services\Cms\ArticleSeoService;
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+use RuntimeException;
+use Throwable;
+
+final class ArticleEnsureSeoMetaBaseline extends Command
+{
+    protected $signature = 'articles:ensure-seo-meta-baseline
+        {--article-id= : Exact article id to lock}
+        {--translation-group-id= : Expected translation_group_id lock}
+        {--expected-slug= : Expected existing article slug}
+        {--expected-canonical= : Expected canonical route or absolute canonical URL}
+        {--dry-run : Validate and plan without writing DB rows}
+        {--execute : Apply the missing SEO meta baseline; omitted by default for dry-run safety}
+        {--json : Emit a JSON summary}
+        {--no-publish : Required execute-mode hold: do not publish}
+        {--no-schema : Required execute-mode hold: do not modify schema gates}
+        {--no-hreflang : Required execute-mode hold: do not modify hreflang gates}
+        {--no-search : Required execute-mode hold: do not submit search channels}
+        {--no-sitemap-llms-change : Required execute-mode hold: do not modify sitemap/llms eligibility}';
+
+    protected $description = 'Safely create or complete a locked article SEO meta baseline without publishing or enabling schema/search surfaces.';
+
+    public function handle(ArticleSeoService $articleSeoService): int
+    {
+        try {
+            $summary = $this->buildSummary($articleSeoService);
+        } catch (RuntimeException $exception) {
+            $summary = $this->failureSummary('runtime_error', $exception->getMessage());
+        } catch (Throwable $exception) {
+            $summary = $this->failureSummary('unexpected_error', $exception->getMessage());
+        }
+
+        $this->emitSummary($summary);
+
+        return ($summary['ok'] ?? false) === true ? self::SUCCESS : self::FAILURE;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function buildSummary(ArticleSeoService $articleSeoService): array
+    {
+        $execute = (bool) $this->option('execute');
+        $dryRun = ! $execute;
+        $errors = [];
+        $articleId = (int) $this->option('article-id');
+        $translationGroupId = trim((string) $this->option('translation-group-id'));
+        $expectedSlug = trim((string) $this->option('expected-slug'));
+        $expectedCanonical = trim((string) $this->option('expected-canonical'));
+
+        if ((bool) $this->option('dry-run') && $execute) {
+            $errors[] = $this->issue('dry_run', 'execute_dry_run_conflict', '--execute cannot be combined with --dry-run.');
+        }
+        if ($execute) {
+            foreach (['no-publish', 'no-schema', 'no-hreflang', 'no-search', 'no-sitemap-llms-change'] as $flag) {
+                if ((bool) $this->option($flag) !== true) {
+                    $errors[] = $this->issue($flag, 'required_safety_flag_missing', 'All no-side-effect safety flags are required for execute mode.');
+                }
+            }
+        }
+
+        if ($articleId <= 0) {
+            $errors[] = $this->issue('article_id', 'article_id_required', '--article-id is required.');
+        }
+        if ($translationGroupId === '') {
+            $errors[] = $this->issue('translation_group_id', 'translation_group_id_required', '--translation-group-id is required.');
+        }
+        if ($expectedSlug === '') {
+            $errors[] = $this->issue('expected_slug', 'expected_slug_required', '--expected-slug is required.');
+        }
+        if ($expectedCanonical === '') {
+            $errors[] = $this->issue('expected_canonical', 'expected_canonical_required', '--expected-canonical is required.');
+        }
+
+        $article = $articleId > 0 ? $this->article($articleId) : null;
+        if (! $article instanceof Article) {
+            $errors[] = $this->issue('article_id', 'article_not_found', 'Article was not found.');
+
+            return $this->summary(false, $dryRun, 'will_skip', $articleId, $translationGroupId, null, null, $errors, []);
+        }
+
+        $before = $this->snapshot($article, $article->seoMeta);
+        $expectedAbsoluteCanonical = $articleSeoService->buildCanonicalUrl((string) $article->slug, (string) $article->locale);
+        $this->validateLocks($article, $translationGroupId, $expectedSlug, $expectedCanonical, $expectedAbsoluteCanonical, $errors);
+        $planned = $this->plannedSeoMeta($article, $expectedAbsoluteCanonical);
+        $after = $this->snapshot($article, $planned);
+
+        if ($errors !== []) {
+            return $this->summary(false, $dryRun, 'will_skip', $articleId, $translationGroupId, $before, $after, $errors, []);
+        }
+
+        if ($dryRun) {
+            return $this->summary(true, true, 'would_ensure_seo_meta_baseline', $articleId, $translationGroupId, $before, $after, [], []);
+        }
+
+        DB::transaction(function () use ($articleSeoService, $articleId): void {
+            $articleSeoService->generateSeoMeta($articleId);
+        });
+
+        $fresh = $this->article($articleId);
+
+        return $this->summary(
+            true,
+            false,
+            'ensured_seo_meta_baseline',
+            $articleId,
+            $translationGroupId,
+            $before,
+            $fresh instanceof Article ? $this->snapshot($fresh, $fresh->seoMeta) : null,
+            [],
+            [],
+        );
+    }
+
+    private function article(int $articleId): ?Article
+    {
+        return Article::query()
+            ->withoutGlobalScopes()
+            ->with(['seoMeta' => static fn ($relation) => $relation->withoutGlobalScopes()])
+            ->find($articleId);
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     */
+    private function validateLocks(Article $article, string $translationGroupId, string $expectedSlug, string $expectedCanonical, ?string $expectedAbsoluteCanonical, array &$errors): void
+    {
+        if ((string) $article->translation_group_id !== $translationGroupId) {
+            $errors[] = $this->issue('article.translation_group_id', 'translation_group_id_mismatch', 'Article translation_group_id does not match expected lock.');
+        }
+        if ((string) $article->slug !== $expectedSlug) {
+            $errors[] = $this->issue('article.slug', 'slug_mismatch', 'Article slug does not match expected lock.');
+        }
+        if ($expectedAbsoluteCanonical === null || ! in_array($expectedCanonical, [$expectedAbsoluteCanonical, $this->canonicalPath($expectedAbsoluteCanonical)], true)) {
+            $errors[] = $this->issue('expected_canonical', 'expected_canonical_mismatch', 'Expected canonical does not match article slug/locale.');
+        }
+
+        $seoMeta = $article->seoMeta;
+        if ($seoMeta instanceof ArticleSeoMeta) {
+            $actualCanonical = trim((string) $seoMeta->canonical_url);
+            if ($actualCanonical !== '' && ! in_array($actualCanonical, [$expectedAbsoluteCanonical, $this->canonicalPath((string) $expectedAbsoluteCanonical)], true)) {
+                $errors[] = $this->issue('article_seo_meta.canonical_url', 'existing_canonical_mismatch', 'Existing SEO meta canonical does not match expected lock.');
+            }
+        }
+    }
+
+    private function canonicalPath(string $canonical): string
+    {
+        $path = parse_url($canonical, PHP_URL_PATH);
+
+        return is_string($path) ? $path : $canonical;
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function plannedSeoMeta(Article $article, ?string $expectedCanonical): array
+    {
+        $existing = $article->seoMeta;
+        $description = trim((string) ($article->excerpt ?? ''));
+        if ($description === '') {
+            $description = trim(strip_tags((string) $article->content_md));
+        }
+
+        return [
+            'exists' => true,
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'seo_title' => $existing instanceof ArticleSeoMeta && trim((string) $existing->seo_title) !== ''
+                ? (string) $existing->seo_title
+                : mb_substr(trim((string) $article->title), 0, 60),
+            'seo_description' => $existing instanceof ArticleSeoMeta && trim((string) $existing->seo_description) !== ''
+                ? (string) $existing->seo_description
+                : mb_substr(preg_replace('/\s+/u', ' ', $description) ?: $description, 0, 160),
+            'canonical_url' => $existing instanceof ArticleSeoMeta && trim((string) $existing->canonical_url) !== ''
+                ? (string) $existing->canonical_url
+                : $expectedCanonical,
+            'og_title' => $existing instanceof ArticleSeoMeta && trim((string) $existing->og_title) !== ''
+                ? (string) $existing->og_title
+                : mb_substr(trim((string) $article->title), 0, 90),
+            'og_description' => $existing instanceof ArticleSeoMeta && trim((string) $existing->og_description) !== ''
+                ? (string) $existing->og_description
+                : mb_substr(preg_replace('/\s+/u', ' ', $description) ?: $description, 0, 200),
+            'og_image_url' => $existing instanceof ArticleSeoMeta ? $existing->og_image_url : null,
+            'robots' => $existing instanceof ArticleSeoMeta && trim((string) $existing->robots) !== ''
+                ? (string) $existing->robots
+                : ((bool) $article->is_indexable ? 'index,follow' : 'noindex,nofollow'),
+            'is_indexable' => (bool) $article->is_indexable,
+            'schema_json' => $existing instanceof ArticleSeoMeta ? $existing->schema_json : null,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>|null
+     */
+    private function snapshot(Article $article, ArticleSeoMeta|array|null $seoMeta): ?array
+    {
+        if ($seoMeta === null) {
+            return [
+                'article_id' => (int) $article->id,
+                'seo_meta_exists' => false,
+            ];
+        }
+
+        $value = static fn (string $key): mixed => $seoMeta instanceof ArticleSeoMeta ? $seoMeta->{$key} : ($seoMeta[$key] ?? null);
+
+        return [
+            'article_id' => (int) $article->id,
+            'locale' => (string) $article->locale,
+            'slug' => (string) $article->slug,
+            'translation_group_id' => (string) $article->translation_group_id,
+            'status' => (string) $article->status,
+            'is_public' => (bool) $article->is_public,
+            'is_indexable' => (bool) $article->is_indexable,
+            'sitemap_eligible' => (bool) $article->sitemap_eligible,
+            'llms_eligible' => (bool) $article->llms_eligible,
+            'seo_meta_exists' => true,
+            'seo_title' => $value('seo_title'),
+            'seo_description' => $value('seo_description'),
+            'canonical_url' => $value('canonical_url'),
+            'og_title' => $value('og_title'),
+            'og_description' => $value('og_description'),
+            'og_image_url' => $value('og_image_url'),
+            'robots' => $value('robots'),
+            'seo_is_indexable' => (bool) $value('is_indexable'),
+            'schema_json_sha256' => hash('sha256', (string) json_encode($value('schema_json'), JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE)),
+        ];
+    }
+
+    /**
+     * @param  list<array<string,mixed>>  $errors
+     * @param  list<array<string,mixed>>  $warnings
+     * @return array<string,mixed>
+     */
+    private function summary(bool $ok, bool $dryRun, string $action, int $articleId, string $translationGroupId, ?array $before, ?array $after, array $errors, array $warnings): array
+    {
+        return [
+            'ok' => $ok,
+            'dry_run' => $dryRun,
+            'action' => $action,
+            'would_write' => $ok && ! $dryRun,
+            'article_id' => $articleId,
+            'translation_group_id' => $translationGroupId,
+            'updates_scope' => [
+                'article_seo_meta_fields' => [
+                    'seo_title',
+                    'seo_description',
+                    'canonical_url',
+                    'og_title',
+                    'og_description',
+                    'robots',
+                    'is_indexable',
+                ],
+            ],
+            'protected_holds' => [
+                'no_publish' => true,
+                'no_schema' => true,
+                'no_hreflang' => true,
+                'no_search' => true,
+                'no_sitemap_llms_change' => true,
+            ],
+            'before' => $before,
+            'after' => $after,
+            'errors' => $errors,
+            'warnings' => $warnings,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function issue(string $field, string $code, string $message): array
+    {
+        return [
+            'field' => $field,
+            'code' => $code,
+            'message' => $message,
+        ];
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function failureSummary(string $code, string $message): array
+    {
+        return [
+            'ok' => false,
+            'dry_run' => ! (bool) $this->option('execute'),
+            'action' => 'will_skip',
+            'would_write' => false,
+            'article_id' => (int) $this->option('article-id'),
+            'translation_group_id' => (string) $this->option('translation-group-id'),
+            'errors' => [[
+                'field' => 'command',
+                'code' => $code,
+                'message' => $message,
+            ]],
+            'warnings' => [],
+        ];
+    }
+
+    /**
+     * @param  array<string,mixed>  $summary
+     */
+    private function emitSummary(array $summary): void
+    {
+        if ((bool) $this->option('json')) {
+            $this->line(json_encode($summary, JSON_PRETTY_PRINT | JSON_UNESCAPED_UNICODE | JSON_UNESCAPED_SLASHES | JSON_INVALID_UTF8_SUBSTITUTE));
+
+            return;
+        }
+
+        $this->line('ok='.(($summary['ok'] ?? false) ? '1' : '0'));
+        $this->line('dry_run='.(($summary['dry_run'] ?? false) ? '1' : '0'));
+        $this->line('action='.(string) ($summary['action'] ?? 'will_skip'));
+        $this->line('would_write='.(($summary['would_write'] ?? false) ? '1' : '0'));
+        $this->line('article_id='.(string) ($summary['article_id'] ?? ''));
+        $this->line('translation_group_id='.(string) ($summary['translation_group_id'] ?? ''));
+        $this->line('errors_count='.(string) count((array) ($summary['errors'] ?? [])));
+        $this->line('warnings_count='.(string) count((array) ($summary['warnings'] ?? [])));
+    }
+}

--- a/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
+++ b/backend/app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php
@@ -579,7 +579,13 @@ final class SeoImageBundleImporter
                 continue;
             }
             $variants[(string) $variant->variant_key] = [
-                'url' => PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $variant->path, $variant->url),
+                'url' => $this->publicMediaUrlForImportedRecord(
+                    (string) $asset->disk,
+                    $variant->path,
+                    $variant->url,
+                    (string) $variant->sync_status,
+                    (string) $variant->cdn_status,
+                ),
                 'width' => (int) $variant->width,
                 'height' => (int) $variant->height,
                 'mime_type' => (string) $variant->mime_type,
@@ -589,7 +595,13 @@ final class SeoImageBundleImporter
         return [
             'id' => (int) $asset->id,
             'asset_key' => (string) $asset->asset_key,
-            'url' => PublicMediaUrlGuard::canonicalMediaUrl((string) $asset->disk, $asset->path, $asset->url),
+            'url' => $this->publicMediaUrlForImportedRecord(
+                (string) $asset->disk,
+                $asset->path,
+                $asset->url,
+                (string) $asset->sync_status,
+                (string) $asset->cdn_status,
+            ),
             'mime_type' => (string) $asset->mime_type,
             'width' => (int) $asset->width,
             'height' => (int) $asset->height,
@@ -601,6 +613,18 @@ final class SeoImageBundleImporter
             'cdn_status' => (string) $asset->cdn_status,
             'variants' => $variants,
         ];
+    }
+
+    private function publicMediaUrlForImportedRecord(string $disk, mixed $path, mixed $url, string $syncStatus, string $cdnStatus): ?string
+    {
+        if ($syncStatus === MediaAsset::SYNC_SKIPPED || $cdnStatus === MediaAsset::CDN_SKIPPED) {
+            $appStorageUrl = PublicMediaUrlGuard::publicAppStorageUrlForPath($disk, $path);
+            if ($appStorageUrl !== null) {
+                return $appStorageUrl;
+            }
+        }
+
+        return PublicMediaUrlGuard::canonicalMediaUrl($disk, $path, $url);
     }
 
     /**

--- a/backend/app/Support/PublicMediaUrlGuard.php
+++ b/backend/app/Support/PublicMediaUrlGuard.php
@@ -82,6 +82,30 @@ final class PublicMediaUrlGuard
         return self::sanitizeNullableUrl(self::canonicalAssetOrigin().$publicPath);
     }
 
+    public static function publicAppStorageUrlForPath(?string $disk, mixed $path): ?string
+    {
+        $normalizedPath = trim((string) $path);
+        if ($normalizedPath === '') {
+            return null;
+        }
+
+        if (preg_match('/^https?:\/\//i', $normalizedPath)) {
+            return self::sanitizeNullableUrl($normalizedPath);
+        }
+
+        $publicPath = self::publicPathForDisk($disk, $normalizedPath);
+        if ($publicPath === '') {
+            return null;
+        }
+
+        $origin = rtrim(trim((string) config('app.url', '')), '/');
+        if ($origin === '' || ! preg_match('/^https:\/\//i', $origin)) {
+            return null;
+        }
+
+        return self::sanitizeNullableUrl($origin.$publicPath);
+    }
+
     public static function canonicalMediaUrl(?string $disk, mixed $path, mixed $url): ?string
     {
         if (self::isPrivateOrOpsDisk($disk)) {

--- a/backend/tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php
+++ b/backend/tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php
@@ -1,0 +1,209 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Feature\Console;
+
+use App\Models\Article;
+use App\Models\ArticleSeoMeta;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Artisan;
+use Tests\TestCase;
+
+final class ArticleEnsureSeoMetaBaselineCommandTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function test_default_invocation_is_dry_run_and_does_not_write(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle();
+
+        $exitCode = Artisan::call('articles:ensure-seo-meta-baseline', [
+            '--article-id' => (string) $article->id,
+            '--translation-group-id' => 'article-8',
+            '--expected-slug' => 'mbti-basics',
+            '--expected-canonical' => '/zh/articles/mbti-basics',
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertTrue($payload['dry_run']);
+        $this->assertFalse($payload['would_write']);
+        $this->assertFalse($payload['before']['seo_meta_exists']);
+        $this->assertTrue($payload['after']['seo_meta_exists']);
+        $this->assertSame('https://fermatmind.com/zh/articles/mbti-basics', $payload['after']['canonical_url']);
+        $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_execute_creates_baseline_without_schema_hreflang_or_indexability_drift(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle();
+
+        $exitCode = Artisan::call('articles:ensure-seo-meta-baseline', [
+            '--article-id' => (string) $article->id,
+            '--translation-group-id' => 'article-8',
+            '--expected-slug' => 'mbti-basics',
+            '--expected-canonical' => '/zh/articles/mbti-basics',
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+            '--no-schema' => true,
+            '--no-hreflang' => true,
+            '--no-search' => true,
+            '--no-sitemap-llms-change' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertTrue($payload['ok']);
+        $this->assertFalse($payload['dry_run']);
+        $this->assertSame('ensured_seo_meta_baseline', $payload['action']);
+
+        $fresh = Article::query()->withoutGlobalScopes()->with('seoMeta')->findOrFail((int) $article->id);
+        $this->assertSame('published', (string) $fresh->status);
+        $this->assertTrue((bool) $fresh->is_public);
+        $this->assertTrue((bool) $fresh->is_indexable);
+        $this->assertTrue((bool) $fresh->sitemap_eligible);
+        $this->assertTrue((bool) $fresh->llms_eligible);
+        $this->assertSame('https://fermatmind.com/zh/articles/mbti-basics', (string) $fresh->seoMeta?->canonical_url);
+        $this->assertSame('index,follow', (string) $fresh->seoMeta?->robots);
+        $this->assertTrue((bool) $fresh->seoMeta?->is_indexable);
+        $this->assertNull($fresh->seoMeta?->schema_json);
+    }
+
+    public function test_execute_requires_all_safety_flags(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle();
+
+        $exitCode = Artisan::call('articles:ensure-seo-meta-baseline', [
+            '--article-id' => (string) $article->id,
+            '--translation-group-id' => 'article-8',
+            '--expected-slug' => 'mbti-basics',
+            '--expected-canonical' => '/zh/articles/mbti-basics',
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'required_safety_flag_missing');
+        $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+    }
+
+    public function test_execute_preserves_existing_schema_json(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle();
+        ArticleSeoMeta::query()->withoutGlobalScopes()->create([
+            'org_id' => 0,
+            'article_id' => (int) $article->id,
+            'locale' => 'zh-CN',
+            'canonical_url' => 'https://fermatmind.com/zh/articles/mbti-basics',
+            'robots' => 'index,follow',
+            'is_indexable' => true,
+            'schema_json' => [
+                'editorial_package_v1' => [
+                    'article_schema_enabled' => false,
+                    'breadcrumb_schema_enabled' => false,
+                    'faq_schema_enabled' => false,
+                    'hreflang_gate_v1' => [
+                        'enabled' => false,
+                    ],
+                ],
+            ],
+        ]);
+
+        $exitCode = Artisan::call('articles:ensure-seo-meta-baseline', [
+            '--article-id' => (string) $article->id,
+            '--translation-group-id' => 'article-8',
+            '--expected-slug' => 'mbti-basics',
+            '--expected-canonical' => '/zh/articles/mbti-basics',
+            '--execute' => true,
+            '--json' => true,
+            '--no-publish' => true,
+            '--no-schema' => true,
+            '--no-hreflang' => true,
+            '--no-search' => true,
+            '--no-sitemap-llms-change' => true,
+        ]);
+
+        $this->assertSame(0, $exitCode);
+        $fresh = ArticleSeoMeta::query()->withoutGlobalScopes()->where('article_id', (int) $article->id)->firstOrFail();
+        $this->assertFalse((bool) data_get($fresh->schema_json, 'editorial_package_v1.article_schema_enabled'));
+        $this->assertFalse((bool) data_get($fresh->schema_json, 'editorial_package_v1.hreflang_gate_v1.enabled'));
+    }
+
+    public function test_lock_mismatch_rejects_without_write(): void
+    {
+        config(['app.frontend_url' => 'https://fermatmind.com']);
+        $article = $this->createArticle();
+
+        $exitCode = Artisan::call('articles:ensure-seo-meta-baseline', [
+            '--article-id' => (string) $article->id,
+            '--translation-group-id' => 'wrong-group',
+            '--expected-slug' => 'mbti-basics',
+            '--expected-canonical' => '/zh/articles/mbti-basics',
+            '--dry-run' => true,
+            '--json' => true,
+        ]);
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(1, $exitCode);
+        $this->assertErrorCode($payload, 'translation_group_id_mismatch');
+        $this->assertSame(0, ArticleSeoMeta::query()->withoutGlobalScopes()->count());
+    }
+
+    private function createArticle(): Article
+    {
+        /** @var Article $article */
+        $article = Article::query()->withoutGlobalScopes()->create([
+            'id' => 8,
+            'org_id' => 0,
+            'slug' => 'mbti-basics',
+            'locale' => 'zh-CN',
+            'translation_group_id' => 'article-8',
+            'source_locale' => 'zh-CN',
+            'translation_status' => Article::TRANSLATION_STATUS_SOURCE,
+            'title' => 'MBTI 性格测试是什么？16 型人格能告诉你什么，不能告诉你什么',
+            'excerpt' => '了解 MBTI 性格测试、16 型人格和四组偏好。',
+            'content_md' => '正文',
+            'content_html' => '',
+            'status' => 'published',
+            'is_public' => true,
+            'is_indexable' => true,
+            'sitemap_eligible' => true,
+            'llms_eligible' => true,
+            'published_at' => now(),
+        ]);
+
+        return $article->refresh();
+    }
+
+    /**
+     * @return array<string,mixed>
+     */
+    private function jsonOutput(): array
+    {
+        $payload = json_decode(Artisan::output(), true);
+        $this->assertIsArray($payload, Artisan::output());
+
+        return $payload;
+    }
+
+    /**
+     * @param  array<string,mixed>  $payload
+     */
+    private function assertErrorCode(array $payload, string $code): void
+    {
+        $this->assertContains($code, array_map(
+            static fn (array $error): string => (string) ($error['code'] ?? ''),
+            $payload['errors'] ?? []
+        ));
+    }
+}

--- a/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
+++ b/backend/tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php
@@ -182,6 +182,23 @@ final class MediaAssetsImportSeoImageBundleCommandTest extends TestCase
         Storage::disk('public')->assertExists((string) $asset->path);
     }
 
+    public function test_non_dry_run_uses_public_api_storage_urls_when_cdn_sync_is_skipped(): void
+    {
+        config(['app.url' => 'https://api.fermatmind.com']);
+        Storage::fake('public');
+        $package = $this->writeImageBundlePackage();
+
+        $exitCode = Artisan::call('media-assets:import-seo-image-bundle', $this->commandOptions($package, [
+            '--json' => true,
+        ]));
+
+        $payload = $this->jsonOutput();
+        $this->assertSame(0, $exitCode);
+        $this->assertStringStartsWith('https://api.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['cover_image_url']);
+        $this->assertStringStartsWith('https://api.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['og_image_url']);
+        $this->assertStringStartsWith('https://api.fermatmind.com/storage/media-library/variants/', $payload['resolved_metadata']['cover_image_variants']['hero']['url']);
+    }
+
     public function test_dry_run_does_not_write_existing_asset_or_storage(): void
     {
         Storage::fake('public');

--- a/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
+++ b/backend/tests/Unit/Services/BigFive/ResultPageV2/BigFiveResultPageV2CoreBodyPreviewTest.php
@@ -1567,6 +1567,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     public function test_runtime_freeze_classifier_ignores_article_publishing_runtime_truth_gate_changes(): void
     {
         $changed = [
+            'backend/app/Console/Commands/ArticleEnsureSeoMetaBaseline.php',
             'backend/app/Console/Commands/ArticleImportLocalBaseline.php',
             'backend/app/Services/Career/StructuredData/CareerArticleStructuredDataBuilder.php',
             'backend/app/Services/Cms/ArticleSeoService.php',
@@ -4008,6 +4009,7 @@ final class BigFiveResultPageV2CoreBodyPreviewTest extends TestCase
     private function isArticlePublishingRuntimeTruthGateFile(string $file): bool
     {
         return in_array($file, [
+            'backend/app/Console/Commands/ArticleEnsureSeoMetaBaseline.php',
             'backend/app/Console/Commands/ArticleImportLocalBaseline.php',
             'backend/app/Http/Controllers/API/V0_5/Cms/LandingSurfaceController.php',
             'backend/app/Services/Career/StructuredData/CareerArticleStructuredDataBuilder.php',


### PR DESCRIPTION
## What changed
- Added `articles:ensure-seo-meta-baseline`, a dry-run-first locked repair command for missing article SEO meta baselines.
- The command requires exact article/translation-group/slug/canonical locks and all no-side-effect flags before execute mode.
- Updated the SEO image bundle importer to emit public API storage URLs when OSS/CDN sync is skipped, avoiding broken `assets.fermatmind.com/storage/...` URLs.
- Added regression coverage for the SEO meta baseline command and skipped-CDN image URL behavior.

## Why
The MBTI pillar update flow found two production-safe repair needs: existing published articles can lack `article_seo_meta`, and local/public-storage image imports should not return CDN asset URLs when CDN sync is disabled.

## Validation
- `./vendor/bin/pint app/Console/Commands/ArticleEnsureSeoMetaBaseline.php app/Services/Cms/SeoImageBundle/SeoImageBundleImporter.php app/Support/PublicMediaUrlGuard.php tests/Feature/Console/ArticleEnsureSeoMetaBaselineCommandTest.php tests/Feature/Console/MediaAssetsImportSeoImageBundleCommandTest.php`
- `php artisan test --filter=ArticleEnsureSeoMetaBaselineCommandTest`
- `php artisan test --filter=MediaAssetsImportSeoImageBundleCommandTest`
- `php artisan test --filter=ArticleUpdateImageMetadataCommandTest`
- `php artisan test --filter=ArticleReplaceInlineImageUrlCommandTest`
- `php artisan list | rg 'articles:ensure-seo-meta-baseline|media-assets:import-seo-image-bundle'`\n- `git diff --check`\n\n## Intentionally deferred\n- No production command execution.\n- No CMS mutation.\n- No article publish/index/sitemap/llms/schema/hreflang/search changes.\n- No production deploy.\n\nRepository rule impact: backend remains the CMS/media authority. This adds controlled repair/import command behavior and does not introduce frontend content fallback.